### PR TITLE
BINIUS-446: the batched three-phase shift reduction

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -8,6 +8,12 @@ use bytes::{Buf, BufMut};
 use super::{ValueIndex, ValueVec};
 use crate::word::Word;
 
+/// The width the half-word (`*32`) shift variants act over.
+///
+/// Those variants shift the upper and lower halves of a word independently.
+/// So every rule stated over a word's positions is applied once per half of this width.
+const HALF_WORD_BITS: usize = 32;
+
 /// A different variants of shifting a value.
 ///
 /// Note that there is no shift left arithmetic because it is redundant.
@@ -462,6 +468,79 @@ impl Shift {
 		self.variant.apply(word, self.amount as usize)
 	}
 
+	/// The input bit each output position reads, or `None` where it reads nothing.
+	///
+	/// Every shift variant has the *at-most-one-source-bit* property.
+	/// An output position takes its value from a single input position, or from no input at all
+	/// where the shift moved zeros in.
+	/// Arithmetic right shift is no exception: it makes *many* output positions read the sign bit,
+	/// which is many-to-one, not one-to-many.
+	///
+	/// So a shift is a permutation with holes over the bit positions, and applying it is a gather:
+	///
+	/// ```text
+	/// shifted[k] = source_bits[k].map(|j| word[j]).unwrap_or(0)
+	/// ```
+	///
+	/// That matters wherever a word's bits have been replaced by something a shift cannot act on
+	/// directly.
+	/// Folding a batch of words over its instance axis leaves one field element per bit position.
+	/// Folding is linear in those bits, so the shift and the fold commute:
+	///
+	/// ```text
+	/// fold(op(w, s))[k] = fold(w)[source_bits[k]]
+	/// ```
+	///
+	/// A folded row can therefore be shifted with 64 moves, rather than a 64x64 matrix of field
+	/// multiplications against the shift indicator.
+	///
+	/// ```
+	/// use binius_core::{constraint_system::Shift, word::Word};
+	///
+	/// // `sll(1)` moves bit 0 to bit 1, and bit 0 then reads nothing.
+	/// let map = Shift::sll(1).source_bits();
+	/// assert_eq!(map[0], None);
+	/// assert_eq!(map[1], Some(0));
+	///
+	/// // `sar` piles every position past the shift onto the sign bit.
+	/// let map = Shift::sar(2).source_bits();
+	/// assert_eq!(map[61], Some(63));
+	/// assert_eq!(map[62], Some(63));
+	/// assert_eq!(map[63], Some(63));
+	/// ```
+	pub fn source_bits(self) -> [Option<u8>; Word::BITS] {
+		let amount = self.amount as usize;
+		// Half-word variants run the rule below once per half; full-width ones once over the word.
+		let width = if self.variant.is_half_word() {
+			HALF_WORD_BITS
+		} else {
+			Word::BITS
+		};
+
+		let mut map = [None; Word::BITS];
+		for (half, positions) in map.chunks_exact_mut(width).enumerate() {
+			let base = (half * width) as u8;
+			for (out, slot) in positions.iter_mut().enumerate() {
+				// Which position within this half the output reads, if any.
+				let read = match self.variant {
+					// Moving left, an output reads a position below it; the low ones read nothing.
+					ShiftVariant::Sll | ShiftVariant::Sll32 => out.checked_sub(amount),
+					// Moving right, an output reads a position above it; those past the top read
+					// nothing.
+					ShiftVariant::Slr | ShiftVariant::Srl32 => {
+						Some(out + amount).filter(|&read| read < width)
+					}
+					// The same, except every position past the top reads the sign bit instead.
+					ShiftVariant::Sar | ShiftVariant::Sra32 => Some((out + amount).min(width - 1)),
+					// Rotating loses nothing: the positions past the top wrap around.
+					ShiftVariant::Rotr | ShiftVariant::Rotr32 => Some((out + amount) % width),
+				};
+				*slot = read.map(|read| base + read as u8);
+			}
+		}
+		map
+	}
+
 	/// Classifies the composition of two shifts, `outer` applied to the result of `inner`.
 	///
 	/// This is the merge rule for a shift sequence: it says whether the two collapse to one shift,
@@ -869,42 +948,12 @@ mod tests {
 		}
 	}
 
-	/// The width the half-word (`*32`) variants act over.
-	const HALF_WORD_BITS: usize = 32;
-
-	/// The bit an output position reads, for the positions that read nothing.
-	const READS_ZERO: u8 = u8::MAX;
-
 	/// What a shift does to a word, as one input bit position per output bit position.
 	///
