### PR TITLE
BINIUS-445: wire the three-phase shift reduction end to end

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -14,9 +14,9 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
-		monster::{build_h, build_monster_segments},
-		phase_1::{PHASE_1_LOG_LEN, build_g, run_phase_1_sumcheck},
-		phase_2::run_sumcheck,
+		monster::{SlotWeights, build_h, build_monster_segments, outer_h_evals},
+		slot_phase::{SLOT_PHASE_LOG_LEN, SlotPhaseOutput, build_g, run_slot_sumcheck},
+		words_phase::run_sumcheck,
 	},
 };
 
@@ -67,28 +67,27 @@ where
 	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
 	let prepared = claims.prepare(|| channel.sample());
 
-	// Phase 1: build g once per key segment, then add them. The public words are
+	// The slot phase: build g once per key segment, then add them. The public words are
 	// constants shared by every instance, so the single-instance builder folds them directly from
 	// their bits; the hidden words are already folded over instances. This scalar path drives the
-	// single-instance phase-1 sumcheck.
-	let mut g = build_g::<F, F, _>(alloc, public_words, &key_collection.public, &prepared);
+	// single-instance slot sumcheck.
+	let mut g = build_g::<F, F, _>(alloc, public_words, &key_collection.public, &prepared, None);
 	let hidden_g =
 		build_g_from_folded_words(alloc, folded_witness.words(), &key_collection.hidden, &prepared);
 	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
 		*slot += *add;
 	}
 	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
-	let phase_1_output =
-		run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
+	let slot_phase = run_slot_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
 
-	// Phase 2: split the phase-1 challenges into the bit position `r_j`, the shift amount `r_s`
-	// and the shift variant `r_v`, in increasing order of significance.
-	let SumcheckOutput {
-		challenges: mut r_j,
-		eval: gamma,
-	} = phase_1_output;
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
+	// The words phase runs at the bit point the slot phase bound, against the monster multilinear.
+	let claim = slot_phase.claim();
+	let SlotPhaseOutput {
+		r_bit: r_j,
+		r_s,
+		r_v,
+		..
+	} = slot_phase;
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
 	// The witness folded at `r_j`, per segment.
@@ -96,14 +95,19 @@ where
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
 
+	// One slot phase bound the inner axes, so its `h` carries the oblong factor and the outer
+	// slot's weight selects the identity every key carries.
+	let operation_scalars = outer_h_evals(&prepared, domain_subspace, &r_j, &r_s, &r_v);
+	let inner = SlotWeights::at(&r_s, &r_v);
+	let outer = SlotWeights::identity_selecting();
+
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		alloc,
 		key_collection,
 		&prepared,
-		domain_subspace,
-		&r_j,
-		&r_s,
-		&r_v,
+		operation_scalars,
+		&inner,
+		&outer,
 	);
 
 	run_sumcheck::<F, P, _, _>(
@@ -113,7 +117,7 @@ where
 		hidden_monster,
 		public_words,
 		r_j,
-		gamma,
+		claim,
 		channel,
 		alloc,
 	)
@@ -143,7 +147,7 @@ where
 ///
 /// # Returns
 ///
-/// One multilinear of [`PHASE_1_LOG_LEN`] variables, holding every shift variant's part.
+/// One multilinear of [`SLOT_PHASE_LOG_LEN`] variables, holding every shift variant's part.
 ///
 /// The segment's dense shift encoding decodes a key's shift index into the variant and the shift
 /// amount. The variant indexes the high variables and the amount the middle ones, so a key names
@@ -165,7 +169,7 @@ pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
 ) -> FieldVec<F, A> {
 	// One zeroed multilinear covering every shift, drawn from the allocator. A key names one
 	// `(variant, amount)` pair, so the scatter below accumulates straight into it.
-	let mut multilinear = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
+	let mut multilinear = FieldBuffer::zeros_in(alloc, SLOT_PHASE_LOG_LEN);
 
 	// Each folded word carries the keys named by the segment-relative range at its position.
 	for (word, range) in folded_words.iter().zip(&segment.key_ranges) {
@@ -497,6 +501,7 @@ mod tests {
 			public_words,
 			&key_collection.public,
 			&prepared,
+			None,
 		);
 		let hidden_g = build_g_from_folded_words(
 			&GlobalAllocator,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -12,16 +12,15 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
-use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		OperatorClaims, OperatorData, build_key_collection,
-		monster::{build_h, build_monster_segments},
-		phase_1::{build_g, run_phase_1_sumcheck},
-		phase_2::run_sumcheck,
+		monster::{SlotWeights, build_h, build_monster_segments, outer_h_evals},
 		prove,
+		slot_phase::{SlotPhaseOutput, build_g, run_slot_sumcheck},
+		words_phase::run_sumcheck,
 	},
 };
 use binius_transcript::ProverTranscript;
@@ -303,10 +302,20 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// `build_g` runs per key segment; the full g multilinear is the sum of the public and
 	// hidden segment ones.
 	let build_combined_g = || {
-		let mut g =
-			build_g::<F, P, _>(&GlobalAllocator, public_words, &key_collection.public, &prepared);
-		let hidden_g =
-			build_g::<F, P, _>(&GlobalAllocator, hidden_words, &key_collection.hidden, &prepared);
+		let mut g = build_g::<F, P, _>(
+			&GlobalAllocator,
+			public_words,
+			&key_collection.public,
+			&prepared,
+			None,
+		);
+		let hidden_g = build_g::<F, P, _>(
+			&GlobalAllocator,
+			hidden_words,
+			&key_collection.hidden,
+			&prepared,
+			None,
+		);
 		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
 			*slot += *add;
 		}
@@ -315,12 +324,9 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	let g = build_combined_g();
 	let h = build_h::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime);
-	let SumcheckOutput {
-		challenges: mut r_j,
-		eval: gamma,
-	} = {
+	let slot_phase = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
-		run_phase_1_sumcheck::<F, P, _, _>(
+		run_slot_sumcheck::<F, P, _, _>(
 			g.clone(),
 			h.clone(),
 			prepared.batched_eval(),
@@ -328,27 +334,37 @@ fn bench_shift_phases(c: &mut Criterion) {
 			&GlobalAllocator,
 		)
 	};
-	// Split the phase-1 challenges into the bit position, the shift amount and the shift variant.
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
+	// The slot phase already split its point into the bit position, the shift amount and the shift
+	// variant.
+	let gamma = slot_phase.claim();
+	let SlotPhaseOutput {
+		r_bit: r_j,
+		r_s,
+		r_v,
+		..
+	} = slot_phase;
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());
+	// The circuits benchmarked here carry lone shifts, so one slot phase bound the inner axes and
+	// the outer slot's weight selects the identity every key carries.
+	let operation_scalars = outer_h_evals(&prepared, &subspace, &r_j, &r_s, &r_v);
+	let inner_weights = SlotWeights::at(&r_s, &r_v);
+	let outer_weights = SlotWeights::identity_selecting();
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		&GlobalAllocator,
 		&key_collection,
 		&prepared,
-		&subspace,
-		&r_j,
-		&r_s,
-		&r_v,
+		operation_scalars,
+		&inner_weights,
+		&outer_weights,
 	);
 
 	let mut group = c.benchmark_group("shift_reduction_phases");
 	group.sample_size(10);
 
 	// Phase 1. `build_g` / `build_h` take their inputs by reference, so no
-	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g`/`h` by value.
+	// per-iteration clone is needed; `run_slot_sumcheck` consumes `g`/`h` by value.
 	group.bench_function("phase1_build_g_parts", |b| {
 		b.iter(&build_combined_g);
 	});
@@ -360,7 +376,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 			|| (g.clone(), h.clone()),
 			|(g, h)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
-				run_phase_1_sumcheck::<F, P, _, _>(
+				run_slot_sumcheck::<F, P, _, _>(
 					g,
 					h,
 					prepared.batched_eval(),
@@ -380,10 +396,9 @@ fn bench_shift_phases(c: &mut Criterion) {
 				&GlobalAllocator,
 				&key_collection,
 				&prepared,
-				&subspace,
-				&r_j,
-				&r_s,
-				&r_v,
+				operation_scalars,
+				&inner_weights,
+				&outer_weights,
 			)
 		});
 	});

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -3,19 +3,12 @@
 
 use binius_core::word::Word;
 
-/// Why a shift sequence's outer slot must hold the identity in the two-phase reduction.
-///
-/// The reduction folds one shift axis pair, so it reads the inner slot and ignores the outer one.
-/// A term carrying both would be reduced against the wrong shifted word.
-pub(crate) const DOUBLE_SHIFT_UNSUPPORTED: &str =
-	"the two-phase shift reduction reads only the inner shift of a sequence";
-
 /// The value vector's two committed segments, each at the width the protocol addresses it at.
 ///
 /// A circuit declares fewer values than the reductions address: the public segment is padded to a
-/// power of two and the hidden segment to at least that width. Both phases of the shift reduction
-/// read the segments at those padded widths, so [`prove()`] fills them once and hands the pair down
-/// rather than having each phase re-derive the split.
+/// power of two and the hidden segment to at least that width. Every phase of the shift reduction
+/// reads the segments at those padded widths, so [`prove()`] fills them once and hands the pair
+/// down rather than having each phase re-derive the split.
 #[derive(Clone, Copy)]
 pub struct SegmentWords<'a> {
 	/// The constants and inout values, zero-filled to the public segment width.
@@ -25,21 +18,21 @@ pub struct SegmentWords<'a> {
 }
 
 mod key_collection;
-// `monster`, `phase_1`, and `phase_2` are internal implementation, exposed (via `#[doc(hidden)]`
-// `pub mod`) only so the `shift_reduction` benchmark can time individual phase functions (see
-// `benches/shift_reduction.rs`). Not a stable API.
+// `monster`, `slot_phase`, and `words_phase` are internal implementation, exposed (via
+// `#[doc(hidden)]` `pub mod`) only so the `shift_reduction` benchmark can time individual phase
+// functions (see `benches/shift_reduction.rs`). Not a stable API.
 mod claims;
 #[doc(hidden)]
 pub mod monster;
-#[doc(hidden)]
-pub mod phase_1;
-#[doc(hidden)]
-pub mod phase_2;
 mod prove;
+#[doc(hidden)]
+pub mod slot_phase;
+#[doc(hidden)]
+pub mod words_phase;
 
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
 pub use key_collection::{
 	DenseShiftEncoding, KeyCollection, KeySegment, Operation, ShiftSlot, SlotRows,
 	build_key_collection,
 };
-pub use prove::{OperatorData, PreparedOperatorData, prove};
+pub use prove::{OperatorData, PreparedOperatorData, has_double_shift, prove};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::iter;
+use std::{iter, ops::Index};
 
 use binius_compute::{Allocator, VecLike};
 use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
@@ -13,6 +13,7 @@ use binius_math::{
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use binius_verifier::protocols::shift::{
 	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, ZERO_ARITY, evaluate_h_op,
+	evaluate_inner_h_op,
 };
 use bytemuck::zeroed_vec;
 use tracing::instrument;
@@ -20,13 +21,13 @@ use tracing::instrument;
 use super::{
 	claims::PreparedOperatorClaims,
 	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation},
-	phase_1::PHASE_1_LOG_LEN,
+	slot_phase::SLOT_PHASE_LOG_LEN,
 };
 
 /// The width the half-word (`*32`) shift variants act over.
 const HALF_WORD_BITS: usize = 32;
 
