### PR TITLE
BINIUS-282: bake padded sumcheck batching into SharedSumcheckProver

### DIFF
--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -128,6 +128,17 @@ impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariatePro
 		let round_sum = self.last_coeffs_or_sum.coeffs().evaluate(challenge);
 		self.last_coeffs_or_sum = RoundState::Claim(round_sum);
 	}
+
+	fn n_padding(&self, store: &MleStore<'_, P>) -> usize {
+		// Both columns of a product claim have the same length, so they share one padding.
+		let n_padding = store.col_padding(self.cols[0]);
+		debug_assert_eq!(
+			store.col_padding(self.cols[1]),
+			n_padding,
+			"a product claim's two columns must share one padding"
+		);
+		n_padding
+	}
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -18,6 +18,22 @@
 //! Folding is eager: [`MleStore::fold`] advances every column immediately, and the round pass
 //! over the columns is a plain read. A deferred-fold variant that fuses the fold into the next
 //! round's read pass can replace the internals without changing this interface.
+//!
+//! # Padding
+//!
+//! A column may be pushed shorter than the store, which pads it up to the store's variable count.
+//! This lets one store batch sumchecks of unequal length.
+//!
+//! A column with `p` padding variables behaves as follows.
+//! - It sits out the first `p` folds, each decrementing its padding.
+//! - It starts folding only once its padding reaches 0.
+//!
+//! Binding runs high-to-low, so the padding variables are the highest-indexed ones and bind first.
+//! Only zero-padding columns fold, so the active columns always share one variable count.
+//! A padded column is left out of the read pass until it becomes active.
+//!
+//! The store only tracks and folds the padding.
+//! Scaling the padded claims by their equality-to-zero prefix is the driving prover's job.
 
 use std::iter;
 
@@ -72,15 +88,23 @@ enum Column<'a, P: PackedField> {
 	SplitHalf(FieldBuffer<P>),
 }
 
-/// A store of equal-length multilinear columns shared by a group of round evaluators.
+/// A store of multilinear columns shared by a group of round evaluators.
 ///
-/// See the [module documentation](self) for the folding invariant.
+/// The active (zero-padding) columns share one variable count.
+/// A column pushed shorter than the store is padded up to it, and joins the active set only once
+/// its padding is folded away.
+/// See the [module documentation](self) for the folding invariant and the padding rules.
 pub struct MleStore<'a, P: PackedField> {
 	n_vars: usize,
 	columns: Vec<Column<'a, P>>,
-	/// Number of logical columns, counting each [`Column::SplitHalf`] entry as two. This is the
-	/// number of assigned [`ColId`]s and the length of the [`Self::final_evals`] output.
-	n_cols: usize,
+	/// Padding variable count of each logical column, indexed by [`ColId`].
+	///
+	/// A column pushed with `k <= n_vars` variables has `n_vars - k` padding.
+	/// Its first `n_vars - k` folds skip it and decrement this entry.
+	/// It starts folding once this reaches 0.
+	/// A split-half entry contributes two full-length (zero-padding) columns.
+	/// This Vec's length is the number of assigned column ids.
+	col_paddings: Vec<usize>,
 	eq_trackers: Vec<Gruen32<P>>,
 }
 
@@ -90,12 +114,12 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		Self {
 			n_vars,
 			columns: Vec::new(),
-			n_cols: 0,
+			col_paddings: Vec::new(),
 			eq_trackers: Vec::new(),
 		}
 	}
 
