### PR TITLE
BINIUS-442: re-key the prover and verifier shift tables on the shift pair

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -450,6 +450,29 @@ impl Shift {
 		!self.is_identity() || matches!(self.variant, ShiftVariant::Sll)
 	}
 
+	/// Where this shift sits in the enumeration of every `(variant, amount)` spelling.
+	///
+	/// The variant indexes runs of `Word::BITS`, and the amount indexes within a run:
+	///
+	/// ```text
+	///     [ Sll 0 .. Sll 63 | Slr 0 .. Slr 63 | ... | Rotr32 0 .. Rotr32 63 ]
+	///       0          63     64         127          448             511
+	/// ```
+	///
+	/// A reduction keying one table entry per spelling addresses it by this index.
+	/// So does the prover's multilinear over the same axis pair, which is what lets the two agree.
+	///
+	/// # Panics
+	///
+	/// Panics if the amount is not below `Word::BITS`.
+	/// Above it a shift would index into the next variant's run, sharing an entry with another
+	/// shift.
+	#[inline]
+	pub const fn index(self) -> usize {
+		assert!((self.amount as usize) < Word::BITS, "shift amount is not below the word width");
+		self.variant as usize * Word::BITS + self.amount as usize
+	}
+
 	/// Applies this shift to a word and returns the result.
 	///
 	/// # Performance
@@ -1282,6 +1305,42 @@ mod tests {
 			deserialize_amount(ShiftVariant::Sll, 63).unwrap(),
 			ShiftedValueIndex::sll(ValueIndex::constant(0), 63)
 		);
+	}
+
+	#[test]
+	fn index_places_a_shift_by_variant_then_amount() {
+		// Runs of `Word::BITS` amounts, one run per variant. A table indexed the other way round
+		// would weight a shifted word by another shift's scalar.
+		//
+		//     [ Sll 0 .. Sll 63 | Slr 0 .. Slr 63 | ... ]
+		//       0          63     64         127
+		assert_eq!(Shift::IDENTITY.index(), 0);
+		assert_eq!(Shift::sll(5).index(), 5);
+		assert_eq!(Shift::srl(0).index(), Word::BITS);
+		assert_eq!(Shift::srl(3).index(), Word::BITS + 3);
+		assert_eq!(Shift::rotr32(31).index(), ShiftVariant::Rotr32 as usize * Word::BITS + 31);
+
+		// Every spelling lands in its own slot, inside the enumeration.
+		let mut seen = vec![false; ShiftVariant::ALL.len() * Word::BITS];
+		for variant in ShiftVariant::ALL {
+			for amount in 0..variant.max_amount() {
+				let index = Shift::new(variant, amount).index();
+				assert!(!seen[index], "{variant:?} {amount} shares an index");
+				seen[index] = true;
+			}
+		}
+	}
+
+	// An amount at the word width would index into the next variant's run, aliasing another shift.
+	// The fields are public, so a hand-built shift can carry one even though `new` rejects it.
+	#[test]
+	#[should_panic(expected = "shift amount is not below the word width")]
+	fn index_rejects_an_amount_at_the_word_width() {
+		let shift = Shift {
+			variant: ShiftVariant::Sll,
+			amount: Word::BITS as u8,
+		};
+		let _ = shift.index();
 	}
 
 	#[test]

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -1,36 +1,20 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, mem, ops::Range};
+use std::{collections::BTreeSet, iter, mem, ops::Range};
 
 use binius_core::{
 	ShiftVariant,
-	constraint_system::{ConstraintSystem, InoutSegment, Operand},
-	word::Word,
+	constraint_system::{ConstraintSystem, InoutSegment, Operand, Shift},
 };
 use binius_field::{Field, WideMul};
 use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
 	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
 };
-use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 use bytes::{Buf, BufMut};
 
-use super::PreparedOperatorData;
-
-/// The number of shifts a key could name, over which [`shift_index`] is dense.
-const SHIFT_PAIR_COUNT: usize = SHIFT_VARIANT_COUNT * Word::BITS;
-
-/// Places a shift in the full space of `SHIFT_PAIR_COUNT` shifts, for the tables that build and
-/// invert a [`DenseShiftEncoding`].
-///
-/// # Panics
-///
-/// Panics if the shift amount is not below `Word::BITS`.
-fn shift_index((variant, amount): (ShiftVariant, u8)) -> usize {
-	assert!((amount as usize) < Word::BITS, "shift amount {amount} out of range");
-	variant as usize * Word::BITS + amount as usize
-}
+use super::{DOUBLE_SHIFT_UNSUPPORTED, PreparedOperatorData};
 
 /// Represents the type of operations handled by the shift protocol.
 ///
@@ -55,34 +39,48 @@ pub enum Operation {
 	BinMul,
 }
 
-/// A dense re-encoding of the shifts occurring in a key segment.
+/// A dense re-encoding of the shift sequences occurring in a key segment.
 ///