-/// The phase-2 scalar weights of one key segment, one table per operation.
+/// The words phase's scalar weights of one key segment, one table per operation.
 ///
 /// A table holds the `arity` weights of each shift sequence the segment uses, in dense shift index
 /// order, so a key's weights are the chunk at `key.dense_shift_idx * arity`.
@@ -37,36 +38,96 @@ struct ScalarTables<F> {
 	binmul: Vec<F>,
 }
 
-/// The equality-indicator weights of a shift sequence's outer slot.
+/// The equality-indicator weights of one shift slot, over its two axes.
 ///
-/// The sequence weight factorizes across its two slots, so each slot carries its own two tensors:
+/// A sequence's weight factorizes across its two slots, so each slot carries its own two tensors:
 /// one over the variant axis, one over the amount axis.
 /// Keeping them apart holds the weights at `2 * SHIFT_COUNT` entries rather than `SHIFT_COUNT^2`.
-struct OuterSlotWeights<F: Field> {
-	/// The equality indicator over the outer variant axis, one weight per shift variant.
+/// The cost is one extra multiply per key.
+pub struct SlotWeights<F: Field> {
+	/// The equality indicator over this slot's variant axis, one weight per shift variant.
 	variant: FieldBuffer<F>,
-	/// The equality indicator over the outer amount axis, one weight per shift amount.
+	/// The equality indicator over this slot's amount axis, one weight per shift amount.
 	amount: FieldBuffer<F>,
 }
 
-impl<F: Field> OuterSlotWeights<F> {
-	/// The weights that select the identity and reject every other outer shift.
+impl<F: Field> SlotWeights<F> {
+	/// The weights at the amount and variant points a phase bound for this slot.
 	///
-	/// This is the equality indicator at the all-zero point, where no challenges were drawn over
-	/// the outer axes.
-	/// Every key's outer slot holds [`Shift::IDENTITY`], spelled `(Sll, 0)`.
-	/// So a well-formed key weighs one, and the scalars match what a single-shift reduction builds.
-	fn identity_selecting() -> Self {
+	/// # Panics
+	///
+	/// Panics if the points are not the widths of the two axes.
+	pub fn at(r_s: &[F], r_v: &[F]) -> Self {
+		assert_eq!(r_s.len(), Word::LOG_BITS);
+		assert_eq!(r_v.len(), LOG_SHIFT_VARIANT_COUNT);
+		Self {
+			variant: eq_ind_partial_eval::<F>(r_v),
+			amount: eq_ind_partial_eval::<F>(r_s),
+		}
+	}
+
+	/// The weights that select the identity and reject every other shift in the slot.
+	///
+	/// This is the equality indicator at the all-zero point, where a reduction stands on a slot it
+	/// never bound: no challenges were drawn over those axes.
+	/// Every key's shift there is [`Shift::IDENTITY`], spelled `(Sll, 0)`.
+	/// So a well-formed key weighs one, and the scalars match what a single-slot reduction builds.
+	pub fn identity_selecting() -> Self {
 		Self {
 			variant: eq_ind_partial_eval::<F>(&[F::ZERO; LOG_SHIFT_VARIANT_COUNT]),
 			amount: eq_ind_partial_eval::<F>(&[F::ZERO; Word::LOG_BITS]),
 		}
 	}
 
-	/// The weight one outer shift contributes to its sequence's scalar.
+	/// The weight one shift in this slot contributes to its sequence's scalar.
 	#[inline]
-	fn weight(&self, shift: Shift) -> F {
+	pub fn weight(&self, shift: Shift) -> F {
 		self.variant.as_ref()[shift.variant as usize] * self.amount.as_ref()[shift.amount as usize]
+	}
+}
+
+/// One scalar per operation, as the words phase weights that operation's keys by.
+///
+/// Every key of an operation shares the weight of the phase that closed the operand claim's bit
+/// axis.
+/// So it is a single factor rather than part of the per-shift tables.
+#[derive(Debug, Clone, Copy)]
+pub struct OperationScalars<F> {
+	/// The scalar shared by every ZERO key.
+	pub zero: F,
+	/// The scalar shared by every AND key.
+	pub bitand: F,
+	/// The scalar shared by every IMUL key.
+	pub intmul: F,
+	/// The scalar shared by every BMUL key.
+	pub binmul: F,
+}
+
+impl<F: Field> OperationScalars<F> {
+	/// Scales every operation's scalar by a factor the whole reduction shares.
+	///
+	/// The inner phase's weight carries no oblong factor.
+	/// So it is one value for all four operations, and folds in here rather than per shift.
+	pub fn scaled_by(self, factor: F) -> Self {
+		Self {
+			zero: self.zero * factor,
+			bitand: self.bitand * factor,
+			intmul: self.intmul * factor,
+			binmul: self.binmul * factor,
+		}
+	}
+}
+
+impl<F> Index<Operation> for OperationScalars<F> {
+	type Output = F;
+
+	fn index(&self, operation: Operation) -> &F {
+		match operation {
+			Operation::Zero => &self.zero,
+			Operation::BitwiseAnd => &self.bitand,
+			Operation::IntegerMul => &self.intmul,
+			Operation::BinMul => &self.binmul,
+		}
 	}
 }
 
@@ -122,19 +183,52 @@ fn fill_h_row<F: Field>(variant: ShiftVariant, amount: usize, row: &mut [F], l_t
 	}
 }
 
-/// Constructs the "h" multilinear for shift operations at a univariate challenge point.
+/// Constructs the "h" multilinear of a phase from its per-output-bit weights.
 ///
 /// See the paper for the definition of the h polynomials. There is one per shift variant, and this
-/// returns all of them as a single multilinear over [`PHASE_1_LOG_LEN`] variables: the shift
+/// returns all of them as a single multilinear over [`SLOT_PHASE_LOG_LEN`] variables: the shift
 /// variant occupies the high
 /// [`LOG_SHIFT_VARIANT_COUNT`](binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT)
 /// variables, the shift amount the middle
 /// [`Word::LOG_BITS`], and the bit position the low [`Word::LOG_BITS`].
 ///
+/// Both phases contract each variant's shift indicator against a weight per output bit position.
+/// Only the weights differ.
+/// The verifier evaluates the same object succinctly rather than building it.
+///
 /// # Usage in Protocol
 ///
-/// Phase 1 runs one sumcheck over this multilinear and its "g" counterpart, so the variant axis is
+/// A phase runs one sumcheck over this multilinear and its "g" counterpart, so the variant axis is
 /// folded by the sumcheck rather than summed across separate provers.
+#[instrument(skip_all, name = "build_h_from_weights")]
+pub fn build_h_from_weights<F, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
+	l_tilde: &[F],
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+{
+	assert_eq!(l_tilde.len(), Word::BITS);
+
+	// One row of `Word::BITS` scalars per `(variant, amount)`, variant most significant.
+	let mut data = zeroed_vec::<F>(1 << SLOT_PHASE_LOG_LEN);
+	for (variant, block) in
+		iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS))
+	{
+		for (amount, row) in block.chunks_exact_mut(Word::BITS).enumerate() {
+			fill_h_row(variant, amount, row, l_tilde);
+		}
+	}
+
+	FieldBuffer::from_values_in(alloc, &data)
+}
+
+/// Constructs the outer phase's "H" multilinear at a univariate challenge point.
+///
+/// The weights are the oblong factor `delta_D(r_zhat_prime, .)`: the Lagrange basis of the bit axis
+/// at the univariate challenge.
+/// This closes the operand claim's bit axis, which is why it belongs to the phase binding the
+/// *output* end of the shift sequence.
 #[instrument(skip_all, name = "build_h")]
 pub fn build_h<F, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
@@ -145,19 +239,78 @@ where
 	F: BinaryField,
 {
 	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-	let l_tilde = l_tilde.as_ref();
+	build_h_from_weights(alloc, l_tilde.as_ref())
+}
 
-	// One row of `Word::BITS` scalars per `(variant, amount)`, variant most significant.
-	let mut data = zeroed_vec::<F>(1 << PHASE_1_LOG_LEN);
-	for (variant, block) in
-		iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS))
-	{
-		for (amount, row) in block.chunks_exact_mut(Word::BITS).enumerate() {
-			fill_h_row(variant, amount, row, l_tilde);
-		}
+/// Constructs the inner phase's "h" multilinear at the intermediate point the outer phase produced.
+///
+/// The weights are the equality indicator of the intermediate point, so this is the bare shift
+/// indicator there.
+/// It carries no oblong factor, since the outer phase already summed the output bit index out.
+///
+/// # Panics
+///
+/// Panics if `r_k` does not have `Word::LOG_BITS` coordinates.
+#[instrument(skip_all, name = "build_inner_h")]
+pub fn build_inner_h<F, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
+	r_k: &[F],
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+{
+	assert_eq!(r_k.len(), Word::LOG_BITS);
+	let eq_r_k = eq_ind_partial_eval::<F>(r_k);
+	build_h_from_weights(alloc, eq_r_k.as_ref())
+}
+
+/// The outer phase's `H` evaluation for each operation, at the point that phase bound.
+///
+/// This weight carries the oblong factor `delta_D(r_zhat_prime, .)`.
+/// Each operation claims at its own univariate challenge, so there is one evaluation per operation
+/// rather than one shared value.
+///
+/// # Arguments
+///
+/// - `r_out`: the bit point the phase bound. Without an outer phase this is the source bit point,
+///   since one phase then closes both the bit axis and the words.
+/// - `r_s`, `r_v`: the amount and variant points of the slot that phase bound.
+pub fn outer_h_evals<F: BinaryField>(
+	prepared: &PreparedOperatorClaims<F>,
+	domain_subspace: &BinarySubspace<F>,
+	r_out: &[F],
+	r_s: &[F],
+	r_v: &[F],
+) -> OperationScalars<F> {
+	// The phase folded the variant axis into its sumcheck.
+	// So the weight is one scalar per operation: its eight indicators interpolated at `r_v`.
+	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
+	let eval_at = |r_zhat_prime: F| {
+		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
+		let h_ops = evaluate_h_op(l_tilde.as_ref(), r_out, r_s);
+		inner_product(h_ops, r_v_tensor.as_ref().iter().copied())
+	};
+	OperationScalars {
+		zero: eval_at(prepared.zero.r_zhat_prime),
+		bitand: eval_at(prepared.bitand.r_zhat_prime),
+		intmul: eval_at(prepared.intmul.r_zhat_prime),
+		binmul: eval_at(prepared.binmul.r_zhat_prime),
 	}
+}
 
-	FieldBuffer::from_values_in(alloc, &data)
+/// The inner phase's `h` evaluation, at the point that phase bound.
+///
+/// This carries no oblong factor, since the outer phase already summed the output bit index out.
+/// So it is one value shared by every operation, folded into the per-operation scalars.
+///
+/// # Arguments
+///
+/// - `r_k`: the intermediate bit point the outer phase produced.
+/// - `r_j`, `r_s`, `r_v`: the source bit point and the inner slot's amount and variant points.
+pub fn inner_h_eval<F: BinaryField>(r_k: &[F], r_j: &[F], r_s: &[F], r_v: &[F]) -> F {
+	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
+	let h_ops = evaluate_inner_h_op(r_k, r_j, r_s);
+	inner_product(h_ops, r_v_tensor.as_ref().iter().copied())
 }
 
 /// Constructs the "monster multilinear" that combines all shift operations into a single
@@ -183,14 +336,22 @@ where
 /// ```text
 /// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor, scalars[key.dense_shift_idx])
 /// ```
-/// where `scalars[key.dense_shift_idx]` is the contiguous per-operand chunk encoding
-/// `λ^(operand_idx+1) × h_op[shift_variant] × r_s_tensor[shift_amount]` for operand index
-/// `operand_idx`, and `(shift_variant, shift_amount)` the pair the key's segment decodes its dense
-/// shift index to.
+/// where a key's entry is the contiguous per-operand chunk encoding
+///
+/// ```text
+/// lambda^(operand + 1) * operation_scalar * inner_weight(s_1) * outer_weight(s_2)
+/// ```
+///
+/// with `(s_1, s_2)` the shift sequence the key's segment decodes its dense shift index to.
+///
+/// # Arguments
+///
+/// - `operation_scalars`: the `h` evaluation each operation's claim contributes to all of its keys.
+/// - `inner`, `outer`: the equality weights of the two shift slots, at the points the phases bound.
 ///
 /// # Usage
 ///
-/// Used in phase 2 of the shift protocol. The two returned buffers are the segments of the
+/// Used in the words phase of the shift protocol. The two returned buffers are the segments of the
 /// witness's monster multilinear: the public piece over `log_public_words` variables and the
 /// hidden piece over `log_witness_words` variables (the hidden words at the base, zeros above).
 /// The sparse first sumcheck round consumes them without materializing the combined buffer.
@@ -199,44 +360,13 @@ pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	key_collection: &KeyCollection,
 	prepared: &PreparedOperatorClaims<F>,
-	domain_subspace: &BinarySubspace<F>,
-	r_j: &[F],
-	r_s: &[F],
-	r_v: &[F],
+	operation_scalars: OperationScalars<F>,
+	inner: &SlotWeights<F>,
+	outer: &SlotWeights<F>,
 ) -> (FieldVec<P, A>, FieldVec<P, A>)
 where
 	F: BinaryField,
 {
-	// Phase 1 folded the variant axis into the sumcheck, so the h multilinear contributes one
-	// scalar per operation — the interpolation of its eight shift indicators at `r_v` — rather
-	// than one per variant.
-	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
-
-	let [zero_h_eval, bitand_h_eval, intmul_h_eval, binmul_h_eval] = [
-		prepared.zero.r_zhat_prime,
-		prepared.bitand.r_zhat_prime,
-		prepared.intmul.r_zhat_prime,
-		prepared.binmul.r_zhat_prime,
-	]
-	.map(|r_zhat_prime| {
-		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-		let h_ops = evaluate_h_op(l_tilde.as_ref(), r_j, r_s);
-		inner_product(h_ops, r_v_tensor.as_ref().iter().copied())
-	});
-
-	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
-
-	// Invariant: a key's sequence weight factorizes across its two slots.
-	//
-	//     eq(r_v1, v_1) * eq(r_s1, s_1)  *  eq(r_v2, v_2) * eq(r_s2, s_2)
-	//     \______ inner slot _________/     \______ outer slot ________/
-	//
-	// So one table per slot suffices, at `2 * SHIFT_COUNT` entries instead of `SHIFT_COUNT^2`.
-	//
-	// Challenges are drawn over the inner axes only, so the outer slot sits at the all-zero point.
-	// There the indicator selects the identity, the only outer shift a key may carry.
-	let outer = OuterSlotWeights::<F>::identity_selecting();
-
 	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
 	// weights for one `key.dense_shift_idx` form a contiguous chunk that [`Key::accumulate_wide`]
 	// can index directly by operand index.
@@ -246,11 +376,9 @@ where
 	let build_scalars =
 		|arity: usize, lambda_powers: &[F], h_eval: F, dense_shift_enc: &DenseShiftEncoding| {
 			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
-			for (dense_shift_idx, [inner, outer_shift]) in dense_shift_enc.iter().enumerate() {
-				let shift_scalar = h_eval
-					* r_v_tensor.as_ref()[inner.variant as usize]
-					* r_s_tensor.as_ref()[inner.amount as usize]
-					* outer.weight(outer_shift);
+			for (dense_shift_idx, shift_seq) in dense_shift_enc.iter().enumerate() {
+				let [inner_shift, outer_shift] = shift_seq;
+				let shift_scalar = h_eval * inner.weight(inner_shift) * outer.weight(outer_shift);
 				for operand_idx in 0..arity {
 					scalars[dense_shift_idx * arity + operand_idx] =
 						lambda_powers[operand_idx] * shift_scalar;
@@ -261,23 +389,28 @@ where
 
 	// Each segment has its own dense shift encoding, so it has its own scalar tables.
 	let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
-		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, zero_h_eval, dense_shift_enc),
+		zero: build_scalars(
+			ZERO_ARITY,
+			&prepared.zero.lambda_powers,
+			operation_scalars.zero,
+			dense_shift_enc,
+		),
 		bitand: build_scalars(
 			BITAND_ARITY,
 			&prepared.bitand.lambda_powers,
-			bitand_h_eval,
+			operation_scalars.bitand,
 			dense_shift_enc,
 		),
 		intmul: build_scalars(
 			INTMUL_ARITY,
 			&prepared.intmul.lambda_powers,
-			intmul_h_eval,
+			operation_scalars.intmul,
 			dense_shift_enc,
 		),
 		binmul: build_scalars(
 			BINMUL_ARITY,
 			&prepared.binmul.lambda_powers,
-			binmul_h_eval,
+			operation_scalars.binmul,
 			dense_shift_enc,
 		),
 	};

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -10,8 +10,12 @@ use binius_math::{
 };
 
 use super::{
-	DOUBLE_SHIFT_UNSUPPORTED, SegmentWords, claims::OperatorClaims, key_collection::KeyCollection,
-	phase_1::prove_phase_1, phase_2::prove_phase_2,
+	SegmentWords,
+	claims::OperatorClaims,
+	key_collection::KeyCollection,
+	monster::{SlotWeights, inner_h_eval, outer_h_evals},
+	slot_phase::{prove_inner_phase, prove_outer_phase, prove_slot_phase},
+	words_phase::prove_words_phase,
 };
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
@@ -124,12 +128,20 @@ impl<F: Field> PreparedOperatorData<F> {
 
 /// Proves the shift protocol reduction, collapsing every operation's claims into one.
 ///
-/// The result is a single multilinear evaluation claim on the witness.
+/// The result is a single multilinear evaluation claim on the witness. That output interface does
+/// not depend on how many phases ran, so ring-switching and everything downstream is untouched.
 ///
-/// Two sumcheck phases run in sequence:
+/// A term's shift sequence is peeled from the output end inward:
 ///
-/// 1. phase 1 proves the batched claims over the shift variants and operand positions;
-/// 2. phase 2 reduces those to a witness evaluation, against the monster multilinear.
+/// 1. the **outer** phase binds `(k, s_2, v_2)` against the intermediate words, and produces the
+///    intermediate bit point `r_k`;
+/// 2. the **inner** phase binds `(j, s_1, v_1)` against the witness words, weighted by what the
+///    outer phase closed on;
+/// 3. the **words** phase reduces to a witness evaluation, against the monster multilinear, whose
+///    per-key scalar is now the product of both slots' weights.
+///
+/// The outer phase is skipped when no term needs both slots, which leaves the two-phase reduction
+/// that predates shift sequences. See [`has_double_shift`].
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
@@ -157,18 +169,11 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// Invariant: two phases bind one shift slot.
-	// A sequence with work in its outer slot needs a third phase to bind the other.
-	debug_assert!(
-		!key_collection.public.dense_shift_enc.has_outer_shift()
-			&& !key_collection.hidden.dense_shift_enc.has_outer_shift(),
-		"{DOUBLE_SHIFT_UNSUPPORTED}"
-	);
-
-	// The segments are passed as the circuit declares them, at whatever length that is. Phase 1
-	// zips each word with its key range, so a segment shorter than its key ranges stops at its
-	// last value — the words past it carry no keys — and phase 2's `fold_words` zero-pads each
-	// fold up to `log2_ceil(len)` variables. Neither needs a padded segment.
+	// The segments are passed as the circuit declares them, at whatever length that is.
+	// A slot phase zips each word with its key range, so a short segment stops at its last value;
+	// the words past it carry no keys.
+	// The words phase zero-pads each fold up to `log2_ceil(len)` variables.
+	// So neither needs a padded segment.
 	let words = SegmentWords {
 		public: public_words,
 		hidden: hidden_words,
@@ -181,25 +186,110 @@ where
 		claims.prepare(|| channel.sample())
 	};
 
-	// Phase 1 outputs challenges `r_j || r_s`, and `gamma` as its evaluation (see paper).
-	let phase_1_output = prove_phase_1::<_, P, _, _>(
-		key_collection,
-		words,
-		&prepared,
-		domain_subspace,
-		channel,
-		alloc,
-	);
+	// Whether any term needs both shift slots.
+	// The constraint system is public, so the verifier derives the same answer and takes the same
+	// branch; this is protocol, not a choice the prover makes.
+	//
+	// SOUNDNESS: a system of lone shifts runs the two-phase reduction.
+	// Skipping a phase whose weight is the identity indicator on every key changes no claim.
+	let three_phase = has_double_shift(key_collection);
 
-	// Phase 2 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
-	// the univariate variable `r_j` and the multilinear variable `r_y`.
-	prove_phase_2::<_, P, _, _>(
+	let (r_j, claim, operation_scalars, inner, outer) = if three_phase {
+		// The outer phase binds `(k, s_2, v_2)` against the intermediate words.
+		let outer_phase = prove_outer_phase::<_, P, _, _>(
+			key_collection,
+			words,
+			&prepared,
+			domain_subspace,
+			channel,
+			alloc,
+		);
+
+		// The inner phase binds `(j, s_1, v_1)` against the witness words, weighted by what the
+		// outer phase closed on.
+		let inner_phase = prove_inner_phase::<_, P, _, _>(
+			key_collection,
+			words,
+			&prepared,
+			&outer_phase,
+			channel,
+			alloc,
+		);
+
+		// The words phase weights a key by both slots.
+		// The outer slot carries the oblong factor, so its evaluation is the per-operation scalar.
+		// The inner slot's carries none, so it is one value for every operation.
+		let operation_scalars = outer_h_evals(
+			&prepared,
+			domain_subspace,
+			&outer_phase.r_bit,
+			&outer_phase.r_s,
+			&outer_phase.r_v,
+		)
+		.scaled_by(inner_h_eval(
+			&outer_phase.r_bit,
+			&inner_phase.r_bit,
+			&inner_phase.r_s,
+			&inner_phase.r_v,
+		));
+
+		(
+			inner_phase.r_bit.clone(),
+			inner_phase.claim(),
+			operation_scalars,
+			SlotWeights::at(&inner_phase.r_s, &inner_phase.r_v),
+			SlotWeights::at(&outer_phase.r_s, &outer_phase.r_v),
+		)
+	} else {
+		// One slot phase binds `(j, s, v)`, and its `h` closes the bit axis as well.
+		let slot_phase = prove_slot_phase::<_, P, _, _>(
+			key_collection,
+			words,
+			&prepared,
+			domain_subspace,
+			channel,
+			alloc,
+		);
+
+		let operation_scalars = outer_h_evals(
+			&prepared,
+			domain_subspace,
+			&slot_phase.r_bit,
+			&slot_phase.r_s,
+			&slot_phase.r_v,
+		);
+
+		(
+			slot_phase.r_bit.clone(),
+			slot_phase.claim(),
+			operation_scalars,
+			SlotWeights::at(&slot_phase.r_s, &slot_phase.r_v),
+			// No phase bound the outer slot, so its weight selects the identity every key carries.
+			SlotWeights::identity_selecting(),
+		)
+	};
+
+	// The words phase outputs challenges `r_y`, and the witness evaluation at the oblong point
+	// given by the univariate variable `r_j` and the multilinear variable `r_y`.
+	prove_words_phase::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
-		domain_subspace,
-		phase_1_output,
+		r_j,
+		claim,
+		operation_scalars,
+		&inner,
+		&outer,
 		channel,
 		alloc,
 	)
+}
+
+/// Whether any of the collection's shift sequences needs both slots.
+///
+/// Both sides of the protocol derive this from the constraint system.
+/// So it selects the same phase structure on each, with nothing sent between them.
+pub fn has_double_shift(key_collection: &KeyCollection) -> bool {
+	key_collection.public.dense_shift_enc.has_outer_shift()
+		|| key_collection.hidden.dense_shift_enc.has_outer_shift()
 }

--- a/crates/prover/src/protocols/shift/slot_phase.rs
+++ b/crates/prover/src/protocols/shift/slot_phase.rs
@@ -6,7 +6,6 @@ use std::{iter, ops::Range};
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
-use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
@@ -25,50 +24,210 @@ use super::{
 	SegmentWords,
 	claims::PreparedOperatorClaims,
 	key_collection::{KeyCollection, KeySegment, ShiftSlot, SlotRows},
-	monster::build_h,
+	monster::{SlotWeights, build_h, build_inner_h},
 };
 
 /// The number of variables in the g (and h) multilinear of phase 1.
 ///
 /// The axes run, from the low index positions up: the bit position within a word, the shift
 /// amount, and the shift variant.
-pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_VARIANT_COUNT;
+pub const SLOT_PHASE_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_VARIANT_COUNT;
 
-/// Proves the first phase of the shift reduction.
+/// What one slot-binding phase produces.
 ///
-/// Builds the g and h multilinears and runs one sumcheck over their product.
-#[instrument(skip_all, name = "prover_phase_1")]
-pub fn prove_phase_1<F, P, Channel, A>(
+/// A phase binds three axes: the bit position, and its slot's amount and variant.
+/// It hands the next phase the point it reached, with both multilinears' evaluations there.
+///
+/// The factors are kept apart rather than only their product:
+///
+/// - the `h` evaluation becomes a weight on the next phase's keys;
+/// - the product is the claim that phase proves.
+pub struct SlotPhaseOutput<F> {
+	/// The bit point the phase bound: `r_j` for the inner slot, `r_k` for the outer one.
+	pub r_bit: Vec<F>,
+	/// The amount point of the slot this phase bound.
+	pub r_s: Vec<F>,
+	/// The variant point of the slot this phase bound.
+	pub r_v: Vec<F>,
+	/// The `g` (or `G`) multilinear's evaluation at that point.
+	pub g_eval: F,
+	/// The `h` (or `H`) multilinear's evaluation at that point.
+	pub h_eval: F,
+}
+
+impl<F: Field> SlotPhaseOutput<F> {
+	/// The claim the next phase proves: the product of the two evaluations.
+	pub fn claim(&self) -> F {
+		self.g_eval * self.h_eval
+	}
+}
+
+/// Proves the outer phase of the three-phase shift reduction.
+///
+/// This binds the sequence's *outer* slot, against the intermediate words.
+/// Its multilinear scatters `op1(w[y], s_1)` rather than `w[y]`, so the sum over the source bit
+/// index is already done and only the outer indicator remains.
+/// Its weight is the oblong one.
+///
+/// # Why this order is forced
+///
+/// The oblong factor `delta_D(r_ihat, ihat)` attaches to the *output* bit index.
+/// That index couples to the rest of the sum only through the outer indicator.
+/// Summing it out therefore yields a function of `(k, s_2)` alone — one 15-variate sumcheck.
+///
+/// Binding the inner shift first would leave an output-side factor still depending on `s_2`, and
+/// the sumcheck would run over `(j, s_1, s_2)` instead: 18 variates.
+#[instrument(skip_all, name = "prove_outer_phase")]
+pub fn prove_outer_phase<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: SegmentWords<'_>,
 	prepared: &PreparedOperatorClaims<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F>
+) -> SlotPhaseOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// Build the g multilinear for the public and hidden segments separately, then sum them. The
-	// public words are the prefix of `words`, and each segment's key ranges are segment-relative.
-	let mut g = build_g::<_, P, _>(alloc, words.public, &key_collection.public, prepared);
-	let hidden_g = build_g::<_, P, _>(alloc, words.hidden, &key_collection.hidden, prepared);
-	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
-		*slot += *add;
-	}
+	let g = sum_segment_multilinears::<F, P, A>(
+		alloc,
+		|segment_words, segment| {
+			build_outer_g::<F, P, A>(alloc, segment_words, segment, prepared, None)
+		},
+		words,
+		key_collection,
+	);
 
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
 	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 
-	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
+	run_slot_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
+}
+
+/// Proves the inner phase of the three-phase shift reduction.
+///
+/// This binds the sequence's *inner* slot, against the witness words themselves.
+/// Its weight is the bare shift indicator at the intermediate point the outer phase produced.
+/// There is no oblong factor, since that phase already summed the output bit index out.
+///
+/// The outer phase's evaluations enter as per-key weights:
+///
+/// ```text
+/// key scale = H_eval * eq(r_s2, s_2) * eq(r_v2, v_2)
+/// ```
+///
+/// which is what makes this phase's claim the product the outer sumcheck closed on.
+#[instrument(skip_all, name = "prove_inner_phase")]
+pub fn prove_inner_phase<F, P, Channel, A>(
+	key_collection: &KeyCollection,
+	words: SegmentWords<'_>,
+	prepared: &PreparedOperatorClaims<F>,
+	outer: &SlotPhaseOutput<F>,
+	channel: &mut Channel,
+	alloc: &A,
+) -> SlotPhaseOutput<F>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+	A: Allocator,
+{
+	// The outer slot's weight per sequence, scaled by that phase's own evaluation.
+	// Together they turn this phase's sum into the product the outer sumcheck closed on.
+	let outer_weights = SlotWeights::at(&outer.r_s, &outer.r_v);
+	let scale_of = |segment: &KeySegment| {
+		segment
+			.dense_shift_enc
+			.iter()
+			.map(|[_, outer_shift]| outer.h_eval * outer_weights.weight(outer_shift))
+			.collect::<Vec<_>>()
+	};
+	let public_scale = scale_of(&key_collection.public);
+	let hidden_scale = scale_of(&key_collection.hidden);
+
+	let mut g = build_g::<F, P, A>(
+		alloc,
+		words.public,
+		&key_collection.public,
+		prepared,
+		Some(&public_scale),
+	);
+	let hidden_g = build_g::<F, P, A>(
+		alloc,
+		words.hidden,
+		&key_collection.hidden,
+		prepared,
+		Some(&hidden_scale),
+	);
+	for (entry, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+		*entry += *add;
+	}
+
+	let h = build_inner_h::<F, P, A>(alloc, &outer.r_bit);
+
+	run_slot_sumcheck(g, h, outer.claim(), channel, alloc)
+}
+
+/// Proves the single slot-binding phase of the two-phase shift reduction.
+///
+/// Every sequence is a lone shift here, so there is no outer slot to bind.
+/// The multilinear scatters the witness words, and the weight is the oblong one.
+#[instrument(skip_all, name = "prove_slot_phase")]
+pub fn prove_slot_phase<F, P, Channel, A>(
+	key_collection: &KeyCollection,
+	words: SegmentWords<'_>,
+	prepared: &PreparedOperatorClaims<F>,
+	domain_subspace: &BinarySubspace<F>,
+	channel: &mut Channel,
+	alloc: &A,
+) -> SlotPhaseOutput<F>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+	A: Allocator,
+{
+	let g = sum_segment_multilinears::<F, P, A>(
+		alloc,
+		|segment_words, segment| build_g::<F, P, A>(alloc, segment_words, segment, prepared, None),
+		words,
+		key_collection,
+	);
+
+	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
+	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+
+	run_slot_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
+}
+
+/// Builds a phase's multilinear over both value-vector segments and sums the two.
+///
+/// The public and hidden words participate through their own key segment, with segment-relative key
+/// ranges.
+/// So each is built against its matching words, and the two results are added.
+fn sum_segment_multilinears<F, P: PackedField<Scalar = F>, A: Allocator>(
+	_alloc: &A,
+	mut build: impl FnMut(&[Word], &KeySegment) -> FieldVec<P, A>,
+	words: SegmentWords<'_>,
+	key_collection: &KeyCollection,
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+{
+	let mut combined = build(words.public, &key_collection.public);
+	let hidden = build(words.hidden, &key_collection.hidden);
+	for (entry, add) in iter::zip(combined.as_mut(), hidden.as_ref()) {
+		*entry += *add;
+	}
+	combined
 }
 
 /// Runs the phase 1 sumcheck protocol for shift constraint verification.
 ///
-/// One bivariate-product sumcheck over `g` and `h`, both multilinears of [`PHASE_1_LOG_LEN`]
+/// One bivariate-product sumcheck over `g` and `h`, both multilinears of [`SLOT_PHASE_LOG_LEN`]
 /// variables. The shift variant is the high [`LOG_SHIFT_VARIANT_COUNT`] variables of each, so the
 /// sumcheck folds the variant axis rather than the prover summing a separate claim per variant.
 ///
@@ -88,9 +247,10 @@ where
 ///
 /// # Returns
 ///
-/// `SumcheckOutput` containing the challenge vector and the final evaluation `gamma`.
-#[instrument(skip_all, name = "run_sumcheck")]
-pub fn run_phase_1_sumcheck<
+/// The point the sumcheck reached, split into its three axes, and both multilinears' evaluations
+/// there. See [`SlotPhaseOutput`] for why the two evaluations are kept apart.
+#[instrument(skip_all, name = "run_slot_sumcheck")]
+pub fn run_slot_sumcheck<
 	F: Field,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
@@ -101,7 +261,7 @@ pub fn run_phase_1_sumcheck<
 	sum: F,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F> {
+) -> SlotPhaseOutput<F> {
 	let prover = bivariate_product_prover(alloc, [g, h], sum);
 
 	let ProveSingleOutput {
@@ -114,9 +274,19 @@ pub fn run_phase_1_sumcheck<
 		.try_into()
 		.expect("prover has 2 multilinear polynomials");
 
-	SumcheckOutput {
-		challenges,
-		eval: g_eval * h_eval,
+	// The axis order of both multilinears, least significant first:
+	//
+	//     bit position | shift amount | shift variant
+	let mut r_bit = challenges;
+	let r_v = r_bit.split_off(Word::LOG_BITS * 2);
+	let r_s = r_bit.split_off(Word::LOG_BITS);
+
+	SlotPhaseOutput {
+		r_bit,
+		r_s,
+		r_v,
+		g_eval,
+		h_eval,
 	}
 }
 
@@ -135,8 +305,9 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	words: &[Word],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
+	scale: Option<&[F]>,
 ) -> FieldVec<P, A> {
-	build_slot_g(alloc, words, segment, prepared, ShiftSlot::Inner)
+	build_slot_g(alloc, words, segment, prepared, ShiftSlot::Inner, scale)
 }
 
 /// Constructs the outer phase's "G" multilinear for one key segment.
@@ -174,8 +345,9 @@ pub fn build_outer_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	words: &[Word],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
+	scale: Option<&[F]>,
 ) -> FieldVec<P, A> {
-	build_slot_g(alloc, words, segment, prepared, ShiftSlot::Outer)
+	build_slot_g(alloc, words, segment, prepared, ShiftSlot::Outer, scale)
 }
 
 /// Constructs one phase's shift multilinear for one key segment.
@@ -213,7 +385,7 @@ pub fn build_outer_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 ///
 /// # Returns
 ///
-/// One multilinear of [`PHASE_1_LOG_LEN`] variables holding every shift variant's part: the
+/// One multilinear of [`SLOT_PHASE_LOG_LEN`] variables holding every shift variant's part: the
 /// variant indexes the high [`LOG_SHIFT_VARIANT_COUNT`] variables, and within a variant the rows
 /// of `Word::BITS` scalars run in order of shift amount.
 #[instrument(skip_all, name = "build_slot_g")]
@@ -223,9 +395,15 @@ pub fn build_slot_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
 	slot: ShiftSlot,
+	scale: Option<&[F]>,
 ) -> FieldVec<P, A> {
 	// One row of `Word::BITS` scalars per shift the chosen slot takes.
 	let slot_rows = segment.dense_shift_enc.slot_rows(slot);
+	// Invariant: a scale carries one factor per shift sequence, indexed as the keys are.
+	debug_assert!(
+		scale.is_none_or(|scale| scale.len() == segment.dense_shift_enc.len()),
+		"a per-sequence scale covers the segment's dense shift encoding"
+	);
 	let row_len = Word::BITS >> P::LOG_WIDTH;
 	let acc_size = slot_rows.len() * row_len;
 
@@ -257,11 +435,16 @@ pub fn build_slot_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 				for key in keys {
 					let operator_data = &prepared[key.operation];
 
-					let acc = key.accumulate(
+					let mut acc = key.accumulate(
 						&segment.constraint_indices,
 						operator_data.r_x_prime_tensor.as_ref(),
 						&operator_data.lambda_powers,
 					);
+					// The other slot's weight, when a previous phase bound it: one multiply per
+					// key.
+					if let Some(scale) = scale {
+						acc *= scale[key.dense_shift_idx as usize];
+					}
 					let acc_packed = P::broadcast(acc);
 
 					// The following loop is an optimized version of the following
@@ -358,7 +541,7 @@ fn scatter_shift_rows<P: PackedField, A: Allocator>(
 
 	// A row is a whole number of packed elements, so it copies in at row alignment.
 	let row_len = Word::BITS >> P::LOG_WIDTH;
-	let mut g = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
+	let mut g = FieldBuffer::zeros_in(alloc, SLOT_PHASE_LOG_LEN);
 	for (shift, row) in iter::zip(slot_rows.shifts(), multilinears.chunks(row_len)) {
 		// The variant indexes the high variables and the amount the middle ones. A slot's shifts
 		// are distinct, so no two rows land in the same place and each destination is still zero.
@@ -459,7 +642,7 @@ mod tests {
 		segment: &KeySegment,
 		prepared: &PreparedOperatorClaims<B128>,
 	) -> Vec<B128> {
-		let mut reference = vec![B128::ZERO; 1 << PHASE_1_LOG_LEN];
+		let mut reference = vec![B128::ZERO; 1 << SLOT_PHASE_LOG_LEN];
 		for (word, range) in iter::zip(words, &segment.key_ranges) {
 			for key in &segment.keys[range.start as usize..range.end as usize] {
 				let operator_data = &prepared[key.operation];
@@ -524,6 +707,7 @@ mod tests {
 			&words,
 			&key_collection.hidden,
 			&prepared,
+			None,
 		);
 		let reference = reference_outer_g(&words, &key_collection.hidden, &prepared);
 
@@ -558,6 +742,7 @@ mod tests {
 			&words,
 			&key_collection.hidden,
 			&prepared,
+			None,
 		);
 		let reference = reference_outer_g(&words, &key_collection.hidden, &prepared);
 
@@ -591,10 +776,15 @@ mod tests {
 		let outer_keys = build_key_collection(&outer_cs, InoutSegment::Public);
 		let inner_keys = build_key_collection(&inner_cs, InoutSegment::Public);
 
-		let from_outer =
-			build_outer_g::<B128, B128, _>(&GlobalAllocator, &words, &outer_keys.hidden, &prepared);
+		let from_outer = build_outer_g::<B128, B128, _>(
+			&GlobalAllocator,
+			&words,
+			&outer_keys.hidden,
+			&prepared,
+			None,
+		);
 		let from_inner =
-			build_g::<B128, B128, _>(&GlobalAllocator, &words, &inner_keys.hidden, &prepared);
+			build_g::<B128, B128, _>(&GlobalAllocator, &words, &inner_keys.hidden, &prepared, None);
 
 		assert_eq!(from_outer.as_ref(), from_inner.as_ref());
 	}

--- a/crates/prover/src/protocols/shift/words_phase.rs
+++ b/crates/prover/src/protocols/shift/words_phase.rs
@@ -14,7 +14,7 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec,
+	FieldBuffer, FieldVec,
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
 };
 use binius_utils::{
@@ -28,42 +28,48 @@ use binius_verifier::protocols::shift::evaluate_words_mle;
 use tracing::instrument;
 
 use super::{
-	SegmentWords, claims::PreparedOperatorClaims, key_collection::KeyCollection,
-	monster::build_monster_segments,
+	SegmentWords,
+	claims::PreparedOperatorClaims,
+	key_collection::KeyCollection,
+	monster::{OperationScalars, SlotWeights, build_monster_segments},
 };
 use crate::fold_word::fold_words;
 
-/// Proves the second phase of the shift protocol reduction.
+/// Proves the words phase of the shift protocol reduction, the last one.
 ///
-/// This function implements phase 2 of the shift protocol prover, which takes the output
-/// from phase 1 and completes the shift reduction by proving the relationship between
-/// the witness and the monster multilinear polynomial.
+/// This takes the point the slot-binding phases reached and completes the shift reduction by
+/// proving the relationship between the witness and the monster multilinear polynomial.
 ///
 /// # Protocol Steps
-/// 1. **Challenge Splitting**: Splits phase 1 challenges into `r_j` and `r_s` components
-/// 2. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
-/// 3. **Monster Multilinear Construction**: Builds the monster segments from the key collection and
-///    the prepared claims
-/// 4. **Sumcheck Execution**: Runs the bivariate product sumcheck with a sparse first round over
+/// 1. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
+/// 2. **Monster Multilinear Construction**: Builds the monster segments from the key collection,
+///    the prepared claims and the two slots' weights
+/// 3. **Sumcheck Execution**: Runs the bivariate product sumcheck with a sparse first round over
 ///    the segment selector
 ///
 /// # Parameters
 /// - `key_collection`: Prover's key collection representing the constraint system
 /// - `words`: The value vector words
 /// - `prepared`: The prepared claim of each operation, indexed by the operation a key names
-/// - `phase_1_output`: Challenges and evaluation from the first phase
+/// - `r_j`: the source bit point, which the witness fold closes on
+/// - `claim`: the sum this phase proves, as the last slot phase closed on it
+/// - `operation_scalars`, `inner`, `outer`: the per-operation and per-slot weights of a key
 /// - `channel`: The prover's channel
 ///
 /// # Returns
 /// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and the witness
 /// evaluation, or an error if the protocol fails.
-#[instrument(skip_all, name = "prove_phase_2")]
-pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
+#[allow(clippy::too_many_arguments)]
+#[instrument(skip_all, name = "prove_words_phase")]
+pub fn prove_words_phase<F, P: PackedField<Scalar = F>, Channel, A>(
 	key_collection: &KeyCollection,
 	words: SegmentWords<'_>,
 	prepared: &PreparedOperatorClaims<F>,
-	domain_subspace: &BinarySubspace<F>,
-	phase_1_output: SumcheckOutput<F>,
+	r_j: Vec<F>,
+	claim: F,
+	operation_scalars: OperationScalars<F>,
+	inner: &SlotWeights<F>,
+	outer: &SlotWeights<F>,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F>
@@ -72,15 +78,6 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	let SumcheckOutput {
-		challenges: mut r_j,
-		eval: gamma,
-	} = phase_1_output;
-	// Split the challenges as `r_j, r_s, r_v`: the bit position, then the shift amount, then the
-	// shift variant, in increasing order of significance.
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
-
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
 	// Fold each segment separately; the combined witness is never materialized. `fold_words`
@@ -89,7 +86,7 @@ where
 	let hidden_folded = fold_words::<_, P, _>(alloc, words.hidden, r_j_tensor.as_ref());
 
 	let (public_monster, hidden_monster) =
-		build_monster_segments(alloc, key_collection, prepared, domain_subspace, &r_j, &r_s, &r_v);
+		build_monster_segments(alloc, key_collection, prepared, operation_scalars, inner, outer);
 
 	// Both halves of the sumcheck share one word-index address space, spanning the wider of the
 	// two segments. The hidden segment is normally the wider one, but a system with more public
@@ -105,7 +102,7 @@ where
 		hidden_monster,
 		words.public,
 		r_j,
-		gamma,
+		claim,
 		channel,
 		alloc,
 	)

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -7,11 +7,12 @@ use binius_circuits::{fixed_byte_vec::ByteVec, sha256::sha256_varlen};
 use binius_compute::GlobalAllocator;
 use binius_core::{
 	constraint_system::{
-		AndConstraint, BmulConstraint, ConstraintSystem, ImulConstraint, InoutSegment, ValueVec,
+		AndConstraint, BmulConstraint, Composition, ConstraintSystem, ImulConstraint, InoutSegment,
+		Shift, ShiftedValueIndex, ValueIndex, ValueVec, ZeroConstraint,
 	},
 	word::Word,
 };
-use binius_field::{AESTowerField8b, BinaryField};
+use binius_field::{AESTowerField8b, BinaryField, Field, Random};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_math::{
 	BinarySubspace,
@@ -27,10 +28,13 @@ use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::StdChallenger,
-	protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
+	protocols::shift::{
+		LOG_SHIFT_VARIANT_COUNT, OperatorData as VerifierOperatorData, VerifyOutput, check_eval,
+		has_double_shift, verify,
+	},
 };
 use itertools::Itertools;
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 use sha2::{Digest, Sha256 as Sha256Hasher};
 
 pub fn create_sha256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
@@ -428,5 +432,324 @@ fn test_shift_prove_and_verify() {
 		.concat();
 		assert_eq!(prover_output.challenges, eval_point);
 		assert_eq!(prover_output.eval, verifier_output.witness_eval);
+	}
+}
+
+/// The field the double-shift reduction tests run over.
+type DoubleShiftF = binius_field::BinaryField128bGhash;
+/// The packed field those tests instantiate the prover with.
+type DoubleShiftP = binius_field::PackedBinaryGhash2x128b;
+
+/// Every shift-variant pair whose composition genuinely needs two slots.
+///
+/// A pair that collapses would be rejected by validation, so the fixtures below draw from this
+/// list. Amounts are chosen to keep each pair irreducible for its variant combination.
+/// Dropping bits one way and moving them back the other is the shape no single shift has.
+fn irreducible_pairs() -> Vec<[Shift; 2]> {
+	let candidates = [
+		[Shift::srl(3), Shift::sll(3)],
+		[Shift::srl(5), Shift::sll(9)],
+		[Shift::sll(8), Shift::srl(2)],
+		[Shift::sll(17), Shift::srl(11)],
+		[Shift::sar(7), Shift::sll(4)],
+		[Shift::rotr(1), Shift::sll(6)],
+		[Shift::rotr(13), Shift::srl(5)],
+		[Shift::srl32(4), Shift::sll32(11)],
+		[Shift::sll32(6), Shift::srl32(3)],
+		[Shift::sra32(9), Shift::sll32(3)],
+		[Shift::rotr32(5), Shift::srl32(7)],
+		[Shift::rotr32(2), Shift::sll32(8)],
+		// Crossing the two families: a half-word shift after a full-width one.
+		[Shift::srl(33), Shift::sll32(4)],
+		[Shift::sll(35), Shift::srl32(6)],
+	];
+	// Keep only the pairs that really need both slots, so the fixture cannot silently degenerate.
+	let pairs = candidates
+		.into_iter()
+		.filter(|&[inner, outer]| Shift::compose(inner, outer) == Composition::Pair)
+		.collect::<Vec<_>>();
+	assert!(pairs.len() >= 12, "the fixture needs a spread of genuine pairs, got {}", pairs.len());
+	pairs
+}
+
+/// A constraint system whose operands carry genuine shift pairs, with a satisfying value vector.
+///
+/// The frontend does not emit pairs yet, so this is built by hand.
+/// The layout is
+///
+/// ```text
+/// private[0 .. n_sources]   random source words
+/// private[n_sources]        the AND constraint's C operand, set to A & B
+/// private[n_sources + 1]    the ZERO constraint's second term, set to cancel the first
+/// ```
+///
+/// so both constraints are satisfied by construction, whatever the pairs move.
+fn create_double_shift_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	let pairs = irreducible_pairs();
+	let n_sources = pairs.len();
+	let n_private = n_sources + 2;
+
+	// Spread the pairs over the source words: the first third builds `A`, the next `B`, and one
+	// more drives the ZERO constraint.
+	let split = n_sources / 3;
+	let term =
+		|index: usize| ShiftedValueIndex::new(ValueIndex::private(index as u32), pairs[index]);
+
+	let a_terms = (0..split).map(term).collect::<Vec<_>>();
+	let b_terms = (split..2 * split).map(term).collect::<Vec<_>>();
+	let zero_term = term(2 * split);
+
+	let c_index = ValueIndex::private(n_sources as u32);
+	let zero_cancel_index = ValueIndex::private(n_sources as u32 + 1);
+
+	let cs = ConstraintSystem {
+		constants: Vec::new(),
+		n_inout: 0,
+		n_private,
+		// `val` must vanish: the pair-shifted word XORed with the word holding that same value.
+		zero_constraints: vec![ZeroConstraint::new(vec![
+			zero_term,
+			ShiftedValueIndex::plain(zero_cancel_index),
+		])],
+		// `A & B ^ C = 0`, with `C` the plain word holding the conjunction.
+		and_constraints: vec![AndConstraint([
+			a_terms,
+			b_terms,
+			vec![ShiftedValueIndex::plain(c_index)],
+		])],
+		imul_constraints: Vec::new(),
+		bmul_constraints: Vec::new(),
+	};
+
+	// Random source words, then the two derived words that make the system satisfied.
+	let mut rng = StdRng::seed_from_u64(7);
+	let mut private = (0..n_private)
+		.map(|_| Word(rng.random::<u64>()))
+		.collect::<Vec<_>>();
+	private[n_sources] = Word::ZERO;
+	private[n_sources + 1] = Word::ZERO;
+
+	let mut value_vec = ValueVec::new_from_data(0, &[], &private);
+	let [a_operand, b_operand, _] = cs.and_constraints[0].0.each_ref();
+	let conjunction = value_vec.eval_operand(a_operand) & value_vec.eval_operand(b_operand);
+	value_vec[c_index] = conjunction;
+	let shifted = value_vec.eval_operand(&[zero_term]);
+	value_vec[zero_cancel_index] = shifted;
+
+	cs.validate().unwrap();
+	cs.verify(&value_vec).unwrap();
+	(cs, value_vec)
+}
+
+/// Runs the reduction over one constraint system and returns the verifier's output.
+///
+/// The claims are computed the way the single-shift round trip computes them.
+/// So this exercises the real path rather than a stand-in.
+fn prove_and_verify_reduction(
+	cs: &ConstraintSystem,
+	value_vec: &ValueVec,
+	tamper: bool,
+) -> Result<VerifyOutput<DoubleShiftF>, binius_verifier::protocols::shift::Error> {
+	type F = DoubleShiftF;
+	type P = DoubleShiftP;
+
+	let mut rng = StdRng::seed_from_u64(11);
+	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+	let r_zhat_prime = F::random(&mut rng);
+
+	let point_of = |log_count: Option<usize>| {
+		(0..log_count.unwrap_or(0) as u128)
+			.map(F::new)
+			.collect::<Vec<_>>()
+	};
+	let r_x_prime_zero = point_of(cs.log_zero_constraints());
+	let r_x_prime_bitand = point_of(cs.log_and_constraints());
+	// An unused operation reduces over an empty point, as both sides synthesize for it.
+	// A used one needs its real point, or a key naming its constraints indexes past the tensor.
+	let r_x_prime_intmul = point_of(cs.log_imul_constraints());
+	let r_x_prime_binmul = point_of(cs.log_bmul_constraints());
+
+	// The operand claims, from the images the witness actually produces.
+	let evaluate_at = |image: Vec<Word>, r_x_prime: &[F]| {
+		evaluate_image(&subspace, &image, r_zhat_prime, eq_ind_partial_eval(r_x_prime).as_ref())
+	};
+	let bitand_evals = compute_bitand_images(&cs.and_constraints, value_vec)
+		.map(|image| evaluate_at(image, &r_x_prime_bitand));
+	let intmul_evals: [F; 4] = if cs.imul_constraints.is_empty() {
+		[F::ZERO; 4]
+	} else {
+		compute_intmul_images(&cs.imul_constraints, value_vec)
+			.map(|image| evaluate_at(image, &r_x_prime_intmul))
+	};
+	let binmul_evals: [F; 6] = if cs.bmul_constraints.is_empty() {
+		[F::ZERO; 6]
+	} else {
+		compute_binmul_images(&cs.bmul_constraints, value_vec)
+			.map(|image| evaluate_at(image, &r_x_prime_binmul))
+	};
+
+	// A tampered run claims something the witness does not satisfy.
+	let bitand_evals = if tamper {
+		let mut evals = bitand_evals;
+		evals[0] += F::ONE;
+		evals
+	} else {
+		bitand_evals
+	};
+
+	let zero_data = OperatorData {
+		evals: [F::ZERO],
+		r_zhat_prime,
+		r_x_prime: r_x_prime_zero.clone(),
+	};
+	let bitand_data = OperatorData {
+		evals: bitand_evals,
+		r_zhat_prime,
+		r_x_prime: r_x_prime_bitand.clone(),
+	};
+	let intmul_data = OperatorData {
+		evals: intmul_evals,
+		r_zhat_prime,
+		r_x_prime: r_x_prime_intmul.clone(),
+	};
+	let binmul_data = OperatorData {
+		evals: binmul_evals,
+		r_zhat_prime,
+		r_x_prime: r_x_prime_binmul.clone(),
+	};
+
+	let key_collection = build_key_collection(cs, InoutSegment::Public);
+	let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
+	prove::<F, P, _, _>(
+		&key_collection,
+		value_vec.public(),
+		value_vec.non_public(),
+		OperatorClaims {
+			zero: zero_data,
+			bitand: bitand_data,
+			intmul: intmul_data,
+			binmul: binmul_data,
+		},
+		&subspace,
+		&mut prover_transcript,
+		&GlobalAllocator,
+	);
+
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	let verifier_zero = VerifierOperatorData::new(r_x_prime_zero, [F::ZERO]);
+	let verifier_bitand = VerifierOperatorData::new(r_x_prime_bitand, bitand_evals);
+	let verifier_intmul = VerifierOperatorData::new(r_x_prime_intmul, intmul_evals);
+	let verifier_binmul = VerifierOperatorData::new(r_x_prime_binmul, binmul_evals);
+
+	let output = verify(
+		cs,
+		InoutSegment::Public,
+		&verifier_zero,
+		&verifier_bitand,
+		&verifier_intmul,
+		&verifier_binmul,
+		&mut verifier_transcript,
+	)?;
+	check_eval(
+		cs,
+		InoutSegment::Public,
+		value_vec.public(),
+		&verifier_zero,
+		&verifier_bitand,
+		&verifier_intmul,
+		&verifier_binmul,
+		&subspace,
+		r_zhat_prime,
+		&output,
+		&mut verifier_transcript,
+	)?;
+	Ok(output)
+}
+
+#[test]
+fn double_shifted_terms_prove_and_verify() {
+	// Invariant: a system built on genuine shift pairs verifies.
+	//
+	// Terms whose two shifts do not collapse are reduced through the outer phase against the
+	// intermediate words, then the inner phase against the witness.
+	let (cs, value_vec) = create_double_shift_cs_with_witness();
+	let output = prove_and_verify_reduction(&cs, &value_vec, false).unwrap();
+
+	// The outer phase ran, which is what distinguishes this from the two-phase path.
+	let outer = output
+		.outer
+		.as_ref()
+		.expect("a system with genuine shift pairs runs the outer phase");
+	assert_eq!(outer.r_k.len(), Word::LOG_BITS);
+	assert_eq!(outer.r_s.len(), Word::LOG_BITS);
+	assert_eq!(outer.r_v.len(), LOG_SHIFT_VARIANT_COUNT);
+}
+
+#[test]
+fn double_shifted_terms_reject_an_unsatisfied_claim() {
+	// Invariant: a claim the witness does not satisfy must not verify, pairs or not.
+	//
+	// Perturbing the claim is the same thing from the reduction's side as perturbing the witness:
+	// the sum it is handed stops matching the one the witness produces, and that difference
+	// travels to the final evaluation check.
+	let (cs, value_vec) = create_double_shift_cs_with_witness();
+	let result = prove_and_verify_reduction(&cs, &value_vec, true);
+	assert!(result.is_err(), "a claim the witness does not satisfy must not verify");
+}
+
+#[test]
+fn lone_shifts_skip_the_outer_phase() {
+	// Invariant: a system of lone shifts skips the outer phase, and both sides agree it does.
+	//
+	// The phase structure is derived from the constraint system, so no message says which is in
+	// use. That is what leaves a single-shift circuit's transcript unchanged.
+	let (cs, value_vec) = create_slice_cs_with_witness();
+	assert!(
+		!has_double_shift(&cs),
+		"the frontend emits lone shifts, so this system needs no outer phase"
+	);
+
+	let output = prove_and_verify_reduction(&cs, &value_vec, false).unwrap();
+	assert!(output.outer.is_none(), "a system of lone shifts must not run the outer phase");
+}
+
+#[test]
+fn each_irreducible_pair_proves_and_verifies_alone() {
+	// Invariant: every irreducible variant combination survives the reduction on its own.
+	//
+	// Run together, one pair's contribution could mask another's.
+	// One constraint system per pair keeps a mis-handled variant from hiding.
+	for shift_seq in irreducible_pairs() {
+		// `A = pair(w_0)`, `B = w_1`, `C = A & B`, on three private words.
+		let a_term = ShiftedValueIndex::new(ValueIndex::private(0), shift_seq);
+		let cs = ConstraintSystem {
+			constants: Vec::new(),
+			n_inout: 0,
+			n_private: 3,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![a_term],
+				vec![ShiftedValueIndex::plain(ValueIndex::private(1))],
+				vec![ShiftedValueIndex::plain(ValueIndex::private(2))],
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		};
+		cs.validate().unwrap();
+
+		let mut rng = StdRng::seed_from_u64(3);
+		let private = vec![
+			Word(rng.random::<u64>()),
+			Word(rng.random::<u64>()),
+			Word::ZERO,
+		];
+		let mut value_vec = ValueVec::new_from_data(0, &[], &private);
+		let conjunction = value_vec.eval_operand(&[a_term]) & private[1];
+		value_vec[ValueIndex::private(2)] = conjunction;
+		cs.verify(&value_vec).unwrap();
+
+		let output = prove_and_verify_reduction(&cs, &value_vec, false)
+			.unwrap_or_else(|error| panic!("{shift_seq:?} failed to verify: {error}"));
+		assert!(output.outer.is_some(), "{shift_seq:?} must run the outer phase");
 	}
 }

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -38,4 +38,7 @@ mod error;
 mod verify;
 
 pub use error::Error;
-pub use verify::{OperatorData, VerifyOutput, check_eval, evaluate_words_mle, verify};
+pub use verify::{
+	OperatorData, OuterPhasePoint, VerifyOutput, check_eval, evaluate_words_mle, has_double_shift,
+	verify,
+};

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -21,13 +21,6 @@ use super::{
 	shift_ind::{partial_eval_phi, partial_eval_sigmas, partial_eval_sigmas_transpose},
 };
 
-/// Why a term's outer shift slot must hold the identity in the two-phase reduction.
-///
-/// A shift key names one shift, so the reduction reads the inner slot and ignores the outer one.
-/// A term carrying both would verify against the wrong shifted word.
-const DOUBLE_SHIFT_UNSUPPORTED: &str =
-	"the two-phase shift reduction reads only the inner shift of a term";
-
 /// Contracts each shift variant's indicator against a weight per output bit position.
 ///
 /// This is the verifier's version of the h-parts evaluation.
@@ -312,7 +305,6 @@ where
 			let mut constraint_eval = E::zero();
 			for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 				for svi in operand {
-					debug_assert!(!svi.is_doubly_shifted(), "{DOUBLE_SHIFT_UNSUPPORTED}");
 					let inner = shift_index(svi.inner()) * ARITY + operand_id;
 					let outer = shift_index(svi.outer());
 					constraint_eval += operand_shift_scalars[inner].clone()
@@ -353,7 +345,6 @@ where
 				let mut constraint_eval = F::ZERO;
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
-						debug_assert!(!svi.is_doubly_shifted(), "{DOUBLE_SHIFT_UNSUPPORTED}");
 						let inner = shift_index(svi.inner()) * ARITY + operand_id;
 						let outer = shift_index(svi.outer());
 						constraint_eval += operand_shift_scalars[inner]

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -4,7 +4,7 @@
 use std::{array, iter};
 
 use binius_core::{
-	constraint_system::{ConstraintSystem, InoutSegment},
+	constraint_system::{ConstraintSystem, InoutSegment, Operand},
 	word::Word,
 };
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
@@ -25,7 +25,8 @@ use getset::Getters;
 
 use super::{
 	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, OperationEvalFn,
-	SHIFT_COUNT, ShiftScalars, ZERO_ARITY, encode_operation_input, error::Error, evaluate_h_op,
+	SHIFT_COUNT, SHIFT_VARIANT_COUNT, ShiftScalars, ZERO_ARITY, encode_operation_input,
+	error::Error, evaluate_h_op, evaluate_inner_h_op,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -92,6 +93,22 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 	}
 }
 
+/// The point the outer phase of the three-phase reduction bound.
+///
+/// The outer phase peels the sequence's *outer* shift, against the intermediate words.
+/// It closes the operand claim's bit axis, so its weight is the oblong one.
+/// The bit point it produces is the intermediate position the inner phase's indicator is taken at.
+#[derive(Debug, Clone)]
+pub struct OuterPhasePoint<F> {
+	/// The intermediate bit point, which the inner phase's weight is evaluated at.
+	pub r_k: Vec<F>,
+	/// Challenge point for the outer slot's shift-amount variables (length `Word::LOG_BITS`).
+	pub r_s: Vec<F>,
+	/// Challenge point for the outer slot's shift-variant variables (length
+	/// `LOG_SHIFT_VARIANT_COUNT`).
+	pub r_v: Vec<F>,
+}
+
 /// Output of the shift reduction verification protocol.
 ///
 /// Contains all the challenge points, evaluation claims, and random coefficients
@@ -109,10 +126,17 @@ pub struct VerifyOutput<F> {
 	binmul_lambda: F,
 	/// Challenge point for the bit index variables (length `Word::LOG_BITS`).
 	pub r_j: Vec<F>,
-	/// Challenge point for the shift-amount variables (length `Word::LOG_BITS`).
+	/// Challenge point for the inner slot's shift-amount variables (length `Word::LOG_BITS`).
 	pub r_s: Vec<F>,
-	/// Challenge point for the shift-variant variables (length `LOG_SHIFT_VARIANT_COUNT`).
+	/// Challenge point for the inner slot's shift-variant variables (length
+	/// `LOG_SHIFT_VARIANT_COUNT`).
 	pub r_v: Vec<F>,
+	/// The outer phase's challenge points, absent when the reduction ran without that phase.
+	///
+	/// A system whose every term carries a lone shift needs no outer phase.
+	/// Its weight would be the identity indicator on every key.
+	/// Both sides derive that from the system, so the absence is not something the prover chose.
+	pub outer: Option<OuterPhasePoint<F>>,
 	/// Challenge point for the word index variables (length `log_segment_words`).
 	pub r_y: Vec<F>,
 	/// Challenge for the witness's segment selector variable.
@@ -150,17 +174,23 @@ impl<F> VerifyOutput<F> {
 	}
 }
 
-/// Verifies the shift protocol using a two-phase sumcheck approach.
+/// Verifies the shift protocol, peeling a term's shift sequence from the output end inward.
 ///
 /// # Protocol Overview
 /// 1. **Sampling Phase**: Samples random lambda coefficients for batching bitand, intmul and binmul
 ///    evaluation claims across operands.
-/// 2. **First Sumcheck**: Verifies the batched evaluation claim over `Word::LOG_BITS * 2` variables
-/// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j`, `r_s` and `r_v` components
-/// 4. **Second Sumcheck**: Verifies the gamma claim over `log_word_count` variables
+/// 2. **Outer Sumcheck**: Only when a term needs both shift slots. Binds `(k, s_2, v_2)` over
+///    `Word::LOG_BITS * 2 + LOG_SHIFT_VARIANT_COUNT` variables, producing the intermediate bit
+///    point `r_k`.
+/// 3. **Inner Sumcheck**: Binds `(j, s_1, v_1)` over the same number of variables. This is the only
+///    slot sumcheck when every term carries a lone shift, and then it closes the bit axis itself.
+/// 4. **Words Sumcheck**: Verifies the gamma claim over `log_word_count` variables
 /// 5. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
 ///    monster multilinear evaluations for AND constraints (bitand), IMUL constraints (intmul) and
 ///    BMUL constraints (binmul)
+///
+/// Which of the two structures ran is derived from the constraint system by
+/// [`has_double_shift`], so no message tells the verifier which to expect.
 ///
 /// # Parameters
 /// - `constraint_system`: The constraint system containing AND, IMUL and BMUL constraints
@@ -201,18 +231,42 @@ where
 		+ intmul_data.batched_eval(intmul_lambda.clone())
 		+ binmul_data.batched_eval(binmul_lambda.clone());
 
+	// Whether any term needs both shift slots, and so whether the outer phase ran.
+	// The system is public, so this selects the same structure the prover followed.
+	let three_phase = has_double_shift(constraint_system);
+
+	// A slot-binding phase runs one sumcheck over the bit position and its slot's two shift axes.
+	let slot_phase_vars = Word::LOG_BITS * 2 + LOG_SHIFT_VARIANT_COUNT;
+	let split_slot_point = |mut challenges: Vec<C::Elem>| {
+		challenges.reverse();
+		// Split as the bit position within a word, then the shift amount, then the shift variant,
+		// in increasing order of significance.
+		let r_v = challenges.split_off(Word::LOG_BITS * 2);
+		let r_s = challenges.split_off(Word::LOG_BITS);
+		(challenges, r_s, r_v)
+	};
+
+	// The outer phase, when the system needs it: it binds `(k, s_2, v_2)` and closes the bit axis.
+	let (outer, claim) = if three_phase {
+		let SumcheckOutput {
+			eval: gamma,
+			challenges,
+		} = verify_sumcheck(slot_phase_vars, 2, eval, channel)?;
+		let (r_k, r_s, r_v) = split_slot_point(challenges);
+		(Some(OuterPhasePoint { r_k, r_s, r_v }), gamma)
+	} else {
+		(None, eval)
+	};
+
+	// The inner phase binds `(j, s_1, v_1)`.
+	// Without an outer phase it is the only slot phase, and its weight closes the bit axis too.
 	let SumcheckOutput {
 		eval: gamma,
-		challenges: mut r_j,
-	} = verify_sumcheck(Word::LOG_BITS * 2 + LOG_SHIFT_VARIANT_COUNT, 2, eval, channel)?;
+		challenges,
+	} = verify_sumcheck(slot_phase_vars, 2, claim, channel)?;
+	let (r_j, r_s, r_v) = split_slot_point(challenges);
 
-	r_j.reverse();
-	// Split the challenges as `r_j, r_s, r_v`: the bit position within a word, then the shift
-	// amount, then the shift variant, in increasing order of significance.
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
-
-	// The second sumcheck runs over the witness: the public segment in the low half-cube and
+	// The words sumcheck runs over the witness: the public segment in the low half-cube and
 	// the hidden segment in the high half-cube, selected by the top word-index variable. Each
 	// half spans the wider of the two segments, which the prover zero-pads the shorter one up
 	// to, so a public segment longer than the hidden one draws the extra word-index challenges.
@@ -238,9 +292,44 @@ where
 		r_segment,
 		r_s,
 		r_v,
+		outer,
 		eval,
 		witness_eval,
 	})
+}
+
+/// Whether any term of the constraint system needs both shift slots.
+///
+/// This selects the reduction's phase structure.
+/// Both sides derive it from the system, so no message says which structure is in use.
+///
+/// A term is doubly shifted when its outer slot carries work.
+/// The canonical form places a lone shift inner, so a system of lone shifts answers false.
+pub fn has_double_shift(constraint_system: &ConstraintSystem) -> bool {
+	let operands = |operand: &Operand| operand.iter().any(|svi| svi.is_doubly_shifted());
+	constraint_system
+		.zero_constraints
+		.iter()
+		.flat_map(|constraint| constraint.as_ref().iter())
+		.chain(
+			constraint_system
+				.and_constraints
+				.iter()
+				.flat_map(|constraint| constraint.as_ref().iter()),
+		)
+		.chain(
+			constraint_system
+				.imul_constraints
+				.iter()
+				.flat_map(|constraint| constraint.as_ref().iter()),
+		)
+		.chain(
+			constraint_system
+				.bmul_constraints
+				.iter()
+				.flat_map(|constraint| constraint.as_ref().iter()),
+		)
+		.any(operands)
 }
 
 /// Validates the evaluation claims from the shift reduction protocol.
@@ -298,6 +387,7 @@ where
 		r_j,
 		r_s,
 		r_v,
+		outer,
 		r_y,
 		r_segment,
 		witness_eval,
@@ -319,6 +409,17 @@ where
 		let r_v_len = r_v.len();
 		let r_y_len = r_y.len();
 
+		// The outer phase's point trails the rest, when that phase ran.
+		// Its three sections have fixed widths, so its presence alone cuts them back apart.
+		let outer_point = outer.iter().flat_map(|outer| {
+			outer
+				.r_k
+				.iter()
+				.chain(&outer.r_s)
+				.chain(&outer.r_v)
+				.cloned()
+		});
+
 		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime)
 			.chain(iter::once(zero_lambda.clone()))
 			.chain(iter::once(bitand_lambda.clone()))
@@ -333,6 +434,7 @@ where
 			.chain(r_v.iter().cloned())
 			.chain(r_y.iter().cloned())
 			.chain(iter::once(r_segment.clone()))
+			.chain(outer_point)
 			.collect();
 
 		let eval_fn = MonsterEvalFn {
@@ -347,6 +449,7 @@ where
 			r_s_len,
 			r_v_len,
 			r_y_len,
+			three_phase: outer.is_some(),
 		};
 		channel.compute_public_value(&inputs, eval_fn)
 	};
@@ -426,6 +529,10 @@ struct MonsterEvalFn<'a, F: BinaryField> {
 	r_v_len: usize,
 	/// Length of the `r_y` section (the column challenges).
 	r_y_len: usize,
+	/// Whether the outer phase's point trails the input, which is whether that phase ran.
+	///
+	/// Its three sections have fixed widths, so no lengths need storing alongside.
+	three_phase: bool,
 }
 
 /// The per-operation [`OperationEvalFn`] inputs [`MonsterEvalFn::operation_inputs`] splits out of
