### PR TITLE
Benchmark M4 operation witness assembly

### DIFF
--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -1,94 +1,207 @@
 // Copyright 2026 The Binius Developers
-//! Benchmark for assembling a batched per-operation witness — the operand-column layout an
-//! operation reduction consumes.
+//! Benchmark for assembling one batched operation-witness column from sparse operands.
 //!
-//! Currently covers the BitAnd operation's two columns; the IntMul
-//! equivalent will be added alongside its protocol. Uses the Keccak-f1600 permutation circuit
-//! (see the `keccak_witness_gen` bench) as a realistic, AND-heavy constraint system: the circuit
-//! applies one permutation to a 25-word state, the state words are witness inputs and the permuted
-//! outputs are force-committed. Populating the batch table and preparing the constants/constraints
-//! are done once as setup; only the witness assembly is timed, over 8192 instances.
+//! This targets [`OperandColumns::build`] directly. Setup constructs a minimal witness-only
+//! [`ValueTable`] and generates random [`Operand`]s with varied sparse row structure: number of
+//! shifted value indices, value indices, shift amounts, and shift variants. Only the column
+//! assembly is timed.
 
-use std::array;
-
-use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_compute::BufferPool;
-use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::OperandColumns;
-use criterion::{Criterion, criterion_group, criterion_main};
+use binius_core::{
+	ValueIndex,
+	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex, ZeroConstraint},
+	word::Word,
+};
+use binius_frontend::{CircuitBuilder, Wire};
+use binius_m4_prover::{OperandColumns, ValueTable};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::prelude::*;
 
 /// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
 const LOG_INSTANCES: usize = 13;
 
-/// The number of 64-bit lanes in a Keccak-f1600 state.
-const STATE_LANES: usize = 25;
+/// Witness rows available for generated operands to read from.
+const N_WITNESS_VALUES: usize = 1024;
 
-/// Builds a circuit that applies one Keccak-f1600 permutation to a public input state and promotes
-/// the permuted lanes to public outputs. Returns the circuit and the 25 input state wires.
-fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
-	let builder = CircuitBuilder::new();
-	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_inout());
+/// Constants available for generated operands to read from.
+const N_CONSTANTS: usize = 16;
 
-	// Permute a copy of the input wires in place; `state` then holds the output wires.
-	let mut state = input;
-	keccak_f1600(&builder, &mut state);
+/// Number of operands in each benchmark case.
+const N_OPERANDS: usize = 1024;
 
-	// Promoting the permuted state keeps the whole permutation alive under dead-code elimination.
-	for wire in state {
-		builder.mark_inout(wire);
-	}
+const SHIFT_VARIANTS: [ShiftVariant; 8] = [
+	ShiftVariant::Sll,
+	ShiftVariant::Slr,
+	ShiftVariant::Sar,
+	ShiftVariant::Rotr,
+	ShiftVariant::Sll32,
+	ShiftVariant::Srl32,
+	ShiftVariant::Sra32,
+	ShiftVariant::Rotr32,
+];
 
-	(builder.build(), input)
+struct OperandCase {
+	name: &'static str,
+	min_terms: usize,
+	max_terms: usize,
+	seed: u64,
 }
 
-/// A deterministic, instance- and lane-dependent input word. Keccak's timing is data-independent,
-/// so the exact values only need to be non-degenerate.
-const fn input_word(instance: usize, lane: usize) -> Word {
-	let mixed = (instance as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15)
-		^ (lane as u64).wrapping_mul(0x0100_0000_01b3);
+const CASES: [OperandCase; 3] = [
+	OperandCase {
+		name: "sparse_0_to_2_terms",
+		min_terms: 0,
+		max_terms: 2,
+		seed: 0,
+	},
+	OperandCase {
+		name: "mixed_0_to_4_terms",
+		min_terms: 0,
+		max_terms: 4,
+		seed: 1,
+	},
+	OperandCase {
+		name: "dense_1_to_8_terms",
+		min_terms: 1,
+		max_terms: 8,
+		seed: 2,
+	},
+];
+
+fn build_table_fixture() -> (ValueTable, Vec<Word>) {
+	let builder = CircuitBuilder::new();
+
+	for i in 0..N_CONSTANTS {
+		builder.add_constant(fixture_constant_word(i));
+	}
+
+	let witnesses: Vec<Wire> = (0..N_WITNESS_VALUES)
+		.map(|_| {
+			let wire = builder.add_witness();
+			builder.force_commit(wire);
+			wire
+		})
+		.collect();
+
+	let circuit = builder.build();
+	let table = ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
+		for (index, &wire) in witnesses.iter().enumerate() {
+			w[wire] = fixture_witness_word(instance, index);
+		}
+	})
+	.unwrap();
+
+	let constants = circuit.constraint_system().constants.clone();
+	assert!(constants.len() >= N_CONSTANTS);
+	assert!(table.n_hidden_words() >= N_WITNESS_VALUES);
+
+	(table, constants)
+}
+
+const fn fixture_constant_word(index: usize) -> Word {
+	Word((index as u64).wrapping_mul(0xd6e8_feb8_6659_fd93) ^ 0xa076_1d64_78bd_642f)
+}
+
+const fn fixture_witness_word(instance: usize, index: usize) -> Word {
+	let mixed = (instance as u64)
+		.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+		.rotate_left((index % Word::BITS) as u32)
+		^ (index as u64).wrapping_mul(0xbf58_476d_1ce4_e5b9);
 	Word(mixed)
 }
 
