### PR TITLE
BINIUS-278: benchmark XMSS signature verification on M4

### DIFF
--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -42,3 +42,7 @@ harness = false
 [[bench]]
 name = "blake3_compressions"
 harness = false
+
+[[bench]]
+name = "xmss"
+harness = false

--- a/crates/m4-prover/benches/xmss.rs
+++ b/crates/m4-prover/benches/xmss.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 The Binius Developers
+//! End-to-end M4 proving throughput for XMSS signature verification.
+//!
+//! One full XMSS verification runs per instance, and the whole batch is proved together, so the
+//! throughput is signatures per second. The circuit is all-BLAKE3 and MUL-free, which the batched
+//! M4 prover requires.
+//!
+//! A single valid signature is generated once and replicated across every instance. Proving cost
+//! is data-independent, so this measures the same throughput as distinct signatures while keeping
+//! setup to one nonce grind.
+//!
+//! Environment overrides:
+//! - `LOG_INSTANCES`: base-2 log of the signature count (default 13 = 8192).
+//! - `LOG_INV_RATE`: base-2 log of the inverse Reed-Solomon rate (default 1 = rate 1/2).
+//! - `WOTS_SPEC`: Winternitz spec, 1 (w=2) or 2 (w=4) (default 1).
+//! - `XMSS_TREE_HEIGHT`: Merkle tree height; the tree has 2^height leaves (default 13).
+
+#[path = "utils/m4_bench.rs"]
+mod m4_bench;
+
+use std::{array, env};
+
+use binius_circuits::hash_based_sig::{
+	winternitz_ots::{NONCE_WIRES_COUNT, WinternitzSpec},
+	witness_utils::ValidatorSignatureData,
+	xmss::{XmssSignature, circuit_xmss},
+};
+use binius_core::word::Word;
+use binius_frontend::{Circuit, CircuitBuilder, Wire};
+use binius_m4_prover::BatchWitnessFiller;
+use criterion::{Criterion, criterion_group, criterion_main};
+use m4_bench::bench_m4_proving;
+use rand::prelude::*;
+
+/// Base-2 logarithm of the signature count: 2^13 = 8192 signatures.
+const DEFAULT_LOG_INSTANCES: usize = 13;
+
+/// Base-2 logarithm of the inverse Reed-Solomon rate: rate 1/2, matching the hash benches.
+const DEFAULT_LOG_INV_RATE: usize = 1;
+
+/// Merkle tree height: the tree has 2^height leaves, one per epoch.
+const DEFAULT_TREE_HEIGHT: usize = 13;
+
+/// One signature verification per instance: the throughput count is signatures per second.
+const SIGNATURES_PER_INSTANCE: u64 = 1;
+
+/// The witness input wires of one XMSS verification instance.
+///
+/// Every wire is a witness input: the public data folds into the witness, since the batch table
+/// forbids inout wires. The circuit's internal root-equality assertion keeps the computation alive.
+struct XmssWires {
+	/// The per-signer domain parameter, eight bytes per wire.
+	domain_param: Vec<Wire>,
+	/// The 32-byte message, four wires.
+	message: Vec<Wire>,
+	/// The committed Merkle root, four wires.
+	root_hash: [Wire; 4],
+	/// The signature witness: nonce, epoch, chain values, chain ends, and authentication path.
+	signature: XmssSignature,
+}
+
+/// Packs little-endian bytes into 64-bit word wires, zero-filling any trailing wires.
+///
+/// Mirrors the single-instance packing helper, but writes into the batch filler one wire at a time.
+fn pack_bytes_le(w: &mut BatchWitnessFiller<'_, '_>, wires: &[Wire], bytes: &[u8]) {
+	assert!(bytes.len() <= wires.len() * 8, "bytes overflow the wire capacity");
+
+	// Pack each 8-byte little-endian chunk into its word.
+	for (&wire, chunk) in wires.iter().zip(bytes.chunks(8)) {
+		let mut word = [0u8; 8];
+		word[..chunk.len()].copy_from_slice(chunk);
+		w[wire] = Word(u64::from_le_bytes(word));
+	}
+	// Zero any wire past the packed bytes.
+	for &wire in &wires[bytes.len().div_ceil(8)..] {
+		w[wire] = Word::ZERO;
+	}
+}
+
+/// Builds one XMSS verification circuit with every input allocated as a witness.
+///
+/// With no inout wires the circuit is eligible for the batch witness table.
+/// The verification asserts the recomputed root equals the committed root, so nothing is pruned.
+fn build_xmss_circuit(spec: &WinternitzSpec, tree_height: usize) -> (Circuit, XmssWires) {
+	let builder = CircuitBuilder::new();
+
+	// The per-signer domain parameter is a byte string; each wire holds 8 of its bytes.
+	let param_wire_count = spec.domain_param_len.div_ceil(8);
+	let domain_param: Vec<Wire> = (0..param_wire_count)
+		.map(|_| builder.add_witness())
+		.collect();
+	// The message digest is 32 bytes across four 64-bit wires.
+	let message: Vec<Wire> = (0..4).map(|_| builder.add_witness()).collect();
+	// The committed Merkle root is 32 bytes across four wires.
+	let root_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
+
+	// The nonce feeds the message hash and fills four wires exactly.
+	let nonce: Vec<Wire> = (0..NONCE_WIRES_COUNT)
+		.map(|_| builder.add_witness())
+		.collect();
+	// The epoch is the signing leaf index within the tree.
+	let epoch = builder.add_witness();
+	// One chain value per Winternitz coordinate (the signature), each a four-wire digest.
+	let signature_hashes: Vec<[Wire; 4]> = (0..spec.dimension())
+		.map(|_| array::from_fn(|_| builder.add_witness()))
+		.collect();
+	// One chain end per coordinate (the one-time public key), each a four-wire digest.
+	let public_key_hashes: Vec<[Wire; 4]> = (0..spec.dimension())
+		.map(|_| array::from_fn(|_| builder.add_witness()))
+		.collect();
+	// One authentication-path node per tree level.
+	let auth_path: Vec<[Wire; 4]> = (0..tree_height)
+		.map(|_| array::from_fn(|_| builder.add_witness()))
+		.collect();
+
+	let signature = XmssSignature {
+		nonce,
+		epoch,
+		signature_hashes,
+		public_key_hashes,
+		auth_path,
+	};
+
+	circuit_xmss(&builder, spec, &domain_param, &message, &signature, &root_hash);
+
+	(
+		builder.build(),
+		XmssWires {
+			domain_param,
+			message,
+			root_hash,
+			signature,
+		},
+	)
+}
+
+/// The plaintext inputs and signature data of one valid XMSS signature.
+struct SignatureData {
+	/// The per-signer domain parameter bytes.
+	param_bytes: Vec<u8>,
+	/// The 32-byte message digest.
+	message_bytes: [u8; 32],
+	/// The signing leaf index within the tree.
+	epoch: u32,
+	/// The signed data: nonce, chain values, chain ends, Merkle root, and authentication path.
+	data: ValidatorSignatureData,
+}
+
+/// Generates one valid XMSS signature: a random parameter, message, and epoch, then a signature.
+///
+/// The nonce grind and Merkle tree build happen here, once, outside any timed region.
+fn generate_signature(spec: &WinternitzSpec, tree_height: usize) -> SignatureData {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let mut param_bytes = vec![0u8; spec.domain_param_len];
+	rng.fill_bytes(&mut param_bytes);
+	let mut message_bytes = [0u8; 32];
+	rng.fill_bytes(&mut message_bytes);
+	let epoch = rng.next_u32() % (1u32 << tree_height);
+
+	let data = ValidatorSignatureData::generate(
+		&mut rng,
+		&param_bytes,
+		&message_bytes,
+		epoch,
+		spec,
+		tree_height,
+	);
+
+	SignatureData {
+		param_bytes,
+		message_bytes,
+		epoch,
+		data,
+	}
+}
+
+/// Packs the signature into one instance's witness input wires.
+fn fill_instance(wires: &XmssWires, sig: &SignatureData, w: &mut BatchWitnessFiller<'_, '_>) {
+	// The public inputs, folded into the witness.
+	pack_bytes_le(w, &wires.domain_param, &sig.param_bytes);
+	pack_bytes_le(w, &wires.message, &sig.message_bytes);
+	pack_bytes_le(w, &wires.root_hash, &sig.data.root);
+
+	// The signature's nonce and epoch.
+	pack_bytes_le(w, &wires.signature.nonce, &sig.data.nonce);
+	w[wires.signature.epoch] = Word::from_u64(sig.epoch as u64);
+	// One chain value per coordinate.
+	for (dst, src) in wires
+		.signature
+		.signature_hashes
+		.iter()
+		.zip(&sig.data.signature_hashes)
+	{
+		pack_bytes_le(w, dst, src);
+	}
+	// One chain end per coordinate.
+	for (dst, src) in wires
+		.signature
+		.public_key_hashes
+		.iter()
+		.zip(&sig.data.public_key_hashes)
+	{
+		pack_bytes_le(w, dst, src);
+	}
+	// One authentication-path node per tree level.
+	for (dst, src) in wires.signature.auth_path.iter().zip(&sig.data.auth_path) {
+		pack_bytes_le(w, dst, src);
+	}
+}
+
+fn bench_prove_xmss(c: &mut Criterion) {
+	// Batch size, code rate, spec, and tree height are environment-tunable for sweeping.
+	let log_instances = env_usize("LOG_INSTANCES").unwrap_or(DEFAULT_LOG_INSTANCES);
+	let log_inv_rate = env_usize("LOG_INV_RATE").unwrap_or(DEFAULT_LOG_INV_RATE);
+	let tree_height = env_usize("XMSS_TREE_HEIGHT").unwrap_or(DEFAULT_TREE_HEIGHT);
+	let spec = match env_usize("WOTS_SPEC") {
+		Some(2) => WinternitzSpec::spec_2(),
+		_ => WinternitzSpec::spec_1(),
+	};
+
+	// One circuit and one signature, replicated across the batch by the shared driver.
+	let (circuit, wires) = build_xmss_circuit(&spec, tree_height);
+	let sig = generate_signature(&spec, tree_height);
+
+	bench_m4_proving(
+		c,
+		"xmss",
+		&circuit,
+		log_instances,
+		log_inv_rate,
+		SIGNATURES_PER_INSTANCE,
+		|_, w| fill_instance(&wires, &sig, w),
+	);
+}
+
+/// Reads a `usize` environment variable, returning `None` when unset or not a number.
+fn env_usize(key: &str) -> Option<usize> {
+	env::var(key).ok().and_then(|s| s.parse().ok())
+}
+
+criterion_group!(xmss, bench_prove_xmss);
+criterion_main!(xmss);

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -141,7 +141,13 @@ mod tests {
 	use std::array;
 
 	use assert_matches::assert_matches;
+	use binius_circuits::hash_based_sig::{
+		winternitz_ots::{NONCE_WIRES_COUNT, WinternitzSpec},
+		witness_utils::ValidatorSignatureData,
+		xmss::{XmssSignature, circuit_xmss},
+	};
 	use binius_field::PackedBinaryGhash1x128b;
+	use binius_frontend::{CircuitBuilder, Wire};
 	use binius_iop::{
 		basefold::{Error as BaseFoldError, VerificationError as BaseFoldVerificationError},
 		channel::Error as IOPChannelError,
@@ -153,7 +159,24 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::test_utils::{N_INPUT_WORDS, crc64_circuit, populate_crc64_witness};
+	use crate::{
+		BatchWitnessFiller,
+		test_utils::{N_INPUT_WORDS, crc64_circuit, populate_crc64_witness},
+	};
+
+	// Packs little-endian bytes into 64-bit word wires, zero-filling any trailing wires.
+	fn pack_bytes_le(w: &mut BatchWitnessFiller<'_, '_>, wires: &[Wire], bytes: &[u8]) {
+		// Each wire takes the next 8 bytes, little-endian; a short final chunk is zero-extended.
+		for (&wire, chunk) in wires.iter().zip(bytes.chunks(8)) {
+			let mut word = [0u8; 8];
+			word[..chunk.len()].copy_from_slice(chunk);
+			w[wire] = Word(u64::from_le_bytes(word));
+		}
+		// Any wire past the packed bytes is zeroed.
+		for &wire in &wires[bytes.len().div_ceil(8)..] {
+			w[wire] = Word::ZERO;
+		}
+	}
 
 	type P = PackedBinaryGhash1x128b;
 
@@ -193,6 +216,132 @@ mod tests {
 		verifier
 			.verify(&mut verifier_transcript)
 			.expect("a faithful proof verifies");
+		verifier_transcript
+			.finalize()
+			.expect("no trailing proof data");
+	}
+
+	// Invariant: a batch of full XMSS signature verifications proves and verifies through M4.
+	//
+	// XMSS verification recomputes a Merkle root from a signature and asserts it equals the
+	// committed root. The signature is a Winternitz one-time signature: one hash chain per
+	// codeword coordinate, whose chain ends hash into a Merkle leaf, plus an authentication path
+	// from that leaf to the root. Every hash is BLAKE3, so the circuit is MUL-free, as M4 requires.
+	//
+	// Fixture: spec_1 (72 Winternitz chains of length 4), a height-2 tree (4 epochs), 2^3 = 8
+	// instances.
+	#[test]
+	fn xmss_batch_round_trips() {
+		let spec = WinternitzSpec::spec_1();
+		let tree_height = 2;
+		let log_instances = 3;
+
+		// Allocate every circuit input as a witness wire, so the circuit has no inout wires.
+		// M4 forbids inout, so the public data (parameter, message, root) becomes witness too.
+		// The verification still asserts the recomputed root equals the committed root.
+		// So no gate is pruned even though nothing is a public output.
+		let builder = CircuitBuilder::new();
+		// The per-signer domain parameter is a byte string; each wire holds 8 of its bytes.
+		let param: Vec<Wire> = (0..spec.domain_param_len.div_ceil(8))
+			.map(|_| builder.add_witness())
+			.collect();
+		// The message digest is 32 bytes across four 64-bit wires.
+		let message: Vec<Wire> = (0..4).map(|_| builder.add_witness()).collect();
+		// The committed Merkle root is 32 bytes across four wires.
+		let root_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
+		// The nonce feeds the message hash and fills four wires exactly.
+		let nonce: Vec<Wire> = (0..NONCE_WIRES_COUNT)
+			.map(|_| builder.add_witness())
+			.collect();
+		// The epoch is the signing leaf index within the tree.
+		let epoch = builder.add_witness();
+		// One chain value per Winternitz coordinate (the signature), each a four-wire digest.
+		let signature_hashes: Vec<[Wire; 4]> = (0..spec.dimension())
+			.map(|_| array::from_fn(|_| builder.add_witness()))
+			.collect();
+		// One chain end per coordinate (the one-time public key), each a four-wire digest.
+		let public_key_hashes: Vec<[Wire; 4]> = (0..spec.dimension())
+			.map(|_| array::from_fn(|_| builder.add_witness()))
+			.collect();
+		// One authentication-path node per tree level.
+		let auth_path: Vec<[Wire; 4]> = (0..tree_height)
+			.map(|_| array::from_fn(|_| builder.add_witness()))
+			.collect();
+		// Assemble the signature and emit the verification constraints.
+		let signature = XmssSignature {
+			nonce: nonce.clone(),
+			epoch,
+			signature_hashes: signature_hashes.clone(),
+			public_key_hashes: public_key_hashes.clone(),
+			auth_path: auth_path.clone(),
+		};
+		circuit_xmss(&builder, &spec, &param, &message, &signature, &root_hash);
+		let circuit = builder.build();
+
+		// Generate one valid signature.
+		// This runs the nonce grind and builds the Merkle tree, so it is one-time setup here.
+		let mut rng = StdRng::seed_from_u64(0);
+		// A random per-signer domain parameter.
+		let mut param_bytes = vec![0u8; spec.domain_param_len];
+		rng.fill_bytes(&mut param_bytes);
+		// A random 32-byte message.
+		let mut message_bytes = [0u8; 32];
+		rng.fill_bytes(&mut message_bytes);
+		// A signing epoch inside the tree: any leaf index below 2^tree_height = 4.
+		let sig_epoch = rng.next_u32() % (1u32 << tree_height);
+		// Sign: derive the chain values, chain ends, Merkle leaf, and authentication path.
+		let data = ValidatorSignatureData::generate(
+			&mut rng,
+			&param_bytes,
+			&message_bytes,
+			sig_epoch,
+			&spec,
+			tree_height,
+		);
+
+		// Fill all 8 instances with that one signature.
+		// Proving is data-independent, so identical instances measure the same work as distinct
+		// ones, and one signature suffices.
+		let table = ValueTable::populate(&circuit, log_instances, |_, w| {
+			// The public inputs, folded into the witness.
+			pack_bytes_le(w, &param, &param_bytes);
+			pack_bytes_le(w, &message, &message_bytes);
+			pack_bytes_le(w, &root_hash, &data.root);
+			// The signature's nonce and epoch.
+			pack_bytes_le(w, &nonce, &data.nonce);
+			w[epoch] = Word::from_u64(sig_epoch as u64);
+			// One chain value per coordinate.
+			for (dst, src) in signature_hashes.iter().zip(&data.signature_hashes) {
+				pack_bytes_le(w, dst, src);
+			}
+			// One chain end per coordinate.
+			for (dst, src) in public_key_hashes.iter().zip(&data.public_key_hashes) {
+				pack_bytes_le(w, dst, src);
+			}
+			// One authentication-path node per tree level.
+			for (dst, src) in auth_path.iter().zip(&data.auth_path) {
+				pack_bytes_le(w, dst, src);
+			}
+		})
+		.unwrap();
+
+		// Prepare the shared constraint system, which fixes the public-segment layout.
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+
+		// Setup once: the verifier fixes the shape and FRI parameters; the prover inherits them.
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<P>::setup(&verifier);
+
+		// Prove: commit the batch witness, reduce, and open, on a fresh transcript.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(&table, &mut prover_transcript);
+
+		// Verify: replay the transcript end to end; it must accept and leave no trailing data.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		verifier
+			.verify(&mut verifier_transcript)
+			.expect("a faithful XMSS proof verifies");
 		verifier_transcript
 			.finalize()
 			.expect("no trailing proof data");


### PR DESCRIPTION
Closes [BINIUS-278](https://linear.app/jimpo/issue/BINIUS-278).

Drives the XMSS verification circuit through the data-parallel M4 prover and adds a signatures-per-second benchmark, plus a batch round-trip test. No protocol change.

### The problem

The M4 prover can prove a batch of one circuit end to end, but nothing drives a real signature circuit through it, and there is no signatures-per-second benchmark.

The XMSS verification circuit is a good fit: it is all-BLAKE3, hence MUL-free, which the batched prover requires. The obstacle is that the multi-signature builder allocates its public data (parameter, message, root, signature) as inout wires, and the batch witness table forbids inout wires.

### The idea

The single-signature verification takes its input wires as parameters; only the builder chose to allocate them as inout.

- Allocate every input as a witness wire, so the circuit has no inout wires and is eligible for the batch witness table.
- The verification still asserts the recomputed Merkle root equals the committed root, so nothing is pruned even though there is no public output.
- One instance is one signature verification, so the batch throughput is signatures per second.

No protocol work is needed: the oracle-binding step and the non-power-of-two-constant handling a real circuit needs are already in place.

### The change

- **new** `crates/m4-prover/benches/xmss.rs`: builds one witness-allocated verification circuit, generates one valid signature with the existing signing helpers, replicates it across instances, and reports signatures per second through the shared proving driver.
- **new** test `prove::xmss_batch_round_trips`: proves and verifies a small batch end to end.
- **changed** `crates/m4-prover/Cargo.toml`: registers the benchmark.

The signature is generated once, outside the timed path, and replicated across instances. Proving is data-independent, so this measures the same throughput as distinct signatures while keeping setup to a single nonce grind.

### Scope

- reuses the shared `bench_m4_proving` driver, the `circuit_xmss` gadget, and the `ValidatorSignatureData` signing helpers
- the benchmark is tunable through `LOG_INSTANCES`, `WOTS_SPEC`, `XMSS_TREE_HEIGHT`, and `LOG_INV_RATE`
- left untouched: the M4 prover and verifier

### Soundness

- The prover and verifier are unchanged; this only builds an existing circuit with witness inputs and benchmarks it.
- The verification's own checks — the epoch range, the Winternitz target sum, and the Merkle root — are unchanged.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-m4-prover --all-targets`, nightly `fmt --check` — clean.
- Tests: `binius-m4-prover` passes, including the new `xmss_batch_round_trips` full prove-and-verify over a small batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)