@@ -499,6 +606,15 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		// `r_segment` is the top word-index coordinate, appended after `r_y`; it selects the public
 		// (0) vs hidden (1) segment.
 		let r_segment = vals[off].clone();
+		off += 1;
+		// The outer phase's point trails it, at its three fixed widths, when that phase ran.
+		let outer_point = self.three_phase.then(|| {
+			let r_k = &vals[off..off + Word::LOG_BITS];
+			let r_s2 = &vals[off + Word::LOG_BITS..off + Word::LOG_BITS * 2];
+			let r_v2 =
+				&vals[off + Word::LOG_BITS * 2..off + Word::LOG_BITS * 2 + LOG_SHIFT_VARIANT_COUNT];
+			(r_k, r_s2, r_v2)
+		});
 
 		// Build the word-index equality tensor over the value vector: public words in the low
 		// segment, hidden words in the high segment.
@@ -537,17 +653,49 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 				&hidden_tensor[cs.n_inout..cs.n_inout + cs.n_private],
 			],
 		};
-		let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
-		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
-
-		// Phase 1 folded the shift variant into its sumcheck, so the h multilinear contributes a
-		// single evaluation here: the multilinear interpolation of the eight shift indicators over
-		// the variant axis.
+		// A slot phase folded the shift variant into its sumcheck, so each `h` contributes a single
+		// evaluation here: the multilinear interpolation of the eight shift indicators over the
+		// variant axis.
 		let eq_r_v = eq_ind_partial_eval_scalars(r_v_v);