-fn bench_assemble_operation_witness(c: &mut Criterion) {
-	let (circuit, input) = build_keccak_circuit();
-
-	// Setup (not timed): populate the wire-major batch table for every instance.
-	let table = circuit
-		.populate_batch(LOG_INSTANCES, |instance, w| {
-			for lane in 0..STATE_LANES {
-				w[input[lane]] = input_word(instance, lane);
-			}
+fn generate_constraints(
+	case: &OperandCase,
+	constants_len: usize,
+	witness_offset: usize,
+) -> (Vec<ZeroConstraint>, usize) {
+	let mut rng = StdRng::seed_from_u64(case.seed);
+	let constraints = (0..N_OPERANDS)
+		.map(|_| {
+			ZeroConstraint([random_operand(
+				&mut rng,
+				case,
+				constants_len,
+				witness_offset,
+			)])
 		})
-		.unwrap();
+		.collect::<Vec<_>>();
+	let total_shifted_indices = constraints
+		.iter()
+		.map(|constraint| constraint.val().len())
+		.sum();
 
-	// The circuit's constants, shared by every instance.
-	let constants = circuit.constraint_system().constants.clone();
+	assert!(
+		total_shifted_indices > 0,
+		"benchmark fixture must have at least one shifted value index"
+	);
 
-	// The per-instance AND constraints, at their true (unpadded) count.
-	let and_constraints = {
-		let cs = circuit.constraint_system().clone();
-		cs.validate().unwrap();
-		cs.and_constraints
-	};
+	(constraints, total_shifted_indices)
+}
 
-	// The columns are drawn from a pool that lives across the timed iterations, matching how the
-	// prover recycles its working buffers between proofs.
-	//
-	// So this benchmark measures assembly onto recycled blocks, not onto fresh ones: every
-	// iteration after the first reuses the blocks its predecessor freed. Comparing it against a
-	// revision that allocated a fresh `Vec` per call therefore measures the allocator, not the
-	// assembly algorithm — the per-word work is unchanged. Read a delta here as "cost of the
-	// allocation strategy", never as an algorithmic speedup.
+fn random_operand(
+	rng: &mut impl Rng,
+	case: &OperandCase,
+	constants_len: usize,
+	witness_offset: usize,
+) -> Operand {
+	let n_terms = rng.random_range(case.min_terms..=case.max_terms);
+	(0..n_terms)
+		.map(|_| random_shifted_value_index(rng, constants_len, witness_offset))
+		.collect()
+}
+
+fn random_shifted_value_index(
+	rng: &mut impl Rng,
+	constants_len: usize,
+	witness_offset: usize,
+) -> ShiftedValueIndex {
+	let value_index = random_value_index(rng, constants_len, witness_offset);
+	let shift_variant = SHIFT_VARIANTS[rng.random_range(0..SHIFT_VARIANTS.len())];
+	let amount = rng.random_range(0..shift_variant.max_amount()) as u8;
+
+	ShiftedValueIndex {
+		value_index,
+		shift_variant,
+		amount,
+	}
+}
+
+fn random_value_index(
+	rng: &mut impl Rng,
+	constants_len: usize,
+	witness_offset: usize,
+) -> ValueIndex {
+	if rng.random_range(0..8) == 0 {
+		ValueIndex(rng.random_range(0..constants_len) as u32)
+	} else {
+		ValueIndex((witness_offset + rng.random_range(0..N_WITNESS_VALUES)) as u32)
+	}
+}
+
+fn bench_assemble_operation_witness(c: &mut Criterion) {
+	let (table, constants) = build_table_fixture();
+	let witness_offset = table.layout().offset_witness;
 	let pool = BufferPool::new();
 	let alloc = &pool;
 
 	let mut group = c.benchmark_group("assemble_operation_witness");
-	group.bench_function("bitand_keccak_f1600", |b| {
-		b.iter(|| -> OperandColumns<&BufferPool, 2> {
-			OperandColumns::<_, 2>::build(&table, &constants, &and_constraints, &alloc)
-		});
-	});
+
+	for case in CASES {
+		let (constraints, total_shifted_indices) =
+			generate_constraints(&case, constants.len(), witness_offset);
+
+		group.throughput(Throughput::Elements(total_shifted_indices as u64));
+		group.bench_with_input(
+			BenchmarkId::from_parameter(case.name),
+			&constraints,
+			|b, constraints| {
+				b.iter(|| -> OperandColumns<&BufferPool, 1> {
+					OperandColumns::<_, 1>::build(&table, &constants, constraints, &alloc)
+				});
+			},
+		);
+	}
 
 	group.finish();
 }

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -1,15 +1,25 @@
 // Copyright 2026 The Binius Developers
-//! Benchmark for assembling one batched operation-witness column from sparse operands.
+//! Benchmark for assembling a batched per-operation witness — the operand-column layout an
+//! operation reduction consumes.
 //!
-//! This targets [`OperandColumns::build`] directly. Setup constructs a minimal witness-only
-//! [`ValueTable`] and generates random [`Operand`]s with varied sparse row structure: number of
-//! shifted value indices, value indices, shift amounts, and shift variants. Only the column
-//! assembly is timed.
+//! This targets [`OperandColumns::build`] at the BitAnd arity, the shape the M4 prover builds from
+//! a constraint system's AND constraints. Setup constructs a minimal witness-only [`ValueTable`]
+//! and generates random operands of a controlled term density, which a fixed circuit cannot vary:
+//! the number of terms, the value indices they name, and their shift sequences.
+//!
+//! The generated operands read the table from uniformly drawn rows, with none of the locality a
+//! circuit's program order gives, so a case's per-word rate is pessimistic in absolute terms. Read
+//! the cases against each other.
+//!
+//! Populating the batch table and preparing the constants and constraints are setup; only the
+//! column assembly is timed, over 8192 instances.
 
 use binius_compute::BufferPool;
 use binius_core::{
 	ValueIndex, ValueTable,
-	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex, ZeroConstraint},
+	constraint_system::{
+		AndConstraint, Composition, Operand, Shift, ShiftVariant, ShiftedValueIndex,
+	},
 	word::Word,
 };
 use binius_frontend::{CircuitBuilder, Wire};
@@ -26,20 +36,23 @@ const N_WITNESS_VALUES: usize = 1024;
 /// Constants available for generated operands to read from.
 const N_CONSTANTS: usize = 16;
 
-/// Number of operands in each benchmark case.
-const N_OPERANDS: usize = 1024;
+/// Number of constraints in each generated benchmark case.
+const N_CONSTRAINTS: usize = 1024;
 
-const SHIFT_VARIANTS: [ShiftVariant; 8] = [
-	ShiftVariant::Sll,
-	ShiftVariant::Slr,
-	ShiftVariant::Sar,
-	ShiftVariant::Rotr,
-	ShiftVariant::Sll32,
-	ShiftVariant::Srl32,
-	ShiftVariant::Sra32,
-	ShiftVariant::Rotr32,
-];
+/// One term in this many names a constant, the rest naming witness rows.
+///
+/// A constant is splatted from a single word and never touches the table, so the ratio moves the
+/// result directly. It is kept low because a circuit's operands mostly name wires.
+const CONSTANT_TERM_ODDS: u32 = 8;
 
+/// How the three term classes are drawn, as their share of this many draws.
+///
+/// Each class takes its own path through the assembly: an unshifted term copies its row, a singly
+/// shifted one shifts as it streams, and a doubly shifted one resolves both slots per word. The
+/// shares are arbitrary, and only have to keep every path represented.
+const TERM_CLASS_DRAWS: u32 = 4;
+
+/// One generated benchmark case: a term density and the seed that generates it.
 struct OperandCase {
 	name: &'static str,
 	min_terms: usize,
@@ -47,16 +60,20 @@ struct OperandCase {
 	seed: u64,
 }
 
+/// The generated cases, from barely-populated operands to the widest a frontend emits.
+///
+/// Every operand carries at least one term: an empty one is written by a single fill, which
+/// measures memory bandwidth rather than operand assembly.
 const CASES: [OperandCase; 3] = [
 	OperandCase {
-		name: "sparse_0_to_2_terms",
-		min_terms: 0,
+		name: "sparse_1_to_2_terms",
+		min_terms: 1,
 		max_terms: 2,
 		seed: 0,
 	},
 	OperandCase {
-		name: "mixed_0_to_4_terms",
-		min_terms: 0,
+		name: "mixed_1_to_4_terms",
+		min_terms: 1,
 		max_terms: 4,
 		seed: 1,
 	},
@@ -68,6 +85,10 @@ const CASES: [OperandCase; 3] = [
 	},
 ];
 
+/// The synthetic fixture: a witness-only batch table and the constants the generated terms read.
+///
+/// The circuit carries no constraints of its own. It exists to allocate the rows the generated
+/// value indices name, and to populate them with words the shifts have something to move.
 fn build_table_fixture() -> (ValueTable, Vec<Word>) {
 	let builder = CircuitBuilder::new();
 
@@ -100,10 +121,14 @@ fn build_table_fixture() -> (ValueTable, Vec<Word>) {
 	(table, constants)
 }
 
+/// A distinct constant word per index, so the frontend cannot deduplicate the fixture's constants.
 const fn fixture_constant_word(index: usize) -> Word {
 	Word((index as u64).wrapping_mul(0xd6e8_feb8_6659_fd93) ^ 0xa076_1d64_78bd_642f)
 }
 
+/// A deterministic, instance- and row-dependent witness word.
+///
+/// Assembly is data-independent, so the words only need to be non-degenerate under a shift.
 const fn fixture_witness_word(instance: usize, index: usize) -> Word {
 	let mixed = (instance as u64)
 		.wrapping_mul(0x9e37_79b9_7f4a_7c15)
@@ -112,24 +137,23 @@ const fn fixture_witness_word(instance: usize, index: usize) -> Word {
 	Word(mixed)
 }
 
-fn generate_constraints(case: &OperandCase, constants_len: usize) -> (Vec<ZeroConstraint>, usize) {
+/// Generates one case's constraints, at the case's term density.
+///
+/// Only the first two operands are assembled into columns, so the third is left empty.
+fn generate_constraints(case: &OperandCase, constants_len: usize) -> Vec<AndConstraint> {
 	let mut rng = StdRng::seed_from_u64(case.seed);
-	let constraints = (0..N_OPERANDS)
-		.map(|_| ZeroConstraint([random_operand(&mut rng, case, constants_len)]))
-		.collect::<Vec<_>>();
-	let total_shifted_indices = constraints
-		.iter()
-		.map(|constraint| constraint.val().len())
-		.sum();
-
-	assert!(
-		total_shifted_indices > 0,
-		"benchmark fixture must have at least one shifted value index"
-	);
-
-	(constraints, total_shifted_indices)
+	(0..N_CONSTRAINTS)
+		.map(|_| {
+			AndConstraint([
+				random_operand(&mut rng, case, constants_len),
+				random_operand(&mut rng, case, constants_len),
+				Operand::default(),
+			])
+		})
+		.collect()
 }
 
+/// One operand: a XOR of between `min_terms` and `max_terms` shifted values.
 fn random_operand(rng: &mut impl Rng, case: &OperandCase, constants_len: usize) -> Operand {
 	let n_terms = rng.random_range(case.min_terms..=case.max_terms);
 	(0..n_terms)
@@ -137,46 +161,87 @@ fn random_operand(rng: &mut impl Rng, case: &OperandCase, constants_len: usize) 
 		.collect()
 }
 
+/// One term, drawn across all three classes the assembly distinguishes.
 fn random_shifted_value_index(rng: &mut impl Rng, constants_len: usize) -> ShiftedValueIndex {
 	let value_index = random_value_index(rng, constants_len);
-	let variant = SHIFT_VARIANTS[rng.random_range(0..SHIFT_VARIANTS.len())];
-	let amount = rng.random_range(0..variant.max_amount());
-
-	// A constraint system carries canonical shifts, which spell the identity one way only.
-	let shift = if amount == 0 {
-		Shift::IDENTITY
-	} else {
-		Shift::new(variant, amount)
-	};
-
-	ShiftedValueIndex::single(value_index, shift)
+	match rng.random_range(0..TERM_CLASS_DRAWS) {
+		0 => ShiftedValueIndex::plain(value_index),
+		1 => ShiftedValueIndex::new(value_index, random_shift_pair(rng)),
+		_ => ShiftedValueIndex::single(value_index, random_shift(rng)),
+	}
 }
 
+/// One value index, naming a constant or a committed witness row.
 fn random_value_index(rng: &mut impl Rng, constants_len: usize) -> ValueIndex {
-	if rng.random_range(0..8) == 0 {
+	if rng.random_range(0..CONSTANT_TERM_ODDS) == 0 {
 		ValueIndex::constant(rng.random_range(0..constants_len) as u32)
 	} else {
 		ValueIndex::private(rng.random_range(0..N_WITNESS_VALUES) as u32)
 	}
 }
 
+/// One shift that moves the word, never the identity.
+fn random_shift(rng: &mut impl Rng) -> Shift {
+	let variant = ShiftVariant::ALL[rng.random_range(0..ShiftVariant::ALL.len())];
+	Shift::new(variant, rng.random_range(1..variant.max_amount()))
+}
+
+/// A shift sequence that genuinely needs both slots.
+///
+/// A pair collapsing to one shift, or clearing the word, is not a term a constraint system carries,
+/// so it is redrawn. Two shifts of one variant always compose, which is the bulk of the redraws.
+fn random_shift_pair(rng: &mut impl Rng) -> [Shift; 2] {
+	loop {
+		let inner = random_shift(rng);
+		let outer = random_shift(rng);
+		if Shift::compose(inner, outer) == Composition::Pair {
+			return [inner, outer];
+		}
+	}
+}
+
+/// The number of words a case streams, which is the throughput the assembly is rated on.
+///
+/// Every term of every assembled column passes over one stripe of instances, so a term costs a
+/// stripe rather than a word.
+///
+/// # Panics
+///
+/// Panics if the constraints carry no terms at all, which would rate the case on nothing.
+fn streamed_words(constraints: &[AndConstraint]) -> u64 {
+	let n_terms: usize = constraints
+		.iter()
+		.map(|constraint| constraint.a().len() + constraint.b().len())
+		.sum();
+	assert!(n_terms > 0, "benchmark fixture must have at least one shifted value index");
+	(n_terms as u64) << LOG_INSTANCES
+}
+
 fn bench_assemble_operation_witness(c: &mut Criterion) {
-	let (table, constants) = build_table_fixture();
+	// The columns are drawn from a pool that lives across the timed iterations, matching how the
+	// prover recycles its working buffers between proofs.
+	//
+	// So this benchmark measures assembly onto recycled blocks, not onto fresh ones: every
+	// iteration after the first reuses the blocks its predecessor freed. Comparing it against a
+	// revision that allocated a fresh `Vec` per call therefore measures the allocator, not the
+	// assembly algorithm — the per-word work is unchanged. Read a delta here as "cost of the
+	// allocation strategy", never as an algorithmic speedup.
 	let pool = BufferPool::new();
 	let alloc = &pool;
 
 	let mut group = c.benchmark_group("assemble_operation_witness");
 
+	let (table, constants) = build_table_fixture();
 	for case in CASES {
-		let (constraints, total_shifted_indices) = generate_constraints(&case, constants.len());
+		let constraints = generate_constraints(&case, constants.len());
 
-		group.throughput(Throughput::Elements(total_shifted_indices as u64));
+		group.throughput(Throughput::Elements(streamed_words(&constraints)));
 		group.bench_with_input(
 			BenchmarkId::from_parameter(case.name),
 			&constraints,
 			|b, constraints| {
-				b.iter(|| -> OperandColumns<&BufferPool, 1> {
-					OperandColumns::<_, 1>::build(&table, &constants, constraints, &alloc)
+				b.iter(|| -> OperandColumns<&BufferPool, 2> {
+					OperandColumns::<_, 2>::build(&table, &constants, constraints, &alloc)
 				});
 			},
 		);

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -3,17 +3,22 @@
 //! operation reduction consumes.
 //!
 //! This targets [`OperandColumns::build`] at the BitAnd arity, the shape the M4 prover builds from
-//! a constraint system's AND constraints. Setup constructs a minimal witness-only [`ValueTable`]
-//! and generates random operands of a controlled term density, which a fixed circuit cannot vary:
-//! the number of terms, the value indices they name, and their shift sequences.
+//! a constraint system's AND constraints. Two fixtures share the benchmark group:
 //!
-//! The generated operands read the table from uniformly drawn rows, with none of the locality a
-//! circuit's program order gives, so a case's per-word rate is pessimistic in absolute terms. Read
-//! the cases against each other.
+//! * `bitand_keccak_f1600` assembles the real AND constraints of a Keccak-f1600 permutation circuit
+//!   (see the `keccak_witness_gen` bench). Operand density, shift mix and wire locality are
+//!   whatever the frontend emits, so this is the production-shaped measurement.
+//! * The `*_terms` cases assemble synthetic operands of a controlled term density, which a fixed
+//!   circuit cannot vary. They read the same table over and over from uniformly drawn rows, with
+//!   none of the locality a circuit's program order gives, so their per-word rate is pessimistic.
+//!   Read them against each other rather than against the Keccak case.
 //!
-//! Populating the batch table and preparing the constants and constraints are setup; only the
+//! Populating the batch tables and preparing the constants and constraints are setup; only the
 //! column assembly is timed, over 8192 instances.
 
+use std::array;
+
+use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_compute::BufferPool;
 use binius_core::{
 	ValueIndex, ValueTable,
@@ -22,13 +27,16 @@ use binius_core::{
 	},
 	word::Word,
 };
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_m4_prover::OperandColumns;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
 
 /// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
 const LOG_INSTANCES: usize = 13;
+
+/// The number of 64-bit lanes in a Keccak-f1600 state.
+const STATE_LANES: usize = 25;
 
 /// Witness rows available for generated operands to read from.
 const N_WITNESS_VALUES: usize = 1024;
@@ -84,6 +92,50 @@ const CASES: [OperandCase; 3] = [
 		seed: 2,
 	},
 ];
+
+/// Builds a circuit that applies one Keccak-f1600 permutation to a public input state and promotes
+/// the permuted lanes to public outputs. Returns the circuit and the 25 input state wires.
+fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
+	let builder = CircuitBuilder::new();
+	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_inout());
+
+	// Permute a copy of the input wires in place; `state` then holds the output wires.
+	let mut state = input;
+	keccak_f1600(&builder, &mut state);
+
+	// Promoting the permuted state keeps the whole permutation alive under dead-code elimination.
+	for wire in state {
+		builder.mark_inout(wire);
+	}
+
+	(builder.build(), input)
+}
+
+/// The Keccak fixture: a populated batch table, the circuit's constants and its AND constraints.
+fn build_keccak_fixture() -> (ValueTable, Vec<Word>, Vec<AndConstraint>) {
+	let (circuit, input) = build_keccak_circuit();
+
+	let table = circuit
+		.populate_batch(LOG_INSTANCES, |instance, filler| {
+			for lane in 0..STATE_LANES {
+				filler[input[lane]] = keccak_input_word(instance, lane);
+			}
+		})
+		.unwrap();
+
+	let cs = circuit.constraint_system().clone();
+	cs.validate().unwrap();
+
+	(table, cs.constants, cs.and_constraints)
+}
+
+/// A deterministic, instance- and lane-dependent input word. Keccak's timing is data-independent,
+/// so the exact values only need to be non-degenerate.
+const fn keccak_input_word(instance: usize, lane: usize) -> Word {
+	let mixed = (instance as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+		^ (lane as u64).wrapping_mul(0x0100_0000_01b3);
+	Word(mixed)
+}
 
 /// The synthetic fixture: a witness-only batch table and the constants the generated terms read.
 ///
@@ -230,6 +282,19 @@ fn bench_assemble_operation_witness(c: &mut Criterion) {
 	let alloc = &pool;
 
 	let mut group = c.benchmark_group("assemble_operation_witness");
+
+	let (keccak_table, keccak_constants, keccak_constraints) = build_keccak_fixture();
+	group.throughput(Throughput::Elements(streamed_words(&keccak_constraints)));
+	group.bench_function("bitand_keccak_f1600", |b| {
+		b.iter(|| -> OperandColumns<&BufferPool, 2> {
+			OperandColumns::<_, 2>::build(
+				&keccak_table,
+				&keccak_constants,
+				&keccak_constraints,
+				&alloc,
+			)
+		});
+	});
 
 	let (table, constants) = build_table_fixture();
 	for case in CASES {

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -1,93 +1,207 @@
 // Copyright 2026 The Binius Developers
-//! Benchmark for assembling a batched per-operation witness — the operand-column layout an
-//! operation reduction consumes.
+//! Benchmark for assembling one batched operation-witness column from sparse operands.
 //!
-//! Currently covers the BitAnd operation's two columns; the IntMul
-//! equivalent will be added alongside its protocol. Uses the Keccak-f1600 permutation circuit
-//! (see the `keccak_witness_gen` bench) as a realistic, AND-heavy constraint system: the circuit
-//! applies one permutation to a 25-word state, the state words are witness inputs and the permuted
-//! outputs are force-committed. Populating the batch table and preparing the constants/constraints
-//! are done once as setup; only the witness assembly is timed, over 8192 instances.
+//! This targets [`OperandColumns::build`] directly. Setup constructs a minimal witness-only
+//! [`ValueTable`] and generates random [`Operand`]s with varied sparse row structure: number of
+//! shifted value indices, value indices, shift amounts, and shift variants. Only the column
+//! assembly is timed.
 
-use std::array;
-
-use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_compute::BufferPool;
-use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
+use binius_core::{
+	ValueIndex,
+	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex, ZeroConstraint},
+	word::Word,
+};
+use binius_frontend::{CircuitBuilder, Wire};
 use binius_m4_prover::{OperandColumns, ValueTable};
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 /// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
 const LOG_INSTANCES: usize = 13;
 
-/// The number of 64-bit lanes in a Keccak-f1600 state.
-const STATE_LANES: usize = 25;
+/// Witness rows available for generated operands to read from.
+const N_WITNESS_VALUES: usize = 1024;
 
-/// Builds a circuit that applies one Keccak-f1600 permutation to a witness-input state and
-/// force-commits the permuted output words. Returns the circuit and the 25 input state wires.
-fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
+/// Constants available for generated operands to read from.
+const N_CONSTANTS: usize = 16;
+
+/// Number of operands in each benchmark case.
+const N_OPERANDS: usize = 1024;
+
+const SHIFT_VARIANTS: [ShiftVariant; 8] = [
+	ShiftVariant::Sll,
+	ShiftVariant::Slr,
+	ShiftVariant::Sar,
+	ShiftVariant::Rotr,
+	ShiftVariant::Sll32,
+	ShiftVariant::Srl32,
+	ShiftVariant::Sra32,
+	ShiftVariant::Rotr32,
+];
+
+struct OperandCase {
+	name: &'static str,
+	min_terms: usize,
+	max_terms: usize,
+	seed: u64,
+}
+
+const CASES: [OperandCase; 3] = [
+	OperandCase {
+		name: "sparse_0_to_2_terms",
+		min_terms: 0,
+		max_terms: 2,
+		seed: 0,
+	},
+	OperandCase {
+		name: "mixed_0_to_4_terms",
+		min_terms: 0,
+		max_terms: 4,
+		seed: 1,
+	},
+	OperandCase {
+		name: "dense_1_to_8_terms",
+		min_terms: 1,
+		max_terms: 8,
+		seed: 2,
+	},
+];
+
+fn build_table_fixture() -> (ValueTable, Vec<Word>) {
 	let builder = CircuitBuilder::new();
-	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_witness());
 
-	// Permute a copy of the input wires in place; `state` then holds the output wires.
-	let mut state = input;
-	keccak_f1600(&builder, &mut state);
-
-	// Pin the outputs so dead-code elimination keeps the whole permutation.
-	for wire in state {
-		builder.force_commit(wire);
+	for i in 0..N_CONSTANTS {
+		builder.add_constant(fixture_constant_word(i));
 	}
 
-	(builder.build(), input)
-}
+	let witnesses: Vec<Wire> = (0..N_WITNESS_VALUES)
+		.map(|_| {
+			let wire = builder.add_witness();
+			builder.force_commit(wire);
+			wire
+		})
+		.collect();
 
-/// A deterministic, instance- and lane-dependent input word. Keccak's timing is data-independent,
-/// so the exact values only need to be non-degenerate.
-const fn input_word(instance: usize, lane: usize) -> Word {
-	let mixed = (instance as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15)
-		^ (lane as u64).wrapping_mul(0x0100_0000_01b3);
-	Word(mixed)
-}
-
-fn bench_assemble_operation_witness(c: &mut Criterion) {
-	let (circuit, input) = build_keccak_circuit();
-
-	// Setup (not timed): populate the wire-major batch table for every instance.
+	let circuit = builder.build();
 	let table = ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
-		for lane in 0..STATE_LANES {
-			w[input[lane]] = input_word(instance, lane);
+		for (index, &wire) in witnesses.iter().enumerate() {
+			w[wire] = fixture_witness_word(instance, index);
 		}
 	})
 	.unwrap();
 
-	// The circuit's constants, shared by every instance.
 	let constants = circuit.constraint_system().constants.clone();
+	assert!(constants.len() >= N_CONSTANTS);
+	assert!(table.n_hidden_words() >= N_WITNESS_VALUES);
 
-	// The per-instance AND constraints, at their true (unpadded) count.
-	let and_constraints = {
-		let cs = circuit.constraint_system().clone();
-		cs.validate().unwrap();
-		cs.and_constraints
-	};
+	(table, constants)
+}
 
-	// The columns are drawn from a pool that lives across the timed iterations, matching how the
-	// prover recycles its working buffers between proofs.
-	//
-	// So this benchmark measures assembly onto recycled blocks, not onto fresh ones: every
-	// iteration after the first reuses the blocks its predecessor freed. Comparing it against a
-	// revision that allocated a fresh `Vec` per call therefore measures the allocator, not the
-	// assembly algorithm — the per-word work is unchanged. Read a delta here as "cost of the
-	// allocation strategy", never as an algorithmic speedup.
+const fn fixture_constant_word(index: usize) -> Word {
+	Word((index as u64).wrapping_mul(0xd6e8_feb8_6659_fd93) ^ 0xa076_1d64_78bd_642f)
+}
+
+const fn fixture_witness_word(instance: usize, index: usize) -> Word {
+	let mixed = (instance as u64)
+		.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+		.rotate_left((index % Word::BITS) as u32)
+		^ (index as u64).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+	Word(mixed)
+}
+
+fn generate_constraints(
+	case: &OperandCase,
+	constants_len: usize,
+	witness_offset: usize,
+) -> (Vec<ZeroConstraint>, usize) {
+	let mut rng = StdRng::seed_from_u64(case.seed);
+	let constraints = (0..N_OPERANDS)
+		.map(|_| {
+			ZeroConstraint([random_operand(
+				&mut rng,
+				case,
+				constants_len,
+				witness_offset,
+			)])
+		})
+		.collect::<Vec<_>>();
+	let total_shifted_indices = constraints
+		.iter()
+		.map(|constraint| constraint.val().len())
+		.sum();
+
+	assert!(
+		total_shifted_indices > 0,
+		"benchmark fixture must have at least one shifted value index"
+	);
+
+	(constraints, total_shifted_indices)
+}
+
+fn random_operand(
+	rng: &mut impl Rng,
+	case: &OperandCase,
+	constants_len: usize,
+	witness_offset: usize,
+) -> Operand {
+	let n_terms = rng.random_range(case.min_terms..=case.max_terms);
+	(0..n_terms)
+		.map(|_| random_shifted_value_index(rng, constants_len, witness_offset))
+		.collect()
+}
+
+fn random_shifted_value_index(
+	rng: &mut impl Rng,
+	constants_len: usize,
+	witness_offset: usize,
+) -> ShiftedValueIndex {
+	let value_index = random_value_index(rng, constants_len, witness_offset);
+	let shift_variant = SHIFT_VARIANTS[rng.random_range(0..SHIFT_VARIANTS.len())];
+	let amount = rng.random_range(0..shift_variant.max_amount()) as u8;
+
+	ShiftedValueIndex {
+		value_index,
+		shift_variant,
+		amount,
+	}
+}
+
+fn random_value_index(
+	rng: &mut impl Rng,
+	constants_len: usize,
+	witness_offset: usize,
+) -> ValueIndex {
+	if rng.random_range(0..8) == 0 {
+		ValueIndex(rng.random_range(0..constants_len) as u32)
+	} else {
+		ValueIndex((witness_offset + rng.random_range(0..N_WITNESS_VALUES)) as u32)
+	}
+}
+
+fn bench_assemble_operation_witness(c: &mut Criterion) {
+	let (table, constants) = build_table_fixture();
+	let witness_offset = table.layout().offset_witness;
 	let pool = BufferPool::new();
 	let alloc = &pool;
 
 	let mut group = c.benchmark_group("assemble_operation_witness");
-	group.bench_function("bitand_keccak_f1600", |b| {
-		b.iter(|| -> OperandColumns<&BufferPool, 2> {
-			OperandColumns::<_, 2>::build(&table, &constants, &and_constraints, &alloc)
-		});
-	});
+
+	for case in CASES {
+		let (constraints, total_shifted_indices) =
+			generate_constraints(&case, constants.len(), witness_offset);
+
+		group.throughput(Throughput::Elements(total_shifted_indices as u64));
+		group.bench_with_input(
+			BenchmarkId::from_parameter(case.name),
+			&constraints,
+			|b, constraints| {
+				b.iter(|| -> OperandColumns<&BufferPool, 1> {
+					OperandColumns::<_, 1>::build(&table, &constants, constraints, &alloc)
+				});
+			},
+		);
+	}
 
 	group.finish();
 }

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -8,12 +8,12 @@
 
 use binius_compute::BufferPool;
 use binius_core::{
-	ValueIndex,
-	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex, ZeroConstraint},
+	ValueIndex, ValueTable,
+	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex, ZeroConstraint},
 	word::Word,
 };
 use binius_frontend::{CircuitBuilder, Wire};
-use binius_m4_prover::{OperandColumns, ValueTable};
+use binius_m4_prover::OperandColumns;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
 
@@ -84,16 +84,18 @@ fn build_table_fixture() -> (ValueTable, Vec<Word>) {
 		.collect();
 
 	let circuit = builder.build();
-	let table = ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
-		for (index, &wire) in witnesses.iter().enumerate() {
-			w[wire] = fixture_witness_word(instance, index);
-		}
-	})
-	.unwrap();
+	let table = circuit
+		.populate_batch(LOG_INSTANCES, |instance, filler| {
+			for (index, &wire) in witnesses.iter().enumerate() {
+				filler[wire] = fixture_witness_word(instance, index);
+			}
+		})
+		.unwrap();
 
 	let constants = circuit.constraint_system().constants.clone();
 	assert!(constants.len() >= N_CONSTANTS);
-	assert!(table.n_hidden_words() >= N_WITNESS_VALUES);
+	// Every generated private index must name a committed witness row.
+	assert!(table.layout().n_witness >= N_WITNESS_VALUES);
 
 	(table, constants)
 }
@@ -110,21 +112,10 @@ const fn fixture_witness_word(instance: usize, index: usize) -> Word {
 	Word(mixed)
 }
 
-fn generate_constraints(
-	case: &OperandCase,
-	constants_len: usize,
-	witness_offset: usize,
-) -> (Vec<ZeroConstraint>, usize) {
+fn generate_constraints(case: &OperandCase, constants_len: usize) -> (Vec<ZeroConstraint>, usize) {
 	let mut rng = StdRng::seed_from_u64(case.seed);
 	let constraints = (0..N_OPERANDS)
-		.map(|_| {
-			ZeroConstraint([random_operand(
-				&mut rng,
-				case,
-				constants_len,
-				witness_offset,
-			)])
-		})
+		.map(|_| ZeroConstraint([random_operand(&mut rng, case, constants_len)]))
 		.collect::<Vec<_>>();
 	let total_shifted_indices = constraints
 		.iter()
@@ -139,57 +130,45 @@ fn generate_constraints(
 	(constraints, total_shifted_indices)
 }
 
-fn random_operand(
-	rng: &mut impl Rng,
-	case: &OperandCase,
-	constants_len: usize,
-	witness_offset: usize,
-) -> Operand {
+fn random_operand(rng: &mut impl Rng, case: &OperandCase, constants_len: usize) -> Operand {
 	let n_terms = rng.random_range(case.min_terms..=case.max_terms);
 	(0..n_terms)
-		.map(|_| random_shifted_value_index(rng, constants_len, witness_offset))
+		.map(|_| random_shifted_value_index(rng, constants_len))
 		.collect()
 }
 
-fn random_shifted_value_index(
-	rng: &mut impl Rng,
-	constants_len: usize,
-	witness_offset: usize,
-) -> ShiftedValueIndex {
-	let value_index = random_value_index(rng, constants_len, witness_offset);
-	let shift_variant = SHIFT_VARIANTS[rng.random_range(0..SHIFT_VARIANTS.len())];
-	let amount = rng.random_range(0..shift_variant.max_amount()) as u8;
+fn random_shifted_value_index(rng: &mut impl Rng, constants_len: usize) -> ShiftedValueIndex {
+	let value_index = random_value_index(rng, constants_len);
+	let variant = SHIFT_VARIANTS[rng.random_range(0..SHIFT_VARIANTS.len())];
+	let amount = rng.random_range(0..variant.max_amount());
 
-	ShiftedValueIndex {
-		value_index,
-		shift_variant,
-		amount,
-	}
+	// A constraint system carries canonical shifts, which spell the identity one way only.
+	let shift = if amount == 0 {
+		Shift::IDENTITY
+	} else {
+		Shift::new(variant, amount)
+	};
+
+	ShiftedValueIndex::single(value_index, shift)
 }
 
-fn random_value_index(
-	rng: &mut impl Rng,
-	constants_len: usize,
-	witness_offset: usize,
-) -> ValueIndex {
+fn random_value_index(rng: &mut impl Rng, constants_len: usize) -> ValueIndex {
 	if rng.random_range(0..8) == 0 {
-		ValueIndex(rng.random_range(0..constants_len) as u32)
+		ValueIndex::constant(rng.random_range(0..constants_len) as u32)
 	} else {
-		ValueIndex((witness_offset + rng.random_range(0..N_WITNESS_VALUES)) as u32)
+		ValueIndex::private(rng.random_range(0..N_WITNESS_VALUES) as u32)
 	}
 }
 
 fn bench_assemble_operation_witness(c: &mut Criterion) {
 	let (table, constants) = build_table_fixture();
-	let witness_offset = table.layout().offset_witness;
 	let pool = BufferPool::new();
 	let alloc = &pool;
 
 	let mut group = c.benchmark_group("assemble_operation_witness");
 
 	for case in CASES {
-		let (constraints, total_shifted_indices) =
-			generate_constraints(&case, constants.len(), witness_offset);
+		let (constraints, total_shifted_indices) = generate_constraints(&case, constants.len());
 
 		group.throughput(Throughput::Elements(total_shifted_indices as u64));
 		group.bench_with_input(


### PR DESCRIPTION
## Summary
- Replaces the circuit-fixture benchmark with a targeted one-column benchmark for `OperandColumns::build`, the current replacement for the former `build_operation_witness` helper.
- Generates deterministic random `Operand`s directly, varying the number of shifted value indices, value indices, shift amounts, and shift variants.
- Measures Criterion throughput in shifted value indices, i.e. the total non-zero entries across all generated operands.
- Uses the current pooled-buffer path via `BufferPool`, matching the prover allocation strategy.

This keeps setup minimal: a witness-only `ValueTable` provides rows for the generated operands to read, while benchmark-local `ZeroConstraint`s provide the one-operand, arity-preserving input expected by the current `OperandColumns` API. No operation circuit constraint systems are built for the benchmark cases.

## Benchmark
Short local pass on Apple M4 Pro, `RAYON_NUM_THREADS=8`, `--sample-size 10 --warm-up-time 1 --measurement-time 3`, after rebasing onto current `main`:

| case | time | throughput |
|---|---:|---:|
| `sparse_0_to_2_terms` | 1.98 ms | 496 K shifted indices/s |
| `mixed_0_to_4_terms` | 3.90 ms | 517 K shifted indices/s |
| `dense_1_to_8_terms` | 8.97 ms | 528 K shifted indices/s |

## Test plan
- `cargo +nightly-2026-01-01 fmt --all --check`
- `cargo bench -p binius-m4-prover --bench assemble_operation_witness --no-run`
- `RAYON_NUM_THREADS=8 cargo bench -p binius-m4-prover --bench assemble_operation_witness -- --sample-size 10 --warm-up-time 1 --measurement-time 3`
- `cargo test -p binius-m4-prover --lib`
- `cargo test -p binius-m4-prover --lib --features rayon`
- `cargo clippy -p binius-m4-prover --all-features --tests --benches -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-m4-prover --no-deps`
- `cargo check --workspace --all-targets`