-	/// This is an independent model of a shift's meaning, written from the definitions rather than
-	/// from the composition rules it is used to check. Entry `i` is the input bit that output bit
-	/// `i` reads, or [`READS_ZERO`].
-	fn bit_map(shift: Shift) -> [u8; Word::BITS] {
-		let mut map = [READS_ZERO; Word::BITS];
-		let amount = shift.amount as usize;
-		let width = if shift.variant.is_half_word() {
-			HALF_WORD_BITS
-		} else {
-			Word::BITS
-		};
-		for (half, positions) in map.chunks_exact_mut(width).enumerate() {
-			let base = (half * width) as u8;
-			for (out, slot) in positions.iter_mut().enumerate() {
-				let read = match shift.variant {
-					ShiftVariant::Sll | ShiftVariant::Sll32 => out.checked_sub(amount),
-					ShiftVariant::Slr | ShiftVariant::Srl32 => {
-						Some(out + amount).filter(|&read| read < width)
-					}
-					ShiftVariant::Sar | ShiftVariant::Sra32 => Some((out + amount).min(width - 1)),
-					ShiftVariant::Rotr | ShiftVariant::Rotr32 => Some((out + amount) % width),
-				};
-				if let Some(read) = read {
-					*slot = base + read as u8;
-				}
-			}
-		}
-		map
+	/// The test below pins this against the word operations, independently of the composition rules
+	/// it is then used to check.
+	fn bit_map(shift: Shift) -> [Option<u8>; Word::BITS] {
+		shift.source_bits()
 	}
 
 	/// What composing two shifts denotes, worked out at the bit level.
@@ -914,17 +963,15 @@ mod tests {
 	fn reference_composition(
 		inner: Shift,
 		outer: Shift,
-		by_map: &std::collections::HashMap<[u8; Word::BITS], Shift>,
+		by_map: &std::collections::HashMap<[Option<u8>; Word::BITS], Shift>,
 	) -> Composition {
 		let (inner_map, outer_map) = (bit_map(inner), bit_map(outer));
-		let mut composed = [READS_ZERO; Word::BITS];
+		let mut composed = [None; Word::BITS];
 		for (slot, &read) in iter::zip(&mut composed, &outer_map) {
-			if read != READS_ZERO {
-				*slot = inner_map[read as usize];
-			}
+			*slot = read.and_then(|read| inner_map[read as usize]);
 		}
 
-		if composed == [READS_ZERO; Word::BITS] {
+		if composed == [None; Word::BITS] {
 			return Composition::Zero;
 		}
 		match by_map.get(&composed) {
@@ -958,7 +1005,7 @@ mod tests {
 				let from_map = map
 					.iter()
 					.enumerate()
-					.filter(|&(_, &read)| read as usize == bit)
+					.filter(|&(_, &read)| read == Some(bit as u8))
 					.map(|(out, _)| 1u64 << out)
 					.fold(0u64, |acc, position| acc | position);
 				assert_eq!(from_map, expected, "{shift:?} disagrees on input bit {bit}");

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -13,14 +13,18 @@ use binius_math::{BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
-		monster::{SlotWeights, build_h, build_monster_segments, outer_h_evals},
-		slot_phase::{SLOT_PHASE_LOG_LEN, SlotPhaseOutput, build_g, run_slot_sumcheck},
+		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftSlot,
+		has_double_shift,
+		monster::{
+			SlotWeights, build_h, build_inner_h, build_monster_segments, inner_h_eval,
+			outer_h_evals,
+		},
+		slot_phase::{SLOT_PHASE_LOG_LEN, build_slot_g, run_slot_sumcheck},
 		words_phase::run_sumcheck,
 	},
 };
 
-use crate::witness::{FoldedWitness, FoldedWord};
+use crate::witness::{FoldedWitness, FoldedWord, shift_folded_word};
 
 /// Proves the batched shift-reduction, collapsing every operation's claims into one.
 ///
@@ -30,12 +34,22 @@ use crate::witness::{FoldedWitness, FoldedWord};
 /// The hidden witness enters already folded over the instance axis, as a [`FoldedWitness`].
 /// The public words are constants shared by every instance, so they are passed as raw words.
 ///
-/// The two phases call the single-instance prover's own subroutines.
-/// Phase 1 builds the hidden segment's g with [`build_g_from_folded_words`].
-/// It builds the public segment's g with the single-instance `build_g`, then sums the two.
-/// Phase 2 contracts the hidden witness along its bit axis with [`FoldedWitness::fold_bits`].
-/// It folds the public segment the same way, at the same challenge `r_j`.
-/// It then reuses `build_monster_segments` and `run_sumcheck` unchanged.
+/// Every phase calls the single-instance prover's own subroutines, supplying its own builder for
+/// the hidden segment:
+///
+/// ```text
+/// outer phase   build_outer_g_from_folded_words   the folded row gathered through the inner shift
+/// inner phase   build_g_from_folded_words         the folded row itself
+/// words phase   FoldedWitness::fold_bits          the row contracted along its bit axis
+/// ```
+///
+/// The public segment goes through the single-instance `build_slot_g` in each case, and the two are
+/// summed. `build_h`, `build_inner_h`, `build_monster_segments` and `run_sumcheck` are reused
+/// unchanged.
+///
+/// The outer phase is skipped when no term needs both shift slots, which leaves the two-phase
+/// reduction. That predicate is derived from the constraint system, so the verifier follows the
+/// same branch without being told.
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
@@ -67,39 +81,125 @@ where
 	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
 	let prepared = claims.prepare(|| channel.sample());
 
-	// The slot phase: build g once per key segment, then add them. The public words are
-	// constants shared by every instance, so the single-instance builder folds them directly from
-	// their bits; the hidden words are already folded over instances. This scalar path drives the
-	// single-instance slot sumcheck.
-	let mut g = build_g::<F, F, _>(alloc, public_words, &key_collection.public, &prepared, None);
-	let hidden_g =
-		build_g_from_folded_words(alloc, folded_witness.words(), &key_collection.hidden, &prepared);
-	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
-		*slot += *add;
-	}
-	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
-	let slot_phase = run_slot_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
+	// Whether any term needs both shift slots, which selects the phase structure.
+	// The system is public, so the verifier derives the same answer and takes the same branch.
+	let three_phase = has_double_shift(key_collection);
 
-	// The words phase runs at the bit point the slot phase bound, against the monster multilinear.
-	let claim = slot_phase.claim();
-	let SlotPhaseOutput {
-		r_bit: r_j,
-		r_s,
-		r_v,
-		..
-	} = slot_phase;
+	// Builds one phase's multilinear over both segments and sums them.
+	// The public words are constants shared by every instance, so the single-instance builder folds
+	// them from their bits; the hidden words arrive already folded over instances.
+	let build_combined =
+		|slot: ShiftSlot, public_scale: Option<&[F]>, hidden_scale: Option<&[F]>| {
+			let mut g = build_slot_g::<F, F, _>(
+				alloc,
+				public_words,
+				&key_collection.public,
+				&prepared,
+				slot,
+				public_scale,
+			);
+			// The hidden segment goes through the batched builder for the slot this phase binds.
+			let folded = folded_witness.words();
+			let hidden_g = match slot {
+				ShiftSlot::Inner => build_g_from_folded_words(
+					alloc,
+					folded,
+					&key_collection.hidden,
+					&prepared,
+					hidden_scale,
+				),
+				ShiftSlot::Outer => build_outer_g_from_folded_words(
+					alloc,
+					folded,
+					&key_collection.hidden,
+					&prepared,
+					hidden_scale,
+				),
+			};
+			for (entry, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+				*entry += *add;
+			}
+			g
+		};
+
+	let (r_j, claim, operation_scalars, inner, outer) = if three_phase {
+		// The outer phase binds `(k, s_2, v_2)` against the intermediate rows.
+		let g = build_combined(ShiftSlot::Outer, None, None);
+		let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+		let outer_phase =
+			run_slot_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
+
+		// The inner phase binds the inner axes, each key weighted by what the outer phase closed
+		// on.
+		let outer_weights = SlotWeights::at(&outer_phase.r_s, &outer_phase.r_v);
+		let scale_of = |segment: &KeySegment| {
+			segment
+				.dense_shift_enc
+				.iter()
+				.map(|[_, outer_shift]| outer_phase.h_eval * outer_weights.weight(outer_shift))
+				.collect::<Vec<_>>()
+		};
+		let public_scale = scale_of(&key_collection.public);
+		let hidden_scale = scale_of(&key_collection.hidden);
+
+		let g = build_combined(ShiftSlot::Inner, Some(&public_scale), Some(&hidden_scale));
+		let h = build_inner_h::<F, F, _>(alloc, &outer_phase.r_bit);
+		let inner_phase =
+			run_slot_sumcheck::<F, F, _, _>(g, h, outer_phase.claim(), channel, alloc);
+
+		let operation_scalars = outer_h_evals(
+			&prepared,
+			domain_subspace,
+			&outer_phase.r_bit,
+			&outer_phase.r_s,
+			&outer_phase.r_v,
+		)
+		.scaled_by(inner_h_eval(
+			&outer_phase.r_bit,
+			&inner_phase.r_bit,
+			&inner_phase.r_s,
+			&inner_phase.r_v,
+		));
+
+		(
+			inner_phase.r_bit.clone(),
+			inner_phase.claim(),
+			operation_scalars,
+			SlotWeights::at(&inner_phase.r_s, &inner_phase.r_v),
+			outer_weights,
+		)
+	} else {
+		// One slot phase binds the inner axes, so its `h` carries the oblong factor and the outer
+		// slot's weight selects the identity every key carries.
+		let g = build_combined(ShiftSlot::Inner, None, None);
+		let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+		let slot_phase =
+			run_slot_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
+
+		let operation_scalars = outer_h_evals(
+			&prepared,
+			domain_subspace,
+			&slot_phase.r_bit,
+			&slot_phase.r_s,
+			&slot_phase.r_v,
+		);
+
+		(
+			slot_phase.r_bit.clone(),
+			slot_phase.claim(),
+			operation_scalars,
+			SlotWeights::at(&slot_phase.r_s, &slot_phase.r_v),
+			SlotWeights::identity_selecting(),
+		)
+	};
+
+	// The words phase runs at the bit point the last slot phase bound.
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
 	// The witness folded at `r_j`, per segment.
 	// The public fold is a raw-word fold; the hidden fold contracts the already-oblong bits.
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
-
-	// One slot phase bound the inner axes, so its `h` carries the oblong factor and the outer
-	// slot's weight selects the identity every key carries.
-	let operation_scalars = outer_h_evals(&prepared, domain_subspace, &r_j, &r_s, &r_v);
-	let inner = SlotWeights::at(&r_s, &r_v);
-	let outer = SlotWeights::identity_selecting();
 
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		alloc,
@@ -123,25 +223,75 @@ where
 	)
 }
 
-/// Constructs the phase-1 "g" multilinear parts, one per shift variant, from instance-folded words.
+/// Constructs the inner phase's "g" multilinear parts from instance-folded words.
 ///
-/// This is the batched analogue of the single-instance [`build_g`].
+/// This is [`build_slot_g_from_folded_words`] on the [`ShiftSlot::Inner`] slot: it scatters the
+/// folded word itself, into the row its sequence's inner shift names.
+pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
+	alloc: &A,
+	folded_words: &[FoldedWord<F>],
+	segment: &KeySegment,
+	prepared: &PreparedOperatorClaims<F>,
+	scale: Option<&[F]>,
+) -> FieldVec<F, A> {
+	build_slot_g_from_folded_words(alloc, folded_words, segment, prepared, ShiftSlot::Inner, scale)
+}
+
+/// Constructs the outer phase's "G" multilinear parts from instance-folded words.
+///
+/// This is [`build_slot_g_from_folded_words`] on the [`ShiftSlot::Outer`] slot: it scatters the
+/// *intermediate* folded word — the folded word with its sequence's inner shift already applied —
+/// into the row the outer shift names.
+///
+/// **This is cleaner than the single-instance case, not harder.**
+/// There the intermediate word is formed with a machine shift over packed bits.
+/// Here the bits have become field elements, which a machine shift cannot touch.
+///
+/// It does not need to.
+/// Every variant reads at most one source bit per output position, and folding over instances is
+/// linear in the bits, so the two commute.
+/// Forming the intermediate row is a **gather** over the 64 folded elements — exactly the
+/// permutation the unfolded path applies to bits.
+pub fn build_outer_g_from_folded_words<F: BinaryField, A: Allocator>(
+	alloc: &A,
+	folded_words: &[FoldedWord<F>],
+	segment: &KeySegment,
+	prepared: &PreparedOperatorClaims<F>,
+	scale: Option<&[F]>,
+) -> FieldVec<F, A> {
+	build_slot_g_from_folded_words(alloc, folded_words, segment, prepared, ShiftSlot::Outer, scale)
+}
+
+/// Constructs one phase's shift multilinear parts, one per shift variant, from instance-folded
+/// words.
+///
+/// This is the batched analogue of the single-instance `build_slot_g`.
 /// It consumes a key segment's words already folded over the instance axis.
 /// So each word is a [`FoldedWord`], whose bits are field elements rather than a packed `u64`.
 ///
 /// The single-instance builder scatters an accumulator onto a word's set bits by masking.
 /// This one scales the accumulator by each folded bit with a field multiplication.
-/// The two coincide when the folded bit is 0 or 1.
+/// The two coincide when a folded bit is zero or one.
 ///
 /// Use this for the hidden (committed) segment, whose words are folded over instances.
-/// Use [`build_g`] for the public segment, whose words are shared constants.
-/// Adding the two results gives the complete g multilinear.
+/// Use the single-instance builder for the public segment, whose words are shared constants.
+/// Adding the two results gives the complete multilinear.
+///
+/// The two phases differ in exactly two places, both fixed by `slot`:
+///
+/// ```text
+/// slot     row named by            elements scattered
+/// Inner    the inner shift         the folded word
+/// Outer    the outer shift         the folded word gathered through the inner shift
+/// ```
 ///
 /// # Arguments
 ///
 /// - `folded_words`: the segment's words folded over instances, in `segment.key_ranges` order.
 /// - `segment`: the shift keys of this segment, grouped by the word they act on.
 /// - `prepared`: the per-operation claims, indexed by the operation each key names.
+/// - `slot`: which slot of a key's shift sequence names its row.
+/// - `scale`: an optional extra factor per shift sequence, as the other slot's phase weights it.
 ///
 /// Words past the segment's key ranges are power-of-two padding, and are ignored.
 ///
@@ -149,9 +299,8 @@ where
 ///
 /// One multilinear of [`SLOT_PHASE_LOG_LEN`] variables, holding every shift variant's part.
 ///
-/// The segment's dense shift encoding decodes a key's shift index into the variant and the shift
-/// amount. The variant indexes the high variables and the amount the middle ones, so a key names
-/// one run of bit slots:
+/// The bound slot's variant indexes the high variables and its amount the middle ones, so a key
+/// names one run of bit slots:
 ///
 /// ```text
 /// g[(variant * Word::BITS + amount) * Word::BITS + bit] += folded_bit * acc(key)
@@ -161,14 +310,23 @@ where
 /// Every word carrying that key accumulates into the same slots.
 ///
 /// This scalar implementation ignores the single-instance builder's packing and parallelism.
-pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
+pub fn build_slot_g_from_folded_words<F: BinaryField, A: Allocator>(
 	alloc: &A,
 	folded_words: &[FoldedWord<F>],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
+	slot: ShiftSlot,
+	scale: Option<&[F]>,
 ) -> FieldVec<F, A> {
-	// One zeroed multilinear covering every shift, drawn from the allocator. A key names one
-	// `(variant, amount)` pair, so the scatter below accumulates straight into it.
+	// Invariant: a scale carries one factor per shift sequence, indexed as the keys are.
+	debug_assert!(
+		scale.is_none_or(|scale| scale.len() == segment.dense_shift_enc.len()),
+		"a per-sequence scale covers the segment's dense shift encoding"
+	);
+
+	// One zeroed multilinear covering every shift, drawn from the allocator.
+	// A key names one `(variant, amount)` in the bound slot, and several sequences may agree on it,
+	// so the scatter below accumulates rather than overwrites.
 	let mut multilinear = FieldBuffer::zeros_in(alloc, SLOT_PHASE_LOG_LEN);
 
 	// Each folded word carries the keys named by the segment-relative range at its position.
@@ -178,25 +336,36 @@ pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
 			let operator_data = &prepared[key.operation];
 
 			// The lambda-weighted partial evaluation tensor for this shifted word.
-			let acc = key.accumulate(
+			let mut acc = key.accumulate(
 				&segment.constraint_indices,
 				operator_data.r_x_prime_tensor.as_ref(),
 				&operator_data.lambda_powers,
 			);
+			// The other slot's weight, when a previous phase already bound it.
+			if let Some(scale) = scale {
+				acc *= scale[key.dense_shift_idx as usize];
+			}
 
-			// The key's shift variant indexes the high variables and its shift amount the middle
-			// ones, which together name one run of bit slots. Phase 1 folds one shift axis pair, so
-			// this reads the sequence's inner slot; the outer one holds the identity.
+			// The bound slot's variant indexes the high variables and its amount the middle ones,
+			// which together name one run of bit slots.
 			let [inner, outer] = segment.dense_shift_enc.decode(key.dense_shift_idx as usize);
-			debug_assert!(
-				outer.is_identity(),
-				"the two-phase shift reduction reads only the inner shift of a sequence"
-			);
-			let base = (inner.variant as usize * Word::BITS + inner.amount as usize) * Word::BITS;
+			let row_shift = match slot {
+				ShiftSlot::Inner => inner,
+				ShiftSlot::Outer => outer,
+			};
+			let base =
+				(row_shift.variant as usize * Word::BITS + row_shift.amount as usize) * Word::BITS;
 			let slots = &mut multilinear.as_mut()[base..base + Word::BITS];
 
+			// The outer slot scatters the intermediate row: the folded word gathered through the
+			// inner shift. The inner slot scatters the folded word untouched.
+			let scattered = match slot {
+				ShiftSlot::Inner => *word,
+				ShiftSlot::Outer => shift_folded_word(word, inner),
+			};
+
 			// Scatter the accumulator across this key's bit slots, scaling each by the folded bit.
-			for (slot, &folded_bit) in iter::zip(slots, word) {
+			for (slot, &folded_bit) in iter::zip(slots, &scattered) {
 				*slot += acc * folded_bit;
 			}
 		}
@@ -211,7 +380,9 @@ mod tests {
 
 	use binius_compute::GlobalAllocator;
 	use binius_core::{
-		constraint_system::{AndConstraint, InoutSegment},
+		constraint_system::{
+			AndConstraint, Composition, InoutSegment, Shift, ShiftedValueIndex, ValueIndex,
+		},
 		word::Word,
 	};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
@@ -289,6 +460,86 @@ mod tests {
 			}
 		}
 		folded
+	}
+
+	// Shift pairs whose composition genuinely needs both slots, spread over the variants.
+	//
+	// The frontend emits lone shifts, so a fixture meaning to exercise the outer phase names pairs
+	// itself. Each is checked irreducible, so the fixture cannot silently take the two-phase path.
+	fn irreducible_pairs() -> Vec<[Shift; 2]> {
+		let pairs = [
+			[Shift::srl(3), Shift::sll(3)],
+			[Shift::sll(8), Shift::srl(2)],
+			[Shift::sar(7), Shift::sll(4)],
+			[Shift::rotr(1), Shift::sll(6)],
+			[Shift::srl32(4), Shift::sll32(11)],
+			[Shift::sra32(9), Shift::sll32(3)],
+			[Shift::rotr32(5), Shift::srl32(7)],
+			// Two sequences agreeing on their outer shift must merge into one accumulator row.
+			[Shift::srl(6), Shift::sll(3)],
+		];
+		for &[inner, outer] in &pairs {
+			assert_eq!(
+				Shift::compose(inner, outer),
+				Composition::Pair,
+				"{inner:?} then {outer:?} collapses, so it would not reach the outer phase"
+			);
+		}
+		pairs.to_vec()
+	}
+
+	// The oblong evaluation of the three AND operand columns *as the constraints declare them*.
+	//
+	// The batched AND check derives its third column as the conjunction of the other two, since
+	// that is what a satisfying witness gives. The shift reduction instead proves each *declared*
+	// column against its claim.
+	//
+	// So a fixture that does not satisfy the relation must read its third claim off the declared
+	// operand rather than derive it.
+	fn evaluate_declared_and_operands<P: PackedField<Scalar = B128>>(
+		table: &ValueTable,
+		constants: &[Word],
+		and_constraints: &[AndConstraint],
+		domain_subspace: &BinarySubspace<B128>,
+		r_z: B128,
+		r_x: &[B128],
+		r_rho: &[B128],
+	) -> [B128; 3] {
+		let columns =
+			OperandColumns::<_, 3>::build(table, constants, and_constraints, &GlobalAllocator);
+		let lagrange = lagrange_evals_scalars::<B128, B128>(domain_subspace, &r_z);
+		let row_point: Vec<B128> = r_rho.iter().chain(r_x).copied().collect();
+		columns.as_slices().map(|column| {
+			let folded_column = fold_words::<B128, P, _>(&GlobalAllocator, column, &lagrange);
+			evaluate(&folded_column, &row_point)
+		})
+	}
+
+	// One AND constraint whose operands carry genuine shift pairs over the table's private words.
+	//
+	// The reduction proves that each operand column evaluates to the claim it is handed, not that
+	// the AND relation holds. The claims come from these same constraints, so the fixture need not
+	// satisfy the relation.
+	fn double_shifted_and_constraints(n_private: usize) -> Vec<AndConstraint> {
+		let pairs = irreducible_pairs();
+		assert!(pairs.len() <= n_private, "the fixture needs one private word per pair");
+
+		let term =
+			|index: usize| ShiftedValueIndex::new(ValueIndex::private(index as u32), pairs[index]);
+		let split = pairs.len() / 2;
+		vec![AndConstraint([
+			(0..split).map(term).collect(),
+			// Mixing a pair with a lone shift and an unshifted term keeps every term class in one
+			// operand, so the outer phase has to handle a degenerate slot alongside a working one.
+			(split..pairs.len())
+				.map(term)
+				.chain([
+					ShiftedValueIndex::rotr(ValueIndex::private(0), 9),
+					ShiftedValueIndex::plain(ValueIndex::private(1)),
+				])
+				.collect(),
+			Vec::new(),
+		])]
 	}
 
 	// The batched prove round-trips with the single-instance shift verifier: the two agree on the
@@ -496,11 +747,12 @@ mod tests {
 		// The g multilinear: the public segment folds from raw constant words via the
 		// single-instance builder, the hidden segment from the instance-folded words. Add them.
 		// The h multilinear comes from the single-instance prover.
-		let mut g = build_g::<B128, B128, _>(
+		let mut g = build_slot_g::<B128, B128, _>(
 			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
 			&prepared,
+			ShiftSlot::Inner,
 			None,
 		);
 		let hidden_g = build_g_from_folded_words(
@@ -508,6 +760,7 @@ mod tests {
 			&hidden_folded,
 			&key_collection.hidden,
 			&prepared,
+			None,
 		);
 		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
 			*slot += *add;
@@ -518,5 +771,235 @@ mod tests {
 		// The lambda-powers scaling of the batched AND-check evals, plus the empty intmul claim.
 		let expected = prepared.bitand.batched_eval + prepared.intmul.batched_eval;
 		assert_eq!(inner_product, expected);
+	}
+
+	// The same round trip, over a constraint system whose AND operands carry genuine shift pairs.
+	//
+	// This is the case the batched three-phase reduction exists for: the outer phase runs against
+	// the intermediate rows, formed by gathering each folded row through its inner shift.
+	#[test]
+	fn prove_and_verify_round_trip_with_double_shifts() {
+		type P = PackedBinaryGhash1x128b;
+
+		let c = crc64_circuit();
+
+		let log_instances = 4;
+		let n_instances = 1usize << log_instances;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..n_instances)
+			.map(|_| std::array::from_fn(|_| rng.random()))
+			.collect();
+		let table = populate_crc64_witness(&c, &inputs);
+
+		// The circuit's own constraints, with the AND set replaced by one carrying shift pairs. The
+		// value counts are untouched, so the table still matches the system.
+		let mut cs = c.circuit.constraint_system().clone();
+		cs.and_constraints = double_shifted_and_constraints(cs.n_private);
+		cs.validate().unwrap();
+		assert!(
+			binius_prover::protocols::shift::has_double_shift(&build_key_collection(
+				&cs,
+				InoutSegment::Hidden
+			)),
+			"the fixture must reach the outer phase"
+		);
+		let key_collection = build_key_collection(&cs, InoutSegment::Hidden);
+
+		let domain_subspace =
+			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let r_z = B128::random(&mut rng);
+		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
+		let r_x_zero = random_scalars::<B128>(&mut rng, cs.log_zero_constraints().unwrap_or(0));
+		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
+
+		let folded_witness =
+			FoldedWitness::<B128, _>::fold_instances(&table, &r_rho, &GlobalAllocator);
+		let public_words = &cs.constants;
+
+		// The operand claims, from the columns these constraints actually produce.
+		let bitand_evals = evaluate_declared_and_operands::<P>(
+			&table,
+			public_words,
+			&cs.and_constraints,
+			&domain_subspace,
+			r_z,
+			&r_x,
+			&r_rho,
+		);
+
+		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
+		let prover_output = prove::<B128, P, _, _>(
+			&key_collection,
+			public_words,
+			&folded_witness,
+			OperatorClaims {
+				zero: OperatorData {
+					evals: [B128::ZERO],
+					r_zhat_prime: r_z,
+					r_x_prime: r_x_zero.clone(),
+				},
+				bitand: OperatorData {
+					evals: bitand_evals,
+					r_zhat_prime: r_z,
+					r_x_prime: r_x.clone(),
+				},
+				intmul: OperatorData::zero_claim(r_z),
+				binmul: OperatorData::zero_claim(r_z),
+			},
+			&domain_subspace,
+			&mut prover_transcript,
+			&GlobalAllocator,
+		);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let verifier_zero = VerifierOperatorData::new(r_x_zero, [B128::ZERO]);
+		let verifier_bitand = VerifierOperatorData::new(r_x, bitand_evals);
+		let verifier_intmul = VerifierOperatorData::new(Vec::new(), [B128::ZERO; 4]);
+		let verifier_bmul = VerifierOperatorData::new(Vec::new(), [B128::ZERO; 6]);
+		let verifier_output = verify(
+			&cs,
+			InoutSegment::Hidden,
+			&verifier_zero,
+			&verifier_bitand,
+			&verifier_intmul,
+			&verifier_bmul,
+			&mut verifier_transcript,
+		)
+		.unwrap();
+		check_eval(
+			&cs,
+			InoutSegment::Hidden,
+			public_words,
+			&verifier_zero,
+			&verifier_bitand,
+			&verifier_intmul,
+			&verifier_bmul,
+			&domain_subspace,
+			r_z,
+			&verifier_output,
+			&mut verifier_transcript,
+		)
+		.unwrap();
+		verifier_transcript.finalize().unwrap();
+
+		// The outer phase ran, which is what separates this from the two-phase round trip.
+		assert!(
+			verifier_output.outer.is_some(),
+			"a system with genuine shift pairs runs the outer phase"
+		);
+
+		// The witness evaluation equals the instance-folded witness evaluated at the point, with
+		// the segment's zero-padding contributing the (1 - r) factors above the folded length.
+		let r_y = verifier_output.r_y();
+		let log_folded = folded_witness.log_padded_words();
+		let base = folded_witness.evaluate(verifier_output.r_j(), &r_y[..log_folded]);
+		let expected_eval = r_y[log_folded..]
+			.iter()
+			.fold(base, |acc, &r_y_i| acc * (B128::ONE - r_y_i));
+		assert_eq!(expected_eval, verifier_output.witness_eval);
+
+		// Prover and verifier agree on the reduced challenges and the witness evaluation.
+		let eval_point = [
+			verifier_output.r_j(),
+			r_y,
+			std::slice::from_ref(&verifier_output.r_segment),
+		]
+		.concat();
+		assert_eq!(prover_output.challenges, eval_point);
+		assert_eq!(prover_output.eval, verifier_output.witness_eval);
+	}
+
+	// The outer phase's identity: summing the G·H inner products over the shift variants
+	// reconstructs the lambda-batched operand evaluation claim.
+	//
+	// This is the batched analogue of `phase_1_g_h_inner_product_matches_batched_evals`, one phase
+	// further out. `G` comes from the batched builder on the instance-folded witness, gathering
+	// each row through its inner shift; `H` is the single-instance prover's `build_h`, unchanged.
+	// Their inner product must equal the claim the outer sumcheck is handed — which is what pins
+	// the gather against the operand columns the AND check actually produced.
+	#[test]
+	fn outer_g_h_inner_product_matches_batched_evals() {
+		type P = PackedBinaryGhash1x128b;
+
+		let c = crc64_circuit();
+
+		let log_instances = 4;
+		let n_instances = 1usize << log_instances;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..n_instances)
+			.map(|_| std::array::from_fn(|_| rng.random()))
+			.collect();
+		let table = populate_crc64_witness(&c, &inputs);
+
+		let mut cs = c.circuit.constraint_system().clone();
+		cs.and_constraints = double_shifted_and_constraints(cs.n_private);
+		cs.validate().unwrap();
+		let key_collection = build_key_collection(&cs, InoutSegment::Hidden);
+
+		let domain_subspace =
+			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let r_z = B128::random(&mut rng);
+		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
+		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
+
+		let bitand_evals = evaluate_declared_and_operands::<P>(
+			&table,
+			&cs.constants,
+			&cs.and_constraints,
+			&domain_subspace,
+			r_z,
+			&r_x,
+			&r_rho,
+		);
+
+		// The hidden segment spans value indices `[offset_inout, combined_len)`.
+		let offset = table.layout().offset_inout();
+		let combined = table.layout().combined_len();
+		let public_words = &cs.constants;
+		let hidden_folded =
+			fold_words_over_instances(&table, &cs.constants, &r_rho, offset..combined);
+
+		let claims = OperatorClaims {
+			zero: OperatorData {
+				evals: [B128::ZERO],
+				r_zhat_prime: r_z,
+				r_x_prime: random_scalars::<B128>(&mut rng, cs.log_zero_constraints().unwrap_or(0)),
+			},
+			bitand: OperatorData {
+				evals: bitand_evals,
+				r_zhat_prime: r_z,
+				r_x_prime: r_x,
+			},
+			intmul: OperatorData::zero_claim(r_z),
+			binmul: OperatorData::zero_claim(r_z),
+		};
+		let prepared = claims.prepare(|| B128::random(&mut rng));
+
+		// The G multilinear: the public segment through the single-instance builder on the outer
+		// slot, the hidden segment through the batched one. Add them.
+		let mut g = build_slot_g::<B128, B128, _>(
+			&GlobalAllocator,
+			public_words,
+			&key_collection.public,
+			&prepared,
+			ShiftSlot::Outer,
+			None,
+		);
+		let hidden_g = build_outer_g_from_folded_words(
+			&GlobalAllocator,
+			&hidden_folded,
+			&key_collection.hidden,
+			&prepared,
+			None,
+		);
+		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+			*slot += *add;
+		}
+		let h = build_h::<B128, B128, _>(&GlobalAllocator, &domain_subspace, r_z);
+
+		let expected = prepared.bitand.batched_eval + prepared.intmul.batched_eval;
+		assert_eq!(inner_product_buffers(&g, &h), expected);
 	}
 }

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -3,7 +3,7 @@
 //! The committed witness with its instance axis collapsed at a challenge point.
 
 use binius_compute::{Allocator, VecLike};
-use binius_core::word::Word;
+use binius_core::{constraint_system::Shift, word::Word};
 use binius_field::{BinaryField, PackedField};
 use binius_math::{FieldVec, inner_product::inner_product};
 use binius_prover::fold_word::WordFolder;
@@ -15,6 +15,38 @@ use crate::ValueTable;
 ///
 /// Each bit position becomes one element, so the word is carried in oblong form.
 pub type FoldedWord<F> = [F; Word::BITS];
+
+/// Applies a shift to a word whose bits have been folded over the instance axis.
+///
+/// A shift cannot act on field elements the way it acts on bits, but it does not need to.
+/// Every variant reads at most one source bit per output position, so a shift is a permutation with
+/// holes over those positions.
+/// Folding over instances is linear in the bits, so the two commute:
+///
+/// ```text
+/// fold(op(w, s))[k] = fold(w)[source_bits[k]]
+/// ```
+///
+/// which makes this a **gather**: 64 moves, with a zero wherever the output position reads nothing.
+/// Going through the shift indicator would be a 64x64 matrix of field multiplications for the same
+/// answer.
+///
+/// # Arguments
+///
+/// - `word`: the word's bits, already folded over the instance axis.
+/// - `shift`: the shift to apply.
+pub fn shift_folded_word<F: BinaryField>(word: &FoldedWord<F>, shift: Shift) -> FoldedWord<F> {
+	// The common case copies straight through, with no source map to build.
+	if shift.is_identity() {
+		return *word;
+	}
+	let source_bits = shift.source_bits();
+	std::array::from_fn(|out| match source_bits[out] {
+		Some(source) => word[source as usize],
+		// The shift moved a zero into this position, and zero folds to zero whatever the point.
+		None => F::ZERO,
+	})
+}
 
 /// The committed witness of a batch, with its instance axis collapsed at a point.
 ///
@@ -161,7 +193,7 @@ mod tests {
 	use std::iter;
 
 	use binius_compute::GlobalAllocator;
-	use binius_field::PackedBinaryGhash1x128b;
+	use binius_field::{Field, PackedBinaryGhash1x128b, Random};
 	use binius_frontend::{CircuitBuilder, Wire};
 	use binius_math::{
 		multilinear::{
@@ -312,6 +344,133 @@ mod tests {
 
 			assert_eq!(lhs, rhs, "mismatch at log_instances = {log_instances}");
 		}
+	}
+
+	#[test]
+	fn shifting_a_folded_row_matches_folding_the_shifted_words() {
+		// Invariant: shifting a folded row equals folding the shifted words.
+		//
+		// The shift is a permutation with holes over the bit positions, and the fold is linear in
+		// those bits, so the two commute. That is what turns forming an intermediate row into a
+		// gather rather than a 64x64 field product against the shift indicator.
+		//
+		// Every canonical shift is covered, so a wrong source map cannot hide.
+		use binius_core::{ShiftVariant, constraint_system::Shift};
+
+		let mut rng = StdRng::seed_from_u64(4);
+
+		// One word per instance, drawn at random, and the point the instance axis folds at.
+		const LOG_INSTANCES: usize = 4;
+		let words = (0..1 << LOG_INSTANCES)
+			.map(|_| Word(rng.random::<u64>()))
+			.collect::<Vec<_>>();
+		let r_rho = random_scalars::<B128>(&mut rng, LOG_INSTANCES);
+		let eq = eq_ind_partial_eval::<B128>(&r_rho);
+
+		// Folds a batch of words over the instance axis, one field element per bit position.
+		let fold = |words: &[Word]| -> FoldedWord<B128> {
+			let mut folded = [B128::ZERO; Word::BITS];
+			for (word, &weight) in iter::zip(words, eq.as_ref()) {
+				for (bit, slot) in folded.iter_mut().enumerate() {
+					if (word.0 >> bit) & 1 == 1 {
+						*slot += weight;
+					}
+				}
+			}
+			folded
+		};
+
+		let folded = fold(&words);
+		for variant in ShiftVariant::ALL {
+			for amount in 0..variant.max_amount() {
+				let shift = Shift::new(variant, amount);
+
+				// Route A: shift every word, then fold.
+				let shifted_words = words
+					.iter()
+					.map(|&word| shift.apply(word))
+					.collect::<Vec<_>>();
+				let expected = fold(&shifted_words);
+
+				// Route B: fold once, then gather through the shift's source map.
+				let gathered = shift_folded_word(&folded, shift);
+
+				assert_eq!(
+					gathered, expected,
+					"{shift:?} disagrees with folding the shifted words"
+				);
+			}
+		}
+	}
+
+	#[test]
+	#[ignore = "reports a measurement rather than asserting a property"]
+	fn gather_versus_indicator_contraction() {
+		// What the gather buys over contracting against the shift indicator.
+		//
+		//     gather   : read the source map, move 64 elements
+		//     reference: sum shift-ind(k, j, s) * row[j] over all 64 source positions
+		//
+		// The reference is the 64x64 field product the at-most-one-source-bit property lets the
+		// outer phase skip. Both routes form the same row, which is asserted before the timings.
+		use std::time::Instant;
+
+		use binius_core::{ShiftVariant, constraint_system::Shift};
+
+		let mut rng = StdRng::seed_from_u64(9);
+		// One folded row per key the outer phase would touch, at a realistic count for sha256's
+		// private segment.
+		const N_ROWS: usize = 8192;
+		let rows = (0..N_ROWS)
+			.map(|_| std::array::from_fn(|_| B128::random(&mut rng)))
+			.collect::<Vec<FoldedWord<B128>>>();
+		// A spread of variants, so neither route is measured on one alone.
+		let shifts = ShiftVariant::ALL
+			.into_iter()
+			.map(|variant| Shift::new(variant, 7))
+			.collect::<Vec<_>>();
+
+		// The reference: contract the row against the shift indicator over every source position.
+		let by_indicator = |row: &FoldedWord<B128>, shift: Shift| -> FoldedWord<B128> {
+			let source_bits = shift.source_bits();
+			std::array::from_fn(|out| {
+				(0..Word::BITS)
+					.map(|source| {
+						let indicator = if source_bits[out] == Some(source as u8) {
+							B128::ONE
+						} else {
+							B128::ZERO
+						};
+						indicator * row[source]
+					})
+					.sum()
+			})
+		};
+
+		// Time both, touching the results so neither is optimized away.
+		let mut checksum = [B128::ZERO; 2];
+		let mut elapsed = [std::time::Duration::ZERO; 2];
+		for (index, route) in [
+			&by_indicator as &dyn Fn(&FoldedWord<B128>, Shift) -> FoldedWord<B128>,
+			&|row, shift| shift_folded_word(row, shift),
+		]
+		.into_iter()
+		.enumerate()
+		{
+			let start = Instant::now();
+			for (row, &shift) in iter::zip(&rows, shifts.iter().cycle()) {
+				checksum[index] += route(row, shift)[0];
+			}
+			elapsed[index] = start.elapsed();
+		}
+
+		// Both routes must agree, or the timings compare different computations.
+		assert_eq!(checksum[0], checksum[1]);
+		let [indicator, gather] = elapsed;
+		println!("intermediate rows: {N_ROWS}");
+		println!("  indicator contraction: {indicator:?}");
+		println!("  gather:                {gather:?}");
+		println!("  speedup:               {:.1}x", indicator.as_secs_f64() / gather.as_secs_f64());
 	}
 
 	#[test]

--- a/crates/m4-prover/src/witness/mod.rs
+++ b/crates/m4-prover/src/witness/mod.rs
@@ -16,5 +16,5 @@
 mod instance_fold;
 mod operand_columns;
 
-pub use instance_fold::{FoldedWitness, FoldedWord};
+pub use instance_fold::{FoldedWitness, FoldedWord, shift_folded_word};
 pub use operand_columns::OperandColumns;


### PR DESCRIPTION
Closes [BINIUS-446](https://linear.app/jimpo/issue/BINIUS-446).

> **Top of the stack.** #2101 ([BINIUS-445](https://linear.app/jimpo/issue/BINIUS-445)) → #2100 → #2099 → #2098 → #2097 → #2096. Review bottom-up; this PR's diff is only its own increment.

Gives the m4 prover the outer phase, and the builder for its intermediate rows.

### The idea — cleaner than it sounds

In the single-instance prover the intermediate word is formed with **one machine shift** over packed bits.

Here the instance axis has already been folded, so a bit position is no longer a bit — it is a field element, and a machine shift cannot touch it.

**It does not need to.** Every shift variant reads *at most one source bit per output position*, and folding over instances is linear in those bits. So the shift and the fold commute:

```
fold(op(w, s))[k] = fold(w)[source_bits[k]]
```

Forming the intermediate row is therefore a **gather** over the 64 folded elements — exactly the permutation-with-holes the unfolded path applies to bits.

`sar` is no exception: it makes *many* output positions read the sign bit, which is many-to-one, not one-to-many.

### Benchmark

The alternative is contracting against the shift indicator: `sum_j shift-ind(k, j, s) * row[j]` over all 64 source positions.

| route | 8,192 intermediate rows |
|---|---|
| indicator contraction | 73.5 ms |
| gather | 0.65 ms |
| **speedup** | **113×** |

Both routes are asserted equal before timing. Reported by an `#[ignore]`d test, so it runs on demand rather than in CI.

### The change

```
+ Shift::source_bits() -> [Option<u8>; 64]        // in binius-core
+ shift_folded_word(row, shift)                    // the gather
+ build_outer_g_from_folded_words(..)              // alongside the existing inner builder
```

and `m4_prover::shift::prove` gains the same two-branch phase structure as the single-instance prover, reusing its subroutines throughout:

| phase | hidden segment built by |
|---|---|
| outer | the folded row gathered through its inner shift |
| inner | the folded row itself |
| words | the row contracted along its bit axis |

The public segment goes through the single-instance builder in each case, and the two are summed.
`build_h`, `build_inner_h`, `build_monster_segments` and the words sumcheck are reused unchanged.

### On exposing the source map

The gather needs it, so `binius-core` now exposes it.

The composition tests already carried a **private copy of the same map** as their independent oracle. They now share the public one — still pinned against the word operations by its own test, so the chain that validates the composition rules is unchanged, just no longer duplicated.

### Scope

- **new:** the source map on the shift type, the folded-row gather, the outer builder, and the third phase in the batched prover
- **changed:** the existing batched builder is now a thin wrapper on a slot-parameterized one; the composition tests drop their duplicate map
- **left untouched:** every m4 caller — the reduction's output interface does not depend on how many phases ran

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy --workspace --all-targets` — clean
- nightly `cargo fmt --all` — clean
- `binius-m4-prover` 47, `binius-core` 113, shift integration 5/5 — pass
- `prove_verify` 14/14 pass **unchanged**
- run in both debug and release

### Tests added

- **the gather equals folding the shifted words**, over every canonical shift, so a variant whose source map is wrong cannot hide
- **the batched round trip on genuine shift pairs**, verified against the single-instance verifier, with the outer phase confirmed to have run
- **the outer-phase identity**: summing the `G·H` inner products reconstructs the lambda-batched operand claim — which is what pins the gather against the operand columns the AND check actually produced
- the source map is checked against the word operations at every canonical shift, and by doctest at the two interesting positions

> One fixture subtlety worth knowing if you write more of these: the batched AND check *derives* its third column as the conjunction of the other two, but the shift reduction proves each **declared** column against its claim. A fixture that does not satisfy the AND relation must therefore read its third claim off the declared operand rather than derive it — which is what the new helper does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)