### PR TITLE
fix(core): bound the declared segment sizes in validate

### DIFF
--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -99,6 +99,28 @@ impl ConstraintSystem {
 	/// Serialization format version for compatibility checking
 	pub const SERIALIZATION_VERSION: u32 = 10;
 
+	/// The maximum number of values [`Self::validate`] accepts in the inout or private segment.
+	///
+	/// These two counts are declared rather than derived: unlike [`Self::constants`], `n_inout`
+	/// and `n_private` serialize as plain numbers with no backing data, so a payload can claim a
+	/// segment of any size while staying small. `ZKVerifier::setup`, in the binius-verifier
+	/// crate, allocates a word per inout value before reaching anything that would reveal the
+	/// claim as false — so a single four-byte edit to an honest payload is enough to ask for
+	/// gigabytes. Both it and `Verifier::setup` call [`Self::validate`] first, which is what puts
+	/// this bound ahead of the allocation.
+	///
+	/// This is a policy limit rather than a structural one: 2^26 values is 512 MiB per segment.
+	/// The largest circuit in the examples is zklogin, at 302 inout and 259,584 private values,
+	/// so the headroom is 258x on the binding one. It is deliberately sized against the largest
+	/// *intended* circuit rather than the largest present one — a statement aggregating a few
+	/// hundred zklogin-scale proofs approaches the limit, and rejecting a legitimate circuit
+	/// would be worse than the allocation this prevents.
+	///
+	/// Raising it is fine. Note what the ceiling buys, though: it converts an unbounded
+	/// allocation into a bounded one, and 512 MiB per request is still worth pairing with a
+	/// payload-size limit wherever constraint systems arrive from unauthenticated peers.
+	pub const MAX_VALUES_PER_SEGMENT: usize = 1 << 26;
+
 	/// Returns the number of constants.
 	pub const fn n_const(&self) -> usize {
 		self.constants.len()
@@ -202,6 +224,7 @@ impl ConstraintSystem {
 	///
 	/// Specifically checks that:
 	///
+	/// - the declared segment sizes are within [`Self::MAX_VALUES_PER_SEGMENT`].
 	/// - every [shifted value index][super::ShiftedValueIndex] is canonical.
 	/// - referenced value indices are within their segment.
 	/// - constraints do not reference scratch values.
@@ -210,6 +233,16 @@ impl ConstraintSystem {
 	/// - a genuine shift pair does not collapse to one shift, nor clear the word.
 	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
 		tracing::debug_span!("Validating constraint system");
+
+		// Bound the two declared counts before anything reads them; see
+		// `MAX_VALUES_PER_SEGMENT`. The constants need no bound of their own: they are backed by
+		// the words in the payload, so claiming more of them costs the sender proportionally.
+		for segment in [ValueSegment::InOut, ValueSegment::Private] {
+			let len = self.segment_len(segment);
+			if len > Self::MAX_VALUES_PER_SEGMENT {
+				return Err(ConstraintSystemError::SegmentTooLarge { segment, len });
+			}
+		}
 
 		self.validate_constraints(
 			&self.zero_constraints,
@@ -1352,5 +1385,48 @@ mod tests {
 			}
 			other => panic!("wrong error: {other:?}"),
 		}
+	}
+
+	/// `n_inout` is declared, not derived: it serializes as a plain number with no backing data.
+	/// `ZKVerifier::setup` allocates a word per inout value, so a payload of a few hundred bytes
+	/// could otherwise demand gigabytes.
+	#[test]
+	fn an_oversized_inout_segment_is_rejected() {
+		let mut cs = test_shape();
+		cs.n_inout = ConstraintSystem::MAX_VALUES_PER_SEGMENT + 1;
+
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::SegmentTooLarge {
+				segment: ValueSegment::InOut,
+				..
+			})
+		));
+	}
+
+	#[test]
+	fn an_oversized_private_segment_is_rejected() {
+		let mut cs = test_shape();
+		cs.n_private = ConstraintSystem::MAX_VALUES_PER_SEGMENT + 1;
+
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::SegmentTooLarge {
+				segment: ValueSegment::Private,
+				..
+			})
+		));
+	}
+
+	/// The bound is inclusive, so a system sitting exactly on it still validates. Pinned
+	/// separately because an off-by-one here would reject the largest legitimate circuit rather
+	/// than only crafted ones.
+	#[test]
+	fn segments_exactly_at_the_cap_are_accepted() {
+		let mut cs = test_shape();
+		cs.n_inout = ConstraintSystem::MAX_VALUES_PER_SEGMENT;
+		cs.n_private = ConstraintSystem::MAX_VALUES_PER_SEGMENT;
+
+		assert!(cs.validate().is_ok());
 	}
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -4,12 +4,17 @@
 
 use std::fmt;
 
