### PR TITLE
BINIUS-387: pass the non-padding AND constraint count into the AND-reduction prover

### DIFF
--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -866,11 +866,13 @@ mod tests {
 		let [a, b] =
 			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 		let log_total = checked_log_2(a.len());
+		let n_real_rows = and_constraints.len() << table.log_instances();
 
 		// Prover and verifier agree on the reduced claim over the batched columns.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prove_output = and_reduction::prove::<_, B128, P, _, _>(
 			[a, b],
+			n_real_rows,
 			&mut prover_transcript,
 			&GlobalAllocator,
 		);
@@ -902,11 +904,13 @@ mod tests {
 		let [a, b] =
 			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 		let log_total = checked_log_2(a.len());
+		let n_real_rows = and_constraints.len() << table.log_instances();
 
 		// Produce a faithful proof.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let _ = and_reduction::prove::<_, B128, P, _, _>(
 			[a, b],
+			n_real_rows,
 			&mut prover_transcript,
 			&GlobalAllocator,
 		);
@@ -961,9 +965,10 @@ mod tests {
 				.map(|(&a, &b)| a & b)
 				.collect();
 			let log_total = checked_log_2(a.len());
+			let n_real_rows = and_constraints.len() << table.log_instances();
 
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let prove_output = and_reduction::prove::<_, B128, P, _, _>([a, b], &mut prover_transcript, &GlobalAllocator);
+			let prove_output = and_reduction::prove::<_, B128, P, _, _>([a, b], n_real_rows, &mut prover_transcript, &GlobalAllocator);
 
 			let mut verifier_transcript = prover_transcript.into_verifier();
 			let verify_output =

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -212,7 +212,17 @@ impl IOPProver {
 			// Reduce over borrowed columns so the owned `a`/`b` can be moved into `and_columns`
 			// afterward, avoiding a full clone. Nothing touches the channel between the reduction
 			// and building `and_columns`, so the transcript is unchanged.
-			let output = and_reduction::prove::<_, B128, P, _, _>([&a[..], &b[..]], channel, alloc);
+			//
+			// The columns are laid out constraint-major (`row = constraint_index * n_instances +
+			// instance`), so the real-row boundary is the constraint count scaled by the instance
+			// count, not the constraint count alone.
+			let n_real_rows = cs.n_and_constraints() << table.log_instances();
+			let output = and_reduction::prove::<_, B128, P, _, _>(
+				[&a[..], &b[..]],
+				n_real_rows,
+				channel,
+				alloc,
+			);
 			let and_columns = (mul.is_some() || bmul.is_some()).then(|| {
 				// The re-randomization re-reads the three BitAnd operand columns.
 				// Only `A` and `B` are stored.

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -53,6 +53,7 @@ fn bench(c: &mut Criterion) {
 		bench.iter(|| {
 			univariate_round_message_extension_domain::<B128>(
 				log_words,
+				1 << log_words,
 				&a_words,
 				&b_words,
 				&big_field_zerocheck_challenges,
@@ -76,6 +77,7 @@ fn bench(c: &mut Criterion) {
 			bench.iter(|| {
 				univariate_round_message_extension_domain::<B128>(
 					log_words,
+					padded_real,
 					&a_words_padded,
 					&b_words_padded,
 					&big_field_zerocheck_challenges,
@@ -87,6 +89,7 @@ fn bench(c: &mut Criterion) {
 
 	let urm = univariate_round_message_extension_domain::<B128>(
 		log_words,
+		1 << log_words,
 		&a_words,
 		&b_words,
 		&big_field_zerocheck_challenges,
@@ -100,8 +103,24 @@ fn bench(c: &mut Criterion) {
 			let folder = BitAxisFolder::new(&lagrange_evals);
 			folder.fold_bitand_operands::<OptimalPackedB128, _>(
 				&GlobalAllocator,
+				1 << log_words,
 				&a_words,
 				&b_words,
+			)
+		});
+	});
+
+	// Same padded shape as the round-message bench above: the fold step has no padding-skip logic
+	// before BINIUS-387, so this bench is the one that shows that change's speedup directly.
+	group.bench_function(format!("univariate fold 2^{log_words} (40% zero padding)"), |bench| {
+		bench.iter(|| {
+			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
+			let folder = BitAxisFolder::new(&lagrange_evals);
+			folder.fold_bitand_operands::<OptimalPackedB128, _>(
+				&GlobalAllocator,
+				padded_real,
+				&a_words_padded,
+				&b_words_padded,
 			)
 		});
 	});
@@ -123,8 +142,12 @@ fn bench(c: &mut Criterion) {
 
 	let alloc = &pool;
 	// Fold the operands once; each iteration clones the result from the pool.
-	let proving_polys =
-		folder.fold_bitand_operands::<OptimalPackedB128, _>(&alloc, &a_words, &b_words);
+	let proving_polys = folder.fold_bitand_operands::<OptimalPackedB128, _>(
+		&alloc,
+		1 << log_words,
+		&a_words,
+		&b_words,
+	);
 	group.bench_function(format!("remaining zerocheck 2^{log_words}"), |bench| {
 		bench.iter_batched(
 			|| proving_polys.clone(),

--- a/crates/prover/src/and_reduction/mod.rs
+++ b/crates/prover/src/and_reduction/mod.rs
@@ -33,10 +33,17 @@ pub use ntt_lookup::NTTLookup;
 /// `BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)`, matching the domain the shift reduction
 /// folds its bit axis over.
 ///
+/// `n_real_rows` is the true, non-padding row count: one row per AND constraint for the
+/// single-instance prover, one per (instance, constraint) pair for the M4 batch prover. Rows from
+/// this index onward are zero-padding, zeroed by the caller when it built `columns` up to the
+/// next power of two. Passing the exact boundary lets the round-1 message and fold step skip whole
+/// windows/chunks entirely past it, instead of rediscovering the padding at runtime.
+///
 /// See [`binius_verifier::protocols::bitand`] for the protocol specification and
 /// [`AndCheckOutput`] for the output shape.
 pub fn prove<A, F, PChallenge, Channel, Data>(
 	columns: [Data; 2],
+	n_real_rows: usize,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> AndCheckOutput<F>
@@ -55,6 +62,7 @@ where
 	// one per (instance, constraint) pair for the M4 batch prover, in both cases zero-padded up to
 	// a power of two.
 	let log_constraint_count = checked_log_2(a.len());
+	assert!(n_real_rows <= a.len());
 
 	// Pin the first few zerocheck coordinates to fixed small-field elements (friendly challenges),
 	// and draw the rest from the large field. The prover and verifier pin and draw the same split,
@@ -65,6 +73,7 @@ where
 
 	let prover = OblongZerocheckProver::<_, PChallenge, _>::new(
 		log_constraint_count,
+		n_real_rows,
 		a,
 		b,
 		big_field_zerocheck_challenges,

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -38,6 +38,7 @@ where
 	FChallenge: BinaryField,
 {
 	log_words: usize,
+	n_real_rows: usize,
 	first_col: Data,
 	second_col: Data,
 	big_field_zerocheck_challenges: Vec<FChallenge>,
@@ -73,6 +74,10 @@ where
 	/// # Arguments
 	///
 	/// * `log_words` - Base-2 logarithm of the number of words in each column
+	/// * `n_real_rows` - The number of non-padding rows at the start of each column. Rows from this
+	///   index onward must already be zero in both operands, per the reductions' zero-padding
+	///   contract; this lets the round-1 message and fold step skip whole windows/chunks entirely
+	///   past the boundary instead of rediscovering them at runtime.
 	/// * `first_col` - The oblong multilinear polynomial A in the AND constraint A & B ^ C = 0
 	/// * `second_col` - The oblong multilinear polynomial B in the AND constraint
 	/// * `big_field_zerocheck_challenges` - Challenges Z_{k+1},...,Zₙ in the large field FChallenge
@@ -86,6 +91,7 @@ where
 	/// 3. Caches these evaluations for later use in the execute() method
 	pub fn new(
 		log_words: usize,
+		n_real_rows: usize,
 		first_col: Data,
 		second_col: Data,
 		big_field_zerocheck_challenges: Vec<F>,
@@ -95,6 +101,7 @@ where
 			.in_scope(|| {
 				sumcheck_round_messages::univariate_round_message_extension_domain::<F>(
 					log_words,
+					n_real_rows,
 					&first_col,
 					&second_col,
 					&big_field_zerocheck_challenges,
@@ -104,6 +111,7 @@ where
 
 		Self {
 			log_words,
+			n_real_rows,
 			first_col,
 			second_col,
 			univariate_round_message,
@@ -170,8 +178,12 @@ where
 		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
-		let proving_polys =
-			folder.fold_bitand_operands::<PChallenge, _>(alloc, &self.first_col, &self.second_col);
+		let proving_polys = folder.fold_bitand_operands::<PChallenge, _>(
+			alloc,
+			self.n_real_rows,
+			&self.first_col,
+			&self.second_col,
+		);
 
 		let upcasted_small_field_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES
 			.iter()
@@ -319,8 +331,11 @@ mod test {
 		// Prover is instantiated
 		let big_field_zerocheck_challenges = prover_challenger
 			.sample_vec(log_num_rows - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
+		// Every row here is real (no padding boundary in this fixture), so n_real_rows covers the
+		// whole column.
 		let prover = OblongZerocheckProver::<_, OptimalPackedB128, _>::new(
 			log_num_rows,
+			1 << log_num_rows,
 			first_mlv.clone(),
 			second_mlv.clone(),
 			big_field_zerocheck_challenges.to_vec(),

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -50,6 +50,9 @@ use crate::fold_word::duplicate_to_fixed_chunks;
 /// # Arguments
 ///
 /// * `log_words` - Base-2 logarithm of the number of words in each column
+/// * `n_real_rows` - The number of non-padding rows at the start of each column. The padding
+///   contract guarantees every row from this index onward is `Word::ZERO` in both operands, so
+///   whole windows entirely past this boundary are skipped without reading their words.
 /// * `a_words` - First multiplicand (a) as a one-bit oblong multilinear polynomial
 /// * `b_words` - Second multiplicand (b) as a one-bit oblong multilinear polynomial
 /// * `eq_ind_big_field_challenges` - Partial equality indicator evaluations for big field variables
@@ -67,6 +70,7 @@ use crate::fold_word::duplicate_to_fixed_chunks;
 /// * `F` - The challenge field type (must be a binary field)
 pub fn univariate_round_message_extension_domain<F>(
 	log_words: usize,
+	n_real_rows: usize,
 	a_words: &[Word],
 	b_words: &[Word],
 	big_field_challenges: &[F],
@@ -84,6 +88,7 @@ where
 	for col in [a_words, b_words] {
 		assert_eq!(col.len(), 1 << log_words);
 	}
+	assert!(n_real_rows <= a_words.len());
 
 	let ntt_lookup = tracing::debug_span!("Compute univariate LDE table")
 		.in_scope(|| NTTLookup::new(prover_message_domain));
@@ -132,18 +137,17 @@ where
 	// Accumulate resulting polynomial evals by iterating over each hypercube vertex.
 	(a_col_chunks.as_ref(), b_col_chunks.as_ref())
 		.into_par_iter()
-		.map(|(a_chunk, b_chunk)| {
-			// Skip zero-padding windows: their chunks add nothing to the round message.
+		.enumerate()
+		.map(|(window_idx, (a_chunk, b_chunk))| {
+			// Skip windows entirely past the last real row: the padding contract guarantees every
+			// word from `n_real_rows` onward is `Word::ZERO` in both operands, so `A = B = C = 0`
+			// there and the term `A*B - C` vanishes over the whole window without reading its
+			// words.
 			//
-			// Invariant: C is derived as C = A & B.
-			//   A = 0 forces C = 0, so the term A*B - C vanishes.
-			//   B = 0 forces C = 0, so the term A*B - C vanishes.
-			//   A chunk all-zero in either operand sums to exactly 0 over the window.
-			//
-			// A populated chunk stops the scan at its first non-zero word.
-			// Dense inputs therefore pay only a couple of word comparisons.
-			if a_chunk.iter().all(|w| *w == Word::ZERO) || b_chunk.iter().all(|w| *w == Word::ZERO)
-			{
+			// A window that straddles the boundary still holds real rows, so it runs the full
+			// computation below; only a window entirely past the boundary is free to skip.
+			let window_start_row = window_idx << LOG_CHUNK_SIZE;
+			if window_start_row >= n_real_rows {
 				return [F::ZERO; ROWS_PER_HYPERCUBE_VERTEX];
 			}
 
@@ -265,12 +269,13 @@ mod test {
 		// 2^10 rows total; each 64-bit word packs 2^SKIPPED_VARS rows, leaving this many words.
 		let log_num_words = 10 - SKIPPED_VARS;
 
-		// Every word is random and non-zero, so no window is skipped.
-		// This pins the dense path, where the skip must leave the result unchanged.
+		// Every word is random and non-zero, and n_real_rows covers every row, so no window is
+		// skipped. This pins the dense path, where the skip must leave the result unchanged.
 		let mlv_1 = random_words(log_num_words, &mut rng);
 		let mlv_2 = random_words(log_num_words, &mut rng);
+		let n_real_rows = mlv_1.len();
 
-		assert_round_message_consistent(&mlv_1, &mlv_2, &mut rng);
+		assert_round_message_consistent(n_real_rows, &mlv_1, &mlv_2, &mut rng);
 	}
 
 	#[test]
@@ -287,19 +292,44 @@ mod test {
 		let mut mlv_2 = random_words(log_num_words, &mut rng);
 
 		// Zero the top 512 words in both operands: the last 4 windows become all-zero.
-		// This is the padding a non-power-of-two AND count leaves after rounding up.
+		// This is the padding a non-power-of-two AND count leaves after rounding up, with the
+		// boundary landing exactly on a window edge.
 		//
 		//     words:   [ 0 .. 512 random | 512 .. 1024 zero      ]
 		//     windows: [ w0 w1 w2 w3     | w4 w5 w6 w7 (skipped)  ]
-		let padding_start = (1 << log_num_words) / 2;
+		let n_real_rows = (1 << log_num_words) / 2;
 		for words in [&mut mlv_1, &mut mlv_2] {
-			words[padding_start..].fill(Word::ZERO);
+			words[n_real_rows..].fill(Word::ZERO);
 		}
 
 		// The skipped windows must contribute exactly zero.
 		// The verifier-side fold recomputes the claim independently.
 		// A window skipped in error would break the equality inside the helper.
-		assert_round_message_consistent(&mlv_1, &mlv_2, &mut rng);
+		assert_round_message_consistent(n_real_rows, &mlv_1, &mlv_2, &mut rng);
+	}
+
+	#[test]
+	fn test_first_round_message_with_boundary_inside_a_window() {
+		// A third seed, distinct from the other two tests' witnesses.
+		let mut rng = StdRng::from_seed([2; 32]);
+
+		// Four whole windows of 128 words, with the real-row boundary landing 40 words into the
+		// third: the true AND constraint count rarely lands on a window edge, so this is the shape
+		// that matters for real (Keccak/SHA-256-sized) batches.
+		let log_chunk_size = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len() + 4;
+		let log_num_words = log_chunk_size + 2;
+
+		let mut mlv_1 = random_words(log_num_words, &mut rng);
+		let mut mlv_2 = random_words(log_num_words, &mut rng);
+
+		//     words:   [ 0 .. 256 random | 256 .. 296 random | 296 .. 384 zero | 384 .. 512 zero ]
+		//     windows: [ w0 w1 real      | w2 straddles, runs in full          | w3 skipped      ]
+		let n_real_rows = 2 * (1 << log_chunk_size) + 40;
+		for words in [&mut mlv_1, &mut mlv_2] {
+			words[n_real_rows..].fill(Word::ZERO);
+		}
+
+		assert_round_message_consistent(n_real_rows, &mlv_1, &mlv_2, &mut rng);
 	}
 
 	/// Asserts the first-round univariate message agrees with the next-round sum claim.
@@ -308,7 +338,12 @@ mod test {
 	/// - Extrapolate the round message at the challenge to get the expected next-round sum.
 	/// - Fold A, B, and C = A & B at the same challenge, then form the sum claim directly.
 	/// - The two values must be equal.
-	fn assert_round_message_consistent(mlv_1: &[Word], mlv_2: &[Word], mut rng: impl Rng) {
+	fn assert_round_message_consistent(
+		n_real_rows: usize,
+		mlv_1: &[Word],
+		mlv_2: &[Word],
+		mut rng: impl Rng,
+	) {
 		assert_eq!(mlv_1.len(), mlv_2.len());
 		let log_num_words = mlv_1.len().ilog2() as usize;
 
@@ -330,6 +365,7 @@ mod test {
 		// Prover generates first round message
 		let first_round_message_on_ext_domain = univariate_round_message_extension_domain::<B128>(
 			log_num_words,
+			n_real_rows,
 			mlv_1,
 			mlv_2,
 			&big_field_zerocheck_challenges,

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -189,13 +189,17 @@ impl<UOut: UnderlierType> LinearTransformationFactory<u64, UOut>
 /// - Two input streams instead of three.
 /// - Two register ANDs per word pair replace one memory stream.
 /// - The bytewise lookup tables stay hot across all three outputs.
+/// - A chunk entirely past `n_real_rows` is known all-zero, so it is written directly instead of
+///   paying the bytewise lookup on padding words.
 ///
 /// # Preconditions
 ///
 /// * The two word-lists have equal length.
+/// * `n_real_rows <= a_words.len()`.
 fn fold_bitand_operands_with_transform<F, P, T, A>(
 	alloc: &A,
 	transform: &T,
+	n_real_rows: usize,
 	a_words: &[Word],
 	b_words: &[Word],
 ) -> [FieldBuffer<P, A::Vec<P>>; 3]
@@ -206,6 +210,7 @@ where
 	A: Allocator,
 {
 	assert_eq!(a_words.len(), b_words.len());
+	assert!(n_real_rows <= a_words.len());
 
 	// Padding contract, mirrored from the single-column fold:
 	// the high words up to the next power of two read as zero.
@@ -231,6 +236,11 @@ where
 
 	// Phase 2: fold the aligned chunks in parallel.
 	// Each task owns one chunk of both inputs and writes one packed element per output.
+	//
+	// A chunk whose row range lies entirely at or past `n_real_rows` is guaranteed all-zero by the
+	// padding contract, so `A = B = C = 0` there: write the zero element directly instead of paying
+	// the bytewise lookup on padding words. A chunk that straddles the boundary still holds real
+	// rows, so it runs the lookup normally.
 	(
 		a_out,
 		b_out,
@@ -239,7 +249,15 @@ where
 		b_aligned.par_chunks_exact(P::WIDTH),
 	)
 		.into_par_iter()
-		.for_each(|(a_i, b_i, c_i, a_chunk, b_chunk)| {
+		.enumerate()
+		.for_each(|(chunk_idx, (a_i, b_i, c_i, a_chunk, b_chunk))| {
+			if chunk_idx * P::WIDTH >= n_real_rows {
+				a_i.write(P::default());
+				b_i.write(P::default());
+				c_i.write(P::default());
+				return;
+			}
+
 			// Safety:
 			// - both aligned slices have length n_chunks * P::WIDTH
 			// - both are split into P::WIDTH chunks
@@ -265,13 +283,21 @@ where
 
 	// Phase 3: fold the short tail into one final packed element per output.
 	if !a_remaining.is_empty() {
-		a_values
-			.push(P::from_scalars(a_remaining.iter().map(|&word| transform.transform(&word.0))));
-		b_values
-			.push(P::from_scalars(b_remaining.iter().map(|&word| transform.transform(&word.0))));
-		c_values.push(P::from_scalars(
-			iter::zip(a_remaining, b_remaining).map(|(&a, &b)| transform.transform(&(a & b).0)),
-		));
+		if n_chunks * P::WIDTH >= n_real_rows {
+			a_values.push(P::default());
+			b_values.push(P::default());
+			c_values.push(P::default());
+		} else {
+			a_values.push(P::from_scalars(
+				a_remaining.iter().map(|&word| transform.transform(&word.0)),
+			));
+			b_values.push(P::from_scalars(
+				b_remaining.iter().map(|&word| transform.transform(&word.0)),
+			));
+			c_values.push(P::from_scalars(
+				iter::zip(a_remaining, b_remaining).map(|(&a, &b)| transform.transform(&(a & b).0)),
+			));
+		}
 	}
 
 	// Phase 4: zero-pad each output up to the power-of-two capacity.
@@ -332,12 +358,20 @@ impl<F: BinaryField> BitAxisFolder<F> {
 	///
 	/// The AND column is derived in registers and never written to memory.
 	///
+	/// # Arguments
+	///
+	/// * `n_real_rows` - The number of non-padding rows at the start of `a` and `b`. Rows from this
+	///   index onward must already be `Word::ZERO` in both operands; whole packed-width chunks
+	///   entirely past this boundary are skipped rather than folded.
+	///
 	/// # Preconditions
 	///
 	/// * The two word-lists have equal length.
+	/// * `n_real_rows <= a.len()`.
 	pub fn fold_bitand_operands<P, A>(
 		&self,
 		alloc: &A,
+		n_real_rows: usize,
 		a: &[Word],
 		b: &[Word],
 	) -> [FieldBuffer<P, A::Vec<P>>; 3]
@@ -345,7 +379,7 @@ impl<F: BinaryField> BitAxisFolder<F> {
 		P: PackedField<Scalar = F>,
 		A: Allocator,
 	{
-		fold_bitand_operands_with_transform(alloc, &self.transform, a, b)
+		fold_bitand_operands_with_transform(alloc, &self.transform, n_real_rows, a, b)
 	}
 }
 
@@ -840,9 +874,12 @@ mod tests {
 			let vec = random_scalars::<B128>(&mut rng, Word::BITS);
 			let folder = BitAxisFolder::new(&vec);
 
-			// Fold the two stored columns and the derived column in one fused pass.
+			// Fold the two stored columns and the derived column in one fused pass. Every word here
+			// is real (no padding boundary within this fixture), so n_real_rows covers the whole
+			// column and the skip path never triggers.
 			let [a_fused, b_fused, c_fused] = folder.fold_bitand_operands::<OptimalPackedB128, _>(
 				&GlobalAllocator,
+				n_words,
 				&a_words,
 				&b_words,
 			);
@@ -863,6 +900,50 @@ mod tests {
 				"c mismatch at n_words = {n_words}"
 			);
 		}
+	}
+
+	#[test]
+	fn test_fold_bitand_operands_skips_padding_without_changing_output() {
+		let mut rng = StdRng::seed_from_u64(1);
+
+		// A boundary inside the third packed-width chunk: not aligned to `P::WIDTH`, so that chunk
+		// still holds real rows and must run the fold in full, while only the whole chunk after it
+		// is free to skip.
+		let width = OptimalPackedB128::WIDTH;
+		let n_words = 4 * width;
+		let n_real_rows = 2 * width + width / 2;
+
+		let mut a_words = (0..n_words)
+			.map(|_| Word::from_u64(rng.random::<u64>()))
+			.collect::<Vec<_>>();
+		let mut b_words = (0..n_words)
+			.map(|_| Word::from_u64(rng.random::<u64>()))
+			.collect::<Vec<_>>();
+		for words in [&mut a_words, &mut b_words] {
+			words[n_real_rows..].fill(Word::ZERO);
+		}
+
+		let vec = random_scalars::<B128>(&mut rng, Word::BITS);
+		let folder = BitAxisFolder::new(&vec);
+
+		// The padding contract already zeroes every word past `n_real_rows`, so the words there are
+		// truly zero whether or not the fold is told about the boundary. Passing the real boundary
+		// (taking the skip path) must therefore agree exactly with passing the full length (running
+		// every chunk through the lookup, as if nothing were known to be padding).
+		let skipped = folder.fold_bitand_operands::<OptimalPackedB128, _>(
+			&GlobalAllocator,
+			n_real_rows,
+			&a_words,
+			&b_words,
+		);
+		let unskipped = folder.fold_bitand_operands::<OptimalPackedB128, _>(
+			&GlobalAllocator,
+			n_words,
+			&a_words,
+			&b_words,
+		);
+
+		assert_eq!(skipped, unskipped);
 	}
 
 	fn naive_fold_words_both_axes<F, P>(

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -192,7 +192,12 @@ impl IOPProver {
 				c_eval,
 				z_challenge,
 				eval_point,
-			} = and_reduction::prove::<_, B128, P, _, _>(bitand_columns, &mut *channel, alloc);
+			} = and_reduction::prove::<_, B128, P, _, _>(
+				bitand_columns,
+				cs.n_and_constraints(),
+				&mut *channel,
+				alloc,
+			);
 			OperatorData {
 				evals: vec![a_eval, b_eval, c_eval],
 				r_zhat_prime: z_challenge,


### PR DESCRIPTION
Linear: [BINIUS-387](https://linear.app/jimpo/issue/BINIUS-387/pass-the-non-padding-and-constraint-count-into-the-and-reduction)

Follow-up to [BINIUS-340](https://linear.app/jimpo/issue/BINIUS-340/skip-all-zero-padding-windows-in-the-and-reduction-round-1-message) and [BINIUS-364](https://linear.app/jimpo/issue/BINIUS-364/dont-require-power-of-two-of-constraints). Pure performance change — no arithmetization or protocol change; output stays bit-identical.

### The problem

`and_reduction::prove` only ever saw the already-padded column length (`checked_log_2(a.len())`). BINIUS-364 added `ConstraintSystem::n_and_constraints()`, the true non-padded AND count, but it was never threaded into the reduction — so:

- The round-1 message (`univariate_round_message_extension_domain`) had to *rediscover* padding windows at runtime via a per-window `.all() == Word::ZERO` scan (BINIUS-340).
- The fold step (`fold_bitand_operands`) had no skip logic at all — it unconditionally ran the Method-of-Four-Russians lookup on every chunk, real or padding.

### The change

Thread an explicit `n_real_rows: usize` (the exact row index where real rows end and zero padding begins) from the two `and_reduction::prove` call sites down into `OblongZerocheckProver::new`, and from there into both consumers:

- **Round-1 message**: the runtime all-zero scan is gone, replaced by a direct index check (`window_start_row >= n_real_rows`) — a whole window strictly past the boundary is skipped without reading its words. A window that straddles the boundary still holds real rows and runs the full computation, unchanged.
- **Fold step**: the same boundary check now skips whole `P::WIDTH` chunks (and the short tail) entirely past `n_real_rows`, writing the zero element directly instead of paying the bytewise lookup on words already known to be zero.

Call sites:
- `crates/prover/src/prove.rs` (single-instance): `cs.n_and_constraints()`.
- `crates/m4-prover/src/prove.rs` (M4 batch): `cs.n_and_constraints() << table.log_instances()`, since M4 lays columns out constraint-major (`row = constraint_index * n_instances + instance`) and pads only the flattened tail — confirmed against `operand_witness.rs`'s `build_operation_witness`.

### Why output stays identical

The padding contract already guarantees every row from `n_real_rows` onward is `Word::ZERO` in both operands. Folding a zero word (via the bytewise lookup transform) always produces the zero field element regardless of the weight vector, and `C = A & B` derived from two zero words is also zero — so writing the zero element directly for a known-padding chunk is exactly what the unskipped computation would have produced anyway. `two_proofs_from_one_prover_are_byte_identical` and `test_prove_verify_non_power_of_two_constraint_counts` (both pre-existing) pass unchanged, and the new tests below pin this explicitly.

### Tests

- `sumcheck_round_messages.rs`: added `test_first_round_message_with_boundary_inside_a_window`, a boundary landing 40 words into a window (not aligned to the 128-word window size) — the shape that matters for real Keccak/SHA-256-sized batches. The two pre-existing tests now pass `n_real_rows` explicitly (dense / window-aligned boundary).
- `fold_word.rs`: added `test_fold_bitand_operands_skips_padding_without_changing_output`, pinning the skip path (boundary inside a chunk, not aligned to `P::WIDTH`) against running the same input with no boundary at all — the two must agree exactly, since the "padding" words are truly zero either way.
- `crates/m4-prover/src/operand_witness.rs`: the three existing `and_reduction::prove` test call sites now pass the real row count (`and_constraints.len() << table.log_instances()`).

### Perf impact

Criterion bench (`crates/prover/benches/and_reduction.rs`), added a `(40% zero padding)` variant of the fold-step bench matching the existing round-message padding bench (`log_words = 21`, 3/5 real, 2/5 zero — the Keccak/SHA-256-shaped case the issue calls out):

| bench | time |
| --- | ---: |
| `univariate fold 2^21` (dense, this branch) | 102.98 ms |
| `univariate fold 2^21 (40% zero padding)` (this branch) | 88.90 ms |

Comparing dense vs. 40%-padded **within this branch** isolates the skip's effect cleanly: **~13.7% faster** on this shape. I also ran the same dense bench against a `main`-based scratch workspace baseline (121.51 ms) — the ~15% gap there is *not* attributable to this change (the dense case never takes the skip path, so it should be identical to `main`); it's noise between separate `cargo bench` invocations on this machine, not a real regression-then-fix. The reliable number is the same-branch dense-vs-padded comparison above.

I did not measure end-to-end example prove time; the fold step is one part of the BitAnd phase, and its share of total prove time varies by circuit padding fraction (see BINIUS-386's per-circuit padding table for how much this varies — `hashsign` pads ~44%, several others ~6-20%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)