-		let h_eval = inner_product_scalars(h_op_evals, eq_r_v.iter().cloned());
+		let fold_over_variants = |h_ops: [E; SHIFT_VARIANT_COUNT], eq_r_v: &[E]| {
+			inner_product_scalars(h_ops, eq_r_v.iter().cloned())
+		};
 
-		// A key's sequence selects itself through an equality indicator over both slots' axes,
-		// scaled by the one h evaluation.
+		// The two slots' `h` evaluations, and where the oblong factor sits.
+		//
+		// The outer phase closes the bit axis, so its weight carries the oblong factor at the
+		// intermediate point.
+		// The inner phase's is the bare indicator at that same point, with no oblong factor.
+		// Without an outer phase there is one slot phase, whose weight carries the factor itself.
+		let (inner_h_eval, outer_h_eval, eq_r_s2, eq_r_v2) = match outer_point {
+			Some((r_k, r_s2, r_v2)) => {
+				let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
+				let eq_r_v2 = eq_ind_partial_eval_scalars(r_v2);
+				let outer_h = fold_over_variants(evaluate_h_op(&l_tilde, r_k, r_s2), &eq_r_v2);
+				let inner_h = fold_over_variants(evaluate_inner_h_op(r_k, r_j_v, r_s_v), &eq_r_v);
+				(inner_h, outer_h, eq_ind_partial_eval_scalars(r_s2), eq_r_v2)
+			}
+			None => {
+				let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
+				let inner_h = fold_over_variants(evaluate_h_op(&l_tilde, r_j_v, r_s_v), &eq_r_v);
+				// No phase bound the outer axes, so their indicator sits at the all-zero point.
+				// There it selects the identity, the only outer shift a term may carry.
+				//
+				//     index 0 = (Sll, 0) -> one
+				//     every other index  -> zero
+				let zero_amount = vec![E::zero(); Word::LOG_BITS];
+				let zero_variant = vec![E::zero(); LOG_SHIFT_VARIANT_COUNT];
+				(
+					inner_h,
+					E::from(F::ONE),
+					eq_ind_partial_eval_scalars(&zero_amount),
+					eq_ind_partial_eval_scalars(&zero_variant),
+				)
+			}
+		};
+
+		// A key's sequence selects itself through an equality indicator over both slots' axes, each
+		// scaled by its phase's h evaluation.
 		// The weight factorizes, so it is one table per slot rather than one over the sequence
 		// space — see [`ShiftScalars`].
 		//