-use crate::constraint_system::{Composition, ConstraintKind, ValueSegment};
+use crate::constraint_system::{Composition, ConstraintKind, ConstraintSystem, ValueSegment};
 
 /// Constraint system related error.
 #[allow(missing_docs)] // errors are self-documenting
 #[derive(Debug, thiserror::Error)]
 pub enum ConstraintSystemError {
+	#[error(
+		"the {segment:?} segment declares {len} values, over the maximum of {}",
+		ConstraintSystem::MAX_VALUES_PER_SEGMENT
+	)]
+	SegmentTooLarge { segment: ValueSegment, len: usize },
 	#[error("{constraint_kind} #{constraint_index} operand {operand_name} is malformed: {source}")]
 	ConstraintOperand {
 		constraint_kind: ConstraintKind,


### PR DESCRIPTION
`n_inout` and `n_private` serialize as plain numbers with no backing data, so a serialized constraint system can declare a segment of any size while staying tiny. `ZKVerifier::setup` allocates `2^log_public_words` words from that claim at `zk_config.rs:79`, before reaching anything that would contradict it.

Two four-byte edits to an honest 130-byte payload — `n_inout` and `n_private` — produce a system where `validate()` returns `Ok` with `log_public_words = 20`. The same two fields at 2^30 ask setup for 8 GiB, and since `usize` serializes as a `u32` the ceiling is around 34 GB.

`ZKVerifier` and `ZKProver` both implement `DeserializeBytes`, so this is reachable wherever either is rebuilt from bytes that did not come from a trusted peer.

**This is availability, not soundness.** No invalid proof is accepted and nothing cryptographic changes.

### Why the existing checks miss it

The three checks in `validate_shape` are all relative: power-of-two, `>= MIN_WORDS_PER_SEGMENT`, and `hidden >= public`. A system claiming 2^30 of each satisfies all three.

Two existing behaviours do constrain the shape of this, which is worth recording because they explain where the gap actually is:

- Inflating the public segment alone fails on `HiddenSegmentTooShort`, so both segments have to move together.
- Editing the *pad* counts trips `PaddingValueIndex`, since the shape check does verify that constraints avoid padding.

It is specifically the real counts that were unconstrained — growing them just looks like more public inputs, which nothing had reason to reject.

### The fix

Cap both segments in `validate_shape`, so the bound applies wherever `validate` is already called rather than at a single call site. `ZKVerifier::setup` runs it at `zk_config.rs:69`, ahead of the allocation.

This does **not** reach the M4 or standalone Spartan setups: M4 does not call this `validate`, and the Spartan verifier takes a different `ConstraintSystem` type. Neither implements `DeserializeBytes` today, so neither is fed untrusted bytes — but giving either one a deserialization path later would need its own bound.

### On the constant

2^26 words is 512 MiB per segment. zklogin, the largest circuit in the examples, has a 2^11 public and 2^18 hidden segment, so there is 256x headroom on the binding one.

It is deliberately sized against the largest *intended* circuit rather than the largest present one: a statement aggregating a few hundred zklogin-scale proofs approaches the limit, and rejecting a legitimate circuit would be worse than the allocation this prevents. If you have a target circuit size in mind that I have undershot, say so and I will raise it.

Worth being explicit that this converts an unbounded allocation into a bounded one rather than solving the problem outright — 512 MiB per request still wants a payload-size limit wherever constraint systems arrive from unauthenticated peers.

### Verification

- `cargo test --workspace`: **1490 passed, 0 failed** — identical to the baseline on `main`, so the cap rejects nothing `main` accepts
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo +nightly-2026-07-01 fmt --check`: clean

Three tests are added. One pins the *inclusive* boundary specifically, since an off-by-one there would reject the largest legitimate circuit rather than only crafted ones.
