### PR TITLE
BINIUS-444: build the outer-phase G tables from intermediate words

### DIFF
--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -121,6 +121,111 @@ impl DenseShiftEncoding {
 		// `new` bounds the length, so every index it yields fits.
 		index as u16
 	}
+
+	/// Whether any sequence carries work in its outer slot.
+	///
+	/// False means every sequence is a lone shift.
+	/// The outer phase would then bind axes whose weight is already the identity indicator, so a
+	/// reduction can skip that phase entirely.
+	pub fn has_outer_shift(&self) -> bool {
+		self.shifts
+			.iter()
+			.any(|shift_seq| !shift_seq[ShiftSlot::Outer as usize].is_identity())
+	}
+
+	/// Groups the segment's sequences by the shift one slot of them takes.
+	///
+	/// A phase binds one slot's axes, so its accumulator holds one row per distinct shift *that
+	/// slot* takes — not one per sequence.
+	/// Several sequences can share a slot shift, and their contributions belong in one row:
+	///
+	/// ```text
+	/// [srl(3), sll(3)]  \
+	///                    >  agree on the outer shift -> one row
+	/// [srl(5), sll(3)]  /
+	/// ```
+	///
+	/// This is the map that sends each sequence to its row.
+	pub fn slot_rows(&self, slot: ShiftSlot) -> SlotRows {
+		let shift_of = |shift_seq: &[Shift; 2]| shift_seq[slot as usize];
+
+		// The distinct shifts the slot takes, ascending, one row each.
+		let shifts = self
+			.shifts
+			.iter()
+			.map(shift_of)
+			.collect::<BTreeSet<_>>()
+			.into_iter()
+			.collect::<Vec<_>>();
+
+		// Each sequence's row, found by search over that ordered list.
+		let row_of_sequence = self
+			.shifts
+			.iter()
+			.map(|shift_seq| {
+				let row = shifts
+					.binary_search(&shift_of(shift_seq))
+					.expect("every slot shift is in the list collected from the same sequences");
+				row as u16
+			})
+			.collect();
+
+		SlotRows {
+			shifts,
+			row_of_sequence,
+		}
+	}
+}
+
+/// Which slot of a shift sequence a reduction phase binds.
+///
+/// The discriminant indexes the sequence, so a slot reads its own shift off it directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShiftSlot {
+	/// The shift applied first, which the inner phase binds.
+	Inner = 0,
+	/// The shift applied to the inner shift's result, which the outer phase binds.
+	Outer = 1,
+}
+
+/// The accumulator rows of one slot of a segment's shift sequences.
+///
+/// Built by [`DenseShiftEncoding::slot_rows`].
+/// A builder accumulates a key's contribution into the row its sequence maps to.
+/// The scatter then copies each row to the offset that row's shift names in the multilinear.
+#[derive(Debug, Clone)]
+pub struct SlotRows {
+	/// The distinct shifts this slot takes, ascending. One accumulator row each.
+	shifts: Vec<Shift>,
+	/// The row each dense sequence index accumulates into.
+	row_of_sequence: Vec<u16>,
+}
+
+impl SlotRows {
+	/// The number of accumulator rows, one per distinct shift the slot takes.
+	pub const fn len(&self) -> usize {
+		self.shifts.len()
+	}
+
+	/// Whether the slot takes no shifts at all, which happens when the segment has no keys.
+	pub const fn is_empty(&self) -> bool {
+		self.shifts.is_empty()
+	}
+
+	/// The row a dense sequence index accumulates into.
+	///
+	/// # Panics
+	///
+	/// Panics if the dense index is not one of the encoding's.
+	#[inline]
+	pub fn row(&self, dense_shift_idx: u16) -> usize {
+		self.row_of_sequence[dense_shift_idx as usize] as usize
+	}
+
+	/// The shift each row carries, in row order.
+	pub fn shifts(&self) -> impl Iterator<Item = Shift> + '_ {
+		self.shifts.iter().copied()
+	}
 }
 
 /// A `Key` specifies an operation, a shift sequence, and a range of constraint indices.

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -39,6 +39,7 @@ mod prove;
 
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
 pub use key_collection::{
-	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
+	DenseShiftEncoding, KeyCollection, KeySegment, Operation, ShiftSlot, SlotRows,
+	build_key_collection,
 };
 pub use prove::{OperatorData, PreparedOperatorData, prove};

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -22,9 +22,9 @@ use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	DOUBLE_SHIFT_UNSUPPORTED, SegmentWords,
+	SegmentWords,
 	claims::PreparedOperatorClaims,