@@ -555,18 +703,10 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		// Each is indexed by `variant * Word::BITS + amount`.
 		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
 		let inner_shift_scalars = Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
-			h_eval.clone() * &eq_r_v[i / Word::BITS] * &eq_r_s[i % Word::BITS]
+			inner_h_eval.clone() * &eq_r_v[i / Word::BITS] * &eq_r_s[i % Word::BITS]
 		}));
-
-		// The outer slot's table, at the all-zero point: no challenges are drawn over those axes.
-		// There the indicator selects the identity, the only outer shift a term may carry.
-		//
-		//     index 0 = (Sll, 0) -> one
-		//     every other index  -> zero
-		//
-		// So a well-formed term's weight is unchanged.
 		let outer_shift_scalars = Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
-			if i == 0 { E::from(F::ONE) } else { E::zero() }
+			outer_h_eval.clone() * &eq_r_v2[i / Word::BITS] * &eq_r_s2[i % Word::BITS]
 		}));
 		let shift_scalars = ShiftScalars {
 			inner: &inner_shift_scalars,


### PR DESCRIPTION
Closes [BINIUS-445](https://linear.app/jimpo/issue/BINIUS-445).

> **Stacked on #2100** ([BINIUS-441](https://linear.app/jimpo/issue/BINIUS-441)) → #2099 → #2098 → #2097 → #2096. Review in that order; this PR's diff is only its own increment.

**This is the protocol change.** Prover and verifier move together.
Where double-shifted value indices first actually verify.

### The shape

Three sumchecks in sequence, peeling a term's shift sequence from the output end inward:

| phase | binds | against | weight |
|---|---|---|---|
| **outer** | `(k, s_2, v_2)` | the intermediate words | the oblong factor |
| **inner** | `(j, s_1, v_1)` | the witness words | the bare indicator at $r_k$ |
| **words** | `r_y` | the monster multilinear | both slots' weights, multiplied |

Each slot phase is one 15-variate bivariate product, so one runner serves both.

### Why the order is forced

This is the load-bearing detail, and it is now in a doc comment.

The oblong factor $\delta_D(r_{\hat i}, \hat i)$ attaches to the **output** bit index.
That index couples to the rest of the sum *only* through the outer indicator.

- Sum it out → a function of `(k, s_2)` alone → **one 15-variate sumcheck**.
- Bind the inner shift first → an output-side factor still depending on `s_2` → the sumcheck runs over `(j, s_1, s_2)`: **18 variates**.

### How the phases compose

The outer sumcheck closes on a product. The inner phase's claim *is* that product, because the outer phase's own evaluation is folded into the inner phase's per-key weight:

```
key scale = H_eval * eq(r_s2, s_2) * eq(r_v2, v_2)
```

So `sum(h_inner * g_scaled) = H_eval * G_eval = gamma_outer`, and no division is needed anywhere.

The words phase then weights a key by the product of both slots' tables, plus each phase's `h` evaluation — the two-table structure #2097 put in place, now with real challenges on both sides.

### The output interface does not change

One evaluation claim on the witness at $(r_j, r_y)$, whatever ran.
Ring-switching and everything downstream is untouched — and there is a test that pins exactly that.

### The degeneration stopgap — included

The ticket listed this as pending a call. It is implemented, and it is worth a look.

When no term needs both slots, the outer phase is **skipped entirely**.
Both sides derive that predicate from the constraint system, so it selects the same structure on each with **nothing sent between them**.

- **Upside:** a circuit of lone shifts produces the transcript it produced before this change, *byte for byte* — not one with an extra phase whose weight is the identity indicator on every key. Every existing circuit pays nothing.
- **Downside to weigh:** the three-phase path is then exercised only by the new double-shift tests, never by the existing suite.

### Scope

- **renamed:** the phase modules, to names that survive a third phase (`phase_1` → `slot_phase`, `phase_2` → `words_phase`), with the benchmark following
- **new:** the outer and inner phase provers, the shared slot-phase output, the per-slot weights and per-operation scalars, the verifier's optional outer point, and the shared phase predicate
- **changed:** the monster builder now takes both slots' weights instead of deriving one; the verifier's evaluator branches on whether the outer phase ran
- **lifted:** the verifier's assertion that no term is doubly shifted — both evaluation paths now weight a term by both slots

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-prover -p binius-verifier -p binius-m4-prover --all-targets` — clean
- nightly `cargo fmt --all` — clean
- prover shift 18, verifier shift 14, `binius-core` 113, `binius-m4-prover` 44 — pass
- shift integration **5/5 in both debug and release**; `prove_verify` 14/14 **unchanged**

> Run in **both** profiles deliberately: a stale `debug_assert` on the verifier's evaluation path only fires with debug assertions on, and a release-only run would have missed it. That assertion is lifted here.

### Tests added

- **genuine shift pairs prove and verify**, on a hand-built system whose AND and ZERO constraints carry irreducible pairs, with the outer phase confirmed to have run
- **every irreducible variant combination alone.** Run together, one pair's contribution could mask another's; one constraint system per pair keeps a mis-handled variant from hiding.
- **an unsatisfied claim is rejected**
- **lone shifts skip the outer phase**, and both sides agree they do

🤖 Generated with [Claude Code](https://claude.com/claude-code)