-/// A key names one of `SHIFT_PAIR_COUNT` shifts, of which a constraint system typically uses a few
-/// dozen. Encoding the shifts a segment does use as a contiguous range lets the prover size its
-/// per-shift tables by the shifts actually used rather than by the whole space.
+/// A key names a sequence of two shifts, each slot drawn from
+/// [`SHIFT_COUNT`](binius_verifier::protocols::shift::SHIFT_COUNT) spellings.
+///
+/// - The sequence space is therefore `SHIFT_COUNT^2` = 262,144 entries.
+/// - A constraint system uses a few dozen of them.
+/// - So the sequences a segment does use are re-encoded as a contiguous range.
+///
+/// A per-sequence table is then sized by the sequences present, not by the space they come from.
+/// At most one sequence exists per shifted value index, which is what it has always been.
+/// Only the space grew, which is why a sequence is located by search rather than by a lookup table.
 #[derive(Debug, Clone, Default)]
 pub struct DenseShiftEncoding {
-	/// The shift each dense index encodes, ordered by variant and then by amount.
-	shifts: Vec<(ShiftVariant, u8)>,
+	/// The shift sequence each dense index encodes, in ascending sequence order.
+	///
+	/// Invariant: sorted and distinct, which is what makes [`Self::dense_idx`] a binary search and
+	/// what a deserialized encoding is checked for.
+	shifts: Vec<[Shift; 2]>,
 }
 
 impl DenseShiftEncoding {
-	/// Builds the encoding of the shifts in an iterator, which need be neither sorted nor distinct.
+	/// Builds the encoding of the shift sequences in an iterator, neither sorted nor distinct.
 	///
 	/// # Panics
 	///
-	/// Panics if any shift amount is not below `Word::BITS`.
-	fn new(shifts: impl IntoIterator<Item = (ShiftVariant, u8)>) -> Self {
-		let mut used = [None; SHIFT_PAIR_COUNT];
-		for shift in shifts {
-			used[shift_index(shift)] = Some(shift);
-		}
+	/// Panics if the sequences do not fit the `u16` a [`Key`] addresses them with.
+	/// That needs more than 65,536 distinct sequences in one segment, which no real system reaches.
+	fn new(shifts: impl IntoIterator<Item = [Shift; 2]>) -> Self {
+		// A sorted set dedupes and orders in one pass, over the sequences present.
+		let shifts = shifts.into_iter().collect::<BTreeSet<_>>();
+		assert!(
+			shifts.len() <= u16::MAX as usize + 1,
+			"a key segment uses {} distinct shift sequences, more than the u16 dense index addresses",
+			shifts.len()
+		);
 		Self {
-			shifts: used.into_iter().flatten().collect(),
+			shifts: shifts.into_iter().collect(),
 		}
 	}
 
-	/// The number of distinct shifts the segment uses.
+	/// The number of distinct shift sequences the segment uses.
 	pub const fn len(&self) -> usize {
 		self.shifts.len()
 	}
@@ -92,50 +90,67 @@ impl DenseShiftEncoding {
 		self.shifts.is_empty()
 	}
 
-	/// The shift a dense index encodes.
+	/// The shift sequence a dense index encodes.
 	///
 	/// # Panics
 	///
 	/// Panics if the dense index is not below [`Self::len`].
 	#[inline]
-	pub fn decode(&self, dense_idx: usize) -> (ShiftVariant, u8) {
+	pub fn decode(&self, dense_idx: usize) -> [Shift; 2] {
 		self.shifts[dense_idx]
 	}
 
-	/// The shifts the segment uses, in dense index order.
-	pub fn iter(&self) -> impl Iterator<Item = (ShiftVariant, u8)> + '_ {
+	/// The shift sequences the segment uses, in dense index order.
+	pub fn iter(&self) -> impl Iterator<Item = [Shift; 2]> + '_ {
 		self.shifts.iter().copied()
 	}
 
-	/// Where every shift the segment uses sits in the full space of `SHIFT_PAIR_COUNT` shifts, in
-	/// dense index order.
+	/// Where the inner shift of every sequence the segment uses sits in the space one slot spans,
+	/// in dense index order.
 	///
-	/// The indices are strictly increasing, which is what lets two segments' encodings merge.
+	/// The reduction's row axis is one shift slot wide, so a sequence is placed by its inner shift.
+	/// The outer slot holds the identity on every sequence, so distinct sequences have distinct
+	/// inner shifts and the indices come out strictly increasing.
+	/// That is what lets two segments' encodings merge.
+	///
+	/// # Panics
+	///
+	/// Panics in debug builds if a sequence carries a shift outside its inner slot.
 	pub fn shift_indices(&self) -> impl Iterator<Item = usize> + '_ {
-		self.shifts.iter().map(|&shift| shift_index(shift))
+		self.shifts.iter().map(|&[inner, outer]| {
+			debug_assert!(outer.is_identity(), "{DOUBLE_SHIFT_UNSUPPORTED}");
+			inner.index()
+		})
 	}
 
-	/// The dense index of every shift, for lookup while the keys are built.
+	/// The dense index of one shift sequence, for lookup while the keys are built.
 	///
-	/// The entries of the shifts the segment does not use are meaningless.
-	fn inverse(&self) -> [u16; SHIFT_PAIR_COUNT] {
-		let mut inverse = [0u16; SHIFT_PAIR_COUNT];
-		for (dense_idx, &shift) in self.shifts.iter().enumerate() {
-			inverse[shift_index(shift)] = dense_idx as u16;
-		}
-		inverse
+	/// The sequences are sorted, so this is a binary search over the ones the segment uses.
+	/// A lookup table over the whole sequence space would instead be 262,144 entries wide.
+	///
+	/// # Panics
+	///
+	/// Panics if the sequence is not one this encoding covers.
+	fn dense_idx(&self, shift_seq: [Shift; 2]) -> u16 {
+		let index = self
+			.shifts
+			.binary_search(&shift_seq)
+			.expect("the encoding covers every shift sequence its segment's keys name");
+		// `new` bounds the length, so every index it yields fits.
+		index as u16
 	}
 }
 
-/// A `Key` specifies an operation, a shift, and a range of constraint indices.
+/// A `Key` specifies an operation, a shift sequence, and a range of constraint indices.
 ///
 /// The key identifies a 2D matrix of constraint information: the constraints of one operation in
-/// which one witness word participates, shifted by one shift variant and one shift amount. Every
-/// `Key` corresponds to a unique word (not referenced in the `Key`). The `range` specifies a range
-/// within a list of constraint indices, those constraint indices in which the word participates
-/// with respect to the key. If constraint index `i` is among the values within the range, that
-/// means the word participates in constraint `i` of operation `operation`, as the operand that
-/// constraint index names, shifted by the variant and amount the key's shift index encodes.
+/// which one witness word participates, shifted by one sequence of two shifts.
+/// Every `Key` corresponds to a unique word (not referenced in the `Key`).
+/// The `range` specifies a range within a list of constraint indices, those constraint indices in
+/// which the word participates with respect to the key.
+/// If constraint index `i` is among the values within the range, that means the word participates
+/// in constraint `i` of operation `operation`, as the operand that constraint index names, shifted
+/// by the sequence the key's shift index encodes.
 ///
 /// # Relationship to Formal Specification
 ///
@@ -147,15 +162,15 @@ impl DenseShiftEncoding {
 /// # Structure
 ///
 /// - **Operation**: Constraint type (ZERO, AND, IMUL or BMUL)
-/// - **Dense shift index**: The shift variant and shift amount, as encoded by the segment
+/// - **Dense shift index**: The shift sequence, as encoded by the segment
 /// - **Range**: Constraint indices where this shifted word appears
 ///
 /// # Shift index encoding
 ///
 /// The shift index is an index into the [`DenseShiftEncoding`] of the [`KeySegment`] holding the
-/// key, which decodes it back to the shift variant and shift amount. Keys index the shifts their
-/// segment actually uses rather than the whole shift space, so a table the prover builds per shift
-/// is proportional to the former.
+/// key, which decodes it back to the sequence's two shifts.
+/// Keys index the sequences their segment actually uses rather than the whole sequence space.
+/// A table the prover builds per sequence is therefore proportional to the former.
 ///
 /// # Performance Considerations
 ///
@@ -275,7 +290,7 @@ impl Key {
 /// - **key_ranges**: For every word of the segment there is a range of keys within the `keys`
 ///   vector
 /// - **constraint_indices**: Flattened list of constraint indices referenced by the keys
-/// - **dense_shift_enc**: The `(shift variant, shift amount)` pairs the segment's keys name
+/// - **dense_shift_enc**: The shift sequences the segment's keys name
 ///
 /// # Organization
 ///
@@ -342,8 +357,8 @@ impl KeyCollection {
 /// rather than a range that indexes into the flattened `constraint_indices` vector.
 /// During construction, these indices are later flattened to create the final `Key`.
 struct BuilderKey {
-	/// The `(shift variant, shift amount)` of the shifted value the key references.
-	pub shift: (ShiftVariant, u8),
+	/// The shift sequence of the shifted value the key references, inner shift first.
+	pub shift_seq: [Shift; 2],
 	pub operation: Operation,
 	pub constraint_indices: Vec<ConstraintIndex>,
 }
@@ -367,31 +382,24 @@ fn update_with_operand(
 	for (constraint_idx, operand_value) in operand_values.enumerate() {
 		// Each operand value is a Vec<ShiftedValueIndex> - multiple shifted word references
 		for term in operand_value.as_ref() {
-			// The reduction still folds a single shift per key, so the outer slot must be the
-			// identity. Widening the reduction to the pair is what lifts this.
-			debug_assert!(
-				!term.is_doubly_shifted(),
-				"the two-phase shift reduction reads only the inner shift of a term"
-			);
-
 			// The lists are indexed by word position, so resolve the term's segment-relative
 			// index against the segment starts.
 			let builder_keys = &mut builder_key_lists[cs.word_offset(term.value_index)];
-			let shift = (term.inner().variant, term.inner().amount);
+			let shift_seq = term.shift_seq;
 
-			// Find existing builder key or create a new one for this (operation, shift) pair
+			// Find existing builder key or create a new one for this (operation, sequence) pair
 			let constraint_index = ConstraintIndex {
 				operand_index: operand_index as u8,
 				constraint_index: constraint_idx as u32,
 			};
 			if let Some(builder_key) = builder_keys
 				.iter_mut()
-				.find(|key| key.shift == shift && key.operation == operation)
+				.find(|key| key.shift_seq == shift_seq && key.operation == operation)
 			{
 				builder_key.constraint_indices.push(constraint_index);
 			} else {
 				builder_keys.push(BuilderKey {
-					shift,
+					shift_seq,
 					operation,
 					constraint_indices: vec![constraint_index],
 				});
@@ -461,9 +469,8 @@ fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 		builder_key_lists
 			.iter()
 			.flatten()
-			.map(|builder_key| builder_key.shift),
+			.map(|builder_key| builder_key.shift_seq),
 	);
-	let dense_shift_idx = dense_shift_enc.inverse();
 
 	let key_ranges = builder_key_lists
 		.iter()
@@ -479,7 +486,7 @@ fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 
 	for builder_key in builder_key_lists.into_iter().flatten() {
 		let BuilderKey {
-			shift,
+			shift_seq,
 			operation,
 			constraint_indices: mut builder_constraint_indices,
 		} = builder_key;
@@ -491,7 +498,7 @@ fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 		constraint_indices.extend(builder_constraint_indices);
 		let end = constraint_indices.len() as u32;
 		keys.push(Key {
-			dense_shift_idx: dense_shift_idx[shift_index(shift)],
+			dense_shift_idx: dense_shift_enc.dense_idx(shift_seq),
 			operation,
 			range: start..end,
 		});
@@ -579,9 +586,11 @@ impl DeserializeBytes for ConstraintIndex {
 impl SerializeBytes for DenseShiftEncoding {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		(self.shifts.len() as u32).serialize(&mut write_buf)?;
-		for (variant, amount) in &self.shifts {
-			variant.serialize(&mut write_buf)?;
-			amount.serialize(&mut write_buf)?;
+		for shift_seq in &self.shifts {
+			for shift in shift_seq {
+				shift.variant.serialize(&mut write_buf)?;
+				shift.amount.serialize(&mut write_buf)?;
+			}
 		}
 		Ok(())
 	}
@@ -592,21 +601,31 @@ impl DeserializeBytes for DenseShiftEncoding {
 		let len = u32::deserialize(&mut read_buf)? as usize;
 		let mut shifts = Vec::with_capacity(len);
 		for _ in 0..len {
-			let variant = ShiftVariant::deserialize(&mut read_buf)?;
-			let amount = u8::deserialize(&mut read_buf)?;
-			shifts.push((variant, amount));
+			let mut shift_seq = [Shift::IDENTITY; 2];
+			for shift in &mut shift_seq {
+				let variant = ShiftVariant::deserialize(&mut read_buf)?;
+				let amount = u8::deserialize(&mut read_buf)?;
+				*shift = Shift { variant, amount };
+			}
+			shifts.push(shift_seq);
 		}
 
-		// A dense index is only meaningful against a list of distinct shifts, which the ordering
-		// this writes them in also gives.
+		// Half-word (*32) variants cap at 32, full-width ones at 64.
+		// An amount past its variant's bound denotes no shift at all.
 		let amounts_in_range = shifts
 			.iter()
-			.all(|&(_, amount)| (amount as usize) < Word::BITS);
-		if !amounts_in_range
-			|| !shifts
-				.windows(2)
-				.all(|shifts| shift_index(shifts[0]) < shift_index(shifts[1]))
-		{
+			.flatten()
+			.all(|shift| (shift.amount as usize) < shift.variant.max_amount());
+		// A dense index is only meaningful against a list of distinct sequences, which the strictly
+		// ascending order this writes them in also gives.
+		let strictly_ascending = shifts.windows(2).all(|window| window[0] < window[1]);
+		if !amounts_in_range || !strictly_ascending {
+			return Err(SerializationError::InvalidConstruction {
+				name: "DenseShiftEncoding::shifts",
+			});
+		}
+		// A key addresses a sequence with a `u16`, so a longer list could not be indexed.
+		if len > u16::MAX as usize + 1 {
 			return Err(SerializationError::InvalidConstruction {
 				name: "DenseShiftEncoding::shifts",
 			});
@@ -687,9 +706,13 @@ impl DeserializeBytes for KeyCollection {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::constraint_system::{AndConstraint, ShiftedValueIndex, ValueIndex};
+	use binius_core::{
+		constraint_system::{AndConstraint, ShiftedValueIndex, ValueIndex},
+		word::Word,
+	};
 	use binius_field::{BinaryField128bGhash, Field};
 	use binius_math::FieldBuffer;
+	use binius_verifier::protocols::shift::SHIFT_COUNT;
 
 	use super::*;
 
@@ -699,10 +722,16 @@ mod tests {
 		F::new(value)
 	}
 
+	/// A shift sequence carrying one shift, which the canonical form places in the inner slot.
+	fn single(shift: Shift) -> [Shift; 2] {
+		[shift, Shift::IDENTITY]
+	}
+
 	/// A constraint system with a handful of distinct shifts, differing between the two segments.
 	///
-	/// The public segment references `(Sll, 0)` and `(Slr, 3)`; the hidden one references
-	/// `(Sll, 0)`, `(Sar, 7)` and `(Rotr, 1)`.
+	/// The public segment references `Sll(0)` and `Slr(3)`.
+	/// The hidden one references `Sll(0)`, `Sar(7)` and `Rotr(1)`.
+	/// Every outer slot is the identity, so the sequences sort by their inner shift alone.
 	fn shifted_constraint_system() -> ConstraintSystem {
 		// The system has four constants and no inout values, so the public segment is the
 		// constants and the hidden one is the private values.
@@ -730,33 +759,83 @@ mod tests {
 	}
 
 	#[test]
-	fn dense_shift_encoding_covers_the_pairs_its_segment_uses() {
+	fn dense_shift_encoding_covers_the_sequences_its_segment_uses() {
 		let key_collection =
 			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
 
-		let public_pairs = key_collection
+		let public_sequences = key_collection
 			.public
 			.dense_shift_enc
 			.iter()
 			.collect::<Vec<_>>();
-		assert_eq!(public_pairs, [(ShiftVariant::Sll, 0), (ShiftVariant::Slr, 3)]);
+		assert_eq!(public_sequences, [single(Shift::IDENTITY), single(Shift::srl(3))]);
 
-		let hidden_pairs = key_collection
+		let hidden_sequences = key_collection
 			.hidden
 			.dense_shift_enc
 			.iter()
 			.collect::<Vec<_>>();
 		assert_eq!(
-			hidden_pairs,
+			hidden_sequences,
 			[
-				(ShiftVariant::Sll, 0),
-				(ShiftVariant::Sar, 7),
-				(ShiftVariant::Rotr, 1),
+				single(Shift::IDENTITY),
+				single(Shift::sar(7)),
+				single(Shift::rotr(1)),
 			]
 		);
 
-		// The point of the encoding: a segment names far fewer pairs than the space holds.
-		assert!(key_collection.hidden.dense_shift_enc.len() < SHIFT_PAIR_COUNT);
+		// The point of the encoding: a segment names far fewer sequences than the space holds, and
+		// the space is now the square of one slot's alphabet.
+		assert!(key_collection.hidden.dense_shift_enc.len() < SHIFT_COUNT * SHIFT_COUNT);
+	}
+
+	#[test]
+	fn dense_shift_encoding_distinguishes_sequences_sharing_an_inner_shift() {
+		// Two terms sharing an inner shift but differing outside must land on distinct indices.
+		// Keyed on the inner shift alone they would collide and accumulate into one row.
+		let hidden = ValueIndex::private(1);
+		let cs = ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_inout: 0,
+			n_private: 4,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![
+					ShiftedValueIndex::new(hidden, [Shift::srl(3), Shift::sll(3)]),
+					ShiftedValueIndex::new(hidden, [Shift::srl(3), Shift::sll(5)]),
+					ShiftedValueIndex::srl(hidden, 3),
+				],
+				Vec::new(),
+				Vec::new(),
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		};
+
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let sequences = key_collection
+			.hidden
+			.dense_shift_enc
+			.iter()
+			.collect::<Vec<_>>();
+		assert_eq!(
+			sequences,
+			[
+				single(Shift::srl(3)),
+				[Shift::srl(3), Shift::sll(3)],
+				[Shift::srl(3), Shift::sll(5)],
+			]
+		);
+
+		// The word's three keys therefore hold three distinct dense indices.
+		let mut indices = key_collection
+			.hidden
+			.word_keys(1)
+			.iter()
+			.map(|key| key.dense_shift_idx)
+			.collect::<Vec<_>>();
+		indices.sort_unstable();
+		assert_eq!(indices, [0, 1, 2]);
 	}
 
 	#[test]
@@ -764,28 +843,28 @@ mod tests {
 		let key_collection =
 			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
 
-		// The shifts a word's keys name, as its own segment's encoding decodes them.
-		let word_pairs = |segment: &KeySegment, word: usize| {
-			let mut pairs = segment
+		// The shift sequences a word's keys name, as its own segment's encoding decodes them.
+		let word_sequences = |segment: &KeySegment, word: usize| {
+			let mut sequences = segment
 				.word_keys(word)
 				.iter()
 				.map(|key| segment.dense_shift_enc.decode(key.dense_shift_idx as usize))
 				.collect::<Vec<_>>();
-			pairs.sort();
-			pairs
+			sequences.sort();
+			sequences
 		};
 
 		// Value index 1 is the second public word; value index 5 the second hidden one.
 		assert_eq!(
-			word_pairs(&key_collection.public, 1),
-			[(ShiftVariant::Sll, 0), (ShiftVariant::Slr, 3)]
+			word_sequences(&key_collection.public, 1),
+			[single(Shift::IDENTITY), single(Shift::srl(3))]
 		);
 		assert_eq!(
-			word_pairs(&key_collection.hidden, 1),
+			word_sequences(&key_collection.hidden, 1),
 			[
-				(ShiftVariant::Sll, 0),
-				(ShiftVariant::Sar, 7),
-				(ShiftVariant::Rotr, 1),
+				single(Shift::IDENTITY),
+				single(Shift::sar(7)),
+				single(Shift::rotr(1)),
 			]
 		);
 	}
@@ -810,34 +889,84 @@ mod tests {
 		}
 	}
 
+	// Serializes an encoding built raw, bypassing `new`'s sorting and deduplication, so that a
+	// malformed list reaches the deserializer.
+	fn deserialize_raw(shifts: Vec<[Shift; 2]>) -> Result<DenseShiftEncoding, SerializationError> {
+		let mut buf = Vec::new();
+		DenseShiftEncoding { shifts }.serialize(&mut buf).unwrap();
+		DenseShiftEncoding::deserialize(buf.as_slice())
+	}
+
 	#[test]
 	fn dense_shift_encoding_rejects_an_unordered_serialization() {
-		let encoding = DenseShiftEncoding {
-			shifts: vec![(ShiftVariant::Slr, 3), (ShiftVariant::Sll, 0)],
-		};
+		// A dense index means nothing against an unsorted list: `dense_idx` binary-searches it.
+		match deserialize_raw(vec![single(Shift::srl(3)), single(Shift::IDENTITY)]).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "DenseShiftEncoding::shifts");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
 
-		let mut buf = Vec::new();
-		encoding.serialize(&mut buf).unwrap();
-
-		assert!(matches!(
-			DenseShiftEncoding::deserialize(buf.as_slice()),
-			Err(SerializationError::InvalidConstruction { .. })
-		));
+	#[test]
+	fn dense_shift_encoding_rejects_a_repeated_sequence() {
+		// Ascending order is checked strictly, so a repeat is rejected along with a swap: two equal
+		// sequences would give one shift sequence two dense indices.
+		match deserialize_raw(vec![single(Shift::srl(3)), single(Shift::srl(3))]).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "DenseShiftEncoding::shifts");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
 	}
 
 	#[test]
 	fn dense_shift_encoding_rejects_an_out_of_range_shift_amount() {
-		let encoding = DenseShiftEncoding {
-			shifts: vec![(ShiftVariant::Sll, Word::BITS as u8)],
+		// The bound is the variant's own: a half-word (*32) variant caps at 32, not at 64.
+		let out_of_range = Shift {
+			variant: ShiftVariant::Sll32,
+			amount: 32,
 		};
+		match deserialize_raw(vec![single(out_of_range)]).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "DenseShiftEncoding::shifts");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
 
-		let mut buf = Vec::new();
-		encoding.serialize(&mut buf).unwrap();
+	#[test]
+	fn dense_shift_encoding_rejects_an_out_of_range_outer_shift_amount() {
+		// Both slots are checked, so an outer amount its variant cannot represent is rejected too.
+		let out_of_range = Shift {
+			variant: ShiftVariant::Sll,
+			amount: Word::BITS as u8,
+		};
+		match deserialize_raw(vec![[Shift::srl(3), out_of_range]]).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "DenseShiftEncoding::shifts");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
 
-		assert!(matches!(
-			DenseShiftEncoding::deserialize(buf.as_slice()),
-			Err(SerializationError::InvalidConstruction { .. })
-		));
+	#[test]
+	fn dense_shift_encoding_indexes_every_sequence_it_covers() {
+		// Indexing inverts decoding, so a key's index names the sequence it is weighted by.
+		// The input is unsorted and repeats one sequence, which also pins the sort and the dedupe.
+		let sequences = [
+			[Shift::srl(3), Shift::sll(3)],
+			single(Shift::rotr(1)),
+			single(Shift::IDENTITY),
+			single(Shift::rotr(1)),
+		];
+		let encoding = DenseShiftEncoding::new(sequences);
+
+		assert_eq!(encoding.len(), 3);
+		for dense_idx in 0..encoding.len() {
+			let sequence = encoding.decode(dense_idx);
+			assert_eq!(encoding.dense_idx(sequence) as usize, dense_idx);
+		}
 	}
 
 	#[test]

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -3,6 +3,13 @@
 
 use binius_core::word::Word;
 
+/// Why a shift sequence's outer slot must hold the identity in the two-phase reduction.
+///
+/// The reduction folds one shift axis pair, so it reads the inner slot and ignores the outer one.
+/// A term carrying both would be reduced against the wrong shifted word.
+pub(crate) const DOUBLE_SHIFT_UNSUPPORTED: &str =
+	"the two-phase shift reduction reads only the inner shift of a sequence";
+
 /// The value vector's two committed segments, each at the width the protocol addresses it at.
 ///
 /// A circuit declares fewer values than the reductions address: the public segment is padded to a

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -4,14 +4,16 @@
 use std::iter;
 
 use binius_compute::{Allocator, VecLike};
-use binius_core::{ShiftVariant, word::Word};
+use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval,
 	univariate::lagrange_evals,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
+use binius_verifier::protocols::shift::{
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, ZERO_ARITY,
+};
 use bytemuck::zeroed_vec;
 use tracing::instrument;
 
@@ -26,13 +28,46 @@ const HALF_WORD_BITS: usize = 32;
 
 /// The phase-2 scalar weights of one key segment, one table per operation.
 ///
-/// A table holds the `arity` weights of each shift the segment uses, in dense shift index order,
-/// so a key's weights are the chunk at `key.dense_shift_idx * arity`.
+/// A table holds the `arity` weights of each shift sequence the segment uses, in dense shift index
+/// order, so a key's weights are the chunk at `key.dense_shift_idx * arity`.
 struct ScalarTables<F> {
 	zero: Vec<F>,
 	bitand: Vec<F>,
 	intmul: Vec<F>,
 	binmul: Vec<F>,
+}
+
+/// The equality-indicator weights of a shift sequence's outer slot.
+///
+/// The sequence weight factorizes across its two slots, so each slot carries its own two tensors:
+/// one over the variant axis, one over the amount axis.
+/// Keeping them apart holds the weights at `2 * SHIFT_COUNT` entries rather than `SHIFT_COUNT^2`.
+struct OuterSlotWeights<F: Field> {
+	/// The equality indicator over the outer variant axis, one weight per shift variant.
+	variant: FieldBuffer<F>,
+	/// The equality indicator over the outer amount axis, one weight per shift amount.
+	amount: FieldBuffer<F>,
+}
+
+impl<F: Field> OuterSlotWeights<F> {
+	/// The weights that select the identity and reject every other outer shift.
+	///
+	/// This is the equality indicator at the all-zero point, where no challenges were drawn over
+	/// the outer axes.
+	/// Every key's outer slot holds [`Shift::IDENTITY`], spelled `(Sll, 0)`.
+	/// So a well-formed key weighs one, and the scalars match what a single-shift reduction builds.
+	fn identity_selecting() -> Self {
+		Self {
+			variant: eq_ind_partial_eval::<F>(&[F::ZERO; LOG_SHIFT_VARIANT_COUNT]),
+			amount: eq_ind_partial_eval::<F>(&[F::ZERO; Word::LOG_BITS]),
+		}
+	}
+
+	/// The weight one outer shift contributes to its sequence's scalar.
+	#[inline]
+	fn weight(&self, shift: Shift) -> F {
+		self.variant.as_ref()[shift.variant as usize] * self.amount.as_ref()[shift.amount as usize]
+	}
 }
 
 /// Fills one row of the phase-1 "h" multilinear: the shift indicator of one `(variant, amount)`
@@ -174,19 +209,31 @@ where
 	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
 
+	// Invariant: a key's sequence weight factorizes across its two slots.
+	//
+	//     eq(r_v1, v_1) * eq(r_s1, s_1)  *  eq(r_v2, v_2) * eq(r_s2, s_2)
+	//     \______ inner slot _________/     \______ outer slot ________/
+	//
+	// So one table per slot suffices, at `2 * SHIFT_COUNT` entries instead of `SHIFT_COUNT^2`.
+	//
+	// Challenges are drawn over the inner axes only, so the outer slot sits at the all-zero point.
+	// There the indicator selects the identity, the only outer shift a key may carry.
+	let outer = OuterSlotWeights::<F>::identity_selecting();
+
 	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
 	// weights for one `key.dense_shift_idx` form a contiguous chunk that [`Key::accumulate_wide`]
 	// can index directly by operand index.
 	//
-	// A key's shift now selects itself through a pure equality indicator over both of phase 1's
-	// shift axes, and the h evaluation is a single factor shared by every key.
+	// A key's sequence selects itself through an equality indicator over both slots' axes.
+	// The h evaluation is one factor shared by every key of the operation.
 	let build_scalars =
 		|arity: usize, lambda_powers: &[F], dense_shift_enc: &DenseShiftEncoding| {
 			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
-			for (dense_shift_idx, (variant, amount)) in dense_shift_enc.iter().enumerate() {
+			for (dense_shift_idx, [inner, outer_shift]) in dense_shift_enc.iter().enumerate() {
 				let shift_scalar = h_eval
-					* r_v_tensor.as_ref()[variant as usize]
-					* r_s_tensor.as_ref()[amount as usize];
+					* r_v_tensor.as_ref()[inner.variant as usize]
+					* r_s_tensor.as_ref()[inner.amount as usize]
+					* outer.weight(outer_shift);
 				for operand_idx in 0..arity {
 					scalars[dense_shift_idx * arity + operand_idx] =
 						lambda_powers[operand_idx] * shift_scalar;

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -620,11 +620,8 @@ pub fn build_g<F: Field, P: PackedField<Scalar = F>>(
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_core::{
-		ShiftVariant,
-		constraint_system::{
-			AndConstraint, ConstraintSystem, InoutSegment, ShiftedValueIndex, ValueIndex,
-		},
+	use binius_core::constraint_system::{
+		AndConstraint, ConstraintSystem, InoutSegment, Shift, ShiftedValueIndex, ValueIndex,
 	};
 	use binius_field::{
 		AESTowerField8b, BinaryField128bGhash, Field, PackedBinaryGhash2x128b, Random,
@@ -723,17 +720,15 @@ mod tests {
 
 		// The public segment's two shifts, then the hidden segment's three. `(Sll, 0)` is the first
 		// row of both, so index 0 appears twice.
-		let shift_index = |variant: ShiftVariant, amount: usize| {
-			variant as u32 * Word::BITS as u32 + amount as u32
-		};
+		let row_index = |shift: Shift| shift.index() as u32;
 		assert_eq!(
 			g.indices,
 			[
-				shift_index(ShiftVariant::Sll, 0),
-				shift_index(ShiftVariant::Slr, 3),
-				shift_index(ShiftVariant::Sll, 0),
-				shift_index(ShiftVariant::Sar, 7),
-				shift_index(ShiftVariant::Rotr, 1),
+				row_index(Shift::IDENTITY),
+				row_index(Shift::srl(3)),
+				row_index(Shift::IDENTITY),
+				row_index(Shift::sar(7)),
+				row_index(Shift::rotr(1)),
 			]
 		);
 
@@ -743,15 +738,13 @@ mod tests {
 			assert!(row(position).iter().all(|&value| value == F::new(expected)));
 		}
 
-		// Where `g` is read, the two rows at `(Sll, 0)` add up.
+		// Where `g` is read, the two rows at the identity add up.
 		let dense = g.scatter(&GlobalAllocator);
-		let at = |variant: ShiftVariant, amount: usize| {
-			dense.get((variant as usize * Word::BITS + amount) * Word::BITS)
-		};
-		assert_eq!(at(ShiftVariant::Sll, 0), F::new(0x100) + F::new(0x200));
-		assert_eq!(at(ShiftVariant::Slr, 3), F::new(0x101));
-		assert_eq!(at(ShiftVariant::Sar, 7), F::new(0x201));
-		assert_eq!(at(ShiftVariant::Rotr, 1), F::new(0x202));
+		let at = |shift: Shift| dense.get(shift.index() * Word::BITS);
+		assert_eq!(at(Shift::IDENTITY), F::new(0x100) + F::new(0x200));
+		assert_eq!(at(Shift::srl(3)), F::new(0x101));
+		assert_eq!(at(Shift::sar(7)), F::new(0x201));
+		assert_eq!(at(Shift::rotr(1)), F::new(0x202));
 	}
 
 	/// The scatter puts every row where its shift index names, and leaves the rest zero.
@@ -774,16 +767,13 @@ mod tests {
 		assert_eq!(g.log_len(), PHASE_1_LOG_LEN);
 
 		// Exactly the named rows are non-zero, and each holds what the merged list held.
-		for (row, (variant, amount)) in hidden_enc.iter().enumerate() {
-			let offset = (variant as usize * Word::BITS + amount as usize) * Word::BITS;
+		for (row, shift_index) in hidden_enc.shift_indices().enumerate() {
+			let offset = shift_index * Word::BITS;
 			for bit in 0..Word::BITS {
 				assert_eq!(g.get(offset + bit), F::new(1 + row as u128));
 			}
 		}
-		let named = hidden_enc
-			.iter()
-			.map(|(variant, amount)| variant as usize * Word::BITS + amount as usize)
-			.collect::<Vec<_>>();
+		let named = hidden_enc.shift_indices().collect::<Vec<_>>();
 		for row in (0..1 << LOG_SHIFT_ROWS).filter(|row| !named.contains(row)) {
 			assert!((0..Word::BITS).all(|bit| g.get(row * Word::BITS + bit) == F::ZERO));
 		}

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -17,6 +17,15 @@ pub const SHIFT_VARIANT_COUNT: usize = 1 << LOG_SHIFT_VARIANT_COUNT;
 /// the word index is sized by the constraint system.
 pub const SHIFT_LOG_VARS: usize = Word::LOG_BITS * 3 + LOG_SHIFT_VARIANT_COUNT;
 
+/// The number of `(variant, amount)` spellings one shift slot can take.
+///
+/// A shift is a variant paired with an amount below the word width.
+/// One weight table per shift slot has this many entries.
+///
+/// A term carries two slots, so the sequences it could name number the square of this.
+/// The weight factorizes across the slots, so two tables of this size replace one of that square.
+pub const SHIFT_COUNT: usize = SHIFT_VARIANT_COUNT * Word::BITS;
+
 pub const ZERO_ARITY: usize = 1;
 pub const BITAND_ARITY: usize = 3;
 pub const INTMUL_ARITY: usize = 4;

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -3,7 +3,7 @@
 
 use std::iter;
 
-use binius_core::{constraint_system::Operand, word::Word};
+use binius_core::constraint_system::Operand;
 use binius_field::{
 	BinaryField, FieldOps, WideMul,
 	util::{FieldFn, powers},
@@ -11,7 +11,7 @@ use binius_field::{
 use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
-use super::SHIFT_VARIANT_COUNT;
+use super::SHIFT_COUNT;
 
 /// Why a term's outer shift slot must hold the identity in the two-phase reduction.
 ///
@@ -71,11 +71,15 @@ impl<'a, C, const ARITY: usize> OperationEvalFn<'a, C, ARITY> {
 		}
 	}
 
-	/// Splits the flat [`FieldFn`] input into `(r_x_prime, lambda, shift_scalars, r_y_tensor)`.
+	/// Splits the flat [`FieldFn`] input into its sections.
 	///
 	/// The `r_x'` section has `ceil(log2(constraints.len()))` entries — the reductions run over the
 	/// constraint count rounded up to a power of two — so the split needs no state beyond the
 	/// constraints.
+	///
+	/// Two shift-scalar tables follow, one per slot of a term's shift sequence.
+	/// Each is [`SHIFT_COUNT`] entries wide; see [`ShiftScalars`] for why the weight splits that
+	/// way.
 	///
 	/// The word-index tensor arrives as one run per value segment, in
 	/// [`ValueSegment`](binius_core::constraint_system::ValueSegment) order, and
@@ -86,14 +90,20 @@ impl<'a, C, const ARITY: usize> OperationEvalFn<'a, C, ARITY> {
 	fn split_input<'i, E>(
 		&self,
 		input: &'i [E],
-	) -> (&'i [E], &'i E, &'i [E; SHIFT_VARIANT_COUNT * Word::BITS], [&'i [E]; 3]) {
+	) -> (&'i [E], &'i E, ShiftScalars<'i, E>, [&'i [E]; 3]) {
 		let n_vars = log2_ceil_usize(self.constraints.len());
 		let (r_x_prime, rest) = input.split_at(n_vars);
 		let (lambda, rest) = rest.split_first().expect("input encodes lambda");
-		let (shift_scalars, rest) = rest.split_at(SHIFT_VARIANT_COUNT * Word::BITS);
-		let shift_scalars = shift_scalars
-			.try_into()
-			.expect("input encodes the shift scalars");
+		let (inner, rest) = rest.split_at(SHIFT_COUNT);
+		let (outer, rest) = rest.split_at(SHIFT_COUNT);
+		let shift_scalars = ShiftScalars {
+			inner: inner
+				.try_into()
+				.expect("input encodes the inner shift scalars"),
+			outer: outer
+				.try_into()
+				.expect("input encodes the outer shift scalars"),
+		};
 
 		let (constants, rest) = rest.split_at(self.n_constants);
 		let (inout, rest) = rest.split_at(self.n_inout);
@@ -102,6 +112,39 @@ impl<'a, C, const ARITY: usize> OperationEvalFn<'a, C, ARITY> {
 		(r_x_prime, lambda, shift_scalars, [constants, inout, hidden])
 	}
 }
+
+/// The shift-sequence weight tables, one per slot of the sequence.
+///
+/// A term's sequence weight factorizes across its two slots:
+///
+/// ```text
+/// eq(r_v1, v_1) * eq(r_s1, s_1)  *  eq(r_v2, v_2) * eq(r_s2, s_2)
+/// \_______ inner table _______/     \_______ outer table ______/
+/// ```
+///
+/// One table per slot holds the weights at `2 * SHIFT_COUNT` = 1,024 entries.
+/// Keying a single table on the whole sequence would need `SHIFT_COUNT^2` = 262,144.
+/// Fanning that out over the operand batching coefficients reaches roughly 1.5M multiplications at
+/// BMUL's arity of six.
+///
+/// The cost of the split is one extra multiply per term.
+pub struct ShiftScalars<'a, E> {
+	/// The weight of each spelling the inner shift slot can take, with the operand batching
+	/// coefficients yet to be fanned in.
+	pub inner: &'a [E; SHIFT_COUNT],
+	/// The weight of each spelling the outer shift slot can take.
+	pub outer: &'a [E; SHIFT_COUNT],
+}
+
+// Two shared slices copy freely whatever `E` is. Deriving these would demand `E: Copy`, which the
+// generic evaluation path does not have.
+impl<E> Clone for ShiftScalars<'_, E> {
+	fn clone(&self) -> Self {
+		*self
+	}
+}
+
+impl<E> Copy for ShiftScalars<'_, E> {}
 
 impl<F, C, const ARITY: usize> FieldFn<F> for OperationEvalFn<'_, C, ARITY>
 where
@@ -112,24 +155,27 @@ where
 		let (r_x_prime, lambda, shift_scalars, r_y_tensor) = self.split_input(input);
 
 		let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
+		// The batching coefficients fan into the inner table only, holding it to
+		// `SHIFT_COUNT * arity`; the outer weight multiplies in per term.
 		let operand_shift_scalars =
-			operand_shift_scalar_table(shift_scalars, lambda.clone(), ARITY);
+			operand_shift_scalar_table(shift_scalars.inner, lambda.clone(), ARITY);
 
-		// Accumulate one contribution per constraint. Within a constraint, each shifted-value term
-		// over all operands is weighted by its operand shift scalar and the word-index tensor
-		// entry; the running sum is then scaled by the constraint-index tensor entry. The tensor
-		// covers the padded constraint count, so the zip stops at the last real constraint; the
-		// padding rows have no operand terms and contribute nothing.
+		// One contribution per constraint.
+		// Each term is weighted by its two slots' shift scalars and its word-index tensor entry.
+		// The running sum then scales by the constraint-index tensor entry.
+		//
+		// The tensor covers the padded constraint count, so the zip stops at the last real
+		// constraint; padding rows carry no operand terms and contribute nothing.
 		let mut eval = E::zero();
 		for (constraint, r_x_prime_entry) in iter::zip(self.constraints, &r_x_prime_tensor) {
 			let mut constraint_eval = E::zero();
 			for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 				for svi in operand {
 					assert!(!svi.is_doubly_shifted(), "{DOUBLE_SHIFT_UNSUPPORTED}");
-					let variant = svi.inner().variant as usize;
-					let index =
-						(variant * Word::BITS + svi.inner().amount as usize) * ARITY + operand_id;
-					constraint_eval += operand_shift_scalars[index].clone()
+					let inner = svi.inner().index() * ARITY + operand_id;
+					let outer = svi.outer().index();
+					constraint_eval += operand_shift_scalars[inner].clone()
+						* &shift_scalars.outer[outer]
 						* &r_y_tensor[svi.value_index.segment() as usize]
 							[svi.value_index.index() as usize];
 				}
@@ -151,7 +197,7 @@ where
 		let (r_x_prime, lambda, shift_scalars, r_y_tensor) = self.split_input(input);
 
 		let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
-		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars, *lambda, ARITY);
+		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, *lambda, ARITY);
 
 		// One unreduced wide product per constraint. The constraints partition cleanly across
 		// rayon: each produces a single wide element and they are summed, so there is no large
@@ -167,10 +213,10 @@ where
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
 						assert!(!svi.is_doubly_shifted(), "{DOUBLE_SHIFT_UNSUPPORTED}");
-						let variant = svi.inner().variant as usize;
-						let index = (variant * Word::BITS + svi.inner().amount as usize) * ARITY
-							+ operand_id;
-						constraint_eval += operand_shift_scalars[index]
+						let inner = svi.inner().index() * ARITY + operand_id;
+						let outer = svi.outer().index();
+						constraint_eval += operand_shift_scalars[inner]
+							* shift_scalars.outer[outer]
 							* r_y_tensor[svi.value_index.segment() as usize]
 								[svi.value_index.index() as usize];
 					}
@@ -184,23 +230,26 @@ where
 
 /// Builds the flat [`FieldFn`] input consumed by [`OperationEvalFn`].
 ///
-/// Concatenates `r_x_prime ++ [lambda] ++ shift_scalars ++ r_y_tensor`.
-/// `OperationEvalFn::split_input` is the inverse; it recovers the `r_x'` length from the constraint
-/// count, so only `lambda` and the fixed-length shift scalars need a known position.
+/// Concatenates `r_x_prime ++ [lambda] ++ inner_shift_scalars ++ outer_shift_scalars ++
+/// r_y_tensor`. `OperationEvalFn::split_input` is the inverse; it recovers the `r_x'` length from
+/// the constraint count, so only `lambda` and the two fixed-length shift-scalar tables need a known
+/// position.
 pub fn encode_operation_input<E: Clone>(
 	r_x_prime: &[E],
 	lambda: E,
-	shift_scalars: &[E; SHIFT_VARIANT_COUNT * Word::BITS],
+	shift_scalars: ShiftScalars<'_, E>,
 	r_y_tensor: [&[E]; 3],
 ) -> Vec<E> {
 	let n_words = r_y_tensor
 		.iter()
 		.map(|segment| segment.len())
 		.sum::<usize>();
-	let mut input = Vec::with_capacity(r_x_prime.len() + 1 + shift_scalars.len() + n_words);
+	let mut input = Vec::with_capacity(r_x_prime.len() + 1 + 2 * SHIFT_COUNT + n_words);
 	input.extend_from_slice(r_x_prime);
 	input.push(lambda);
-	input.extend_from_slice(shift_scalars);
+	// The inner table leads the outer one, which is the order `split_input` cuts them back apart.
+	input.extend_from_slice(shift_scalars.inner);
+	input.extend_from_slice(shift_scalars.outer);
 	// One run per value segment, in `ValueSegment` order, which is how `split_input` cuts them
 	// back apart.
 	for segment in r_y_tensor {
@@ -209,12 +258,15 @@ pub fn encode_operation_input<E: Clone>(
 	input
 }
 
-/// Folds the operand batching coefficients (λ powers) into the shared shift scalars, producing a
-/// table indexed by `(variant, amount, operand_id)` whose entry is
-/// `shift_scalars[variant * Word::BITS + amount] · λ^{operand_id + 1}` — the scalar that
-/// multiplies each shifted-value term.
+/// Folds the operand batching coefficients (λ powers) into the inner slot's shift scalars,
+/// producing a table indexed by `(variant, amount, operand_id)` whose entry is
+/// `inner[variant * Word::BITS + amount] · λ^{operand_id + 1}`.
+///
+/// The fan-out stays on this one table.
+/// A term's outer-slot weight multiplies in where the term is read.
+/// So the table is `SHIFT_COUNT * arity` entries rather than `SHIFT_COUNT^2 * arity`.
 fn operand_shift_scalar_table<E: FieldOps>(
-	shift_scalars: &[E; SHIFT_VARIANT_COUNT * Word::BITS],
+	shift_scalars: &[E; SHIFT_COUNT],
 	lambda: E,
 	arity: usize,
 ) -> Vec<E> {
@@ -233,12 +285,13 @@ mod tests {
 	use binius_core::{
 		ShiftVariant,
 		constraint_system::{AndConstraint, Shift, ShiftedValueIndex, ValueIndex},
+		word::Word,
 	};
-	use binius_field::{BinaryField128bGhash, Random};
+	use binius_field::{BinaryField128bGhash, Field, Random};
 	use binius_math::test_utils::random_scalars;
 	use rand::prelude::*;
 
-	use super::*;
+	use super::{super::SHIFT_VARIANT_COUNT, *};
 
 	/// Builds `n_constraints` random arity-3 constraints (like `AndConstraint`), constraint-major:
 	/// one array of operands per constraint.
@@ -282,6 +335,56 @@ mod tests {
 			.collect()
 	}
 
+	#[test]
+	fn evaluate_monster_scales_by_the_outer_slot_weight() {
+		// Invariant: the outer slot's weight reaches the evaluation, and reaches it as a factor.
+		//
+		// Every term the fixture builds carries an identity outer shift, so index 0 is the only
+		// entry read. Scaling it must scale the whole evaluation by the same factor.
+		type F = BinaryField128bGhash;
+		let mut rng = StdRng::seed_from_u64(7);
+
+		let n_words = 40usize;
+		let constraints = random_and_constraints(&mut rng, 32, n_words);
+		let r_x_prime = random_scalars::<F>(&mut rng, 5);
+		let lambda = F::random(&mut rng);
+		let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
+		let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
+		let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
+
+		let eval_fn = OperationEvalFn::new(&constraints, 0, 0, n_words);
+		let eval_with_outer = |outer: &[F; SHIFT_COUNT]| {
+			let shift_scalars = ShiftScalars {
+				inner: &inner,
+				outer,
+			};
+			let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
+			eval_fn.call_native(&input)
+		};
+
+		// The identity-selecting table, which is what the two-phase reduction supplies.
+		let mut identity_selecting = [F::ZERO; SHIFT_COUNT];
+		identity_selecting[0] = F::ONE;
+		let baseline = eval_with_outer(&identity_selecting);
+		// A non-degenerate fixture, or the scaling below proves nothing.
+		assert_ne!(baseline, F::ZERO);
+
+		// Scaling the entry every term reads scales the evaluation by the same factor.
+		let scale = F::random(&mut rng);
+		let mut scaled = [F::ZERO; SHIFT_COUNT];
+		scaled[0] = scale;
+		assert_eq!(eval_with_outer(&scaled), baseline * scale);
+
+		// Zeroing it kills the evaluation, so no term slipped past the outer factor.
+		assert_eq!(eval_with_outer(&[F::ZERO; SHIFT_COUNT]), F::ZERO);
+
+		// The weight of a shift the fixture never names must not enter. Only index 0 is read, so
+		// filling every other entry changes nothing.
+		let mut noise = [F::random(&mut rng); SHIFT_COUNT];
+		noise[0] = F::ONE;
+		assert_eq!(eval_with_outer(&noise), baseline);
+	}
+
 	/// The native `WideMul` variant must produce exactly the same result as the generic
 	/// evaluation (deferred reduction is `F`-linear). Covers a power-of-two constraint count and a
 	/// non-power-of-two one, whose `r_x'` tensor runs past the last constraint.
@@ -296,13 +399,19 @@ mod tests {
 
 			let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
 			let lambda = F::random(&mut rng);
-			let shift_scalars: [F; SHIFT_VARIANT_COUNT * Word::BITS] =
-				std::array::from_fn(|_| F::random(&mut rng));
+			// Both slots draw random weights, so a path that dropped the outer factor, or read
+			// it from the inner table, would disagree with the other.
+			let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
+			let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
+			let shift_scalars = ShiftScalars {
+				inner: &inner,
+				outer: &outer,
+			};
 			let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 			let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
 			let eval_fn = OperationEvalFn::new(&constraints, 0, 0, n_words);
-			let input = encode_operation_input(&r_x_prime, lambda, &shift_scalars, r_y_tensor);
+			let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
 			let generic = eval_fn.call::<F>(&input);
 			let native = eval_fn.call_native(&input);
 			assert_eq!(generic, native, "n_constraints = {n_constraints}");
@@ -334,12 +443,16 @@ mod tests {
 
 		let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
 		let lambda = F::random(&mut rng);
-		let shift_scalars: [F; SHIFT_VARIANT_COUNT * Word::BITS] =
-			std::array::from_fn(|_| F::random(&mut rng));
+		let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
+		let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
+		let shift_scalars = ShiftScalars {
+			inner: &inner,
+			outer: &outer,
+		};
 		let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 		let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
-		let input = encode_operation_input(&r_x_prime, lambda, &shift_scalars, r_y_tensor);
+		let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
 		assert_eq!(
 			OperationEvalFn::new(&constraints, 0, 0, n_words).call::<F>(&input),
 			OperationEvalFn::new(&padded, 0, 0, n_words).call::<F>(&input)

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -24,8 +24,8 @@ use binius_math::{
 use getset::Getters;
 
 use super::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperationEvalFn, SHIFT_LOG_VARS, SHIFT_VARIANT_COUNT,
-	ZERO_ARITY, encode_operation_input, error::Error, shift_ind::evaluate_shift_inds,
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperationEvalFn, SHIFT_COUNT, SHIFT_LOG_VARS,
+	ShiftScalars, ZERO_ARITY, encode_operation_input, error::Error, shift_ind::evaluate_shift_inds,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -518,28 +518,45 @@ impl MonsterEvalFn<'_> {
 				&hidden_tensor[cs.n_inout..cs.n_inout + cs.n_private],
 			],
 		};
-		// A key's shift selects itself through a pure equality indicator over both of phase 1's
-		// shift axes. Built once, so the Zero, BitAnd, IntMul and BinMul monster evaluations share
-		// it. Indexed by `variant * Word::BITS + amount`. The h evaluation scaling all of them is
-		// left for `check_eval` to multiply in.
+		// A term's sequence selects itself through an equality indicator over both slots' axes.
+		// The weight factorizes, so this is one table per slot rather than one over the whole
+		// sequence space — see the two-table split on the scalars type.
+		//
+		// Both are built once, so the Zero, BitAnd, IntMul and BinMul monster evaluations share
+		// them. Each is indexed by `variant * Word::BITS + amount`. The h evaluation scaling all of
+		// them is left for `check_eval` to multiply in.
 		let eq_r_v = eq_ind_partial_eval_scalars(r_v_v);
 		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
-		let shift_scalars =
-			Box::new(array::from_fn::<_, { SHIFT_VARIANT_COUNT * Word::BITS }, _>(|i| {
-				eq_r_v[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
-			}));
+		let inner_shift_scalars = Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
+			eq_r_v[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
+		}));
+
+		// The outer slot's table sits at the all-zero point: no challenges are drawn over its axes.
+		// There the indicator selects the identity, the only outer shift a term may carry.
+		//
+		//     index 0 = (Sll, 0) -> one
+		//     every other index  -> zero
+		//
+		// So a well-formed term's weight is what a single-shift reduction gives it.
+		let outer_shift_scalars = Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
+			if i == 0 { E::one() } else { E::zero() }
+		}));
+		let shift_scalars = ShiftScalars {
+			inner: &inner_shift_scalars,
+			outer: &outer_shift_scalars,
+		};
 
 		// Re-encode the shared tensors with each operation's `r_x'` and `lambda`. IntMul and BinMul
 		// are skipped (no input built) when they have no constraints.
 		let zero_input =
-			encode_operation_input(zero_r_x_prime_v, zero_lambda_v, &shift_scalars, r_y_tensor);
+			encode_operation_input(zero_r_x_prime_v, zero_lambda_v, shift_scalars, r_y_tensor);
 		let bitand_input =
-			encode_operation_input(bitand_r_x_prime_v, bitand_lambda_v, &shift_scalars, r_y_tensor);
+			encode_operation_input(bitand_r_x_prime_v, bitand_lambda_v, shift_scalars, r_y_tensor);
 		let intmul_input = (!self.constraint_system.imul_constraints.is_empty()).then(|| {
-			encode_operation_input(intmul_r_x_prime_v, intmul_lambda_v, &shift_scalars, r_y_tensor)
+			encode_operation_input(intmul_r_x_prime_v, intmul_lambda_v, shift_scalars, r_y_tensor)
 		});
 		let binmul_input = (!self.constraint_system.bmul_constraints.is_empty()).then(|| {
-			encode_operation_input(binmul_r_x_prime_v, binmul_lambda_v, &shift_scalars, r_y_tensor)
+			encode_operation_input(binmul_r_x_prime_v, binmul_lambda_v, shift_scalars, r_y_tensor)
 		});
 
 		OperationInputs {


### PR DESCRIPTION
Closes [BINIUS-442](https://linear.app/jimpo/issue/BINIUS-442).

Moves both sides off "one shift per key" and onto "one shift *sequence* per key", while the outer slot is still always the identity.
Pure refactor — no protocol change, transcripts byte-identical.

> Rebased onto main after the shift-reduction surgery (#2095, #2113, #2114, #2115). See **What the rebase changed** below for what that absorbed and what is left.
>
> Now also on top of #2121, which is why the earlier CI runs on this branch were red. Compiled with `-Ctarget-cpu=native`, an AVX-512 runner picks a packed width of 4, and the one-gate circuit in `cli_artifacts` had a lift block narrower than that — the pre-existing panic #2121 fixes. It reproduced identically on this branch's base, so it was never this diff.

### The problem

Both sides sized their shift tables by the whole shift space, using the fact that it is small.

- **Prover:** building the dense re-encoding collected a segment's shifts into a `[None; 512]` on the stack, and inverted it through a second 512-entry table.
- **Verifier:** `shift_scalars` was a `[E; 512]`, fanned out to `512 * arity` by the operand batching coefficients.

Keyed on a *sequence* of two shifts, that space is $512^2 = 262{,}144$.
The stack arrays cannot survive that, and the verifier's fan-out would reach roughly 1.5M multiplications at BMUL's arity of six.

### The idea

**The space grew; the occupancy did not.**
A segment still names at most one sequence per shifted value index — a few dozen in practice.
So stop indexing by a table over the space, and index by search over what is present.

And on the verifier side, **never build the square at all**, because the per-key weight factorizes:

```
key weight = eq(r_v1, v1) * eq(r_s1, s1)  *  eq(r_v2, v2) * eq(r_s2, s2)  *  lambda^(operand+1)
             \_____ inner table ______/     \_____ outer table ______/
```

Two 512-entry tables, not one of 262,144.
The cost is **one extra multiply per term**.

### Core

Where a shift sits in the enumeration of `(variant, amount)` spellings is a property of the shift, not of either side of the protocol. It had grown four copies — a free function in the prover, another in the verifier, and two test-local closures — so it moves onto the type as `Shift::index()`:

```
variant indexes runs of Word::BITS, amount indexes within a run

    [ Sll 0 .. Sll 63 | Slr 0 .. Slr 63 | ... | Rotr32 0 .. Rotr32 63 ]
      0          63     64         127          448             511
```

The prover's row axis and the verifier's weight tables now read the same definition, which is what makes "the two sides agree on the layout" a fact rather than a convention. It panics on an amount at or above the word width, which would index into the next variant's run and share an entry with another shift — reachable only by building a `Shift` field-wise, since the constructor already rejects it.

### Prover

```
- shifts: Vec<(ShiftVariant, u8)>          // built via [None; 512], inverted via [u16; 512]
+ shifts: Vec<[Shift; 2]>                  // BTreeSet collects + orders; binary search inverts
```

- The sorted set dedupes and orders in one pass, over the sequences present rather than the space they come from.
- `inverse()` — a 512-entry lookup table — becomes `dense_idx()`, a binary search over the sequences the segment uses.
- `Key::dense_shift_idx` is a `u16`, so the build now checks that bound explicitly instead of relying on an implicit "cannot exceed 512".
- Serialization writes both slots per entry and rejects a list that is not strictly ascending, which is what makes a dense index meaningful.
- `shift_indices()` places a sequence on the reduction's row axis by its **inner** shift. The axis is one slot wide, so the outer slot must be the identity there; a `debug_assert` says so, naming the shared `DOUBLE_SHIFT_UNSUPPORTED` reason.
- Phase 2's scalars gain the outer slot's factor. `OuterSlotWeights` holds one tensor per outer axis, so the weights stay at `2 * SHIFT_COUNT` entries rather than `SHIFT_COUNT^2`.

### Verifier

`shift_scalars` becomes a two-field struct, one table per slot:

```
- shift_scalars: &[E; SHIFT_COUNT]
+ ShiftScalars { inner: &[E; SHIFT_COUNT], outer: &[E; SHIFT_COUNT] }
```

- `encode_operation_input` lays the inner table before the outer one; the split is the inverse.
- `operand_shift_scalar_table` keeps the lambda fan-out on the **inner** table only.
- A term's outer weight multiplies in where the term is read.

New `SHIFT_COUNT` names $512$ — the spellings one shift slot can take — replacing the open-coded `SHIFT_VARIANT_COUNT * Word::BITS`.

### What the rebase changed

Main got there first on two of the pieces this PR originally carried, so they are gone from the diff:

- **The sparse re-encoding already exists.** #2095 landed `DenseShiftEncoding` keyed on a single shift, and `SparseShiftRows` keyed on the full-space shift index. What is left here is widening that key to a pair and removing the two stack arrays the square would break.
- **`scatter_shift_rows` is gone.** #2095 replaced it with `SparseShiftRows`, so `crates/m4-prover/src/shift.rs` needs no change at all now and `phase_1.rs` only moves its test onto `shift_indices()`.

One deliberate difference from the pre-rebase version: the h evaluation stays **out** of the inner table. #2115 moved it into `check_eval`, and this keeps it there rather than folding it back in.

### Why today's tests still pass unchanged

The outer slot is the identity on every key, so the outer table is the equality indicator at the all-zero point:

```
index 0 = (Sll, 0) -> one
every other index  -> zero
```

A well-formed term's weight is therefore exactly what a single-shift reduction gives it.
That is the point of landing this before any protocol change depends on it.

### Scope

- **added:** `Shift::index` in core `shift.rs`, replacing four copies of the layout formula
- **changed:** prover `key_collection.rs` (the encoding), prover `monster.rs` (per-slot weights), prover `mod.rs` (the shared assertion reason), verifier `monster.rs` + `verify.rs` (the two tables), verifier `mod.rs` (`SHIFT_COUNT`), and two tests in prover `phase_1.rs`
- **left untouched:** the reduction's phase structure — that is BINIUS-445

### Verification

Run on the rebased commit in a fresh worktree:

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-prover -p binius-verifier -p binius-m4-prover --all-targets` — clean
- nightly `cargo fmt --all` — clean
- shift reduction: 23 prover + 6 verifier tests pass, plus the `Shift::index` tests in core
- `test_shift_prove_and_verify` and the 60 `binius-m4-prover` tests pass **unchanged**, which is the evidence the transcript did not move

### Tests added

- the encoding distinguishes two sequences that share an inner shift but differ outside — keyed on the inner shift alone they would collide into one row
- indexing is the inverse of decoding, on input given unsorted and with a repeat, which also pins the sort and the dedupe
- serialization rejects an unordered list, a repeated sequence, and an out-of-range amount in **either** slot
- the outer weight reaches the evaluation *as a factor*: scaling the one entry every term reads scales the whole evaluation, zeroing it kills the evaluation, and filling the entries no term names changes nothing
- `Shift::index` places a shift by variant then amount, and every spelling in the alphabet gets a slot of its own
- `Shift::index` panics on an amount at the word width, the case that would alias two shifts onto one entry