-	/// Returns the number of variables remaining in the columns.
+	/// Returns the store's current variable count, shared by all active (zero-padding) columns.
 	///
 	/// Decrements with each [`Self::fold`] call.
 	pub const fn n_vars(&self) -> usize {
@@ -104,34 +128,42 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 
 	/// Pushes a borrowed column and returns its identifier.
 	///
-	/// The column is not copied; the first [`Self::fold`] writes into a fresh half-size buffer.
+	/// The column is not copied.
+	/// The first fold that binds it writes into a fresh half-size buffer.
+	/// A column shorter than the store is padded up to it (see the [module documentation](self)).
 	pub fn push(&mut self, column: FieldSlice<'a, P>) -> ColId {
-		// precondition
-		assert_eq!(
-			column.log_len(),
-			self.n_vars,
-			"column must have number of variables equal to the store"
-		);
+		let n_padding = self.column_padding(column.log_len());
 		self.columns.push(Column::Borrowed(column));
-		self.next_col_id()
+		self.push_col_id(n_padding)
 	}
 
 	/// Pushes an owned column and returns its identifier.
+	///
+	/// A column shorter than the store is padded up to it (see [`Self::push`]).
 	pub fn push_owned(&mut self, column: FieldBuffer<P>) -> ColId {
-		// precondition
-		assert_eq!(
-			column.log_len(),
-			self.n_vars,
-			"column must have number of variables equal to the store"
-		);
+		let n_padding = self.column_padding(column.log_len());
 		self.columns.push(Column::Owned(column));
-		self.next_col_id()
+		self.push_col_id(n_padding)
 	}
 
-	/// Allocates the identifier for one newly pushed logical column.
-	const fn next_col_id(&mut self) -> ColId {
-		let id = ColId(self.n_cols);
-		self.n_cols += 1;
+	/// Padding of a column with `log_len` variables pushed into this store.
+	///
+	/// A column may be shorter than the store, in which case it is padded up to it.
+	/// A column longer than the store is rejected.
+	fn column_padding(&self, log_len: usize) -> usize {
+		// precondition
+		assert!(
+			log_len <= self.n_vars,
+			"column cannot have more variables ({log_len}) than the store ({})",
+			self.n_vars,
+		);
+		self.n_vars - log_len
+	}
+
+	/// Allocates the identifier for one newly pushed logical column with the given padding.
+	fn push_col_id(&mut self, n_padding: usize) -> ColId {
+		let id = ColId(self.col_paddings.len());
+		self.col_paddings.push(n_padding);
 		id
 	}
 
@@ -142,7 +174,8 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// it as a single split-half entry, so no up-front copy of the full buffer is made.
 	/// Each [`Self::fold`] advances both halves in place within the buffer. `buffer` splits on its
 	/// highest variable, so its low half fixes that variable to 0 and its high half to 1 —
-	/// matching the store's high-to-low fold order.
+	/// matching the store's high-to-low fold order. Split-half columns are always full-length, so
+	/// they carry no padding.
 	pub fn push_split_half(&mut self, buffer: FieldBuffer<P>) -> [ColId; 2] {
 		// precondition
 		assert_eq!(
@@ -151,10 +184,28 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 			"buffer must have one more variable than the store so each half matches it"
 		);
 		self.columns.push(Column::SplitHalf(buffer));
-		let low = ColId(self.n_cols);
-		let high = ColId(self.n_cols + 1);
-		self.n_cols += 2;
+		let low = self.push_col_id(0);
+		let high = self.push_col_id(0);
 		[low, high]
+	}
+
+	/// Returns the number of padding variables the column still carries.
+	///
+	/// A full-length column returns 0.
+	/// A shorter column returns a positive count that decrements by one on each fold, reaching 0
+	/// when the column becomes active.
+	/// The driving prover reads this to tell whether a claim still binds a padding variable this
+	/// round.
+	pub fn col_padding(&self, id: ColId) -> usize {
+		self.col_paddings[id.index()]
+	}
+
+	/// Whether any column is still in its padding phase.
+	///
+	/// The driving prover reads this to choose between the fused fold-and-read fast path (only
+	/// sound when every column folds) and a padding-aware fold-then-read pass.
+	pub fn has_padded_columns(&self) -> bool {
+		self.col_paddings.iter().any(|&padding| padding > 0)
 	}
 
 	/// Registers an equality-indicator tracker for an MLE-check evaluation point.
@@ -235,37 +286,59 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		self.eq_trackers[id.0].eq_prefix_eval()
 	}
 
-	/// Folds every column and every eq tracker with a verifier challenge.
+	/// Folds every active column and every eq tracker with a verifier challenge.
 	///
-	/// Columns fold on the highest variable, matching the high-to-low binding order of the
-	/// sumcheck provers this store backs.
+	/// A column with positive padding is in a padding round for its claim.
+	/// Its data is left untouched and its padding is decremented, so it joins the active set only
+	/// once its padding reaches 0.
+	/// Active columns fold on the highest variable, matching the high-to-low binding order.
+	/// Trackers are always full-length, so every tracker folds each round.
 	pub fn fold(&mut self, challenge: F) {
 		// precondition
 		assert!(self.n_vars > 0, "fold requires at least one remaining variable");
 
-		// The number of live variables in each column before this fold; a split-half buffer keeps
-		// its full length, so its halves must be truncated to this before folding.
+		// Live-variable count of each active column before this fold; a split-half buffer keeps its
+		// full length, so its halves are truncated to this before folding.
 		let n_vars = self.n_vars;
+		// Walk physical entries while tracking the logical column index that reads its padding.
+		// A single-column entry spans one logical index, a split-half entry two.
+		let mut logical = 0;
 		for column in &mut self.columns {
 			match column {
-				Column::Owned(buffer) => fold_highest_var_inplace(buffer, challenge),
+				Column::Owned(buffer) => {
+					if self.col_paddings[logical] > 0 {
+						// Padding round: spend one padding variable, leave the data untouched.
+						self.col_paddings[logical] -= 1;
+					} else {
+						// Active: bind the highest variable in place.
+						fold_highest_var_inplace(buffer, challenge);
+					}
+					logical += 1;
+				}
 				Column::Borrowed(slice) => {
-					// The first fold of a borrowed column writes into a fresh half-size owned
-					// buffer, avoiding an up-front copy of the full column.
-					*column = Column::Owned(fold_highest_var(slice, challenge));
+					if self.col_paddings[logical] > 0 {
+						// Padding round: spend one padding variable, leave the borrow untouched.
+						self.col_paddings[logical] -= 1;
+					} else {
+						// First active fold: write into a fresh half-size owned buffer, so the full
+						// borrowed column is never copied.
+						*column = Column::Owned(fold_highest_var(slice, challenge));
+					}
+					logical += 1;
 				}
 				Column::SplitHalf(buffer) => {
-					// Fold each half on its own highest variable in place. The two halves are the
-					// two columns, so folding the whole buffer's highest variable would instead
-					// combine them; splitting first binds each column's variable independently. The
-					// buffer keeps its length — the folded columns are the (now shorter) fronts of
-					// its halves — so no copy is made.
+					// A split-half column is always full-length, so it folds every round.
+					// The two halves are the two columns, so folding the whole buffer's highest
+					// variable would combine them; split first to bind each half's variable alone.
 					let mut split = buffer.split_half_mut();
 					let (mut low, mut high) = split.halves();
+					// Drop stale trailing scalars, then bind the highest variable of each half in
+					// place; the folded columns are the shorter fronts, so no copy is made.
 					low.truncate(n_vars);
 					high.truncate(n_vars);
 					fold_highest_var_inplace(&mut low, challenge);
 					fold_highest_var_inplace(&mut high, challenge);
+					logical += 2;
 				}
 			}
 		}
@@ -279,9 +352,10 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	///
 	/// A split-half entry expands into the front `2^n_vars` scalars of its low and high
 	/// halves, so the returned length is the logical column count — larger than the physical entry
-	/// count whenever a split-half column is present.
+	/// count whenever a split-half column is present. A padded column's slice is shorter than the
+	/// store, so this is a valid full read only once every column is active.
 	pub fn column_slices(&self) -> Vec<FieldSlice<'_, P>> {
-		let mut slices = Vec::with_capacity(self.n_cols);
+		let mut slices = Vec::with_capacity(self.col_paddings.len());
 		for column in &self.columns {
 			match column {
 				Column::Borrowed(slice) => slices.push(slice.to_ref()),
@@ -323,6 +397,10 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	///
 	/// `chunk_vars` is capped at `n_vars() - 1`, so leaves never exceed the halved hypercube.
 	///
+	/// A padded column is left out of the pass — its claim is in a padding round and does not read
+	/// the store — and its [`ColId`] maps to no chunk, so reading it panics. When no column is
+	/// padded the mapping is the identity and carries no overhead.
+	///
 	/// ## Preconditions
 	///
 	/// * `n_vars()` must be greater than 0.
@@ -335,18 +413,29 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		assert!(self.n_vars > 0);
 		let chunk_vars = chunk_vars.min(self.n_vars - 1);
 
+		// Build one column chunk per active column, splitting it on the round's highest variable.
+		// A padded column is shorter than the store and cannot split here, so it is excluded and
+		// its id maps to `None`; active ids map to their position among the active columns.
 		let col_slices = self.column_slices();
-		let cols = col_slices
-			.iter()
-			.map(|col| {
-				let (lo, hi) = col.split_half_ref();
-				ColumnChunk { lo, hi }
-			})
-			.collect();
+		let mut cols = Vec::with_capacity(col_slices.len());
+		let mut col_index = Vec::with_capacity(col_slices.len());
+		for (slice, &padding) in iter::zip(&col_slices, &self.col_paddings) {
+			if padding == 0 {
+				col_index.push(Some(cols.len()));
+				let (lo, hi) = slice.split_half_ref();
+				cols.push(ColumnChunk { lo, hi });
+			} else {
+				col_index.push(None);
+			}
+		}
+		// The identity mapping is implicit: skip the indirection when nothing is padded.
+		let col_index = self.has_padded_columns().then_some(col_index.as_slice());
+
 		let eqs = self.eq_expansions().iter().map(|eq| eq.to_ref()).collect();
 		let chunk = EvaluationChunk {
 			n_vars: self.n_vars - 1,
 			cols,
+			col_index,
 			eqs,
 		};
 		map_reduce_helper(chunk, chunk_vars, &map, &reduce)
@@ -365,6 +454,8 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// ## Preconditions
 	///
 	/// * `n_vars()` must be greater than 1.
+	/// * No column may be padded: the fused fold folds every column, so a caller with padded
+	///   columns must fold and read in two padding-aware passes instead.
 	pub fn map_reduce_with_fold<T: Send>(
 		&mut self,
 		chunk_vars: usize,
@@ -373,6 +464,8 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		reduce: impl (Fn(T, T) -> T) + Sync,
 	) -> T {
 		assert!(self.n_vars > 1);
+		// precondition: the fused fold has no padding-skip path
+		debug_assert!(!self.has_padded_columns(), "fused fold requires every column to be active");
 
 		// Decrement n_vars to reflect the fold.
 		let n_vars = self.n_vars - 1;
@@ -401,7 +494,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		// Build one deferred-fold producer per logical column: its low and high halves paired on
 		// the round's highest variable, folding in place (owned/split-half) or into a fresh `dst`
 		// (borrowed).
-		let mut cols = Vec::with_capacity(self.n_cols);
+		let mut cols = Vec::with_capacity(self.col_paddings.len());
 		for (column, dst) in iter::zip(&mut self.columns, &mut dsts) {
 			match column {
 				Column::Borrowed(src) => {
@@ -665,7 +758,13 @@ impl<'a, P: PackedField> PreFoldEvaluationChunk<'a, P> {
 			.into_iter()
 			.map(|eq| FieldSlice::from_slice(n_vars, eq.fold_eq()))
 			.collect();
-		EvaluationChunk { n_vars, cols, eqs }
+		// The fused fold runs only when every column is active, so ids index `cols` directly.
+		EvaluationChunk {
+			n_vars,
+			cols,
+			col_index: None,
+			eqs,
+		}
 	}
 }
 
@@ -690,13 +789,32 @@ pub struct ColumnChunk<'c, P: PackedField> {
 pub struct EvaluationChunk<'c, P: PackedField> {
 	n_vars: usize,
 	cols: Vec<ColumnChunk<'c, P>>,
+	/// Maps each logical [`ColId`] to its position in `cols`, or `None` if that column is padded
+	/// this round and was left out. `None` for the whole map means no column is padded and every
+	/// id indexes `cols` directly.
+	col_index: Option<&'c [Option<usize>]>,
 	eqs: Vec<FieldSlice<'c, P>>,
 }
 
 impl<'c, P: PackedField> EvaluationChunk<'c, P> {
 	/// Returns the low and high halves of a column at this chunk.
+	///
+	/// # Panics
+	///
+	/// Panics if the column is padded this round.
+	/// A padding-round claim does not read the store, so its columns are not chunked.
 	pub fn col(&self, id: ColId) -> &ColumnChunk<'c, P> {
-		&self.cols[id.index()]
+		match self.col_index {
+			// No column is padded, so the id indexes the columns directly.
+			None => &self.cols[id.index()],
+			// Some columns are padded; map the id to its position among the active columns.
+			Some(index) => {
+				let pos = index[id.index()].expect(
+					"column is padded this round and has no chunk; its claim must not read it",
+				);
+				&self.cols[pos]
+			}
+		}
 	}
 
 	/// Returns the equality-indicator expansion of a registered tracker at this chunk.
@@ -710,7 +828,12 @@ impl<'c, P: PackedField> EvaluationChunk<'c, P> {
 	/// Bisects the range into its two halves on the highest remaining variable, splitting both
 	/// halves of every column and every eq expansion. Each returned chunk has one fewer variable.
 	fn split_half(&self) -> [EvaluationChunk<'_, P>; 2] {
-		let Self { n_vars, cols, eqs } = self;
+		let Self {
+			n_vars,
+			cols,
+			col_index,
+			eqs,
+		} = self;
 		let (cols_0, cols_1) = cols
 			.iter()
 			.map(|ColumnChunk { lo, hi }| {
@@ -720,15 +843,18 @@ impl<'c, P: PackedField> EvaluationChunk<'c, P> {
 			})
 			.unzip();
 		let (eqs_0, eqs_1) = eqs.iter().map(|col| col.split_half_ref()).unzip();
+		// The id mapping is the same for both halves; carry it through unchanged.
 		[
 			EvaluationChunk {
 				n_vars: n_vars - 1,
 				cols: cols_0,
+				col_index: *col_index,
 				eqs: eqs_0,
 			},
 			EvaluationChunk {
 				n_vars: n_vars - 1,
 				cols: cols_1,
+				col_index: *col_index,
 				eqs: eqs_1,
 			},
 		]
@@ -779,7 +905,10 @@ fn map_reduce_with_fold_helper<P: PackedField, T: Send>(
 #[cfg(test)]
 mod tests {
 	use binius_field::{Field, FieldOps, PackedField};
-	use binius_math::test_utils::{Packed128b, random_field_buffer, random_scalars};
+	use binius_math::{
+		multilinear::evaluate::evaluate,
+		test_utils::{Packed128b, random_field_buffer, random_scalars},
+	};
 	use itertools::Itertools;
 	use rand::{SeedableRng, rngs::StdRng};
 
@@ -955,5 +1084,128 @@ mod tests {
 			assert_eq!(got, expected, "result mismatch in round {round}");
 			assert_eq!(state(&fold_first), state(&fused), "folded-state mismatch in round {round}");
 		}
+	}
+
+	#[test]
+	fn col_padding_derived_from_length() {
+		type P = Packed128b;
+		let mut rng = StdRng::seed_from_u64(0);
+		// Store over 8 variables, so each pushed column is padded up to that width.
+		let mut store = MleStore::<P>::new(8);
+
+		// A full-length column carries no padding.
+		let full = store.push_owned(random_field_buffer::<P>(&mut rng, 8));
+		// A 5-variable column is padded by 8 - 5 = 3.
+		let short = store.push_owned(random_field_buffer::<P>(&mut rng, 5));
+		// Borrowing follows the same rule: a 3-variable column is padded by 8 - 3 = 5.
+		let borrowed = random_field_buffer::<P>(&mut rng, 3);
+		let borrowed_id = store.push(borrowed.to_ref());
+		// A split-half of a 9-variable buffer yields two full-length (8-variable) columns.
+		let [low, high] = store.push_split_half(random_field_buffer::<P>(&mut rng, 9));
+
+		assert_eq!(store.col_padding(full), 0);
+		assert_eq!(store.col_padding(short), 3);
+		assert_eq!(store.col_padding(borrowed_id), 5);
+		assert_eq!(store.col_padding(low), 0);
+		assert_eq!(store.col_padding(high), 0);
+	}
+
+	#[test]
+	#[should_panic(expected = "column cannot have more variables")]
+	fn push_column_longer_than_store_panics() {
+		type P = Packed128b;
+		let mut rng = StdRng::seed_from_u64(0);
+		// A 5-variable column is longer than a width-4 store, which is not paddable and is
+		// rejected.
+		let mut store = MleStore::<P>::new(4);
+		store.push_owned(random_field_buffer::<P>(&mut rng, 5));
+	}
+
+	#[test]
+	fn fold_decrements_padding_then_folds() {
+		type P = Packed128b;
+		type F = <P as FieldOps>::Scalar;
+		let max_n = 6;
+		let short_n = 4;
+		let mut rng = StdRng::seed_from_u64(1);
+
+		// One full-length column and one padded by max_n - short_n = 2.
+		let full = random_field_buffer::<P>(&mut rng, max_n);
+		let short = random_field_buffer::<P>(&mut rng, short_n);
+
+		let mut store = MleStore::<P>::new(max_n);
+		let full_id = store.push_owned(full.clone());
+		let short_id = store.push_owned(short.clone());
+
+		let challenges = random_scalars::<F>(&mut rng, max_n);
+		for (round, &challenge) in challenges.iter().enumerate() {
+			// The short column is in a padding round for its first max_n - short_n rounds; its
+			// remaining padding counts down 2, 1, then 0 from round 2 on.
+			let expected_short_padding = (max_n - short_n).saturating_sub(round);
+			assert_eq!(store.col_padding(short_id), expected_short_padding);
+			// The full column is active from the start, so it never carries padding.
+			assert_eq!(store.col_padding(full_id), 0);
+			// Every fold decrements the store width, active or not.
+			assert_eq!(store.n_vars(), max_n - round);
+			store.fold(challenge);
+		}
+		assert_eq!(store.n_vars(), 0);
+
+		// Binding is high-to-low, so reverse the challenges for `evaluate`, which wants
+		// low-to-high.
+		let mut point = challenges;
+		point.reverse();
+		let evals = store.final_evals();
+		// The full column binds every variable, so it evaluates at the whole point.
+		assert_eq!(evals[full_id.index()], evaluate(&full, &point));
+		// The short column binds only its active rounds — the last short_n challenges — which are
+		// the low short_n coordinates of the reversed point.
+		assert_eq!(evals[short_id.index()], evaluate(&short, &point[..short_n]));
+	}
+
+	#[test]
+	#[should_panic(expected = "column is padded this round")]
+	fn map_reduce_padded_column_read_panics() {
+		type P = Packed128b;
+		let mut rng = StdRng::seed_from_u64(2);
+		// One full-length column (active) and one padded by 6 - 3 = 3.
+		let mut store = MleStore::<P>::new(6);
+		store.push_owned(random_field_buffer::<P>(&mut rng, 6));
+		let padded = store.push_owned(random_field_buffer::<P>(&mut rng, 3));
+
+		// The padded column is excluded from the pass, so reading its chunk is out of contract.
+		store.map_reduce(
+			0,
+			|chunk| {
+				let _ = chunk.col(padded);
+				0usize
+			},
+			|lhs, _rhs| lhs,
+		);
+	}
+
+	#[test]
+	fn map_reduce_active_column_readable_while_sibling_padded() {
+		type P = Packed128b;
+		let mut rng = StdRng::seed_from_u64(3);
+		// The active column stays readable through the pass while a sibling is padded out.
+		let mut store = MleStore::<P>::new(6);
+		let active = store.push_owned(random_field_buffer::<P>(&mut rng, 6));
+		let _padded = store.push_owned(random_field_buffer::<P>(&mut rng, 3));
+
+		// Count the leaves and confirm the active column is readable at each.
+		let leaves = store.map_reduce(
+			0,
+			|chunk| {
+				let col = chunk.col(active);
+				// At chunk_vars 0 each half is one scalar.
+				assert_eq!(col.lo.len(), 1);
+				assert_eq!(col.hi.len(), 1);
+				1usize
+			},
+			|lhs, rhs| lhs + rhs,
+		);
+		// The halved hypercube over 6 variables at chunk_vars 0 splits into 2^5 leaves.
+		assert_eq!(leaves, 1 << 5);
 	}
 }

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -161,4 +161,9 @@ where
 		// wrapper only advances the inner evaluator's claim state.
 		self.inner.fold(challenge)
 	}
+
+	fn n_padding(&self, store: &MleStore<'_, P>) -> usize {
+		// Padding is a property of the wrapped claim's columns, unchanged by the eq factoring.
+		self.inner.n_padding(store)
+	}
 }

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -232,6 +232,18 @@ where
 
 		self.last_coeffs_or_eval = RoundState::Claim(eval);
 	}
+
+	fn n_padding(&self, store: &MleStore<'_, P>) -> usize {
+		// All columns of one composition claim have the same length, so they share one padding.
+		let n_padding = store.col_padding(self.cols[0]);
+		debug_assert!(
+			self.cols
+				.iter()
+				.all(|&col| store.col_padding(col) == n_padding),
+			"a composition claim's columns must share one padding"
+		);
+		n_padding
+	}
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -16,7 +16,7 @@ use std::iter;
 use auto_impl::auto_impl;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldBuffer;
+use binius_math::{FieldBuffer, multilinear::eq::eq_one_var};
 
 use super::{
 	MleToSumCheckEvaluator,
@@ -83,6 +83,15 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// The store folds the shared columns and eq trackers; this only updates claim state and
 	/// equality prefix products.
 	fn fold(&mut self, challenge: F);
+
+	/// The number of padding variables this claim's columns still carry.
+	///
+	/// A full-length claim returns 0.
+	/// A shorter claim returns a positive count that the driving prover spends over its leading
+	/// rounds before the claim becomes active.
+	/// All of a claim's columns share one padding, so this reports the padding of any one of them,
+	/// read from the store.
+	fn n_padding(&self, store: &MleStore<'_, P>) -> usize;
 }
 
 /// Maximum log2 chunk size of the parallel round pass.
@@ -94,10 +103,34 @@ const MAX_CHUNK_VARS: usize = 12;
 /// A [`SumcheckProver`] over a shared [`MleStore`] and a list of [`RoundEvaluator`]s, one per
 /// claim.
 ///
-/// Each round makes one parallel pass over the store's column chunks, feeding every evaluator,
-/// and lists the round polynomials in evaluator registration order. [`Self::fold`] folds each
-/// shared column and eq tracker once. [`Self::finish`] emits each store column's evaluation once,
-/// computed a single time by the store no matter how many claims read the column.
+/// Each round makes one parallel pass over the store's active column chunks, feeding every active
+/// evaluator, and lists the round polynomials in evaluator order. Folding folds each shared active
+/// column and eq tracker once. Finishing emits each store column's evaluation once, computed a
+/// single time by the store.
+///
+/// # Padding
+///
+/// A claim whose columns are shorter than the store is padded up to it, so one prover can batch
+/// sumchecks of unequal length.
+/// The store folds only the active (zero-padding) columns each round.
+/// This prover handles the padded claims.
+///
+/// The padding variables are the highest-indexed ones, so they are bound first.
+/// While a claim is still binding one, it is in a padding round, where this prover:
+/// - emits the degree-1 polynomial `v * (1 - X)`, with `v` the padding-scaled round claim,
+/// - leaves that claim's evaluator and columns untouched, and
+/// - multiplies that claim's equality-to-zero prefix by `eq(0, r)`.
+///
+/// Once a claim's padding rounds are done, its prefix is fixed.
+/// Every later round polynomial and round claim is then scaled by it.
+///
+/// The prefix is `prod_k eq(0, r_k)` over the claim's padding challenges `r_k`.
+/// Since `eq(0, .)` sums to 1 over the hypercube, scaling by it keeps the claim's sum unchanged.
+/// So the batch stays sound.
+///
+/// The fused fold-and-read fast path is used whenever no column is padded — every current caller,
+/// and every round of a padded batch once the short claims have caught up. While padding is live
+/// the store is folded in a separate padding-aware pass.
 pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
 	store: MleStore<'a, P>,
 	evaluators: Vec<Evaluator>,
@@ -105,6 +138,11 @@ pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
 	/// can fuse it into that round's read pass (see [`MleStore::map_reduce_with_fold`]). The
 	/// evaluators fold eagerly; only the store's column and eq fold waits here.
 	buffered_challenge: Option<P::Scalar>,
+	/// Accumulated equality-to-zero prefix of each claim, indexed like the evaluators.
+	///
+	/// This is `prod_k eq(0, r_k)` over the padding challenges bound so far.
+	/// It stays `1` for a full-length claim.
+	eq_prefixes: Vec<P::Scalar>,
 }
 
 impl<'a, F, P, Evaluator> SharedSumcheckProver<'a, P, Evaluator>
@@ -114,11 +152,15 @@ where
 	Evaluator: RoundEvaluator<F, P>,
 {
 	/// Creates a prover from a store and the evaluators reading its columns, one per claim.
-	pub const fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>) -> Self {
+	pub fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>) -> Self {
+		// Every claim starts with the identity prefix; a padded claim grows its own over its
+		// padding rounds.
+		let eq_prefixes = vec![F::ONE; evaluators.len()];
 		Self {
 			store,
 			evaluators,
 			buffered_challenge: None,
+			eq_prefixes,
 		}
 	}
 
@@ -141,18 +183,26 @@ where
 	/// Its round polynomial is appended after the existing evaluators' in [`Self::execute`].
 	pub fn add_evaluator(&mut self, evaluator: Evaluator) {
 		self.evaluators.push(evaluator);
+		self.eq_prefixes.push(F::ONE);
 	}
 
-	/// Prefix sums of each evaluator's [`RoundEvaluator::degree`] slot count.
+	/// Prefix sums of the accumulator-slot counts of the active (non-padded) evaluators.
 	///
-	/// The returned Vec has one more entry than there are evaluators; `offsets[i]..offsets[i + 1]`
-	/// is evaluator `i`'s run in the flat accumulator buffer, and the last entry is its length.
-	fn accum_offsets(&self) -> Vec<usize> {
+	/// The `k`-th active evaluator owns the window from entry `k` to entry `k + 1` of the flat
+	/// accumulator buffer.
+	/// The returned Vec has one more entry than there are active evaluators, the last being the
+	/// buffer's total length.
+	/// A padded evaluator holds no slots this round.
+	fn active_accum_offsets(&self, active: &[bool]) -> Vec<usize> {
 		iter::once(0)
-			.chain(self.evaluators.iter().scan(0, |acc, evaluator| {
-				*acc += evaluator.degree();
-				Some(*acc)
-			}))
+			.chain(
+				iter::zip(&self.evaluators, active)
+					.filter(|(_, is_active)| **is_active)
+					.scan(0, |acc, (evaluator, _)| {
+						*acc += evaluator.degree();
+						Some(*acc)
+					}),
+			)
 			.collect()
 	}
 }
@@ -174,9 +224,11 @@ where
 	}
 
 	fn round_claim(&self) -> Vec<F> {
-		self.evaluators
-			.iter()
-			.map(|evaluator| evaluator.round_claim(&self.store))
+		// Each claim's round claim is its evaluator's claim scaled by the equality-to-zero prefix.
+		// A padded claim's evaluator is untouched, so its claim is the original sum.
+		// A full-length claim has prefix 1, so it passes through.
+		iter::zip(&self.evaluators, &self.eq_prefixes)
+			.map(|(evaluator, &eq_prefix)| evaluator.round_claim(&self.store) * eq_prefix)
 			.collect()
 	}
 
@@ -184,30 +236,50 @@ where
 		let n_vars_remaining = self.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// One parallel pass over the halved hypercube feeds every evaluator, so shared columns
-		// and eq-indicator chunks are read once per round while they are cache-resident.
-		//
 		// TODO: dynamically choose chunk size based on the number of columns and P byte-size,
 		// based on estimated L1 cache size.
 		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
 
-		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker
-		// buffer; `offsets` holds the run boundaries as a prefix sum, so `offsets[i]..offsets[i +
-		// 1]` is evaluator `i`'s slice.
-		let offsets = self.accum_offsets();
-		let total_slots = *offsets
-			.last()
-			.expect("offsets has one entry per evaluator, plus one");
-
-		// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the split
-		// column halves and eq-indicator expansions each evaluator reads.
+		// The buffered fold can be fused into this round's read only when it folds every column.
+		// With padded columns present, apply it eagerly (padding-aware) first, then read.
 		let buffered_challenge = self.buffered_challenge.take();
+		let fused = buffered_challenge.is_some() && !self.store.has_padded_columns();
+		if let Some(challenge) = buffered_challenge
+			&& !fused
+		{
+			self.store.fold(challenge);
+		}
+
+		// A claim binding a padding variable this round sits out the shared column pass and emits a
+		// synthetic polynomial; the rest are active. On the fused path no column is padded, so all
+		// are active.
+		let active: Vec<bool> = self
+			.evaluators
+			.iter()
+			.map(|evaluator| evaluator.n_padding(&self.store) == 0)
+			.collect();
+
+		// Each active evaluator owns a contiguous slot run in one flat per-worker buffer.
+		let offsets = self.active_accum_offsets(&active);
+		let total_slots = *offsets.last().expect("offsets has the leading zero");
+
+		// One parallel pass over the halved hypercube feeds every active evaluator, so shared
+		// active columns and eq-indicator chunks are read once per round, while resident in
+		// cache.
 		let evaluators = &self.evaluators;
+		let active_ref = &active;
+		let offsets_ref = &offsets;
 		let store = &mut self.store;
 		let map = |chunk: EvaluationChunk<'_, P>| {
 			let mut accum = vec![Default::default(); total_slots];
-			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-				evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
+			// Hand each active evaluator its slot run; a padded evaluator holds no slots.
+			let mut slot = 0;
+			for (evaluator, &is_active) in iter::zip(evaluators, active_ref) {
+				if is_active {
+					evaluator
+						.accumulate(&chunk, &mut accum[offsets_ref[slot]..offsets_ref[slot + 1]]);
+					slot += 1;
+				}
 			}
 			accum
 		};
@@ -218,28 +290,63 @@ where
 			}
 			lhs
 		};
-		let accum = match buffered_challenge {
-			// The previous fold deferred its store fold; apply it and this round's read in one
-			// pass.
-			Some(challenge) => store.map_reduce_with_fold(chunk_vars, challenge, map, reduce),
-			None => store.map_reduce(chunk_vars, map, reduce),
+		let accum = if fused {
+			// The buffered fold folds every column and this round's read in one pass.
+			let challenge = buffered_challenge.expect("a fused round has a buffered challenge");
+			store.map_reduce_with_fold(chunk_vars, challenge, map, reduce)
+		} else {
+			// The store already reflects this round; just read it.
+			store.map_reduce(chunk_vars, map, reduce)
 		};
 
-		// The store is read (immutably) for the round's point coordinates while the evaluators are
-		// interpolated (mutably); they are disjoint fields, so borrow the store separately.
+		// Assemble the round polynomials in evaluator order.
+		// The store and prefixes are read while the evaluators are interpolated mutably; they are
+		// disjoint fields, so borrow them separately.
 		let store = &self.store;
-		iter::zip(&mut self.evaluators, offsets.windows(2))
-			.map(|(evaluator, window)| evaluator.interpolate(store, &accum[window[0]..window[1]]))
+		let eq_prefixes = &self.eq_prefixes;
+		let mut slot = 0;
+		iter::zip(&mut self.evaluators, &active)
+			.enumerate()
+			.map(|(i, (evaluator, &is_active))| {
+				if is_active {
+					// Active claim: interpolate from the pass, then scale by the frozen prefix.
+					let coeffs =
+						evaluator.interpolate(store, &accum[offsets[slot]..offsets[slot + 1]]);
+					slot += 1;
+					coeffs * eq_prefixes[i]
+				} else {
+					// Padding round: emit `v * (1 - X)`, with `v` the scaled round claim.
+					// With `eq(0, X) = 1 - X`, its coefficients are `[v, -v]`.
+					// The evaluator and store are left untouched.
+					let v = evaluator.round_claim(store) * eq_prefixes[i];
+					RoundCoeffs(vec![v, -v])
+				}
+			})
 			.collect()
 	}
 
 	fn fold(&mut self, challenge: F) {
-		// The evaluators advance their local bookkeeping (claim state, equality prefix products)
-		// now, but the store's column and eq fold is deferred: the challenge is buffered so the
-		// next execute can fuse it into that round's read pass.
-		for evaluator in &mut self.evaluators {
-			evaluator.fold(challenge);
+		// A claim binding a padding variable this round only grows its equality-to-zero prefix; its
+		// evaluator and columns are untouched. The store reflects this round, so a positive padding
+		// marks a padding round for that claim.
+		let padded: Vec<bool> = self
+			.evaluators
+			.iter()
+			.map(|evaluator| evaluator.n_padding(&self.store) > 0)
+			.collect();
+
+		// `eq(0, challenge) = 1 - challenge` is the factor a padding round contributes.
+		let eq_zero = eq_one_var(F::ZERO, challenge);
+		for (i, evaluator) in self.evaluators.iter_mut().enumerate() {
+			if padded[i] {
+				self.eq_prefixes[i] *= eq_zero;
+			} else {
+				evaluator.fold(challenge);
+			}
 		}
+
+		// The store's column and eq fold is deferred: the challenge is buffered so the next execute
+		// can fuse it (or, with padding live, apply it in a padding-aware pass).
 		debug_assert!(
 			self.buffered_challenge.is_none(),
 			"fold called twice without an intervening execute"
@@ -305,11 +412,13 @@ where
 		Evaluator: 'static,
 	{
 		let Self { inner, eval_point } = self;
-		// Conversion happens before proving starts, so no fold challenge is buffered yet.
+		// Conversion happens before proving starts, so no fold challenge is buffered and every
+		// equality-to-zero prefix is still the identity; the wrapped prover rebuilds them.
 		let SharedSumcheckProver {
 			mut store,
 			evaluators,
 			buffered_challenge: _,
+			eq_prefixes: _,
 		} = inner;
 		// Every claim of an MLE-check prover shares the prover's evaluation point, so its eq
 		// tracker is already registered on the store (by the evaluators reading it). Recover that
@@ -374,23 +483,28 @@ where
 // claims over shared columns).
 #[cfg(test)]
 mod tests {
-	use binius_field::FieldOps;
-	use binius_ip::sumcheck::{batch_verify, batch_verify_mle};
+	use binius_field::{FieldOps, Random};
+	use binius_ip::sumcheck::{RoundCoeffs, batch_verify, batch_verify_mle};
 	use binius_math::{
 		FieldBuffer,
 		inner_product::inner_product_par,
-		multilinear::{eq::eq_ind, evaluate::evaluate},
+		multilinear::{
+			eq::{eq_ind, eq_ind_zero},
+			evaluate::evaluate,
+		},
 		test_utils::{Packed128b, random_field_buffer, random_scalars},
 		univariate::evaluate_univariate,
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use proptest::prelude::*;
 	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::{
-		MleToSumCheckEvaluator,
+		MleToSumCheckEvaluator, PaddedSumcheckDecorator,
 		batch::{batch_prove, batch_prove_mle},
-		bivariate_product_evaluator::BivariateProductEvaluator,
+		bivariate_product_evaluator::{BivariateProductEvaluator, bivariate_product_prover},
+		common::SumcheckProver,
 		frac_add_mle,
 	};
 
@@ -617,6 +731,200 @@ mod tests {
 			let mut prover_challenges = output.challenges.clone();
 			prover_challenges.reverse();
 			assert_eq!(prover_challenges, sumcheck_output.challenges);
+		}
+	}
+
+	// One product claim `<a_i, b_i> = s_i` per size, with random columns and honest sums.
+	fn product_instances(
+		sizes: &[usize],
+		rng: &mut StdRng,
+	) -> Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> {
+		sizes
+			.iter()
+			.map(|&n| {
+				let a = random_field_buffer::<P>(&mut *rng, n);
+				let b = random_field_buffer::<P>(&mut *rng, n);
+				let sum = inner_product_par(&a, &b);
+				(a, b, sum)
+			})
+			.collect()
+	}
+
+	// One shared prover over a `max_n` store, holding every claim's columns padded up to `max_n`.
+	fn padded_product_shared(
+		instances: &[(FieldBuffer<P>, FieldBuffer<P>, F)],
+		max_n: usize,
+	) -> SharedSumcheckProver<'_, P, BivariateProductEvaluator<P>> {
+		let mut store = MleStore::new(max_n);
+		let mut evaluators = Vec::with_capacity(instances.len());
+		for (a, b, sum) in instances {
+			// Columns shorter than the store are padded up to it automatically.
+			let a_col = store.push(a.to_ref());
+			let b_col = store.push(b.to_ref());
+			evaluators.push(BivariateProductEvaluator::new([a_col, b_col], *sum));
+		}
+		SharedSumcheckProver::new(store, evaluators)
+	}
+
+	// The reference batch: one `PaddedSumcheckDecorator` per claim, each padding its own bivariate
+	// product prover up to `max_n`.
+	fn padded_product_reference(
+		instances: &[(FieldBuffer<P>, FieldBuffer<P>, F)],
+		max_n: usize,
+	) -> Vec<
+		PaddedSumcheckDecorator<F, SharedSumcheckProver<'static, P, BivariateProductEvaluator<P>>>,
+	> {
+		instances
+			.iter()
+			.map(|(a, b, sum)| {
+				let inner = bivariate_product_prover([a.clone(), b.clone()], *sum);
+				PaddedSumcheckDecorator::new(inner, max_n - a.log_len())
+			})
+			.collect()
+	}
+
+	// The shared padded prover reproduces the `PaddedSumcheckDecorator` batch exactly: identical
+	// round claims, round polynomials, and final evaluations on the same challenge sequence.
+	fn assert_padded_matches_reference(sizes: &[usize], seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let max_n = *sizes.iter().max().expect("at least one claim");
+		let instances = product_instances(sizes, &mut rng);
+
+		let mut reference = padded_product_reference(&instances, max_n);
+		let mut shared = padded_product_shared(&instances, max_n);
+
+		assert_eq!(shared.n_vars(), max_n);
+		assert_eq!(shared.n_claims(), sizes.len());
+
+		let mut challenge_rng = StdRng::seed_from_u64(seed.wrapping_add(1));
+		for _ in 0..max_n {
+			assert_eq!(shared.n_vars(), reference[0].n_vars());
+
+			// Round claims agree, whether read before or (implicitly) after execute.
+			let reference_claims: Vec<F> = reference
+				.iter()
+				.flat_map(|prover| prover.round_claim())
+				.collect();
+			assert_eq!(
+				shared.round_claim(),
+				reference_claims,
+				"round claims must match the reference"
+			);
+
+			// Round polynomials agree, batched in the same claim order.
+			let reference_coeffs: Vec<RoundCoeffs<F>> = reference
+				.iter_mut()
+				.flat_map(|prover| prover.execute())
+				.collect();
+			assert_eq!(
+				shared.execute(),
+				reference_coeffs,
+				"round polynomials must match the reference"
+			);
+
+			let challenge = F::random(&mut challenge_rng);
+			for prover in &mut reference {
+				prover.fold(challenge);
+			}
+			shared.fold(challenge);
+		}
+
+		let reference_evals: Vec<F> = reference
+			.into_iter()
+			.flat_map(|prover| prover.finish())
+			.collect();
+		assert_eq!(shared.finish(), reference_evals, "final evaluations must match the reference");
+	}
+
+	// A full prove/verify roundtrip of the shared padded batch through a real transcript and the
+	// standard batched sumcheck verifier.
+	fn assert_padded_prove_verify(sizes: &[usize], seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let max_n = *sizes.iter().max().expect("at least one claim");
+		let instances = product_instances(sizes, &mut rng);
+		let claims: Vec<F> = instances.iter().map(|(_, _, sum)| *sum).collect();
+
+		let shared = padded_product_shared(&instances, max_n);
+		let mut transcript = ProverTranscript::new(StdChallenger::default());
+		let output = batch_prove(vec![shared], &mut transcript);
+
+		// One shared prover emits every column evaluation once, in push order a_0, b_0, a_1, ...
+		assert_eq!(output.multilinear_evals.len(), 1);
+		let evals = output.multilinear_evals[0].clone();
+		assert_eq!(evals.len(), 2 * sizes.len());
+		transcript.message().write_scalar_slice(&evals);
+
+		// The largest claim is never padded, so every batched round polynomial has degree 2.
+		let mut verifier = transcript.into_verifier();
+		let sumcheck_output = batch_verify(max_n, 2, &claims, &mut verifier).unwrap();
+		let verified_evals: Vec<F> = verifier.message().read_vec(2 * sizes.len()).unwrap();
+		assert_eq!(evals, verified_evals, "prover and verifier column evaluations must match");
+
+		// Binding is high-to-low, so reverse for `evaluate`, which wants low-to-high.
+		let mut point = sumcheck_output.challenges.clone();
+		point.reverse();
+
+		// Each claim's reduced evaluation is its product at the point times its equality-to-zero
+		// padding factor over the high (padding) coordinates.
+		let mut composed = Vec::with_capacity(sizes.len());
+		for (i, (a, b, _)) in instances.iter().enumerate() {
+			let n_i = a.log_len();
+			let a_eval = verified_evals[2 * i];
+			let b_eval = verified_evals[2 * i + 1];
+			// A padded column binds only its active rounds: the low `n_i` coordinates of the point.
+			assert_eq!(evaluate(a, &point[..n_i]), a_eval);
+			assert_eq!(evaluate(b, &point[..n_i]), b_eval);
+			composed.push(a_eval * b_eval * eq_ind_zero(&point[n_i..]));
+		}
+		let expected = evaluate_univariate(&composed, sumcheck_output.batch_coeff);
+		assert_eq!(expected, sumcheck_output.eval, "reduced evaluation must match the batch");
+
+		let mut prover_challenges = output.challenges;
+		prover_challenges.reverse();
+		assert_eq!(prover_challenges, sumcheck_output.challenges);
+	}
+
+	#[test]
+	fn test_padded_batch_matches_decorator_reference() {
+		// A single full-length claim: no padding, a plain passthrough.
+		assert_padded_matches_reference(&[8], 0);
+		// Equal sizes: still no padding, the ordinary shared-prover path.
+		assert_padded_matches_reference(&[6, 6, 6], 1);
+		// One shorter claim padded up to the longer, in both orders.
+		assert_padded_matches_reference(&[5, 8], 2);
+		assert_padded_matches_reference(&[8, 5], 3);
+		// A mix of sizes with the largest active from the first round.
+		assert_padded_matches_reference(&[3, 6, 8], 4);
+		// A claim padded by all but one variable.
+		assert_padded_matches_reference(&[1, 8], 5);
+		// A zero-variable claim, padded every round and never active.
+		assert_padded_matches_reference(&[0, 4, 8], 6);
+		// Several claims at several padding depths at once.
+		assert_padded_matches_reference(&[8, 8, 3, 1], 7);
+	}
+
+	#[test]
+	fn test_padded_batch_prove_verify() {
+		// The same size mixes as the reference test, driven end-to-end through a real transcript.
+		assert_padded_prove_verify(&[8], 10);
+		assert_padded_prove_verify(&[7, 7], 11);
+		assert_padded_prove_verify(&[5, 8], 12);
+		assert_padded_prove_verify(&[3, 6, 8], 13);
+		assert_padded_prove_verify(&[0, 4, 8], 14);
+		assert_padded_prove_verify(&[8, 2, 6, 1], 15);
+	}
+
+	proptest! {
+		#![proptest_config(ProptestConfig::with_cases(24))]
+
+		#[test]
+		fn test_padded_batch_matches_reference_proptest(
+			// Any mix of 1 to 5 claims, each 0 to 7 variables, sharing a common maximum width.
+			sizes in prop::collection::vec(0usize..=7, 1..=5),
+			seed: u64,
+		) {
+			// For every such mix, the shared padded prover must match the decorator batch exactly.
+			assert_padded_matches_reference(&sizes, seed);
 		}
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-282](https://linear.app/jimpo/issue/BINIUS-282).

Lets one `SharedSumcheckProver` batch sumchecks of unequal length by padding the short ones up to the longest, folding the logic of `PaddedSumcheckDecorator` into the shared prover and its column store.

### The problem

Sumcheck folds away one variable per round, and a batch folds every claim on the same challenge each round.
So batched claims must have the same number of variables.

Real claims differ in size.
Today each short claim is wrapped in its own `PaddedSumcheckDecorator`, so a batch of $k$ unequal claims is $k$ separate provers, each with its own column store.

### The idea

Hold every claim's columns in one shared store, and let each column remember its padding — how much shorter it is than the store.

Padding a claim of $n_i$ variables up to $n$ gives it $n - n_i$ phantom high variables and multiplies it by $\mathrm{eq}(0, X)$ on them.
Since $\mathrm{eq}(0, \cdot)$ sums to 1 over the cube, the claim's sum is unchanged.

Two rules run the batch:
- A column with padding left does not fold this round; it just drops its padding by one.
- Once a column's padding reaches 0, it folds every round like the rest.

The prover keeps, per claim, the running prefix $\prod_k \mathrm{eq}(0, r_k)$ over its padding rounds.
While a claim is padded it emits the degree-1 stand-in `[v, -v]` (the polynomial `v * (1 - X)`).
Once active it scales its real round polynomials by that now-fixed prefix.

### The change

```
// before: one decorator per claim, each its own store, batched together
let inner = bivariate_product_prover([message, transparent], sum);
provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
batch_prove(provers, channel);

// after: one shared store, columns pushed at their real size (padding inferred)
let a = store.push(message); let b = store.push(transparent);
evaluators.push(BivariateProductEvaluator::new([a, b], sum));
batch_prove(vec![SharedSumcheckProver::new(store, evaluators)], channel);
```

`MleStore::push` now accepts a column shorter than the store and infers its padding from the length.
`fold` folds only the zero-padding columns and decrements the padding of the rest.

### Soundness

- The $\mathrm{eq}(0, \cdot)$ factor sums to 1 over the hypercube, so scaling a padded claim leaves its sum unchanged.
- The largest claim is never padded, so every round still carries a degree-2 polynomial, and a plain fixed-degree verifier checks the whole batch.
- Pinned byte-for-byte to a `PaddedSumcheckDecorator` batch — identical round claims, round polynomials, and final evaluations — over fixed size mixes and a proptest.

### Scope

- **changed:** `crates/ip-prover/src/sumcheck/` — the store (per-column padding), the shared prover (padding-round synthesis and prefix scaling), and the `RoundEvaluator` trait (a padding query, implemented on all three evaluators).
- **left untouched:** `PaddedSumcheckDecorator` and the BaseFold channel that still uses it — migrating that consumer is a follow-up.
- no change to any verifier, or to the existing zero-padding path.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-ip-prover --all-targets` and nightly `cargo fmt` — clean.
- `cargo test -p binius-ip-prover` — 66 pass, including the decorator-equivalence test, its proptest, and the store-level padding tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)