-	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment},
+	key_collection::{KeyCollection, KeySegment, ShiftSlot, SlotRows},
 	monster::build_h,
 };
 
@@ -120,37 +120,15 @@ pub fn run_phase_1_sumcheck<
 	}
 }
 
-/// Constructs the phase-1 "g" multilinear for one key segment.
+/// Constructs the inner phase's "g" multilinear for one key segment.
 ///
-/// This builds the g multilinear polynomials used in phase 1 of the shift protocol, over the words
-/// of a single value-vector segment (public or hidden). It constructs one multilinear polynomial
-/// per shift variant.
-///
-/// The value vector's public and hidden words participate through their own [`KeySegment`], so a
-/// caller builds each segment's parts with the matching words and sums the two results.
-///
-/// # Construction Process
-///
-/// 1. **Parallel Processing**: Words are processed in parallel chunks for efficiency
-/// 2. **Key Processing**: For each word, iterate through its associated keys in the segment
-/// 3. **Accumulation**: For each key, accumulate its contribution weighted by the r_x' tensor
-/// 4. **Word Expansion**: Expand each witness word bitwise to populate the g multilinears
-/// 5. **Lambda Weighting**: Apply lambda powers to weight different operand positions
-///
-/// The accumulator holds one row of `Word::BITS` scalars per shift the segment uses, addressed by
-/// the keys' dense shift index. A scatter through the segment's encoding then spreads those rows
-/// over the full `(shift variant, shift amount)` space of the returned parts.
-///
-/// # Returns
-///
-/// One multilinear of [`PHASE_1_LOG_LEN`] variables holding every shift variant's part: the
-/// variant indexes the high [`LOG_SHIFT_VARIANT_COUNT`] variables, and within a variant the rows
-/// of `Word::BITS` scalars run in order of shift amount.
+/// This is the shared builder on the inner slot.
+/// It scatters the bits of the witness word itself, into the row its inner shift names.
 ///
 /// # Usage
 ///
-/// Used in phase 1 to construct the constant size g multilinears
-/// that will participate in the phase 1 sumcheck protocol.
+/// Used by the inner phase to construct the constant size g multilinears that will participate in
+/// its sumcheck.
 #[instrument(skip_all, name = "build_g")]
 pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
