### PR TITLE
BINIUS-410: parallelize the shift evaluation, which dominates verification

### DIFF
--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -8,8 +8,14 @@ use binius_field::{
 	BinaryField, FieldOps, WideMul,
 	util::{FieldFn, powers},
 };
-use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
-use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_math::multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars};
+use binius_utils::{
+	checked_arithmetics::log2_ceil_usize,
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
+};
 
 use super::SHIFT_COUNT;
 
@@ -196,7 +202,9 @@ where
 	fn call_native(&self, input: &[F]) -> F {
 		let (r_x_prime, lambda, shift_scalars, r_y_tensor) = self.split_input(input);
 
-		let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
+		// The packed expansion threads the tensor's multiplications.
+		// It applies over the base field, which is its own single-element packing.
+		let r_x_prime_tensor = eq_ind_partial_eval::<F>(r_x_prime);
 		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, *lambda, ARITY);
 
 		// One unreduced wide product per constraint. The constraints partition cleanly across
@@ -204,10 +212,14 @@ where
 		// per-task accumulator. The single final reduction is `F`-linear. The tensor covers the
 		// padded constraint count, so the zip stops at the last real constraint; the padding rows
 		// have no operand terms and contribute nothing.
+		//
+		// A constraint names only a handful of terms.
+		// So a minimum task size keeps each task above rayon's own handoff cost.
 		let eval = self
 			.constraints
 			.par_iter()
-			.zip(r_x_prime_tensor.par_iter())
+			.zip(r_x_prime_tensor.as_ref().par_iter())
+			.with_min_task(WorkPerItem::FieldMuls)
 			.map(|(constraint, &r_x_prime_entry)| {
 				let mut constraint_eval = F::ZERO;
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -17,7 +17,8 @@ use binius_math::{
 	inner_product::inner_product_scalars,
 	line::extrapolate_line,
 	multilinear::eq::{
-		eq_ind_partial_eval_scalars, eq_ind_zero, eq_one_var, scaled_eq_ind_partial_eval_scalars,
+		eq_ind_partial_eval_scalars, eq_ind_zero, eq_one_var, scaled_eq_ind_partial_eval,
+		scaled_eq_ind_partial_eval_scalars,
 	},
 	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
@@ -433,7 +434,16 @@ impl MonsterEvalFn<'_> {
 	///
 	/// The Zero and BitAnd inputs are always present; the IntMul and BinMul inputs are `None` when
 	/// that operation has no constraints and is skipped.
-	fn operation_inputs<E: FieldOps>(&self, vals: &[E]) -> OperationInputs<E> {
+	///
+	/// The scaled word-index expansion is supplied by the caller:
+	///
+	/// - That axis spans the whole trace, so it is the expansion worth threading.
+	/// - Only a concrete field element can cross threads, so the generic path stays serial.
+	fn operation_inputs<E: FieldOps>(
+		&self,
+		vals: &[E],
+		scaled_expand: impl Fn(&[E], E) -> Vec<E>,
+	) -> OperationInputs<E> {
 		// Each operation's `r_x'` section is as long as its reduction has constraint variables, and
 		// [`OperationEvalFn::split_input`] re-derives that length from the constraint count alone.
 		// The two derivations must agree or both sides mis-split the same input. An absent IntMul
@@ -497,9 +507,8 @@ impl MonsterEvalFn<'_> {
 
 		let public_scale =
 			eq_one_var(r_segment.clone(), E::zero()) * eq_ind_zero(&r_y_v[log_public_words..]);
-		let public_tensor =
-			scaled_eq_ind_partial_eval_scalars(&r_y_v[..log_public_words], public_scale);
-		let hidden_tensor = scaled_eq_ind_partial_eval_scalars(r_y_v, r_segment);
+		let public_tensor = scaled_expand(&r_y_v[..log_public_words], public_scale);
+		let hidden_tensor = scaled_expand(r_y_v, r_segment);
 
 		// Cut the two indicators into one run per value segment, which is what an operand term's
 		// `(segment, index)` pair reads against. The constants lead the public indicator and the
@@ -575,7 +584,7 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_> {
 			bitand: bitand_input,
 			intmul: intmul_input,
 			binmul: binmul_input,
-		} = self.operation_inputs(vals);
+		} = self.operation_inputs(vals, scaled_eq_ind_partial_eval_scalars);
 		let cs = &self.constraint_system;
 
 		let zero =
@@ -610,7 +619,11 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_> {
 			bitand: bitand_input,
 			intmul: intmul_input,
 			binmul: binmul_input,
-		} = self.operation_inputs(vals);
+		} = self.operation_inputs(vals, |point, scale| {
+			// The packed expansion threads the tensor's multiplications.
+			// It applies over the base field, which is its own single-element packing.
+			scaled_eq_ind_partial_eval::<F>(point, scale).take_data()
+		});
 		let cs = &self.constraint_system;
 
 		let zero =


### PR DESCRIPTION
Closes [BINIUS-410](https://linear.app/jimpo/issue/BINIUS-410).

Accelerates the verifier phase that dominates XMSS verification.
No protocol change, no transcript change — proofs are byte-identical.

### The problem

One phase accounts for ~90% of XMSS verification: `shift::check_eval`, which re-derives the circuit's wiring from the constraint list.
Everything else — the AND check, the shift reduction, the PCS opening — is tens of microseconds.

Two parts of that phase leave work on the table:

- the equality-indicator tensors are built with the scalar routine, a plain sequential loop, even where the element type is a concrete field
- the constraint term loop is threaded, but one constraint names only a handful of terms, so rayon splits it below its own handoff cost

### The idea

The packed expansion is already threaded, and a base field element is its own single-element packing.
So the native path can simply call it instead of the scalar one — no new function.

The constraint term loop gets a minimum task size, so each worker receives real work.

### Benchmark

`hashsign` (XMSS), the dominant phase, median of 9 verifications:

| | main | this change |
|---|---|---|
| verify public-input phase | 6.72 ms | 6.45 ms |

### Scope

- the native monster-evaluation path takes the packed equality-indicator expansion
- the constraint term loop takes a minimum task size
- the generic path is untouched: a symbolic element cannot cross threads, so it keeps the scalar expansion

### What this deliberately leaves open

The term loop is the bulk of the phase and is already parallel, so speeding it up further is a data-layout question rather than a threading one.

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-math -p binius-verifier -p binius-prover --all-targets` with `-D warnings` — clean
- nightly `fmt --all --check` — clean
- `binius-math`, `binius-verifier` and `binius-prover` test suites pass, with and without `--features rayon`

**Regression check:** the `hashsign` and `sha256` proofs are byte-identical to `main` (same SHA-256 digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