@@ -158,9 +136,98 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
 ) -> FieldVec<P, A> {
-	// One row of `Word::BITS` scalars per shift the segment uses.
+	build_slot_g(alloc, words, segment, prepared, ShiftSlot::Inner)
+}
+
+/// Constructs the outer phase's "G" multilinear for one key segment.
+///
+/// This is the shared builder on the outer slot.
+/// It scatters the bits of the *intermediate* word — the witness word with its inner shift already
+/// applied — into the row the outer shift names.
+///
+/// The whole outer phase turns on one identity.
+/// Its definition contains an inner sum over the source bit index,
+///
+/// ```text
+/// sum_j shift-ind_op1(k, j, s_1) * w[y]_j  =  op1(w[y], s_1)_k
+/// ```
+///
+/// and the right-hand side is just bit `k` of the intermediate word.
+///
+/// Every shift variant has the at-most-one-source-bit property: an output position reads exactly
+/// one source position, with arithmetic right shift merely having many positions read the sign bit.
+/// So the sum has at most one nonzero term, and the indicator is a permutation with holes.
+/// The intermediate word therefore costs one machine shift, not 64 field products:
+///
+/// ```text
+/// G[k][s_2] = sum_y sum_{op1, s_1} Z~_{op1,op2}(r'_x, y, s_1, s_2) * op1(w[y], s_1)_k
+/// ```
+///
+/// # Usage
+///
+/// Used by the outer phase.
+/// Its sumcheck has the same bivariate-product shape as the inner phase's, so one runner serves
+/// both.
+#[instrument(skip_all, name = "build_outer_g")]
+pub fn build_outer_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
+	words: &[Word],
+	segment: &KeySegment,
+	prepared: &PreparedOperatorClaims<F>,
+) -> FieldVec<P, A> {
+	build_slot_g(alloc, words, segment, prepared, ShiftSlot::Outer)
+}
+
+/// Constructs one phase's shift multilinear for one key segment.
+///
+/// This builds the multilinear a phase's sumcheck runs against, over the words of a single
+/// value-vector segment (public or hidden).
+/// It constructs one multilinear polynomial per shift variant.
+///
+/// The public and hidden words participate through their own key segment, so a caller builds each
+/// with the matching words and sums the two results.
+///
+/// The two phases differ in exactly two places, both fixed by the bound slot:
+///
+/// ```text
+/// slot     row named by            bits scattered
+/// Inner    the inner shift         w[y]
+/// Outer    the outer shift         op1(w[y], s_1), the intermediate word
+/// ```
+///
+/// Everything else is shared: the per-key accumulation, the packed-mask bit scatter, the rayon fold
+/// and reduce, and the final scatter over the shift axes.
+///
+/// # Construction Process
+///
+/// 1. **Parallel Processing**: Words are processed in parallel chunks for efficiency
+/// 2. **Key Processing**: For each word, iterate through its associated keys in the segment
+/// 3. **Accumulation**: For each key, accumulate its contribution weighted by the r_x' tensor
+/// 4. **Word Expansion**: Expand the (possibly shifted) word bitwise to populate the multilinears
+/// 5. **Lambda Weighting**: Apply lambda powers to weight different operand positions
+///
+/// The accumulator holds one row of `Word::BITS` scalars per shift *the chosen slot takes*, not per
+/// sequence.
+/// Several sequences can agree on that slot, and their contributions belong in one row.
+/// A scatter then spreads those rows over the full `(variant, amount)` space of the returned parts.
+///
+/// # Returns
+///
+/// One multilinear of [`PHASE_1_LOG_LEN`] variables holding every shift variant's part: the
+/// variant indexes the high [`LOG_SHIFT_VARIANT_COUNT`] variables, and within a variant the rows
+/// of `Word::BITS` scalars run in order of shift amount.
+#[instrument(skip_all, name = "build_slot_g")]
+pub fn build_slot_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
+	words: &[Word],
+	segment: &KeySegment,
+	prepared: &PreparedOperatorClaims<F>,
+	slot: ShiftSlot,
+) -> FieldVec<P, A> {
+	// One row of `Word::BITS` scalars per shift the chosen slot takes.
+	let slot_rows = segment.dense_shift_enc.slot_rows(slot);
 	let row_len = Word::BITS >> P::LOG_WIDTH;
-	let acc_size = segment.dense_shift_enc.len() * row_len;
+	let acc_size = slot_rows.len() * row_len;
 
 	const {
 		assert!(
@@ -199,7 +266,7 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 
 					// The following loop is an optimized version of the following
 					// for i in 0..Word::BITS {
-					//     if get_bit(word, i) {
+					//     if get_bit(scattered, i) {
 					//         values[start + i] += acc;
 					//     }
 					// }
@@ -207,10 +274,23 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 						(key.dense_shift_idx as usize) < segment.dense_shift_enc.len(),
 						"a key indexes the dense shift encoding of its own segment"
 					);
-					let start = key.dense_shift_idx as usize * row_len;
+					// The row this slot names, shared by every sequence agreeing on it.
+					let start = slot_rows.row(key.dense_shift_idx) * row_len;
 					let values = &mut multilinears[start..start + row_len];
 					let values_per_byte = Word::BYTES >> P::LOG_WIDTH;
-					let mut remaining_word = word.0;
+					// The outer slot scatters the intermediate word, formed with one machine shift.
+					// The inner slot scatters the witness word untouched.
+					//
+					// A shift that clears the word costs nothing: the loop below skips zero bytes.
+					let scattered = match slot {
+						ShiftSlot::Inner => *word,
+						ShiftSlot::Outer => {
+							let [inner, _] =
+								segment.dense_shift_enc.decode(key.dense_shift_idx as usize);
+							inner.apply(*word)
+						}
+					};
+					let mut remaining_word = scattered.0;
 					let mut byte_index = 0;
 					while remaining_word != 0 {
 						let byte = remaining_word as u8;
@@ -254,24 +334,20 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 		// An empty word list yields no partials at all, and its parts are zero.
 		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice());
 
-	scatter_shift_rows(alloc, &multilinears, &segment.dense_shift_enc)
+	scatter_shift_rows(alloc, &multilinears, &slot_rows)
 }
 
-/// Spreads the rows of a dense phase-1 accumulator over the shift axes of the g multilinear.
+/// Spreads the rows of a dense accumulator over the shift axes of a phase's multilinear.
 ///
-/// The accumulator holds one row of `Word::BITS` scalars per shift sequence the segment uses, in
-/// dense shift index order.
-/// Each row lands at the offset its inner shift's `(variant, amount)` names.
+/// The accumulator holds one row of `Word::BITS` scalars per shift the bound slot takes, in
+/// [`SlotRows`] order.
+/// Each row lands at the offset its shift's `(variant, amount)` names.
 /// Every row the segment does not use stays zero.
-///
-/// Only the inner slot is read, since one shift axis pair is folded.
-/// A term whose outer slot carried work would land on its inner shift's row, against the wrong
-/// shifted word, which the assertion below rules out.
 #[instrument(skip_all, name = "scatter_shift_rows")]
 fn scatter_shift_rows<P: PackedField, A: Allocator>(
 	alloc: &A,
 	multilinears: &[P],
-	dense_shift_enc: &DenseShiftEncoding,
+	slot_rows: &SlotRows,
 ) -> FieldVec<P, A> {
 	const {
 		assert!(
@@ -283,14 +359,298 @@ fn scatter_shift_rows<P: PackedField, A: Allocator>(
 	// A row is a whole number of packed elements, so it copies in at row alignment.
 	let row_len = Word::BITS >> P::LOG_WIDTH;
 	let mut g = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
-	for (shift_seq, row) in iter::zip(dense_shift_enc.iter(), multilinears.chunks(row_len)) {
-		let [inner, outer] = shift_seq;
-		debug_assert!(outer.is_identity(), "{DOUBLE_SHIFT_UNSUPPORTED}");
-
-		// The variant indexes the high variables and the amount the middle ones. Dense indices are
-		// distinct, so no two rows land in the same place and each destination is still zero.
-		let offset = (inner.variant as usize * Word::BITS + inner.amount as usize) * row_len;
+	for (shift, row) in iter::zip(slot_rows.shifts(), multilinears.chunks(row_len)) {
+		// The variant indexes the high variables and the amount the middle ones. A slot's shifts
+		// are distinct, so no two rows land in the same place and each destination is still zero.
+		let offset = (shift.variant as usize * Word::BITS + shift.amount as usize) * row_len;
 		g.as_mut()[offset..][..row_len].copy_from_slice(row);
 	}
 	g
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_compute::GlobalAllocator;
+	use binius_core::{
+		ShiftVariant,
+		constraint_system::{
+			AndConstraint, ConstraintSystem, InoutSegment, Operand, Shift, ShiftedValueIndex,
+			ValueIndex,
+		},
+	};
+	use binius_field::{Field, Random};
+	use binius_verifier::config::B128;
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::protocols::shift::{
+		claims::OperatorClaims, key_collection::build_key_collection, prove::OperatorData,
+	};
+
+	/// The words the fixture's hidden segment holds, one per private value.
+	const N_HIDDEN_WORDS: usize = 4;
+
+	/// A constraint system over `N_HIDDEN_WORDS` private words whose AND operand carries the given
+	/// shift sequences, one term per sequence, spread over the words in turn.
+	///
+	/// `build_key_collection` does not validate, so this may carry sequences the canonical form
+	/// rejects — which is what lets a test pair a degenerate slot with a working one.
+	fn system_with(shift_seqs: &[[Shift; 2]]) -> ConstraintSystem {
+		let terms = shift_seqs
+			.iter()
+			.enumerate()
+			.map(|(term, &shift_seq)| {
+				let index = ValueIndex::private((term % N_HIDDEN_WORDS) as u32);
+				ShiftedValueIndex::new(index, shift_seq)
+			})
+			.collect::<Operand>();
+		ConstraintSystem {
+			constants: Vec::new(),
+			n_inout: 0,
+			n_private: N_HIDDEN_WORDS,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([terms, Operand::new(), Operand::new()])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		}
+	}
+
+	/// A single AND claim at a random point, which is what weights the keys.
+	fn claims(rng: &mut StdRng) -> PreparedOperatorClaims<B128> {
+		let r_z = B128::random(&mut *rng);
+		let claims = OperatorClaims {
+			zero: OperatorData::zero_claim(r_z),
+			bitand: OperatorData {
+				evals: [B128::ZERO; 3],
+				r_zhat_prime: r_z,
+				// One AND constraint, so the constraint point is empty.
+				r_x_prime: Vec::new(),
+			},
+			intmul: OperatorData::zero_claim(r_z),
+			binmul: OperatorData::zero_claim(r_z),
+		};
+		claims.prepare(|| B128::random(&mut *rng))
+	}
+
+	/// The shift indicator, derived from the word operation rather than from the reduction's
+	/// tables.
+	///
+	/// Output bit `k` reads input bit `j` exactly when shifting the one-hot word `1 << j` sets bit
+	/// `k`. That is the definition of the indicator, read straight off `Shift::apply`.
+	fn indicator(shift: Shift, out_bit: usize, source_bit: usize) -> bool {
+		let one_hot = Word(1u64 << source_bit);
+		(shift.apply(one_hot).0 >> out_bit) & 1 == 1
+	}
+
+	/// The naive reference for the outer phase's multilinear.
+	///
+	/// This forms the intermediate word's bit `k` as the *field sum*
+	///
+	/// ```text
+	/// sum_j shift-ind_op1(k, j, s_1) * w[y]_j
+	/// ```
+	///
+	/// spelled out over all 64 source bits, rather than with the machine shift `build_outer_g`
+	/// uses. Two source bits reaching one output position would cancel in this sum and survive the
+	/// machine shift, so agreeing with it is what pins the at-most-one-source-bit property the
+	/// phase rests on.
+	fn reference_outer_g(
+		words: &[Word],
+		segment: &KeySegment,
+		prepared: &PreparedOperatorClaims<B128>,
+	) -> Vec<B128> {
+		let mut reference = vec![B128::ZERO; 1 << PHASE_1_LOG_LEN];
+		for (word, range) in iter::zip(words, &segment.key_ranges) {
+			for key in &segment.keys[range.start as usize..range.end as usize] {
+				let operator_data = &prepared[key.operation];
+				let acc = key.accumulate(
+					&segment.constraint_indices,
+					operator_data.r_x_prime_tensor.as_ref(),
+					&operator_data.lambda_powers,
+				);
+				let [inner, outer] = segment.dense_shift_enc.decode(key.dense_shift_idx as usize);
+
+				// The outer shift names the run of bit slots, as it does in the built form.
+				let base =
+					(outer.variant as usize * Word::BITS + outer.amount as usize) * Word::BITS;
+				for out_bit in 0..Word::BITS {
+					// Bit `out_bit` of the intermediate word, as a sum over every source bit.
+					let intermediate_bit = (0..Word::BITS)
+						.filter(|&source_bit| indicator(inner, out_bit, source_bit))
+						.filter(|&source_bit| (word.0 >> source_bit) & 1 == 1)
+						.map(|_| B128::ONE)
+						.sum::<B128>();
+					reference[base + out_bit] += acc * intermediate_bit;
+				}
+			}
+		}
+		reference
+	}
+
+	/// Random words for the fixture's hidden segment.
+	fn hidden_words(rng: &mut StdRng) -> Vec<Word> {
+		(0..N_HIDDEN_WORDS)
+			.map(|_| Word::from_u64(rng.random()))
+			.collect()
+	}
+
+	#[test]
+	fn outer_g_matches_the_naive_indicator_reference() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Genuine pairs across the variants: each drops bits one way and moves them back the other,
+		// so none collapses to a single shift.
+		let shift_seqs = [
+			[Shift::srl(3), Shift::sll(3)],
+			[Shift::srl(5), Shift::sll(9)],
+			[Shift::sll(8), Shift::srl(2)],
+			[Shift::sar(7), Shift::sll(4)],
+			[Shift::rotr(1), Shift::sll(6)],
+			[Shift::srl32(4), Shift::sll32(11)],
+			[Shift::sra32(9), Shift::sll32(3)],
+			[Shift::rotr32(5), Shift::srl32(7)],
+			// Two sequences agreeing on their outer shift must land in one row.
+			[Shift::srl(6), Shift::sll(3)],
+			// A sequence whose inner shift clears the word contributes nothing.
+			[Shift::sll(63), Shift::srl(40)],
+		];
+		let cs = system_with(&shift_seqs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let words = hidden_words(&mut rng);
+		let prepared = claims(&mut rng);
+
+		let built = build_outer_g::<B128, B128, _>(
+			&GlobalAllocator,
+			&words,
+			&key_collection.hidden,
+			&prepared,
+		);
+		let reference = reference_outer_g(&words, &key_collection.hidden, &prepared);
+
+		assert_eq!(built.as_ref(), reference.as_slice());
+		// A fixture that produced nothing would pass vacuously.
+		assert!(reference.iter().any(|&entry| entry != B128::ZERO));
+	}
+
+	#[test]
+	fn outer_g_over_every_variant_pair_matches_the_reference() {
+		let mut rng = StdRng::seed_from_u64(1);
+
+		// Every ordered variant combination, at amounts that keep the pair irreducible for most of
+		// them. A pair that happens to collapse is still a valid input here: the reference and the
+		// built form must agree on it either way.
+		let shift_seqs = ShiftVariant::ALL
+			.into_iter()
+			.flat_map(|inner_variant| {
+				ShiftVariant::ALL.into_iter().map(move |outer_variant| {
+					[Shift::new(inner_variant, 3), Shift::new(outer_variant, 5)]
+				})
+			})
+			.collect::<Vec<_>>();
+
+		let cs = system_with(&shift_seqs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let words = hidden_words(&mut rng);
+		let prepared = claims(&mut rng);
+
+		let built = build_outer_g::<B128, B128, _>(
+			&GlobalAllocator,
+			&words,
+			&key_collection.hidden,
+			&prepared,
+		);
+		let reference = reference_outer_g(&words, &key_collection.hidden, &prepared);
+
+		assert_eq!(built.as_ref(), reference.as_slice());
+	}
+
+	#[test]
+	fn outer_g_with_a_degenerate_inner_slot_is_the_inner_builder() {
+		// The compatibility property the staged rollout leans on. With the inner slot degenerate
+		// the intermediate word is the witness word itself, and the row is named by the outer
+		// shift — so the outer builder does exactly what the inner builder does on the mirrored
+		// sequences.
+		let mut rng = StdRng::seed_from_u64(2);
+		let words = hidden_words(&mut rng);
+		let prepared = claims(&mut rng);
+
+		let shifts = [
+			Shift::IDENTITY,
+			Shift::srl(3),
+			Shift::sar(7),
+			Shift::rotr(1),
+			Shift::sll32(4),
+		];
+
+		// `[IDENTITY, s]` for the outer builder, `[s, IDENTITY]` for the inner one.
+		let outer_slotted = shifts.map(|shift| [Shift::IDENTITY, shift]);
+		let inner_slotted = shifts.map(|shift| [shift, Shift::IDENTITY]);
+
+		let outer_cs = system_with(&outer_slotted);
+		let inner_cs = system_with(&inner_slotted);
+		let outer_keys = build_key_collection(&outer_cs, InoutSegment::Public);
+		let inner_keys = build_key_collection(&inner_cs, InoutSegment::Public);
+
+		let from_outer =
+			build_outer_g::<B128, B128, _>(&GlobalAllocator, &words, &outer_keys.hidden, &prepared);
+		let from_inner =
+			build_g::<B128, B128, _>(&GlobalAllocator, &words, &inner_keys.hidden, &prepared);
+
+		assert_eq!(from_outer.as_ref(), from_inner.as_ref());
+	}
+
+	#[test]
+	fn slot_rows_merge_sequences_that_share_the_bound_slot() {
+		// Two sequences sharing a slot shift must accumulate into one row, or the scatter would
+		// land two rows on one offset and drop one of them. The dense index is per sequence, so
+		// this is the projection that makes the rows per slot shift.
+		let shift_seqs = [
+			[Shift::srl(3), Shift::sll(3)],
+			[Shift::srl(5), Shift::sll(3)],
+			[Shift::srl(3), Shift::sll(9)],
+		];
+		let cs = system_with(&shift_seqs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let encoding = &key_collection.hidden.dense_shift_enc;
+
+		// Three sequences, but only two distinct shifts in either slot.
+		assert_eq!(encoding.len(), 3);
+		let inner_rows = encoding.slot_rows(ShiftSlot::Inner);
+		let outer_rows = encoding.slot_rows(ShiftSlot::Outer);
+		assert_eq!(inner_rows.len(), 2);
+		assert_eq!(outer_rows.len(), 2);
+		assert_eq!(inner_rows.shifts().collect::<Vec<_>>(), [Shift::srl(3), Shift::srl(5)]);
+		assert_eq!(outer_rows.shifts().collect::<Vec<_>>(), [Shift::sll(3), Shift::sll(9)]);
+
+		// Each sequence maps to the row of its own slot shift.
+		for dense_idx in 0..encoding.len() as u16 {
+			let [inner, outer] = encoding.decode(dense_idx as usize);
+			assert_eq!(inner_rows.shifts().nth(inner_rows.row(dense_idx)), Some(inner));
+			assert_eq!(outer_rows.shifts().nth(outer_rows.row(dense_idx)), Some(outer));
+		}
+	}
+
+	#[test]
+	fn has_outer_shift_reports_whether_a_third_phase_is_needed() {
+		// The degeneration check: a system of lone shifts needs no outer phase.
+		let lone = system_with(&[
+			[Shift::srl(3), Shift::IDENTITY],
+			[Shift::rotr(1), Shift::IDENTITY],
+		]);
+		let lone_keys = build_key_collection(&lone, InoutSegment::Public);
+		assert!(!lone_keys.hidden.dense_shift_enc.has_outer_shift());
+
+		// One genuine pair anywhere is enough to need it.
+		let paired = system_with(&[
+			[Shift::srl(3), Shift::IDENTITY],
+			[Shift::srl(3), Shift::sll(3)],
+		]);
+		let paired_keys = build_key_collection(&paired, InoutSegment::Public);
+		assert!(paired_keys.hidden.dense_shift_enc.has_outer_shift());
+
+		// A segment with no keys at all has nothing to bind.
+		let empty = system_with(&[]);
+		let empty_keys = build_key_collection(&empty, InoutSegment::Public);
+		assert!(!empty_keys.hidden.dense_shift_enc.has_outer_shift());
+	}
 }

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -10,8 +10,8 @@ use binius_math::{
 };
 
 use super::{
-	SegmentWords, claims::OperatorClaims, key_collection::KeyCollection, phase_1::prove_phase_1,
-	phase_2::prove_phase_2,
+	DOUBLE_SHIFT_UNSUPPORTED, SegmentWords, claims::OperatorClaims, key_collection::KeyCollection,
+	phase_1::prove_phase_1, phase_2::prove_phase_2,
 };
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
@@ -157,6 +157,14 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
+	// Invariant: two phases bind one shift slot.
+	// A sequence with work in its outer slot needs a third phase to bind the other.
+	debug_assert!(
+		!key_collection.public.dense_shift_enc.has_outer_shift()
+			&& !key_collection.hidden.dense_shift_enc.has_outer_shift(),
+		"{DOUBLE_SHIFT_UNSUPPORTED}"
+	);
+
 	// The segments are passed as the circuit declares them, at whatever length that is. Phase 1
 	// zips each word with its key range, so a segment shorter than its key ranges stops at its
 	// last value — the words past it carry no keys — and phase 2's `fold_words` zero-pads each


### PR DESCRIPTION
Closes [BINIUS-444](https://linear.app/jimpo/issue/BINIUS-444).

> **Stacked on #2098** ([BINIUS-443](https://linear.app/jimpo/issue/BINIUS-443)) → #2097 → #2096. Review in that order; this PR's diff is only its own increment.

The one piece of the double-shift prover that does not already exist in some form.

### The idea

The outer phase's multilinear is defined with an inner sum over the source bit index:

```
G[k][s_2] = sum_y sum_{op1, s_1} Z~(r'_x, y, s_1, s_2) * [ sum_j shift-ind_op1(k, j, s_1) * w[y]_j ]
                                                          \_________ this inner sum _________/
```

That inner sum has a closed form:

```
sum_j shift-ind_op1(k, j, s_1) * w[y]_j  =  op1(w[y], s_1)_k
```

It is **just bit $k$ of the intermediate word**.

Why: every shift variant has the *at-most-one-source-bit* property.
An output position reads exactly one source position — arithmetic right shift merely has *many* output positions read the sign bit, which is many-to-one, not one-to-many.
So the sum has at most one nonzero term, and the indicator is a permutation with holes.

**The intermediate word therefore costs one machine shift, not 64 field products.**

### The change

The new builder differs from the existing one in exactly two places:

| | row named by | bits scattered |
|---|---|---|
| inner slot | the inner shift | `w[y]` |
| outer slot | the outer shift | `op1(w[y], s_1)`, the intermediate word |

Both are fixed by one slot parameter, so this is **one function** rather than two copies of a ninety-line loop.
Everything else is shared: the per-key accumulation, the packed-mask bit scatter, the rayon fold and reduce, and the final scatter over the shift axes.

```
+ pub fn build_outer_g(..)  -> build_slot_g(.., ShiftSlot::Outer)
  pub fn build_g(..)        -> build_slot_g(.., ShiftSlot::Inner)
```

A shift that clears the word costs nothing: the scatter loop is driven by the remaining nonzero bytes.

### A subtlety keying on sequences introduced

Two sequences can agree on the slot a phase binds:

```
[srl(3), sll(3)]  \
                   >  agree on the outer shift -> must accumulate into ONE row
[srl(5), sll(3)]  /
```

The dense index is per *sequence*, so an accumulator keyed by it would give these two separate rows — and the scatter would then copy both to the same offset, silently dropping one.

So the accumulator holds one row per distinct shift **that slot** takes, and a per-slot projection maps each sequence onto its row.
This was latent before: with the outer slot always the identity, distinct sequences implied distinct inner shifts, so the old keying happened to be safe.

### Scope

- **new:** the outer builder, the slot parameter, the per-slot row projection, and a predicate for whether any sequence needs both slots
- **changed:** the existing builder becomes a thin wrapper; the scatter keys off slot rows
- **left untouched:** the reduction still runs two phases — the outer builder has no caller yet, which is BINIUS-445. The two-phase entry point now asserts no sequence carries an outer shift.

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-prover --all-targets` — clean
- nightly `cargo fmt --all` — clean
- prover shift module: 18 tests pass (13 existing + 5 new)
- `prove_verify` 14/14 pass **unchanged**

### Tests added

The load-bearing one is a **naive indicator reference**: it forms the intermediate word's bit $k$ as the *field sum* over all 64 source positions, spelled out, rather than with the machine shift.

Two source bits reaching one output position would cancel in that sum and survive the machine shift — so agreeing with it is what pins the at-most-one-source-bit property the whole phase rests on.

- the built form equals that reference on a fixture of genuine pairs, including two that share an outer shift and one whose inner shift clears the word
- and again over **every ordered variant combination** (all 64), so no variant's source map can be wrong unnoticed
- a degenerate inner slot makes the outer builder equal the inner builder on mirrored sequences — the compatibility property the staged rollout leans on
- the per-slot projection merges sequences sharing the bound slot, and each sequence maps to the row of its own shift
- the "needs a third phase" predicate: false for lone shifts, true for one genuine pair, false for an empty segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)