### PR TITLE
BINIUS-432: verify a BaseFold opening end to end inside a circuit

### DIFF
--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -18,6 +18,7 @@ binius-ip = { path = "../ip" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 digest.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 binius-compute = { path = "../compute" }

--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -20,7 +20,10 @@ binius-utils = { path = "../utils" }
 digest.workspace = true
 
 [dev-dependencies]
+binius-compute = { path = "../compute" }
 binius-iop-prover = { path = "../iop-prover" }
+binius-ip-prover = { path = "../ip-prover" }
+binius-math = { path = "../math", features = ["test-utils"] }
 binius-prover = { path = "../prover" }
 binius-verifier = { path = "../verifier" }
 proptest.workspace = true

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -48,6 +48,7 @@ mod channel;
 mod filler;
 mod hints;
 pub mod merkle;
+pub mod merkle_channel;
 mod shared;
 pub mod symbolic;
 

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -18,30 +18,33 @@
 //! operations in the same order, and one cursor pairs what the second saw with the wires the first
 //! allocated.
 //!
-//! # Status: a skeleton, and not sound
+//! # Two channels
 //!
-//! The gadgets a real recursive verifier needs are not written. In their place, values that ought
-//! to be derived are left as circuit inputs for the replay to supply:
+//! [`Binius64BuilderChannel`] is a skeleton, and not sound.
+//! Values that ought to be derived are left as circuit inputs for a replay to supply:
 //!
 //! - **The Fiat-Shamir state.** `sample` and `sample_bits` return free wires rather than the
 //!   challenger's output, so nothing ties a challenge to the transcript that produced it.
 //! - **The Merkle openings.** `recv_openings` and `recv_committed_vector` return free wires rather
 //!   than values checked against a commitment root.
 //!
-//! What *is* constrained is the verifier's arithmetic: the sumcheck folding, the eq-indicator and
-//! Lagrange evaluations, the monster multilinear, every `assert_zero` along the way, and both field
-//! gadgets that used to be bare hints.
+//! What it does constrain is the verifier's arithmetic alone:
 //!
-//! So a circuit built here accepts proofs it should reject. It is useful for measuring that
-//! arithmetic and for keeping the pipeline honest while the gadgets are written, not for proving
-//! anything. Each gadget that lands removes entries from the recorded input list; with all of them
-//! in place the only input left is the proof itself.
+//! - the sumcheck folding, and the eq-indicator and Lagrange evaluations
+//! - the monster multilinear, and every `assert_zero` along the way
 //!
-//! The gadget for the first bullet now exists in [`challenger`], reproducing the native
-//! challenger's byte stream over wires.
-//! The gadgets for the second exist in [`merkle`], matching the native binary Merkle scheme.
-//! Driving them from `sample`, `sample_bits`, `recv_openings` and `recv_committed_vector` is what
-//! removes the two remaining bullets.
+//! So a circuit built there accepts proofs it should reject.
+//! It is for measuring that arithmetic, not for proving anything.
+//!
+//! [`merkle_channel`] closes both holes.
+//! It drives the [`challenger`] and [`merkle`] gadgets from those same four methods:
+//!
+//! ```text
+//!   skeleton:        proof -> replay -> wires the circuit could not derive
+//!   merkle_channel:  proof -> wires, and every other value is a gate output
+//! ```
+//!
+//! An unsatisfied circuit there means a rejected proof, which the skeleton cannot say.
 
 pub mod challenger;
 mod channel;

--- a/crates/recursion/src/merkle_channel.rs
+++ b/crates/recursion/src/merkle_channel.rs
@@ -1,0 +1,693 @@
+// Copyright 2026 The Binius Developers
+
+//! A verifier channel that builds a circuit instead of checking a proof.
+//!
+//! A verifier in this codebase never touches a transcript directly.
+//! It talks to a channel, and the protocol code across the interactive-proof, IOP and verifier
+//! crates is generic over which channel it is handed.
+//!
+//! Running that code against this channel verifies nothing.
+//! It *records* the verification as a Binius64 circuit, satisfiable exactly when the proof it was
+//! handed would have been accepted.
+//!
+//! Three gadgets are assembled here: field arithmetic over wires, the Fiat-Shamir state over wires,
+//! and the Merkle commitment checks.
+//!
+//! # Against the skeleton channel
+//!
+//! [`Binius64BuilderChannel`](crate::Binius64BuilderChannel) records the same operations.
+//! It leaves the hashing out, so a replay supplies what it could not derive:
+//!
+//! ```text
+//!     skeleton:  proof -> replay -> wires the circuit could not derive
+//!     this one:  proof -> wires, and every other value is a gate output
+//! ```
+//!
+//! Deriving those values is what costs the SHA-256.
+//! It is also what makes an unsatisfied circuit mean a rejected proof.
+//!
+//! # The proof stream
+//!
+//! A verifier transcript holds one byte tape, and two readers consume it strictly in order.
+//! They differ in one respect only:
+//!
+//! ```text
+//!     message reader:       reads the tape and feeds what it read to the Fiat-Shamir state
+//!     decommitment reader:  reads the tape and feeds the Fiat-Shamir state nothing
+//! ```
+//!
+//! Advice read through the second reader is sound because something already observed binds it: a
+//! Merkle root read as a message.
+//!
+//! Getting that split wrong does not make the circuit unsatisfiable on its own.
+//! It makes the circuit disagree with every real transcript, since the challenges it derives are
+//! then those of a different byte sequence.
+//!
+//! That makes the split the load-bearing property of this module, so the classification is spelled
+//! out:
+//!
+//! | read                                     | reader       | observed |
+//! | ---------------------------------------- | ------------ | -------- |
+//! | one received element                     | message      | yes      |
+//! | a run of received elements               | message      | yes      |
+//! | a commitment root                        | message      | yes      |
+//! | an opening's layer, leaves and branches  | decommitment | no       |
+//! | a whole committed vector                 | decommitment | no       |
+//!
+//! Every read is a whole number of eight-byte groups, since a field element is sixteen bytes and a
+//! SHA-256 digest is thirty-two.
+//! So the tape is modelled as a sequence of *proof words*, one witness wire each, in stream order:
+//!
+//! ```text
+//!     word i  carries proof bytes 8i .. 8i + 8, read little-endian
+//! ```
+//!
+//! # What is an input and what is a gate
+//!
+//! The proof bytes and the inner statement are the only circuit inputs.
+//! Challenges, folded values and recomputed digests are gate outputs, so the compiled circuit
+//! derives every one of them from those inputs on its own.
+//!
+//! - There is no replay of the verifier against a second channel.
+//! - There is no build-versus-fill ordering to keep in step.
+//! - Hints change none of that, since a hint also evaluates from wires the filler has settled.
+//!
+//! # Cost
+//!
+//! Counts are constraints as the frontend compiles them, with `n` the element count.
+//! This module's tests pin every row.
+//!
+//! | operation                                  | AND | BMUL      | ZERO |
+//! | ------------------------------------------ | --- | --------- | ---- |
+//! | receiving one element                      | 0   | 0         | 0    |
+//! | sampling one field element                 | 12  | 0         | 0    |
+//! | sampling one index word                    | 4   | 0         | 0    |
+//! | asserting a wire-carried element is zero   | 0   | 0         | 2    |
+//! | a table lookup over `n` entries            | 0   | 2 (n - 1) | 0    |
+//! | a bit-selected sum over `n` elements       | 0   | 2 n       | 0    |
+//! | one digest read                            | 16  | 0         | 0    |
+//!
+//! An assertion spends the ZERO column, which carries no sumcheck of its own.
+//!
+//! The two sampling rows are the byte assembly alone.
+//! A draw that empties the sampler forces a refill, and 32 bytes of sampler output cost about 700
+//! AND — see the [challenger docs](crate::challenger).
+//!
+//! A digest read pays one byte reversal per word, turning the tape's little-endian words into the
+//! big-endian halves a compression consumes.
+//!
+//! A table lookup and a bit-selected sum are the two operations that reach a word's bits, so their
+//! cost is the select gates they spend.
+//!
+//! Both drop to zero when the index word is one the protocol fixed rather than sampled.
+//! FRI's terminal fold walks its cosets at fixed indices, so every sum there settles while the
+//! circuit is being built.
+
+use std::{array, rc::Rc};
+
+use binius_circuits::{bytes::swap_bytes_32, multiplexer::multi_wire_multiplex};
+use binius_core::word::Word;
+use binius_field::{BinaryField128bGhash as B128, Field, util::FieldFn};
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_hash::sha256::Sha256HashSuite;
+use binius_iop::{
+	merkle_channel::MerkleIPVerifierChannel,
+	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
+};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+
+use crate::{
+	challenger::Sha256Challenger,
+	merkle::{self, DIGEST_WORDS, Digest, ELEMENT_WORDS, Element, element_words},
+	shared::Shared,
+	symbolic::{SymbolicElem, SymbolicWord},
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Proof bytes one proof word carries.
+const WORD_BYTES: usize = Word::BITS / 8;
+
+/// Which of a transcript's two readers a proof-stream read came from.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ReadKind {
+	/// An observed read: the bytes are fed to the Fiat-Shamir state.
+	Message,
+	/// An unobserved read: the bytes are advice, bound by an already-observed commitment.
+	Decommitment,
+}
+
+/// One read a verifier made from the proof stream.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ProofRead {
+	/// Which reader the bytes came from, and so whether the Fiat-Shamir state saw them.
+	pub kind: ReadKind,
+	/// Index of this read's first proof word.
+	pub word_offset: usize,
+	/// Proof words this read consumed.
+	pub n_words: usize,
+}
+
+/// Where a circuit's proof byte stream lives, in the order the verifier read it.
+///
+/// Every read is a whole number of eight-byte groups, so the stream is a sequence of proof words:
+///
+/// ```text
+///     word i  carries proof bytes 8i .. 8i + 8, read little-endian
+/// ```
+///
+/// Filling a circuit from a raw byte tape needs nothing else, since the proof is the only
+/// proof-side input.
+/// The list of reads recorded alongside the wires is there for accounting and diagnostics.
+#[derive(Clone, Debug, Default)]
+pub struct ProofLayout {
+	/// One witness wire per proof word, in stream order.
+	words: Vec<Wire>,
+	/// The reads that allocated those words, in order.
+	reads: Vec<ProofRead>,
+}
+
+impl ProofLayout {
+	/// The witness wires holding the proof stream, in order.
+	pub fn words(&self) -> &[Wire] {
+		// Stream order is the order the verifier read the tape in, which is what population relies
+		// on.
+		&self.words
+	}
+
+	/// The reads the verifier made, in order.
+	pub fn reads(&self) -> &[ProofRead] {
+		// Exposed for accounting: a caller can confirm which reads were observed and which were
+		// not.
+		&self.reads
+	}
+
+	/// Bytes of proof the circuit reads.
+	pub const fn n_bytes(&self) -> usize {
+		// Every proof word is eight tape bytes, so the wire count fixes the byte length exactly.
+		self.words.len() * WORD_BYTES
+	}
+
+	/// Writes a proof byte tape into the wires that carry it.
+	///
+	/// This is the whole of witness population for the proof.
+	/// Nothing else the channel produced is an input, so the compiled circuit derives the rest.
+	///
+	/// # Errors
+	///
+	/// Returns an error unless the tape is exactly as long as the circuit reads.
+	///
+	/// - A short tape would leave wires unset.
+	/// - A long one means the circuit and the prover disagree about the protocol.
+	pub fn populate(&self, w: &mut WitnessFiller, proof: &[u8]) -> Result<(), ProofLengthError> {
+		// Neither a short nor a long tape is worth filling, so the length is checked up front.
+		if proof.len() != self.n_bytes() {
+			return Err(ProofLengthError {
+				expected: self.n_bytes(),
+				actual: proof.len(),
+			});
+		}
+		// Wire i takes tape bytes 8i to 8i + 8, which is the convention every read shares.
+		for (&wire, chunk) in self.words.iter().zip(proof.chunks_exact(WORD_BYTES)) {
+			let bytes = chunk
+				.try_into()
+				.expect("chunks_exact yields chunks of exactly WORD_BYTES");
+			// Little-endian, matching how the transcript serialized the bytes in the first place.
+			w[wire] = Word(u64::from_le_bytes(bytes));
+		}
+		Ok(())
+	}
+}
+
+/// The proof handed to a layout is not the length the circuit reads.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
+#[error("the circuit reads {expected} proof bytes, but {actual} were supplied")]
+pub struct ProofLengthError {
+	/// Bytes the circuit reads.
+	pub expected: usize,
+	/// Bytes supplied.
+	pub actual: usize,
+}
+
+/// A Merkle commitment a verifier channel received.
+#[derive(Clone, Debug)]
+pub struct MerkleCommitment {
+	/// The commitment root, on wires.
+	pub root: Digest,
+	/// Depth of the committed tree.
+	pub depth: usize,
+	/// Field elements each leaf holds.
+	pub leaf_size: usize,
+}
+
+/// A verifier channel that records a verification as a circuit on a builder.
+///
+/// Drive it by running an ordinary verifier over it, take the proof layout it recorded, and build:
+///
+/// ```text
+///     let builder = CircuitBuilder::new();
+///     let mut channel = MerkleVerifierChannel::new(&builder);
+///     verify_something(&mut channel, statement)?;      // emits the gates
+///     let layout = channel.finish();
+///     let circuit = builder.build();
+///     layout.populate(&mut filler, proof_bytes)?;      // the only proof-side input
+/// ```
+///
+/// Each call emits its gates immediately rather than deferring them.
+/// That is why the builder is borrowed for this object's whole life.
+///
+/// See the [module docs](self) for the proof-stream convention and the cost of each operation.
+pub struct MerkleVerifierChannel<'a> {
+	/// Where this channel's gates are emitted.
+	builder: &'a CircuitBuilder,
+	/// The anchor a [`SymbolicElem`] holds so its arithmetic can reach the builder.
+	///
+	/// Its input list stays empty, since nothing here is left for a replay to supply.
+	shared: Rc<Shared>,
+	/// The in-circuit Fiat-Shamir state.
+	challenger: Sha256Challenger<'a>,
+	/// The proof stream read so far.
+	layout: ProofLayout,
+	/// The inout wires the inner statement enters on, in the order it was observed.
+	statement: Vec<Wire>,
+	/// Source of the layer depth an opening decommits to, shared with the native verifier.
+	scheme: BinaryMerkleTreeScheme<B128, Sha256HashSuite>,
+	/// Merkle verifications emitted so far, used to name subcircuits.
+	n_merkle_checks: usize,
+	/// Zero assertions emitted so far, used to name them.
+	n_assertions: usize,
+}
+
+impl<'a> MerkleVerifierChannel<'a> {
+	/// Creates a channel over a fresh Fiat-Shamir state, having read nothing.
+	pub fn new(builder: &'a CircuitBuilder) -> Self {
+		Self {
+			builder,
+			shared: Rc::new(Shared::with_builder(builder.clone())),
+			// The Fiat-Shamir state opens on its protocol seed, which is a constant and so free.
+			challenger: Sha256Challenger::new(builder),
+			// No proof word has been read yet, so the stream starts empty.
+			layout: ProofLayout::default(),
+			// The statement arrives through `observe_words`, which has not been called yet.
+			statement: Vec::new(),
+			// Consulted only for the layer depth an opening decommits to, which must be the depth
+			// the native verifier would have picked.
+			scheme: BinaryMerkleTreeScheme::new(),
+			n_merkle_checks: 0,
+			n_assertions: 0,
+		}
+	}
+
+	/// The proof stream read so far.
+	pub const fn proof_layout(&self) -> &ProofLayout {
+		// Readable mid-verification, unlike the consuming accessor, so a caller can measure as it
+		// goes.
+		&self.layout
+	}
+
+	/// The inout wires the inner statement entered on, in observation order.
+	pub fn statement(&self) -> &[Wire] {
+		// One wire per statement word, which is what a caller populates alongside the proof.
+		&self.statement
+	}
+
+	/// Consumes the channel and returns the proof stream it read.
+	pub fn finish(self) -> ProofLayout {
+		// The layout outlives the channel because filling a witness happens long after the last
+		// gate is emitted.
+		self.layout
+	}
+
+	/// Allocates `n` proof words, recording the read and observing it when it is a message.
+	fn read_words(&mut self, kind: ReadKind, n: usize) -> Vec<Wire> {
+		// A read of nothing must not turn the Fiat-Shamir channel: a native reader only turns it
+		// once it advances the tape.
+		//
+		// An explicit request to observe nothing is the opposite case, and does turn it.
+		if n == 0 {
+			return Vec::new();
+		}
+
+		// The stream is append-only, so this read starts where the previous one ended.
+		let word_offset = self.layout.words.len();
+		// One witness wire per eight tape bytes, which is the only proof-side input there is.
+		let words = (0..n)
+			.map(|_| self.builder.add_witness())
+			.collect::<Vec<_>>();
+		self.layout.words.extend_from_slice(&words);
+		// Recorded so the stream can be audited read by read, and filled in this same order.
+		self.layout.reads.push(ProofRead {
+			kind,
+			word_offset,
+			n_words: n,
+		});
+
+		// Only a message read is observed, which is the whole correctness content of the split.
+		if kind == ReadKind::Message {
+			self.challenger.observe_words(&words);
+		}
+		words
+	}
+
+	/// Reads `n` field elements from the proof stream.
+	fn read_elements(&mut self, kind: ReadKind, n: usize) -> Vec<Element> {
+		// Two words per element, low half first, which is how the tape serializes one.
+		self.read_words(kind, n * ELEMENT_WORDS)
+			.chunks_exact(ELEMENT_WORDS)
+			.map(|words| array::from_fn(|k| words[k]))
+			.collect()
+	}
+
+	/// Reads `n` digests from the proof stream.
+	///
+	/// The tape carries a digest as bytes, so its proof words are little-endian.
+	/// A compression instead consumes big-endian halves, and one byte reversal per word bridges the
+	/// two.
+	fn read_digests(&mut self, kind: ReadKind, n: usize) -> Vec<Digest> {
+		// Four words per digest, each reversed into the form the hashing gadgets read.
+		self.read_words(kind, n * DIGEST_WORDS)
+			.chunks_exact(DIGEST_WORDS)
+			.map(|words| array::from_fn(|j| swap_bytes_32(self.builder, words[j])))
+			.collect()
+	}
+
+	/// A subcircuit named for the next Merkle verification.
+	fn merkle_subcircuit(&mut self, what: &str) -> CircuitBuilder {
+		// A distinct name per check keeps a failing assertion traceable to the check that broke.
+		let name = format!("{what}[{}]", self.n_merkle_checks);
+		self.n_merkle_checks += 1;
+		self.builder.subcircuit(name)
+	}
+
+	/// Wraps a `(lo, hi)` wire pair as an element anchored to this channel's builder.
+	///
+	/// This is how a caller hands the verifier a statement it allocated its own wires for.
+	pub fn elem(&self, lo: Wire, hi: Wire) -> SymbolicElem {
+		SymbolicElem::wires(&self.shared, lo, hi)
+	}
+
+	/// Lifts every element onto wires and returns them as one group per element.
+	fn lower(
+		&self,
+		builder: &CircuitBuilder,
+		elems: &[SymbolicElem],
+	) -> Vec<[Wire; ELEMENT_WORDS]> {
+		elems
+			.iter()
+			.map(|elem| {
+				// An element settled at build time becomes constant wires here, so whatever reads
+				// the table sees one uniform shape.
+				let (lo, hi) = elem.to_wires(builder);
+				[lo, hi]
+			})
+			.collect()
+	}
+}
+
+impl IPVerifierChannel<B128> for MerkleVerifierChannel<'_> {
+	type Elem = SymbolicElem;
+
+	fn recv_one(&mut self) -> Result<SymbolicElem, binius_ip::channel::Error> {
+		// A prover message is observed: it is part of the byte sequence the challenges derive from.
+		let words = self.read_words(ReadKind::Message, ELEMENT_WORDS);
+		// Low half first, the order both the tape and a field multiplication use.
+		Ok(self.elem(words[0], words[1]))
+	}
+
+	fn recv_many(&mut self, n: usize) -> Result<Vec<SymbolicElem>, binius_ip::channel::Error> {
+		// One read rather than n, matching the native channel's single slice read, so the words
+		// land contiguously and the reads stay comparable between the two sides.
+		Ok(self
+			.read_elements(ReadKind::Message, n)
+			.into_iter()
+			// An element off the tape is always wire-carried, never settled at build time.
+			.map(|[lo, hi]| self.elem(lo, hi))
+			.collect())
+	}
+
+	fn sample(&mut self) -> SymbolicElem {
+		// Sixteen bytes of sampler output, packed little-endian into an element's two halves.
+		let (lo, hi) = self.challenger.sample_b128();
+		self.elem(lo, hi)
+	}
+
+	fn observe_one(&mut self, val: B128) -> SymbolicElem {
+		// A value the verifier already holds concretely, so it is observed as a constant.
+		self.observe_many(&[val]);
+		// Handing it back settled is what lets the caller's arithmetic over it fold away.
+		SymbolicElem::Constant(val)
+	}
+
+	fn observe_many(&mut self, vals: &[B128]) -> Vec<SymbolicElem> {
+		// These are values the verifier computed rather than read, so they enter as constant wires,
+		// which the frontend charges nothing for.
+		let words = vals
+			.iter()
+			.flat_map(|val| element_words(u128::from(*val)))
+			.map(|word| self.builder.add_constant_64(word))
+			.collect::<Vec<_>>();
+		// An empty slice is not a no-op: asking for nothing to be observed still turns the
+		// Fiat-Shamir channel, exactly as a native observe does.
+		self.challenger.observe_words(&words);
+		// Nothing reached a wire, so every value stays settled for the caller.
+		vals.iter().copied().map(SymbolicElem::Constant).collect()
+	}
+
+	fn assert_zero(&mut self, val: SymbolicElem) -> Result<(), binius_ip::channel::Error> {
+		match val {
+			SymbolicElem::Constant(c) => {
+				// A value the protocol already fixed is decided right here, with no gate.
+				if c == B128::ZERO {
+					Ok(())
+				} else {
+					// A fixed non-zero value is a claim no witness could rescue, so it is reported
+					// rather than turned into a constraint nothing can satisfy.
+					Err(binius_ip::channel::Error::InvalidAssert)
+				}
+			}
+			SymbolicElem::Wires { lo, hi, .. } => {
+				// A distinct name per assertion keeps a failure traceable to the claim that broke.
+				let builder = self
+					.builder
+					.subcircuit(format!("assert_zero[{}]", self.n_assertions));
+				self.n_assertions += 1;
+				// All 128 bits must vanish, so each half is asserted on its own.
+				builder.assert_zero("lo", lo);
+				builder.assert_zero("hi", hi);
+				Ok(())
+			}
+		}
+	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[SymbolicElem],
+		f: impl FieldFn<B128>,
+	) -> SymbolicElem {
+		// Evaluated symbolically rather than hinted: there is no outer verifier to rebind the
+		// result, so a hint here would be an unconstrained hole the circuit could not close.
+		f.call::<SymbolicElem>(inputs)
+	}
+}
+
+impl WordIPVerifierChannel<B128> for MerkleVerifierChannel<'_> {
+	type Word = SymbolicWord;
+
+	fn observe_words(&mut self, words: &[Word]) -> Vec<SymbolicWord> {
+		// One inout wire per statement word: as build-time constants these numbers would fold into
+		// the gates, tying the circuit to one instance of the statement rather than to all of them.
+		let wires = words
+			.iter()
+			.map(|_| self.builder.add_inout())
+			.collect::<Vec<_>>();
+		self.statement.extend_from_slice(&wires);
+		// Absorbing them is what binds the derived challenges to the statement being verified.
+		self.challenger.observe_words(&wires);
+		wires
+			.into_iter()
+			.map(|wire| SymbolicWord::wire(&self.shared, wire))
+			.collect()
+	}
+
+	/// Adds the elements whose bit is set in the given word, element `i` gated by bit `i`.
+	fn subset_sum(&mut self, elems: &[SymbolicElem], word: &SymbolicWord) -> SymbolicElem {
+		assert!(elems.len() <= Word::BITS, "precondition: at most one element per bit");
+
+		// A fixed word settles which elements the sum runs over, and addition itself is free.
+		if let Some(value) = word.value() {
+			return subset_sum_word(elems, value);
+		}
+
+		// One subcircuit gathers this sum's select gates under a single path.
+		let builder = self.builder.subcircuit("subset_sum");
+		// The word is derived, so this lowering is the wire it already carries.
+		let word_wire = word.to_wire(&builder);
+		// What a cleared bit contributes to the sum.
+		let zero = builder.add_constant(Word::ZERO);
+
+		let mut terms = Vec::with_capacity(elems.len());
+		for (bit, elem) in elems.iter().enumerate() {
+			// A zero element contributes nothing whichever way its bit falls, so it needs no gate.
+			if matches!(elem, SymbolicElem::Constant(c) if *c == B128::ZERO) {
+				continue;
+			}
+			let (lo, hi) = elem.to_wires(&builder);
+			// A select gate reads bit 63 alone, so the bit gating this element is lifted to it.
+			let selected = builder.shl(word_wire, (Word::BITS - 1 - bit) as u32);
+			// One select per half: the element when its bit is set, zero when it is clear.
+			terms.push([
+				builder.select(selected, lo, zero),
+				builder.select(selected, hi, zero),
+			]);
+		}
+		// Nothing could ever contribute, so the sum is the additive identity and stays settled.
+		if terms.is_empty() {
+			return SymbolicElem::Constant(B128::ZERO);
+		}
+
+		// Addition in characteristic 2 is a XOR, so accumulating the selected terms costs nothing.
+		let fold = |k: usize| {
+			// Column k is half k of every term, and the halves never mix.
+			let column = terms.iter().map(|term| term[k]).collect::<Vec<_>>();
+			builder.bxor_multi(&column)
+		};
+		self.elem(fold(0), fold(1))
+	}
+
+	/// Reads the table entry the low bits of the given word address.
+	fn select(&mut self, elems: &[SymbolicElem], word: &SymbolicWord) -> SymbolicElem {
+		assert!(
+			!elems.is_empty() && elems.len().is_power_of_two(),
+			"precondition: a power-of-two number of elements"
+		);
+
+		// A one-entry table needs no gate, since the index addresses no bit at all.
+		if let [only] = elems {
+			return only.clone();
+		}
+		// A fixed word settles which entry is read, so the lookup runs in Rust.
+		if let Some(value) = word.value() {
+			return select_word(elems, value);
+		}
+
+		// One subcircuit gathers the multiplexer's select gates under a single path.
+		let builder = self.builder.subcircuit("select");
+		// Settled entries become constant wires here, so every entry is two wires wide.
+		let groups = self.lower(&builder, elems);
+		let entries = groups.iter().map(|group| &group[..]).collect::<Vec<_>>();
+		// A tree of selects over the entries, both wires of an entry moving together.
+		let selected = multi_wire_multiplex(&builder, &entries, word.to_wire(&builder));
+		self.elem(selected[0], selected[1])
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> SymbolicWord {
+		// The Fiat-Shamir gadget masks the draw in-circuit, so the result provably lies below
+		// 2^bits, which is what lets a protocol drop its own index range check.
+		let wire = self.challenger.sample_bits(bits);
+		// A sampled word has no build-time value, so a lookup on it spends select gates.
+		SymbolicWord::wire(&self.shared, wire)
+	}
+
+	fn pack_words(&mut self, words: &[SymbolicWord]) -> Vec<SymbolicElem> {
+		// A `SymbolicElem` *is* the low and high wire of a 128-bit element, and a word fills half
+		// of it, so packing is pairing the wires up. It costs no gates, and a trailing odd word
+		// takes the low half against a zero high half.
+		words
+			.chunks(ELEMENT_WORDS)
+			.map(|chunk| {
+				let lo = chunk[0].to_wire(self.builder);
+				let hi = chunk.get(1).map_or_else(
+					|| self.builder.add_constant_64(0),
+					|word| word.to_wire(self.builder),
+				);
+				self.elem(lo, hi)
+			})
+			.collect()
+	}
+}
+
+impl MerkleIPVerifierChannel<B128> for MerkleVerifierChannel<'_> {
+	type Commitment = MerkleCommitment;
+
+	fn recv_merkle_commitment(
+		&mut self,
+		leaf_size: usize,
+		depth: usize,
+	) -> Result<MerkleCommitment, binius_iop::merkle_channel::Error> {
+		// The root is a message, and observing it is what binds every unobserved read below it.
+		let root = self.read_digests(ReadKind::Message, 1)[0];
+		// Depth and leaf width come from the statement rather than the tape, so they need no wire.
+		Ok(MerkleCommitment {
+			root,
+			depth,
+			leaf_size,
+		})
+	}
+
+	/// Opens the commitment at every query index, returning the elements the opened leaves hold.
+	///
+	/// # Index range
+	///
+	/// - The native channel rejects an index at or above the tree's leaf count.
+	/// - A wire holds no value while the circuit is built, so no such comparison is possible here.
+	/// - An index is instead opened modulo the leaf count, since only its low bits are ever read.
+	/// - A sampled index is masked in-circuit and a shift only narrows, so an index a protocol
+	///   derived from a challenge is already in range.
+	fn recv_openings(
+		&mut self,
+		commitment: &MerkleCommitment,
+		indices: &[SymbolicWord],
+	) -> Result<Vec<SymbolicElem>, binius_iop::merkle_channel::Error> {
+		let tree_depth = commitment.depth;
+		// The same rule the native verifier applies, so both sides stop climbing at the same level.
+		let layer_depth = self.scheme.optimal_verify_layer(indices.len(), tree_depth);
+
+		// Phase 1: one internal layer, read once and folded up to the root.
+		//
+		// The layer is advice, and the root already read as a message is what binds it.
+		let layer_digests = self.read_digests(ReadKind::Decommitment, 1 << layer_depth);
+		let builder = self.merkle_subcircuit("layer");
+		merkle::verify_layer(&builder, commitment.root, &layer_digests);
+
+		// Phase 2: every query climbs from its own leaf up to that shared layer.
+		let mut values = Vec::with_capacity(indices.len() * commitment.leaf_size);
+		for index in indices {
+			// Leaf and branch are advice too, bound by the layer the root binds.
+			let leaf = self.read_elements(ReadKind::Decommitment, commitment.leaf_size);
+			let branch = self.read_digests(ReadKind::Decommitment, tree_depth - layer_depth);
+
+			// Hashes the leaf, climbs the branch, then matches the layer entry the index addresses.
+			let builder = self.merkle_subcircuit("opening");
+			merkle::verify_opening(
+				&builder,
+				index.to_wire(&builder),
+				&leaf,
+				layer_depth,
+				tree_depth,
+				&layer_digests,
+				&branch,
+			);
+			// The opened elements are wire-carried, and the check above is what makes them usable.
+			values.extend(leaf.into_iter().map(|[lo, hi]| self.elem(lo, hi)));
+		}
+		Ok(values)
+	}
+
+	fn recv_committed_vector(
+		&mut self,
+		commitment: &MerkleCommitment,
+	) -> Result<Vec<SymbolicElem>, binius_iop::merkle_channel::Error> {
+		// One leaf's worth of elements per leaf, across every leaf of the tree.
+		let len = commitment.leaf_size << commitment.depth;
+		// The data is advice, bound by the root the commitment read as a message.
+		let data = self.read_elements(ReadKind::Decommitment, len);
+
+		// The data is the whole opening, so the tree is rebuilt over it rather than climbed.
+		let builder = self.merkle_subcircuit("vector");
+		merkle::verify_vector(&builder, commitment.root, &data, commitment.leaf_size);
+
+		// Every element is wire-carried, and the rebuild above is what makes them usable.
+		Ok(data.into_iter().map(|[lo, hi]| self.elem(lo, hi)).collect())
+	}
+}

--- a/crates/recursion/src/merkle_channel/tests.rs
+++ b/crates/recursion/src/merkle_channel/tests.rs
@@ -1,0 +1,1018 @@
+// Copyright 2026 The Binius Developers
+
+use binius_field::{PackedBinaryGhash2x128b, field::FieldOps};
+use binius_frontend::{CircuitStat, PopulateError};
+use binius_iop::merkle_channel::VerifierMerkleTranscriptChannel;
+use binius_iop_prover::merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel};
+use binius_ip::channel::{select_word, subset_sum_word};
+use binius_ip_prover::channel::{IPProverChannel, WordIPProverChannel};
+use binius_math::{FieldBuffer, test_utils::random_scalars};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+use sha2::Sha256;
+
+use super::*;
+
+/// The Fiat-Shamir challenger all three sides run, and the one the circuit gadget mirrors.
+type Challenger = HasherChallenger<Sha256>;
+
+/// Packing the committed data is held in, two elements to a register.
+type P = PackedBinaryGhash2x128b;
+
+/// The native verifier channel, which checks a proof instead of recording one.
+type NativeChannel = VerifierMerkleTranscriptChannel<
+	binius_transcript::VerifierTranscript<Challenger>,
+	Challenger,
+	B128,
+	Sha256HashSuite,
+>;
+
+/// The prover channel that writes the tape both verifier sides then read.
+type NativeProverChannel =
+	ProverMerkleTranscriptChannel<ProverTranscript<Challenger>, Challenger, B128, Sha256HashSuite>;
+
+/// One step of a script driven identically against the native channel and the circuit channel.
+///
+/// Every operation a Merkle verifier channel offers appears here, so a script is a complete
+/// exercise of the channel's Fiat-Shamir bookkeeping.
+#[derive(Clone, Copy, Debug)]
+enum Op {
+	/// Receive `n` prover elements as an observed message.
+	Recv(usize),
+	/// Sample one field element.
+	Sample,
+	/// Observe `n` statement elements.
+	Observe(usize),
+	/// Observe `n` statement words.
+	ObserveWords(usize),
+	/// Sample `n` bits.
+	Bits(usize),
+	/// Sample `n` query indices and open the committed vector at them.
+	Openings(usize),
+	/// Receive the whole committed vector.
+	Vector,
+}
+
+/// The committed data a Merkle script opens, and the shape it was committed in.
+struct Committed {
+	/// The committed vector, in the order the leaves hold it.
+	scalars: Vec<B128>,
+	/// Field elements one leaf holds.
+	leaf_size: usize,
+	/// Levels between a leaf and the root.
+	depth: usize,
+}
+
+impl Committed {
+	fn new(rng: &mut StdRng, log_len: usize, log_leaf_size: usize) -> Self {
+		Self {
+			// A power-of-two length, since a Merkle tree over the data must be balanced.
+			scalars: random_scalars::<B128>(rng, 1 << log_len),
+			leaf_size: 1 << log_leaf_size,
+			// Every leaf holds the same number of elements, so the depth is what is left over.
+			depth: log_len - log_leaf_size,
+		}
+	}
+}
+
+/// Runs `ops` on the prover side, returning the proof tape it wrote.
+fn prove(committed: &Committed, ops: &[Op], statement: &Statement) -> Vec<u8> {
+	// The prover commits to the same data both verifier sides will open.
+	let data = FieldBuffer::<P, _>::from_values(&committed.scalars);
+	let mut channel = NativeProverChannel::new(ProverTranscript::new(Challenger::default()));
+	// The root opens the tape, which is what makes every later decommitment binding.
+	let commitment = channel.send_merkle_commitment(data.to_ref(), committed.leaf_size);
+
+	for op in ops {
+		match *op {
+			// Prover elements go onto the tape and into the Fiat-Shamir state.
+			Op::Recv(n) => channel.send_many(&statement.sent[..n]),
+			// A sample writes nothing, but it still advances the Fiat-Shamir state.
+			Op::Sample => {
+				IPProverChannel::<B128>::sample(&mut channel);
+			}
+			// Statement values are known to both sides, so they are absorbed and never sent.
+			Op::Observe(n) => channel.observe_many(&statement.observed[..n]),
+			Op::ObserveWords(n) => {
+				WordIPProverChannel::<B128>::observe_words(&mut channel, &statement.words[..n]);
+			}
+			Op::Bits(n) => {
+				WordIPProverChannel::<B128>::sample_bits(&mut channel, n);
+			}
+			Op::Openings(n) => {
+				// Query indices are drawn from the Fiat-Shamir state, so the prover cannot choose
+				// which leaves it opens.
+				let indices = (0..n)
+					.map(|_| {
+						WordIPProverChannel::<B128>::sample_bits(&mut channel, committed.depth)
+					})
+					.collect::<Vec<_>>();
+				channel.send_openings(&commitment, data.to_ref(), &indices);
+			}
+			// The whole vector, which needs no branches because the tree is rebuilt over it.
+			Op::Vector => channel.send_committed_vector(&commitment, data.to_ref()),
+		}
+	}
+	// The finalized tape is the only thing that crosses to the verifier sides.
+	channel.into_transcript().finalize()
+}
+
+/// The statement values a script feeds in, fixed rather than read from the proof.
+struct Statement {
+	/// Elements the prover sends as observed messages.
+	sent: Vec<B128>,
+	/// Elements both sides observe without either sending them.
+	observed: Vec<B128>,
+	/// Words both sides observe, standing in for protocol constants.
+	words: Vec<Word>,
+}
+
+impl Statement {
+	fn new(rng: &mut StdRng, n: usize) -> Self {
+		Self {
+			// One pool per role, so an operation always has enough values to take a prefix of.
+			sent: random_scalars::<B128>(&mut *rng, n),
+			observed: random_scalars::<B128>(&mut *rng, n),
+			words: (0..n).map(|_| Word(rng.random())).collect(),
+		}
+	}
+}
+
+/// Everything a script's verifier side hands back, for the two sides to be compared.
+#[derive(Default, PartialEq, Eq, Debug)]
+struct Trace {
+	/// Field challenges, in order.
+	samples: Vec<u128>,
+	/// Word challenges, in order.
+	bits: Vec<u64>,
+	/// Elements received or opened, in order.
+	values: Vec<u128>,
+}
+
+/// Runs `ops` against the native channel over `proof`, returning what it saw.
+fn verify_natively(
+	committed: &Committed,
+	ops: &[Op],
+	statement: &Statement,
+	proof: &[u8],
+) -> Trace {
+	// A fresh challenger, so the native side derives its challenges from the tape alone.
+	let transcript =
+		binius_transcript::VerifierTranscript::new(Challenger::default(), proof.to_vec());
+	let mut channel = NativeChannel::new(transcript);
+	let commitment = channel
+		.recv_merkle_commitment(committed.leaf_size, committed.depth)
+		.expect("the tape opens with the commitment root");
+
+	let mut trace = Trace::default();
+	for op in ops {
+		match *op {
+			// Received elements are recorded so the circuit can be checked against them.
+			Op::Recv(n) => trace.values.extend(
+				channel
+					.recv_many(n)
+					.expect("the tape holds the sent elements")
+					.into_iter()
+					.map(u128::from),
+			),
+			Op::Sample => trace
+				.samples
+				.push(u128::from(IPVerifierChannel::<B128>::sample(&mut channel))),
+			// An observe returns nothing to compare: it only moves the Fiat-Shamir state.
+			Op::Observe(n) => {
+				channel.observe_many(&statement.observed[..n]);
+			}
+			Op::ObserveWords(n) => {
+				WordIPVerifierChannel::<B128>::observe_words(&mut channel, &statement.words[..n]);
+			}
+			Op::Bits(n) => {
+				let word = WordIPVerifierChannel::<B128>::sample_bits(&mut channel, n);
+				trace.bits.push(word.as_u64());
+			}
+			Op::Openings(n) => {
+				// Indices are recorded too, so the circuit can be shown to query the same leaves.
+				let indices = (0..n)
+					.map(|_| {
+						let word = WordIPVerifierChannel::<B128>::sample_bits(
+							&mut channel,
+							committed.depth,
+						);
+						trace.bits.push(word.as_u64());
+						word
+					})
+					.collect::<Vec<_>>();
+				trace.values.extend(
+					channel
+						.recv_openings(&commitment, &indices)
+						.expect("the prover's own openings must verify")
+						.into_iter()
+						.map(u128::from),
+				);
+			}
+			Op::Vector => trace.values.extend(
+				channel
+					.recv_committed_vector(&commitment)
+					.expect("the prover's own vector must verify")
+					.into_iter()
+					.map(u128::from),
+			),
+		}
+	}
+	// Finalizing fails on leftover bytes, which is what pins the script to the exact tape.
+	channel
+		.into_transcript()
+		.finalize()
+		.expect("the tape must be read out in full");
+	trace
+}
+
+/// Builds a circuit for `ops`, fills it from `proof`, and checks it reproduces `expected`.
+///
+/// Every sampled and received value is pinned to a public wire holding what the native channel
+/// produced, so a disagreement fails witness population rather than a Rust comparison.
+fn verify_in_circuit(
+	committed: &Committed,
+	ops: &[Op],
+	statement: &Statement,
+	proof: &[u8],
+	expected: &Trace,
+) -> (CircuitStat, ProofLayout) {
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+	// The root is read first here too, since the circuit must read the tape in the same order.
+	let commitment = channel
+		.recv_merkle_commitment(committed.leaf_size, committed.depth)
+		.expect("reading a commitment cannot fail");
+
+	// Wires to pin, paired with the value the native channel produced.
+	let mut pins: Vec<(Wire, u64)> = Vec::new();
+	// Three cursors, walked in lockstep with the native run that filled them.
+	let mut samples = expected.samples.iter();
+	let mut bits = expected.bits.iter();
+	let mut values = expected.values.iter();
+
+	let pin_elem = |pins: &mut Vec<(Wire, u64)>, elem: &SymbolicElem, want: u128| {
+		// A settled element becomes constant wires, so both forms are pinned the same way.
+		let (lo, hi) = elem.to_wires(&builder);
+		// The native value enters on public wires, which turns the comparison into a constraint.
+		let claimed = [builder.add_inout(), builder.add_inout()];
+		for (wire, word) in claimed.iter().zip(element_words(want)) {
+			pins.push((*wire, word));
+		}
+		// A distinct name per claim keeps a failure traceable to the value that broke.
+		builder.assert_eq_v(format!("pin[{}]", pins.len()), [lo, hi], claimed);
+	};
+
+	for op in ops {
+		match *op {
+			Op::Recv(n) => {
+				for elem in channel.recv_many(n).expect("reading a message cannot fail") {
+					// One native value per element, taken in the order both sides read them.
+					let want = *values
+						.next()
+						.expect("one native value per received element");
+					pin_elem(&mut pins, &elem, want);
+				}
+			}
+			Op::Sample => {
+				let elem = IPVerifierChannel::<B128>::sample(&mut channel);
+				let want = *samples.next().expect("one native challenge per sample");
+				pin_elem(&mut pins, &elem, want);
+			}
+			Op::Observe(n) => {
+				channel.observe_many(&statement.observed[..n]);
+			}
+			Op::ObserveWords(n) => {
+				// The statement enters on inout wires, so the native words are pinned onto them.
+				let words = &statement.words[..n];
+				let first = channel.statement().len();
+				WordIPVerifierChannel::<B128>::observe_words(&mut channel, words);
+				for (&wire, word) in channel.statement()[first..].iter().zip(words) {
+					pins.push((wire, word.as_u64()));
+				}
+			}
+			Op::Bits(n) => {
+				let word = WordIPVerifierChannel::<B128>::sample_bits(&mut channel, n);
+				let want = *bits.next().expect("one native word per bit sample");
+				// A word is one wire, so one public wire pins it.
+				let claimed = builder.add_inout();
+				pins.push((claimed, want));
+				builder.assert_eq(format!("bits[{}]", pins.len()), word.to_wire(&builder), claimed);
+			}
+			Op::Openings(n) => {
+				let indices = (0..n)
+					.map(|_| {
+						let word = WordIPVerifierChannel::<B128>::sample_bits(
+							&mut channel,
+							committed.depth,
+						);
+						// Pinning the index too proves the circuit queries the same leaves.
+						let want = *bits.next().expect("one native index per query");
+						let claimed = builder.add_inout();
+						pins.push((claimed, want));
+						builder.assert_eq(
+							format!("index[{}]", pins.len()),
+							word.to_wire(&builder),
+							claimed,
+						);
+						word
+					})
+					.collect::<Vec<_>>();
+				for elem in channel
+					.recv_openings(&commitment, &indices)
+					.expect("reading openings cannot fail")
+				{
+					let want = *values.next().expect("one native value per opened element");
+					pin_elem(&mut pins, &elem, want);
+				}
+			}
+			Op::Vector => {
+				for elem in channel
+					.recv_committed_vector(&commitment)
+					.expect("reading the vector cannot fail")
+				{
+					let want = *values
+						.next()
+						.expect("one native value per committed element");
+					pin_elem(&mut pins, &elem, want);
+				}
+			}
+		}
+	}
+
+	// An exhausted cursor is what rules out a circuit that quietly produced fewer values.
+	assert_eq!(samples.len(), 0, "every native challenge must be pinned");
+	assert_eq!(bits.len(), 0, "every native word must be pinned");
+	assert_eq!(values.len(), 0, "every native value must be pinned");
+
+	let layout = channel.finish();
+	let circuit = builder.build();
+	let stat = CircuitStat::collect(&circuit);
+
+	let mut w = circuit.new_witness_filler();
+	// The tape is the only proof-side input, and its length must match the reads exactly.
+	layout
+		.populate(&mut w, proof)
+		.expect("the layout must read exactly the proof the prover wrote");
+	// The native values are the only other input; everything else is derived by evaluation.
+	for (wire, value) in pins {
+		w[wire] = Word(value);
+	}
+
+	// Population evaluates every gate and every assertion, so a disagreement fails here.
+	circuit
+		.populate_wire_witness(&mut w)
+		.expect("the circuit must agree with the native channel");
+	// Verification then re-checks the same witness against the constraint system itself.
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("every constraint must hold");
+
+	(stat, layout)
+}
+
+/// Drives one script through prover, native verifier and circuit, and returns the circuit's report.
+fn run_script(
+	seed: u64,
+	log_len: usize,
+	log_leaf_size: usize,
+	ops: &[Op],
+) -> (CircuitStat, ProofLayout) {
+	let mut rng = StdRng::seed_from_u64(seed);
+	let committed = Committed::new(&mut rng, log_len, log_leaf_size);
+	// Eight values per role is more than any script below takes a prefix of.
+	let statement = Statement::new(&mut rng, 8);
+
+	// Three runs over one script:
+	//
+	//     prover  : writes the tape
+	//     native  : reads it and reports the values it derived
+	//     circuit : reads it on wires and is pinned to those same values
+	let proof = prove(&committed, ops, &statement);
+	let expected = verify_natively(&committed, ops, &statement, &proof);
+	verify_in_circuit(&committed, ops, &statement, &proof, &expected)
+}
+
+#[test]
+fn a_full_script_matches_the_native_channel() {
+	// Invariant: the circuit channel derives the same challenges, query indices and values as the
+	// native channel, over the same tape.
+	//
+	// Fixture state: 32 committed scalars in leaves of 2, so a tree of depth 4.
+	//
+	// The script below walks every operation, in interleavings chosen so that the Fiat-Shamir
+	// channel turns in both directions and the sampler refills mid-value.
+	let ops = [
+		// A sample straight off the commitment root, before any other read.
+		Op::Sample,
+		// Widths that mask nothing, mask everything, and land mid-byte.
+		Op::Bits(0),
+		Op::Bits(32),
+		Op::Bits(5),
+		// A message read turns the Fiat-Shamir channel back to observing.
+		Op::Recv(3),
+		Op::Sample,
+		// Statement values, which are constants in the circuit.
+		Op::Observe(2),
+		Op::ObserveWords(4),
+		Op::Sample,
+		// An empty observe still turns the channel, so the two below are not no-ops.
+		Op::Observe(0),
+		Op::ObserveWords(0),
+		Op::Sample,
+		// Queries at several counts, so the layer depth the openings decommit to varies.
+		Op::Openings(1),
+		Op::Sample,
+		Op::Openings(3),
+		Op::Recv(1),
+		Op::Openings(6),
+		Op::Sample,
+		// The whole vector, checked by rebuilding the tree over it.
+		Op::Vector,
+		Op::Sample,
+		Op::Bits(17),
+	];
+	run_script(0, 5, 1, &ops);
+}
+
+#[test]
+fn a_single_leaf_tree_matches_the_native_channel() {
+	// Invariant: a tree whose root is its only node verifies, with nothing to climb.
+	//
+	// Fixture state: 4 committed scalars in one leaf of 4, so depth 0.
+	//
+	//     decommitted layer:  the root itself, one digest
+	//     branch per query:   0 digests, since a leaf is already at the layer
+	run_script(1, 2, 2, &[Op::Openings(1), Op::Sample, Op::Vector, Op::Bits(8)]);
+}
+
+#[test]
+fn wide_leaves_match_the_native_channel() {
+	// Invariant: a leaf too wide for one hash block verifies, so the leaf hash chains its blocks.
+	//
+	// Fixture state: 64 committed scalars in leaves of 8, so a tree of depth 3.
+	//
+	//     leaf = 8 elements = 128 bytes  ->  two SHA-256 blocks
+	run_script(2, 6, 3, &[Op::Openings(4), Op::Sample, Op::Vector]);
+}
+
+#[test]
+fn the_proof_layout_accounts_for_every_byte_in_order() {
+	// Invariant: the recorded reads tile the proof stream, so no word is read twice, skipped, or
+	// left over.
+	//
+	// Fixture state: 16 committed scalars in leaves of 2, opened by four operations.
+	let ops = [Op::Recv(2), Op::Openings(3), Op::Vector, Op::Recv(1)];
+	let (_, layout) = run_script(3, 4, 1, &ops);
+
+	// Walk the reads in order and require each to begin exactly where the last one ended.
+	//
+	//     read 0: [0, n_0)   read 1: [n_0, n_0 + n_1)   ...
+	let mut cursor = 0;
+	for read in layout.reads() {
+		assert_eq!(read.word_offset, cursor, "a read must start where the last one ended");
+		// A zero-word read is never recorded, since it would not turn the Fiat-Shamir channel.
+		assert!(read.n_words > 0, "an empty read must not be recorded");
+		cursor += read.n_words;
+	}
+	// Ending on the last wire is what rules out a gap or an unread tail.
+	assert_eq!(cursor, layout.words().len(), "the reads must cover every proof word");
+	// The byte length follows from the wire count, eight bytes to a word.
+	assert_eq!(layout.n_bytes(), layout.words().len() * WORD_BYTES);
+}
+
+#[test]
+fn only_the_root_and_prover_messages_are_observed() {
+	// Invariant: exactly the commitment root and the prover's messages are observed.
+	// Everything an opening or a committed vector reads is advice, bound by that root.
+	//
+	// Fixture state: 16 scalars in leaves of 2, so depth 3, and 2 queries decommitting to a layer
+	// of 2 digests.
+	let (log_len, log_leaf_size, n_queries): (usize, usize, usize) = (4, 1, 2);
+	let (leaf_size, depth) = (1 << log_leaf_size, log_len - log_leaf_size);
+	let layer_depth = n_queries.ilog2() as usize;
+
+	let ops = [Op::Recv(1), Op::Openings(n_queries), Op::Vector];
+	let (_, layout) = run_script(4, log_len, log_leaf_size, &ops);
+
+	// The expected stream, read by read:
+	//
+	//     0  root                        message        4 words
+	//     1  one received element        message        2 words
+	//     2  decommitted layer           decommitment   8 words
+	//     3  query 0 leaf                decommitment   4 words
+	//     4  query 0 branch              decommitment   8 words
+	//     5  query 1 leaf                decommitment   4 words
+	//     6  query 1 branch              decommitment   8 words
+	//     7  committed vector            decommitment  32 words
+	let kinds = layout
+		.reads()
+		.iter()
+		.map(|read| (read.kind, read.n_words))
+		.collect::<Vec<_>>();
+
+	// The root and the received element are messages, so the Fiat-Shamir state saw them.
+	assert_eq!(kinds[0], (ReadKind::Message, DIGEST_WORDS), "the commitment root");
+	assert_eq!(kinds[1], (ReadKind::Message, ELEMENT_WORDS), "the received element");
+
+	// Everything the openings and the vector read is advice, bound by that root.
+	assert!(
+		kinds[2..]
+			.iter()
+			.all(|&(kind, _)| kind == ReadKind::Decommitment),
+		"every read after the message must be decommitment advice: {kinds:?}"
+	);
+
+	// The layer is read once, whatever the query count, since every query folds against it.
+	assert_eq!(kinds[2].1, (1 << layer_depth) * DIGEST_WORDS, "the decommitted layer");
+	for query in 0..n_queries {
+		// Then a leaf and the branch climbing from it to the layer, per query.
+		assert_eq!(kinds[3 + 2 * query].1, leaf_size * ELEMENT_WORDS, "the opened leaf");
+		assert_eq!(
+			kinds[4 + 2 * query].1,
+			(depth - layer_depth) * DIGEST_WORDS,
+			"the authentication branch"
+		);
+	}
+	// The vector is every leaf's elements at once, which is why it carries no branch.
+	assert_eq!(
+		kinds[3 + 2 * n_queries].1,
+		(leaf_size << depth) * ELEMENT_WORDS,
+		"the committed vector"
+	);
+	// A read count of its own rules out an extra read hiding past the vector.
+	assert_eq!(kinds.len(), 4 + 2 * n_queries, "no read beyond the vector");
+}
+
+#[test]
+fn populate_rejects_a_proof_of_the_wrong_length() {
+	// Invariant: a tape that is not exactly as long as the circuit reads is refused, since a short
+	// one would leave wires unset and a long one means the two sides disagree on the protocol.
+	//
+	// Fixture state: one read of 2 elements.
+	//
+	//     2 elements = 4 proof words = 32 bytes
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+	channel.recv_many(2).expect("reading a message cannot fail");
+	let layout = channel.finish();
+
+	let expected = 2 * ELEMENT_WORDS * WORD_BYTES;
+	assert_eq!(layout.n_bytes(), expected);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	// Mutation: empty, one byte short, and one byte long.
+	for supplied in [0, expected - 1, expected + 1] {
+		let error = layout
+			.populate(&mut w, &vec![0u8; supplied])
+			.expect_err("a proof of the wrong length must be rejected");
+		// The error reports both lengths, so a caller can see which side is wrong.
+		assert_eq!(
+			error,
+			ProofLengthError {
+				expected,
+				actual: supplied
+			}
+		);
+	}
+	// The exact length is accepted, which pins the rejection to the length and nothing else.
+	layout
+		.populate(&mut w, &vec![0u8; expected])
+		.expect("a proof of the right length must be accepted");
+}
+
+/// Builds a circuit over one bit-selected sum or table lookup and checks it against the native
+/// helper.
+///
+/// The word carrying the index is either fixed at build time or on a witness wire, which is the
+/// split that decides whether any select gate is spent.
+fn run_word_op(
+	elems: &[B128],
+	word: Word,
+	fixed_index: bool,
+	native: fn(&[B128], Word) -> B128,
+	apply: fn(&mut MerkleVerifierChannel<'_>, &[SymbolicElem], &SymbolicWord) -> SymbolicElem,
+) -> CircuitStat {
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+
+	// Half the elements folded and half on wires, so both paths are exercised at once.
+	//
+	//     index 0, 2, 4, ...  settled at build time
+	//     index 1, 3, 5, ...  a witness wire pair
+	let mut inputs = Vec::new();
+	let operands = elems
+		.iter()
+		.enumerate()
+		.map(|(i, &value)| {
+			if i % 2 == 0 {
+				return SymbolicElem::Constant(value);
+			}
+			let wires = [builder.add_witness(), builder.add_witness()];
+			// Record what each half must hold, low half first.
+			for (wire, w) in wires.iter().zip(element_words(u128::from(value))) {
+				inputs.push((*wire, w));
+			}
+			channel.elem(wires[0], wires[1])
+		})
+		.collect::<Vec<_>>();
+
+	let index = if fixed_index {
+		// A word the protocol fixed carries its value, so the operation can settle in Rust.
+		SymbolicWord::from(word)
+	} else {
+		// A sampled word carries no value, so the operation must spend select gates.
+		let wire = builder.add_witness();
+		inputs.push((wire, word.as_u64()));
+		SymbolicWord::wire(&channel.shared, wire)
+	};
+
+	let got = apply(&mut channel, &operands, &index);
+	// A settled result becomes constant wires, so either form is pinned the same way.
+	let (lo, hi) = got.to_wires(&builder);
+	// The native answer enters on public wires, making the comparison a constraint.
+	let claimed = [builder.add_inout(), builder.add_inout()];
+	for (wire, w) in claimed
+		.iter()
+		.zip(element_words(u128::from(native(elems, word))))
+	{
+		inputs.push((*wire, w));
+	}
+	builder.assert_eq_v("result", [lo, hi], claimed);
+
+	let circuit = builder.build();
+	let stat = CircuitStat::collect(&circuit);
+	let mut w = circuit.new_witness_filler();
+	// Only the operands and the native answer are written; evaluation derives the rest.
+	for (wire, value) in inputs {
+		w[wire] = Word(value);
+	}
+	// Population evaluates every gate and every assertion, so a wrong result fails here.
+	circuit
+		.populate_wire_witness(&mut w)
+		.expect("the circuit must reproduce the native result");
+	// Verification then re-checks the same witness against the constraint system itself.
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("every constraint must hold");
+	stat
+}
+
+#[test]
+fn subset_sum_matches_the_native_helper() {
+	// Invariant: the circuit sums exactly the elements whose bit is set, over every table size and
+	// bit pattern that matters.
+	//
+	// Fixture state: element counts 1, 2, 7 and 64, each against three words and both index forms.
+	let mut rng = StdRng::seed_from_u64(5);
+	// One element, a full 64 so the top bit is read, and sizes in between.
+	for n in [1usize, 2, 7, 64] {
+		let elems = random_scalars::<B128>(&mut rng, n);
+		// All bits clear, all set, and a random pattern.
+		for word in [Word::ZERO, Word::ALL_ONE, Word(rng.random())] {
+			for fixed_index in [false, true] {
+				run_word_op(&elems, word, fixed_index, subset_sum_word, |channel, elems, index| {
+					channel.subset_sum(elems, index)
+				});
+			}
+		}
+	}
+}
+
+#[test]
+fn select_matches_the_native_helper() {
+	// Invariant: the circuit reads the entry the low bits of the word address, and ignores the high
+	// bits exactly as the native helper does.
+	//
+	// Fixture state: table sizes 1, 2, 8 and 32, each against every in-range index plus one word
+	// whose high bits must be discarded.
+	let mut rng = StdRng::seed_from_u64(6);
+	for n in [1usize, 2, 8, 32] {
+		let elems = random_scalars::<B128>(&mut rng, n);
+		// Every in-range index, plus a word whose high bits must be ignored.
+		let mut words = (0..n as u64).map(Word::from_u64).collect::<Vec<_>>();
+		words.push(Word(rng.random()));
+		for word in words {
+			for fixed_index in [false, true] {
+				run_word_op(&elems, word, fixed_index, select_word, |channel, elems, index| {
+					channel.select(elems, index)
+				});
+			}
+		}
+	}
+}
+
+#[test]
+fn select_and_subset_sum_cost_two_bmul_per_multiplexer_node() {
+	// Invariant: both operations spend two select gates per multiplexer node, one for each half of
+	// an element, and nothing else.
+	//
+	// Fixture state: 8 elements behind a sampled index.
+	//
+	//     lookup     :  a tree of 8 - 1 = 7 nodes  ->  14 BMUL
+	//     subset sum :  one node per element, 8     ->  16 BMUL
+	let mut rng = StdRng::seed_from_u64(7);
+	let elems = random_scalars::<B128>(&mut rng, 8);
+	let word = Word(rng.random());
+
+	// A multiplexer over n entries is n - 1 select gates, twice over for the two wires.
+	let stat = run_word_op(&elems, word, false, select_word, |channel, elems, index| {
+		channel.select(elems, index)
+	});
+	assert_eq!(stat.n_bmul_constraints, 2 * (elems.len() - 1));
+
+	// A subset sum selects each element against zero, so two gates an element.
+	let stat = run_word_op(&elems, word, false, subset_sum_word, |channel, elems, index| {
+		channel.subset_sum(elems, index)
+	});
+	assert_eq!(stat.n_bmul_constraints, 2 * elems.len());
+}
+
+#[test]
+fn a_fixed_index_needs_no_select_gate() {
+	// Invariant: an index the protocol fixed settles the whole operation in Rust, which is what
+	// makes FRI's terminal fold free.
+	//
+	// Fixture state: the same 8 elements as the cost test, behind a build-time index of 5.
+	//
+	//     sampled index  ->  14 or 16 BMUL
+	//     fixed index    ->   0 BMUL
+	let mut rng = StdRng::seed_from_u64(8);
+	let elems = random_scalars::<B128>(&mut rng, 8);
+	let word = Word::from_u64(5);
+
+	// A word the protocol fixed settles the lookup while the circuit is built.
+	let selected = run_word_op(&elems, word, true, select_word, |channel, elems, index| {
+		channel.select(elems, index)
+	});
+	assert_eq!(selected.n_bmul_constraints, 0, "a fixed index must emit no select gate");
+
+	// The same holds for a sum, where the fixed bits settle which elements take part.
+	let summed = run_word_op(&elems, word, true, subset_sum_word, |channel, elems, index| {
+		channel.subset_sum(elems, index)
+	});
+	assert_eq!(summed.n_bmul_constraints, 0, "a fixed index must emit no select gate");
+}
+
+#[test]
+fn a_zero_element_drops_out_of_a_subset_sum() {
+	// Invariant: an element the protocol fixed to zero contributes nothing whichever way its bit
+	// falls, so it costs no gate even behind a sampled index.
+	//
+	// Fixture state: 8 folded zeros behind a witness index.
+	//
+	//     8 zero elements  ->  0 selects  ->  the sum stays a build-time zero
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+	let word = SymbolicWord::wire(&channel.shared, builder.add_witness());
+
+	// Every element is the folded zero, so nothing can contribute whatever the bits say.
+	let elems = vec![SymbolicElem::Constant(B128::ZERO); 8];
+	let sum = channel.subset_sum(&elems, &word);
+	assert!(matches!(sum, SymbolicElem::Constant(c) if c == B128::ZERO));
+
+	// A settled result means no gate was emitted at all, which the counts confirm.
+	let stat = CircuitStat::collect(&builder.build());
+	assert_eq!(stat.n_bmul_constraints, 0);
+	assert_eq!(stat.n_and_constraints, 0);
+}
+
+#[test]
+fn assert_zero_rejects_a_non_zero_folded_value() {
+	// Invariant: a zero claim over a value the protocol already fixed is decided while the circuit
+	// is built, so it emits no constraint either way.
+	//
+	// Fixture state: two claims, one over a folded zero and one over a folded one.
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+
+	channel
+		.assert_zero(SymbolicElem::Constant(B128::ZERO))
+		.expect("a folded zero satisfies the assertion");
+
+	// A folded non-zero value is a claim no witness could rescue, so it is reported here.
+	match channel.assert_zero(SymbolicElem::Constant(B128::ONE)) {
+		Err(binius_ip::channel::Error::InvalidAssert) => {}
+		other => panic!("expected InvalidAssert, got {other:?}"),
+	}
+
+	// An error rather than an unsatisfiable circuit, which the empty counts confirm.
+	let stat = CircuitStat::collect(&builder.build());
+	assert_eq!(stat.n_and_constraints, 0, "a folded assertion emits no constraint");
+	assert_eq!(stat.n_bmul_constraints, 0);
+}
+
+/// Asserts a wire pair holding `value` is zero, and reports what filling the circuit said.
+fn run_assert_zero(value: B128) -> Result<CircuitStat, PopulateError> {
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+	// Public wires, so the value under test is chosen by the filler rather than derived.
+	let wires = [builder.add_inout(), builder.add_inout()];
+	channel
+		.assert_zero(channel.elem(wires[0], wires[1]))
+		.expect("a wire-carried assertion is always recorded");
+
+	let circuit = builder.build();
+	let stat = CircuitStat::collect(&circuit);
+	let mut w = circuit.new_witness_filler();
+	// Low half first, matching the order the element reads its halves.
+	for (wire, word) in wires.iter().zip(element_words(u128::from(value))) {
+		w[*wire] = Word(word);
+	}
+
+	// Population evaluates the assertions, so a non-zero value is reported from here.
+	circuit.populate_wire_witness(&mut w)?;
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("a satisfied circuit must verify");
+	Ok(stat)
+}
+
+#[test]
+fn assert_zero_constrains_a_wire_pair() {
+	// Invariant: a wire-carried zero claim constrains both halves of the element, so a non-zero bit
+	// anywhere in its 128 fails.
+	//
+	// Fixture state: one claim over a public wire pair, at 2 AND constraints.
+	let stat = run_assert_zero(B128::ZERO).expect("a zero wire pair satisfies the assertion");
+	assert_eq!(stat.n_zero_constraints, ELEMENT_WORDS, "one constraint per wire");
+	assert_eq!(stat.n_and_constraints, 0);
+	assert_eq!(stat.n_bmul_constraints, 0);
+
+	// Mutation: a bit set in the low half, then a bit set in the high half.
+	//
+	//     1        ->  lo = 1, hi = 0  ->  the low assertion fails
+	//     2^64     ->  lo = 0, hi = 1  ->  the high assertion fails
+	for value in [B128::ONE, <B128 as From<u128>>::from(1u128 << 64)] {
+		let Err(error) = run_assert_zero(value) else {
+			panic!("a non-zero wire pair must not satisfy the assertion");
+		};
+		// A truncated failure list would let an unexamined path hide, so require the full one.
+		assert_eq!(
+			error.total,
+			error.failures.len(),
+			"the failure list must be complete, so every path can be checked"
+		);
+		assert!(error.total > 0, "an unsatisfied circuit must report a failure");
+		for failure in &error.failures {
+			// Every failure must come from the named subcircuit the claim was emitted into.
+			assert!(
+				failure.path.starts_with(".assert_zero[0]"),
+				"unexpected failing assertion {:?}",
+				failure.path
+			);
+			assert!(!failure.detail.is_empty(), "a failure must carry a diagnostic");
+		}
+	}
+}
+
+#[test]
+fn compute_public_value_evaluates_symbolically() {
+	use binius_field::util::FieldFn;
+	use binius_transcript::fiat_shamir::CanSample;
+
+	/// Squares its input and adds one, in whatever field it is run over.
+	struct SquarePlusOne;
+
+	impl FieldFn<B128> for SquarePlusOne {
+		fn call<E: FieldOps<Scalar = B128> + From<B128>>(&self, inputs: &[E]) -> E {
+			// One multiplication and one addition, so a circuit run must show one select-free
+			// field multiplication and nothing more.
+			inputs[0].clone().square() + E::from(B128::ONE)
+		}
+	}
+
+	// Invariant: a public-value computation is emitted as gates, not hinted, so the circuit itself
+	// carries the arithmetic.
+	//
+	// Fixture state: the function above over the channel's first challenge.
+	//
+	//     symbolic evaluation  ->  1 BMUL for the squaring
+	//     a hint               ->  0 BMUL, an unconstrained hole
+	//
+	// The channel opens on a fresh challenger, so its first challenge is fixed and computable here.
+	let mut probe = binius_transcript::VerifierTranscript::new(Challenger::default(), Vec::new());
+	let challenge: B128 = CanSample::sample(&mut probe);
+	probe.finalize().expect("the probe reads no tape");
+	let expected = SquarePlusOne.call_native(&[challenge]);
+
+	let builder = CircuitBuilder::new();
+	let mut channel = MerkleVerifierChannel::new(&builder);
+	let x = IPVerifierChannel::<B128>::sample(&mut channel);
+	let y = channel.compute_public_value(&[x], SquarePlusOne);
+
+	// The native answer enters on public wires, so the comparison becomes a constraint.
+	let claimed = [builder.add_inout(), builder.add_inout()];
+	let (lo, hi) = y.to_wires(&builder);
+	builder.assert_eq_v("public_value", [lo, hi], claimed);
+
+	let circuit = builder.build();
+	let stat = CircuitStat::collect(&circuit);
+	// A symbolic evaluation leaves the squaring in the circuit; a hint would leave nothing.
+	assert_eq!(stat.n_bmul_constraints, 1, "the squaring must be constrained, not hinted");
+
+	let mut w = circuit.new_witness_filler();
+	// Only the expected value is written: the challenge and the squaring are both derived.
+	for (wire, word) in claimed.iter().zip(element_words(u128::from(expected))) {
+		w[*wire] = Word(word);
+	}
+	circuit
+		.populate_wire_witness(&mut w)
+		.expect("the circuit must reproduce the native evaluation");
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("every constraint must hold");
+}
+
+#[test]
+fn shift_word_shifts_right() {
+	// Invariant: a shift narrows a word on its wire, and narrows a build-time value in Rust, so the
+	// two forms stay in agreement.
+	//
+	// Fixture state: one sampled word shifted by 5, and one fixed word shifted by 8.
+	//
+	//     0xdead_beef_1234_5678 >> 5  ->  checked in the circuit
+	//     0xff00               >> 8   ->  0xff, settled in Rust
+	let builder = CircuitBuilder::new();
+	let wire = builder.add_inout();
+	let channel = MerkleVerifierChannel::new(&builder);
+	let word = SymbolicWord::wire(&channel.shared, wire);
+	let shifted = word >> 5;
+	assert_eq!(shifted.value(), None, "a sampled word stays sampled through a shift");
+	// The shifted wire is pinned to a public wire the filler sets to the native shift.
+	let claimed = builder.add_inout();
+	builder.assert_eq("shifted", shifted.to_wire(&builder), claimed);
+
+	// A fixed word shifts in Rust as well as on its wire.
+	let fixed = SymbolicWord::from(Word::from_u64(0xff00));
+	assert_eq!((fixed >> 8).value(), Some(Word::from_u64(0xff)));
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	let value = 0xdead_beef_1234_5678u64;
+	w[wire] = Word(value);
+	// The native shift, so the assertion holds only if the gate agrees with it.
+	w[claimed] = Word(value >> 5);
+	circuit
+		.populate_wire_witness(&mut w)
+		.expect("the shift must match the native word shift");
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("every constraint must hold");
+}
+
+#[test]
+fn the_documented_per_operation_costs_hold() {
+	// Invariant: the cost table in the module docs is the measured cost, not an estimate.
+	//
+	// Every measurement pins its result to public wires, otherwise dead-code elimination prunes the
+	// whole circuit, so the claim's own constraints are subtracted back out.
+
+	/// The AND and BMUL counts of a circuit built by `build`.
+	fn cost(build: impl FnOnce(&CircuitBuilder, &mut MerkleVerifierChannel<'_>)) -> (usize, usize) {
+		// A fresh channel per measurement, so no earlier operation's gates are counted.
+		let builder = CircuitBuilder::new();
+		let mut channel = MerkleVerifierChannel::new(&builder);
+		build(&builder, &mut channel);
+		let stat = CircuitStat::collect(&builder.build());
+		(stat.n_and_constraints, stat.n_bmul_constraints)
+	}
+
+	// A received element is two witness wires and nothing else, so nothing lands in either column.
+	let (and, bmul) = cost(|builder, channel| {
+		let elem = channel.recv_one().expect("reading a message cannot fail");
+		let (lo, hi) = elem.to_wires(builder);
+		builder.assert_eq_v("recv", [lo, hi], [builder.add_inout(), builder.add_inout()]);
+	});
+	assert_eq!((and, bmul), (0, 0), "recv_one");
+
+	// The seed digest serves the first sample with no compression, so this is the assembly alone.
+	let (and, bmul) = cost(|builder, channel| {
+		let elem = IPVerifierChannel::<B128>::sample(channel);
+		let (lo, hi) = elem.to_wires(builder);
+		builder.assert_eq_v("sample", [lo, hi], [builder.add_inout(), builder.add_inout()]);
+	});
+	assert_eq!((and, bmul), (12, 0), "sample");
+
+	// A width of 17 needs the mask, so this is four bytes assembled and masked down.
+	let (and, bmul) = cost(|builder, channel| {
+		let word = WordIPVerifierChannel::<B128>::sample_bits(channel, 17);
+		builder.assert_eq("bits", word.to_wire(builder), builder.add_inout());
+	});
+	assert_eq!((and, bmul), (4, 0), "sample_bits");
+
+	// A digest read pays one byte reversal per word, four AND constraints apiece.
+	let (and, bmul) = cost(|builder, channel| {
+		let commitment = channel
+			.recv_merkle_commitment(1, 0)
+			.expect("reading a commitment cannot fail");
+		builder.assert_eq_v("root", commitment.root, array::from_fn(|_| builder.add_inout()));
+	});
+	assert_eq!((and, bmul), (4 * DIGEST_WORDS, 0), "one digest read");
+}

--- a/crates/recursion/src/shared.rs
+++ b/crates/recursion/src/shared.rs
@@ -34,8 +34,15 @@ pub struct Shared {
 
 impl Shared {
 	pub fn new() -> Self {
+		Self::with_builder(CircuitBuilder::new())
+	}
+
+	/// Anchors on a builder the caller already holds.
+	///
+	/// A `CircuitBuilder` is a handle, so a clone emits into the same circuit.
+	pub const fn with_builder(builder: CircuitBuilder) -> Self {
 		Self {
-			builder: CircuitBuilder::new(),
+			builder,
 			inputs: RefCell::new(Vec::new()),
 		}
 	}

--- a/crates/recursion/src/symbolic/word.rs
+++ b/crates/recursion/src/symbolic/word.rs
@@ -37,6 +37,16 @@ impl SymbolicWord {
 		}
 	}
 
+	/// The value, when the word was fixed while the circuit was built.
+	///
+	/// A caller reads this to settle an operation in Rust rather than spend gates on it.
+	pub const fn value(&self) -> Option<Word> {
+		match self {
+			Self::Constant(word) => Some(*word),
+			Self::Wire { .. } => None,
+		}
+	}
+
 	/// Lowers to a wire, materializing a `Constant` on the builder.
 	pub fn to_wire(&self, builder: &CircuitBuilder) -> Wire {
 		match self {

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -1,0 +1,1297 @@
+// Copyright 2026 The Binius Developers
+
+//! A polynomial-commitment opening proved natively, then verified inside a Binius64 circuit.
+//!
+//! # The two halves
+//!
+//! The proof system already has a native commit-prove-verify round trip, and both ends are reused
+//! here:
+//!
+//! ```text
+//!     prover:   native and unchanged, writing one real transcript
+//!     verifier: the same code, over a channel that emits gates instead of checking values
+//! ```
+//!
+//! A satisfied constraint system is then the statement "this transcript opens this claim".
+//! An outer proof can check that statement, which is what makes this one step of recursion.
+//!
+//! # What is an input
+//!
+//! Two things enter the circuit, and nothing else:
+//!
+//! ```text
+//!     the proof byte stream   one witness wire per eight-byte proof word
+//!     the inner statement     the claimed evaluation and the point, on inout wires
+//! ```
+//!
+//! Challenges, folded values and recomputed digests are all gate outputs.
+//!
+//! The statement deliberately does not enter as a build-time constant.
+//! A constant would fold one opening's numbers into the gates, destroying the property below.
+//!
+//! # Build once, verify many
+//!
+//! Every shape the circuit depends on is settled before any proof exists:
+//!
+//! - the code rate and the fold arities
+//! - the oracle layout and the Merkle tree depths
+//! - the number of consistency queries
+//!
+//! So one circuit serves every opening of that shape.
+//! That is what makes recursion practical, since the expensive compilation is paid once per
+//! protocol rather than once per proof.
+//!
+//! # Measurement
+//!
+//! Two of the tests print a constraint table and a phase breakdown.
+//! Run them with `--nocapture` to see the output.
+//!
+//! At `n_vars = 8`, `log_inv_rate = 1` and 32 queries, over a 13,536-byte proof, the measured cost
+//! is 229,675 AND, 14,887 BMUL, 71,362 ZERO and 524,288 committed words, split as:
+//!
+//! ```text
+//!     phase                          AND     BMUL    AND %
+//!     Merkle openings             212315     9216    92.4%
+//!     Fiat-Shamir challenger        9643        0     4.2%
+//!     terminal codeword             7773        0     3.4%
+//!     FRI folding and equalities       0     5655     0.0%
+//!     MLE-check arithmetic             0       16     0.0%
+//! ```
+//!
+//! So the verifier is SHA-256 and almost nothing else:
+//!
+//! - the three hashing phases are the whole AND column
+//! - Merkle openings alone are 92% of it
+//! - the field arithmetic that the fold and the sum-check actually reduce spends no AND at all,
+//!   only 5,671 BMUL
+//!
+//! The AND column is what binds.
+//!
+//! # The cost surface
+//!
+//! One sweep moves a single lever at a time off that shape:
+//!
+//! ```text
+//!     shape                            AND    vs base
+//!     n_vars 8,  rate 1, 32 queries  229675         --
+//!     n_vars 10, rate 1, 32 queries  346681      +51%
+//!     n_vars 8,  rate 2, 32 queries  285585      +24%
+//!     n_vars 8,  rate 1, 16 queries  146249      -36%
+//!     n_vars 8,  rate 1, 64 queries  280193      +22%
+//! ```
+//!
+//! Two readings are worth keeping.
+//!
+//! 1. **Queries are sublinear** — 16 to 32 queries costs +57% but 32 to 64 only +22%, because the
+//!    shared decommitment layer deepens as the query count grows and every climb gets shorter.
+//! 2. **Committed size is not flat** — four times the committed size costs 51% more rather than a
+//!    few percent, so growth is logarithmic with a steep constant.
+//!
+//! Doubling the query count is therefore cheaper than it looks, and the layer depth is the reason.
+//!
+//! Every extra Merkle level is paid once per query across every tree in the fold schedule.
+//! Here the terminal codeword grew with it, from 7,773 to 26,781 AND.
+//!
+//! # Where this sits
+//!
+//! Against the 2.5M-5M AND estimate for a full recursive verifier, one opening of this shape is
+//! around a tenth of the lower bound.
+//!
+//! A production shape costs more: more queries, deeper trees, several oracles, and the
+//! constraint-system checks that sit above the opening.
+//! The levers are visibly the same three, in this order:
+//!
+//! 1. fewer SHA-256 compressions per Merkle level
+//! 2. fewer Merkle levels
+//! 3. the layer-depth trade-off that sets how many levels each query climbs
+//!
+//! The sweep above is the surface that last trade-off would be tuned against.
+
+use std::iter;
+
+use binius_compute::GlobalAllocator;
+use binius_core::{VerificationError, word::Word};
+use binius_field::{BinaryField128bGhash as B128, Field, PackedBinaryGhash1x128b};
+use binius_frontend::{
+	Circuit, CircuitBuilder, CircuitStat, MAX_ASSERTION_FAILURES, PopulateError,
+};
+use binius_hash::{StdDigest, StdHashSuite, sha256::Sha256HashSuite};
+use binius_iop::{
+	basefold::verify_mlecheck_basefold,
+	channel::OracleSpec,
+	fri::FRIParams,
+	merkle_channel::MerkleIPVerifierChannel,
+	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
+};
+use binius_iop_prover::{
+	basefold::prove_mlecheck_basefold,
+	fri::{self, FRIFoldProver, MaskedCodeword},
+	merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel},
+	merkle_tree::prover::BinaryMerkleTreeProver,
+};
+use binius_ip::{
+	channel::{IPVerifierChannel, WordIPVerifierChannel},
+	mlecheck,
+	sumcheck::RoundCoeffs,
+};
+use binius_ip_prover::channel::IPProverChannel;
+use binius_math::{
+	BinarySubspace,
+	inner_product::inner_product_buffers,
+	line::extrapolate_line_packed,
+	multilinear::eq::eq_ind_partial_eval,
+	ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+	test_utils::{random_field_buffer, random_scalars},
+};
+use binius_recursion::{
+	challenger::Sha256Challenger,
+	channel::{
+		ChannelWord, MerkleCommitment, MerkleVerifierChannel, ProofLayout, ProofRead, ReadKind,
+	},
+	elem::Elem,
+	merkle::{self, DIGEST_WORDS, Digest, ELEMENT_WORDS, Element, populate_element},
+};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use binius_utils::rayon::prelude::*;
+use rand::{SeedableRng, rngs::StdRng};
+
+/// The Fiat-Shamir challenger the in-circuit challenger reproduces.
+type StdChallenger = HasherChallenger<StdDigest>;
+
+/// The packed field the native prover runs over.
+type P = PackedBinaryGhash1x128b;
+
+/// The prover channel driving the native half of a round trip.
+type NativeProverChannel<'a> = ProverMerkleTranscriptChannel<
+	&'a mut ProverTranscript<StdChallenger>,
+	StdChallenger,
+	B128,
+	StdHashSuite,
+>;
+
+/// Field elements one committed leaf holds.
+///
+/// A zero-knowledge oracle commits the polynomial interleaved with its mask, so one leaf covers one
+/// `(pi || omega)` coset and the tree has one leaf per codeword position.
+const LEAF_ELEMENTS: usize = 2;
+
+/// The shape of a single-oracle zero-knowledge opening.
+///
+/// Every field is fixed before a proof exists, so a shape is exactly what a circuit is built for.
+#[derive(Clone, Copy, Debug)]
+struct Shape {
+	/// Variables of the committed multilinear.
+	n_vars: usize,
+	/// log2 the inverse Reed-Solomon rate.
+	log_inv_rate: usize,
+	/// FRI consistency queries the verifier makes.
+	n_test_queries: usize,
+}
+
+/// The shape the native round trip in the prover crate uses.
+const NATIVE_SHAPE: Shape = Shape {
+	n_vars: 8,
+	log_inv_rate: 1,
+	n_test_queries: 32,
+};
+
+/// What a shape fixes ahead of any proof: the fold parameters and the transform that encodes.
+struct Setup {
+	/// The fold layout: code dimension, per-oracle shapes, fold arities and query count.
+	fri_params: FRIParams<B128>,
+	/// The additive NTT the prover encodes with.
+	ntt: NeighborsLastSingleThread<GenericOnTheFly<B128>>,
+}
+
+impl Shape {
+	/// Depth of the Merkle tree over the committed interleaved codeword: one coset per leaf.
+	const fn codeword_depth(&self) -> usize {
+		// One leaf per codeword position, and the codeword is 2^log_inv_rate times the message.
+		self.n_vars + self.log_inv_rate
+	}
+
+	/// Derives the fold parameters and the encoding transform, neither of which needs a witness.
+	fn setup(&self) -> Setup {
+		// Only the scheme's digest and node-cost model are consulted here, so no tree is built.
+		let scheme = BinaryMerkleTreeScheme::<B128, Sha256HashSuite>::new();
+
+		// The evaluation domain must span the interleaved codeword: one extra variable for the
+		// mask that buys zero-knowledge, plus the rate.
+		let subspace = BinarySubspace::with_dim(self.n_vars + 1 + self.log_inv_rate);
+		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+		let ntt = NeighborsLastSingleThread::new(domain_context);
+
+		// A single zero-knowledge oracle makes the combined batch parameters valid for the masked
+		// encoder too: one interleaved batch dimension, and a code dimension of `n_vars`.
+		let (fri_params, _) = FRIParams::optimal_for_batch(
+			ntt.domain_context(),
+			&scheme,
+			&[OracleSpec::new_zk(self.n_vars)],
+			self.log_inv_rate,
+			self.n_test_queries,
+		);
+		Setup { fri_params, ntt }
+	}
+}
+
+/// One opening proved natively: the statement it proves, and the transcript proving it.
+struct Opening {
+	/// The claimed evaluation `pi'(r)`.
+	eval_claim: B128,
+	/// The point `r`, low-to-high variable order.
+	eval_point: Vec<B128>,
+	/// The proof byte tape.
+	proof: Vec<u8>,
+}
+
+/// Proves one opening of `shape`, drawing the witness and the point from `seed`.
+///
+/// This is the native round trip's prover half, unchanged.
+/// The masking challenge is sampled off the transcript, so the circuit derives the same value
+/// rather than being handed it.
+fn prove(shape: &Shape, setup: &Setup, seed: u64) -> Opening {
+	// One seed fixes both the committed polynomial and the point, so a transcript is reproducible.
+	let mut rng = StdRng::seed_from_u64(seed);
+	let witness = random_field_buffer::<P>(&mut rng, shape.n_vars);
+	let eval_point: Vec<B128> = random_scalars(&mut rng, shape.n_vars);
+
+	// Phase 1: encode.
+	//
+	// A masked encoding interleaves the polynomial with a random mask of the same size, which is
+	// what stops the opened cosets leaking the polynomial.
+	let merkle_prover = BinaryMerkleTreeProver::<B128, StdHashSuite>::new();
+	let MaskedCodeword { codeword, mask } =
+		fri::encode_masked(&setup.fri_params, 0, &setup.ntt, witness.to_ref(), &mut rng);
+
+	// Phase 2: commit.
+	//
+	// The transcript is the Fiat-Shamir tape, and the commitment is the first thing written to it.
+	let mut transcript = ProverTranscript::new(StdChallenger::default());
+	let mut channel = NativeProverChannel::with_merkle_prover(&mut transcript, merkle_prover);
+	let commitment = channel.send_merkle_commitment(codeword.to_ref(), LEAF_ELEMENTS);
+
+	// Fold the interleaved (pi || omega) codeword to pi' = (1 - gamma) pi + gamma omega.
+	let gamma: B128 = IPProverChannel::sample(&mut channel);
+	let mut witness_prime = witness.clone();
+	let broadcast = P::broadcast(gamma);
+	(witness_prime.as_mut(), mask.as_ref())
+		.into_par_iter()
+		.for_each(|(w, &m)| *w = extrapolate_line_packed(*w, m, broadcast));
+
+	// The claim is the folded polynomial against the equality indicator at the point, which is
+	// exactly pi'(r).
+	let eval_claim = inner_product_buffers(&witness_prime, &eq_ind_partial_eval::<P>(&eval_point));
+
+	// Phase 3: prove.
+	//
+	// The sum-check rounds and the codeword folding advance together, so the transcript ends up
+	// carrying both.
+	let fri_folder =
+		FRIFoldProver::new_batch(&setup.fri_params, &setup.ntt, vec![(codeword, commitment)]);
+	prove_mlecheck_basefold(
+		witness_prime,
+		&eval_point,
+		eval_claim,
+		Some(gamma),
+		&[],
+		fri_folder,
+		&mut channel,
+		&GlobalAllocator,
+	);
+	// Hand the transcript back, releasing the channel's borrow of it.
+	channel.into_transcript();
+
+	// Finalizing seals the tape into the byte stream the circuit reads.
+	Opening {
+		eval_claim,
+		eval_point,
+		proof: transcript.finalize(),
+	}
+}
+
+/// Why a populated witness fails to satisfy the verifier circuit.
+///
+/// Population evaluates the gates and checks the assertions, so an unsatisfiable proof normally
+/// surfaces there.
+/// Constraint verification is the independent second opinion.
+#[derive(Debug)]
+enum Unsatisfied {
+	/// Assertions the witness filler found failing, with the circuit paths they sit under.
+	Assertions(PopulateError),
+	/// A constraint the value vector does not satisfy.
+	Constraints(VerificationError),
+}
+
+/// A circuit that verifies any opening of one fixed shape.
+struct VerifierCircuit {
+	/// The compiled circuit.
+	circuit: Circuit,
+	/// Where the proof byte stream lands.
+	layout: ProofLayout,
+	/// The evaluation claim, on inout wires.
+	eval_claim: Element,
+	/// The evaluation point, one element per variable, on inout wires.
+	eval_point: Vec<Element>,
+	/// The Fiat-Shamir schedule the verifier drove, for the phase breakdown.
+	challenger_ops: Vec<ChallengerOp>,
+	/// The Merkle operations the verifier asked for, for the phase breakdown.
+	merkle_ops: Vec<MerkleOp>,
+	/// Constraint counts and trace size.
+	stat: CircuitStat,
+}
+
+impl VerifierCircuit {
+	/// Builds the verifier for `shape` by running the real verifier against the circuit channel.
+	///
+	/// The channel operations below are the native round trip's verifier half, in the same order.
+	/// The Fiat-Shamir state is a function of that order, so it is not free to change.
+	fn build(shape: &Shape, setup: &Setup) -> Self {
+		// Two layers of channel: the inner one emits gates, the outer one only takes notes.
+		let builder = CircuitBuilder::new();
+		let mut inner = MerkleVerifierChannel::new(&builder);
+		let mut channel = Recording::new(&mut inner);
+
+		// The statement enters on inout wires, one pair per element for the low and high halves.
+		// As build-time constants these numbers would fold into the gates, tying the circuit to one
+		// opening.
+		let claim_wires: Element = [builder.add_inout(), builder.add_inout()];
+		let point_wires: Vec<Element> = (0..shape.n_vars)
+			.map(|_| [builder.add_inout(), builder.add_inout()])
+			.collect();
+		let eval_claim = Elem::new(&builder, claim_wires[0], claim_wires[1]);
+		let eval_point: Vec<Elem> = point_wires
+			.iter()
+			.map(|&[lo, hi]| Elem::new(&builder, lo, hi))
+			.collect();
+
+		// The root is read first, so everything the query phase later opens is already observed.
+		let commitment = channel
+			.recv_merkle_commitment(LEAF_ELEMENTS, shape.codeword_depth())
+			.expect("reading a commitment cannot fail");
+
+		// The masking challenge, drawn from the same Fiat-Shamir state the prover drew it from.
+		let gamma = IPVerifierChannel::<B128>::sample(&mut channel);
+
+		// Every check the verifier makes becomes an assertion rather than a comparison, so the call
+		// cannot fail while the circuit is being built.
+		verify_mlecheck_basefold(
+			&setup.fri_params,
+			&[commitment],
+			eval_claim,
+			&eval_point,
+			Some(gamma),
+			&[],
+			&mut channel,
+		)
+		.expect("the circuit channel rejects nothing: every check it makes becomes a constraint");
+
+		// Both schedules are complete once the verifier has run, and so is the proof layout.
+		let (challenger_ops, merkle_ops) = channel.finish();
+		let layout = inner.finish();
+		let circuit = builder.build();
+		let stat = CircuitStat::collect(&circuit);
+		Self {
+			circuit,
+			layout,
+			eval_claim: claim_wires,
+			eval_point: point_wires,
+			challenger_ops,
+			merkle_ops,
+			stat,
+		}
+	}
+
+	/// Populates the circuit from a statement and a proof, and reports whether it is satisfied.
+	fn check(
+		&self,
+		eval_claim: B128,
+		eval_point: &[B128],
+		proof: &[u8],
+	) -> Result<(), Unsatisfied> {
+		let mut w = self.circuit.new_witness_filler();
+
+		// Input 1: the proof tape, one word per eight bytes, in the order the verifier read it.
+		self.layout
+			.populate(&mut w, proof)
+			.expect("the layout reads exactly the proof the prover wrote");
+
+		// Input 2: the statement, as sixteen little-endian bytes per element.
+		populate_element(&mut w, &self.eval_claim, u128::from(eval_claim));
+		for (element, value) in iter::zip(&self.eval_point, eval_point) {
+			populate_element(&mut w, element, u128::from(*value));
+		}
+
+		// Population derives every other wire and reports the assertions that came out false.
+		self.circuit
+			.populate_wire_witness(&mut w)
+			.map_err(Unsatisfied::Assertions)?;
+
+		// Re-checking the finished witness against the constraint system is the second opinion: it
+		// reads the compiled constraints rather than the gate graph.
+		self.circuit
+			.constraint_system()
+			.verify(&w.into_value_vec())
+			.map_err(Unsatisfied::Constraints)
+	}
+
+	/// Populates and checks one natively proved opening.
+	fn check_opening(&self, opening: &Opening) -> Result<(), Unsatisfied> {
+		// An honest opening supplies its own statement, so the two inputs come from one place.
+		self.check(opening.eval_claim, &opening.eval_point, &opening.proof)
+	}
+}
+
+// Noting the schedule, so the cost can be attributed to a phase
+
+/// One Fiat-Shamir event the verifier caused, in the order it caused it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ChallengerOp {
+	/// `n` proof words fed to the hasher.
+	Observe(usize),
+	/// One 128-bit challenge drawn.
+	SampleB128,
+	/// A `bits`-wide index word drawn.
+	SampleBits(usize),
+}
+
+/// One Merkle operation the verifier asked of the channel.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum MerkleOp {
+	/// Openings of a `leaf_size`-element, depth-`depth` tree at `n_queries` sampled indices.
+	Openings {
+		/// Field elements one leaf holds.
+		leaf_size: usize,
+		/// Depth of the committed tree.
+		depth: usize,
+		/// Indices opened together, which fixes the layer the branches stop at.
+		n_queries: usize,
+	},
+	/// A whole committed vector, read in the clear and checked by rebuilding its tree.
+	Vector {
+		/// Field elements one leaf holds.
+		leaf_size: usize,
+		/// Depth of the committed tree.
+		depth: usize,
+	},
+}
+
+/// A channel that records what it was asked while delegating to the circuit channel.
+///
+/// The proof layout already records every read, but not where the samples fall between them.
+/// The challenger's cost is a function of exactly that interleaving, so recording it here is what
+/// lets the phase breakdown price the challenger on its own.
+struct Recording<'a, 'b> {
+	/// The channel every call is forwarded to.
+	inner: &'b mut MerkleVerifierChannel<'a>,
+	/// The Fiat-Shamir schedule so far.
+	challenger: Vec<ChallengerOp>,
+	/// The Merkle operations so far.
+	merkle: Vec<MerkleOp>,
+}
+
+impl<'a, 'b> Recording<'a, 'b> {
+	/// Wraps `inner`, having recorded nothing.
+	const fn new(inner: &'b mut MerkleVerifierChannel<'a>) -> Self {
+		// Both schedules start empty, since recording begins with the first forwarded call.
+		Self {
+			inner,
+			challenger: Vec::new(),
+			merkle: Vec::new(),
+		}
+	}
+
+	/// Consumes the recorder and returns the two schedules it recorded.
+	fn finish(self) -> (Vec<ChallengerOp>, Vec<MerkleOp>) {
+		// The borrow of the inner channel is dropped here, which is what lets the caller finish it.
+		(self.challenger, self.merkle)
+	}
+
+	/// Records an observation of `n` proof words.
+	///
+	/// A zero-word read is not an observation: the channel only turns once it advances the tape.
+	fn observed(&mut self, n: usize) {
+		// Recording an empty read would insert a spurious channel turn into the replayed schedule.
+		if n > 0 {
+			self.challenger.push(ChallengerOp::Observe(n));
+		}
+	}
+}
+
+impl IPVerifierChannel<B128> for Recording<'_, '_> {
+	type Elem = Elem;
+
+	fn recv_one(&mut self) -> Result<Elem, binius_ip::channel::Error> {
+		// A message read is hashed as it is consumed, and one element is two proof words.
+		self.observed(ELEMENT_WORDS);
+		self.inner.recv_one()
+	}
+
+	fn recv_many(&mut self, n: usize) -> Result<Vec<Elem>, binius_ip::channel::Error> {
+		// One read of n elements, so the words are hashed as a single contiguous run.
+		self.observed(n * ELEMENT_WORDS);
+		self.inner.recv_many(n)
+	}
+
+	fn sample(&mut self) -> Elem {
+		// A 128-bit draw consumes sixteen sampler bytes, plus any refill they force.
+		self.challenger.push(ChallengerOp::SampleB128);
+		IPVerifierChannel::sample(self.inner)
+	}
+
+	fn observe_one(&mut self, val: B128) -> Elem {
+		// Observing always turns the channel, even with nothing to write, so it is always
+		// recorded.
+		self.challenger.push(ChallengerOp::Observe(ELEMENT_WORDS));
+		self.inner.observe_one(val)
+	}
+
+	fn observe_many(&mut self, vals: &[B128]) -> Vec<Elem> {
+		// Values the verifier computed rather than read, hashed together as one run.
+		self.challenger
+			.push(ChallengerOp::Observe(vals.len() * ELEMENT_WORDS));
+		self.inner.observe_many(vals)
+	}
+
+	fn assert_zero(&mut self, val: Elem) -> Result<(), binius_ip::channel::Error> {
+		// An equality constraint touches neither the tape nor the Fiat-Shamir state.
+		self.inner.assert_zero(val)
+	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Elem],
+		f: impl binius_field::util::FieldFn<B128>,
+	) -> Elem {
+		// Arithmetic over wires the verifier already holds, so there is nothing to record.
+		self.inner.compute_public_value(inputs, f)
+	}
+}
+
+impl WordIPVerifierChannel<B128> for Recording<'_, '_> {
+	type Word = ChannelWord;
+
+	fn observe_words(&mut self, words: &[ChannelWord]) {
+		// Words already in circuit form, hashed exactly as they are.
+		self.challenger.push(ChallengerOp::Observe(words.len()));
+		self.inner.observe_words(words);
+	}
+
+	fn subset_sum(&mut self, elems: &[Elem], word: &ChannelWord) -> Elem {
+		// A table lookup over existing elements, so it is pure gate work.
+		self.inner.subset_sum(elems, word)
+	}
+
+	fn select(&mut self, elems: &[Elem], word: &ChannelWord) -> Elem {
+		// Also a lookup, and also invisible to both schedules.
+		self.inner.select(elems, word)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> ChannelWord {
+		// A query index draw, which reads four sampler bytes and masks them down to `bits`.
+		self.challenger.push(ChallengerOp::SampleBits(bits));
+		self.inner.sample_bits(bits)
+	}
+}
+
+impl MerkleIPVerifierChannel<B128> for Recording<'_, '_> {
+	type Commitment = MerkleCommitment;
+
+	fn recv_merkle_commitment(
+		&mut self,
+		leaf_size: usize,
+		depth: usize,
+	) -> Result<MerkleCommitment, binius_iop::merkle_channel::Error> {
+		// A root is a message, so its four words are hashed before anything is opened against it.
+		self.observed(DIGEST_WORDS);
+		self.inner.recv_merkle_commitment(leaf_size, depth)
+	}
+
+	fn recv_openings(
+		&mut self,
+		commitment: &MerkleCommitment,
+		indices: &[ChannelWord],
+	) -> Result<Vec<Elem>, binius_iop::merkle_channel::Error> {
+		// Pricing a climb needs all three numbers: leaf size, tree depth, and how many indices
+		// share one decommitted layer.
+		self.merkle.push(MerkleOp::Openings {
+			leaf_size: commitment.leaf_size,
+			depth: commitment.depth,
+			n_queries: indices.len(),
+		});
+		self.inner.recv_openings(commitment, indices)
+	}
+
+	fn recv_committed_vector(
+		&mut self,
+		commitment: &MerkleCommitment,
+	) -> Result<Vec<Elem>, binius_iop::merkle_channel::Error> {
+		// A vector read in the clear is priced by the tree rebuilt over it, which the shape fixes.
+		self.merkle.push(MerkleOp::Vector {
+			leaf_size: commitment.leaf_size,
+			depth: commitment.depth,
+		});
+		self.inner.recv_committed_vector(commitment)
+	}
+}
+
+// The tests
+
+#[test]
+fn a_native_opening_verifies_in_circuit() {
+	// Invariant: a transcript the native prover wrote satisfies the circuit built from the
+	// verifier.
+	//
+	// Fixture state: the native shape of 8 variables, rate 1 and 32 queries, and one proof.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 0);
+	// Nothing about the proof reaches the builder, so the order of these two lines is immaterial.
+	let verifier = VerifierCircuit::build(&shape, &setup);
+
+	// The circuit reads the whole tape and nothing beyond it, which is what a native verifier
+	// enforces by refusing to leave bytes unread.
+	//
+	//     circuit: as many wires as the reads it made
+	//     prover:  the finalized byte tape
+	//     -> equal, or the two halves disagree about the protocol
+	assert_eq!(
+		verifier.layout.n_bytes(),
+		opening.proof.len(),
+		"the circuit must read exactly the transcript the prover wrote"
+	);
+
+	// Both the assertions and the compiled constraints must pass, since either alone could miss.
+	verifier
+		.check_opening(&opening)
+		.expect("the circuit must accept the opening the native prover proved");
+}
+
+#[test]
+fn one_circuit_verifies_two_different_openings() {
+	// Invariant: one compiled circuit verifies every opening of its shape, not just the one it was
+	// measured against.
+	//
+	// Fixture state: two proofs of the native shape, from two different seeds.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+
+	// Different witness and different evaluation point, so a different transcript throughout.
+	let first = prove(&shape, &setup, 1);
+	let second = prove(&shape, &setup, 2);
+	// Two openings that happened to coincide would make the rest of the test vacuous.
+	assert_ne!(first.eval_point, second.eval_point, "the two openings must differ");
+	assert_ne!(first.proof, second.proof, "the two transcripts must differ");
+	// Equal lengths are the observable half of "the layout depends only on the shape".
+	assert_eq!(
+		first.proof.len(),
+		second.proof.len(),
+		"one shape means one tape length, whatever the witness"
+	);
+
+	// Built once, before either proof is looked at.
+	let verifier = VerifierCircuit::build(&shape, &setup);
+	// The same wires are refilled for the second opening, so nothing carries over between them.
+	for (i, opening) in [&first, &second].into_iter().enumerate() {
+		verifier.check_opening(opening).unwrap_or_else(|error| {
+			panic!("opening {i} must satisfy the shared circuit: {error:?}")
+		});
+	}
+}
+
+/// The proof reads a corruption test aims at, located through the layout rather than by offset.
+struct Targets {
+	/// The first MLE-check round polynomial: an observed message.
+	round_poly: ProofRead,
+	/// The layer the first batch of openings decommits to: unobserved advice.
+	layer: ProofRead,
+	/// The first opened leaf: unobserved advice.
+	leaf: ProofRead,
+	/// The first authentication branch: unobserved advice.
+	branch: ProofRead,
+	/// The terminal codeword, sent in full: unobserved advice.
+	terminal: ProofRead,
+}
+
+/// Locates the reads a corruption test aims at, from the reads the verifier recorded.
+///
+/// Nothing here is a byte offset: a parameter change moves every offset but leaves the *kinds* and
+/// the order of the reads alone.
+fn targets(shape: &Shape, layout: &ProofLayout) -> Targets {
+	let reads = layout.reads();
+
+	// A commitment root is four words and a degree-1 round polynomial is one element, so the round
+	// polynomials are the only two-word messages on the tape.
+	let round_poly = *reads
+		.iter()
+		.find(|read| read.kind == ReadKind::Message && read.n_words == ELEMENT_WORDS)
+		.expect("every MLE-check round sends a round polynomial");
+
+	// An opening batch reads the shared layer first, then a leaf and a branch per query, and the
+	// codeword oracle is the first commitment opened.
+	let decommitments = reads
+		.iter()
+		.filter(|read| read.kind == ReadKind::Decommitment)
+		.collect::<Vec<_>>();
+	// So the first three advice reads are, in order, the layer, one leaf and its branch.
+	let [layer, leaf, branch, ..] = decommitments[..] else {
+		panic!("the query phase reads a layer, a leaf and a branch at the very least");
+	};
+
+	// Recomputing the three widths from the shape is what pins the identification: a read of the
+	// wrong width would mean the reads were matched to the wrong thing.
+	let depth = shape.codeword_depth();
+	let layer_depth = BinaryMerkleTreeScheme::<B128, Sha256HashSuite>::new()
+		.optimal_verify_layer(shape.n_test_queries, depth);
+	assert_eq!(layer.n_words, (1 << layer_depth) * DIGEST_WORDS, "the decommitted layer");
+	assert_eq!(leaf.n_words, LEAF_ELEMENTS * ELEMENT_WORDS, "the opened coset");
+	assert_eq!(branch.n_words, (depth - layer_depth) * DIGEST_WORDS, "the authentication branch");
+	// A shape whose layer reaches the leaves would leave the branch test with nothing to corrupt.
+	assert!(branch.n_words > 0, "the shape must leave a branch to climb");
+
+	// The terminal codeword is the last thing the query phase reads.
+	let terminal = *reads.last().expect("the verifier reads something");
+	assert_eq!(terminal.kind, ReadKind::Decommitment, "the terminal codeword is advice");
+
+	Targets {
+		round_poly,
+		layer: *layer,
+		leaf: *leaf,
+		branch: *branch,
+		terminal,
+	}
+}
+
+/// Returns `proof` with the low bit of the first byte of proof word `word_offset` flipped.
+fn corrupt(proof: &[u8], word_offset: usize) -> Vec<u8> {
+	let mut proof = proof.to_vec();
+	// One bit is the smallest change a sound protocol must still reject, and the first byte of a
+	// word is the one the little-endian read puts in the low bits.
+	proof[word_offset * (Word::BITS / 8)] ^= 1;
+	proof
+}
+
+/// Asserts the circuit rejects `proof`, and returns the paths of the assertions that failed.
+fn rejected(verifier: &VerifierCircuit, opening: &Opening, proof: &[u8]) -> Vec<String> {
+	match verifier.check(opening.eval_claim, &opening.eval_point, proof) {
+		// Acceptance means the corruption slipped through a check that should have caught it.
+		Ok(()) => panic!("a corrupted proof must leave the circuit unsatisfied"),
+		// Reaching constraint verification means population missed a failure it could see, which
+		// would make the assertion paths below useless as diagnostics.
+		Err(Unsatisfied::Constraints(error)) => {
+			panic!("population must find the failure before constraint verification: {error}")
+		}
+		Err(Unsatisfied::Assertions(PopulateError {
+			failures, total, ..
+		})) => {
+			// A reported failure count of zero would contradict the error itself.
+			assert!(total > 0, "an unsatisfied circuit must report a failing assertion");
+			// The list is truncated only by its own cap, so a short list means a lost failure.
+			assert_eq!(
+				failures.len(),
+				total.min(MAX_ASSERTION_FAILURES),
+				"the failure list must be complete up to its cap"
+			);
+			// A path with no detail cannot be debugged, so an empty one is a defect in itself.
+			for failure in &failures {
+				assert!(!failure.detail.is_empty(), "a failure must carry a diagnostic");
+			}
+			// Only the paths are returned: which check fired is what each test asserts on.
+			failures.into_iter().map(|failure| failure.path).collect()
+		}
+	}
+}
+
+#[test]
+fn a_corrupted_opened_value_is_rejected() {
+	// Invariant: an opened coset is decommitment advice, so its own Merkle path is the only thing
+	// binding it.
+	//
+	// Fixture state: the native shape, and the first opened leaf found through the read log.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 3);
+	let verifier = VerifierCircuit::build(&shape, &setup);
+	let targets = targets(&shape, &verifier.layout);
+
+	// Mutation: flip one bit of the first opened coset.
+	//
+	//     before:  leaf  -> hash -> climb -> the layer entry the index addresses
+	//     after:   leaf' -> hash' -> climb -> a digest that entry does not hold
+	//
+	// The challenger never saw those bytes, so the Fiat-Shamir state is untouched and the Merkle
+	// assertions alone catch it.
+	let paths = rejected(&verifier, &opening, &corrupt(&opening.proof, targets.leaf.word_offset));
+	assert!(
+		paths.iter().any(|path| path.contains("opening")),
+		"a corrupted coset must fail a Merkle opening check: {paths:?}"
+	);
+}
+
+#[test]
+fn a_corrupted_merkle_sibling_is_rejected() {
+	// Invariant: an authentication sibling is advice too, so the same mechanism must catch it from
+	// the other side of the compression.
+	//
+	// Fixture state: the native shape, and the first branch found through the read log.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 4);
+	let verifier = VerifierCircuit::build(&shape, &setup);
+	let targets = targets(&shape, &verifier.layout);
+
+	// Mutation: flip one bit of the first sibling digest.
+	//
+	//     before:  (running, sibling)  -> parent -> ... -> the layer entry
+	//     after:   (running, sibling') -> parent' -> ... -> a digest the layer does not hold
+	let paths = rejected(&verifier, &opening, &corrupt(&opening.proof, targets.branch.word_offset));
+	assert!(
+		paths.iter().any(|path| path.contains("opening")),
+		"a corrupted sibling must fail a Merkle opening check: {paths:?}"
+	);
+}
+
+#[test]
+fn a_corrupted_round_polynomial_is_rejected() {
+	// Invariant: a round polynomial is an observed message, so corrupting it moves the Fiat-Shamir
+	// state as well as the sum-check value.
+	//
+	// Fixture state: the native shape, and the first two-word message on the tape.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 5);
+	let verifier = VerifierCircuit::build(&shape, &setup);
+	let targets = targets(&shape, &verifier.layout);
+
+	// Mutation: flip one bit of the first round polynomial.
+	//
+	//     before:  round value  -> challenge -> ... -> query indices -> the committed positions
+	//     after:   round value' -> a different challenge from that round on, indices included
+	//
+	// The opened values and siblings on the tape are unchanged, but the indices addressing them are
+	// not, so every opening now climbs to the wrong entry of the decommitted layer.
+	let paths =
+		rejected(&verifier, &opening, &corrupt(&opening.proof, targets.round_poly.word_offset));
+	assert!(
+		paths.iter().any(|path| path.contains("verify_opening")),
+		"a corrupted round polynomial must move the query indices and fail an opening: {paths:?}"
+	);
+}
+
+#[test]
+fn a_corrupted_terminal_codeword_entry_is_rejected() {
+	// Invariant: the terminal codeword is advice bound two ways at once, by its own commitment and
+	// by the queries that were folded down to it.
+	//
+	// Fixture state: the native shape, and the last read on the tape.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 6);
+	let verifier = VerifierCircuit::build(&shape, &setup);
+	let targets = targets(&shape, &verifier.layout);
+
+	// Mutation: flip one bit of the first terminal entry.
+	//
+	//     before:  entry  -> rebuilt tree == root, and folded query == entry
+	//     after:   entry' -> a different root, and a folded query that no longer matches
+	//
+	// Either failure is enough, so the assertion below accepts whichever fires.
+	let paths =
+		rejected(&verifier, &opening, &corrupt(&opening.proof, targets.terminal.word_offset));
+	assert!(
+		paths
+			.iter()
+			.any(|path| path.contains("vector") || path.contains("assert_zero")),
+		"a corrupted terminal entry must fail the vector check or a FRI equality: {paths:?}"
+	);
+}
+
+#[test]
+fn a_corrupted_layer_digest_is_rejected() {
+	// Invariant: the decommitted layer is folded to the root once and then shared by every query,
+	// so one bad digest breaks the fold whether or not a query climbs through it.
+	//
+	// Fixture state: the native shape, and the first advice read on the tape.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 7);
+	let verifier = VerifierCircuit::build(&shape, &setup);
+	let targets = targets(&shape, &verifier.layout);
+
+	// Mutation: flip one bit of the first layer digest.
+	//
+	//     before:  layer  -> fold -> root, which the challenger already observed
+	//     after:   layer' -> fold -> a root the tape never carried
+	let paths = rejected(&verifier, &opening, &corrupt(&opening.proof, targets.layer.word_offset));
+	assert!(
+		paths.iter().any(|path| path.contains("layer")),
+		"a corrupted layer digest must fail the layer fold: {paths:?}"
+	);
+}
+
+#[test]
+fn a_tampered_eval_claim_is_rejected() {
+	// Invariant: the statement is bound by the protocol's own equalities, not by any hash, so a
+	// wrong claim must still be caught.
+	//
+	// Fixture state: the native shape, one honest proof, and one altered claim.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 8);
+	let verifier = VerifierCircuit::build(&shape, &setup);
+
+	// Mutation: add one to the claimed evaluation, leaving the proof bytes alone.
+	//
+	//     before:  first round polynomial recovers to the claimed sum
+	//     after:   it recovers to a value one away, and the error rides the folding to the end
+	//
+	// The claim is a statement wire and not a proof byte, so the Fiat-Shamir state is identical and
+	// every hash still agrees.
+	let tampered = opening.eval_claim + B128::ONE;
+	match verifier.check(tampered, &opening.eval_point, &opening.proof) {
+		// A tampered claim that satisfies the circuit would make the statement meaningless.
+		Ok(()) => panic!("a tampered claim must leave the circuit unsatisfied"),
+		// Population sees every assertion, so it must be what catches this.
+		Err(Unsatisfied::Constraints(error)) => {
+			panic!("population must find the failure before constraint verification: {error}")
+		}
+		Err(Unsatisfied::Assertions(PopulateError {
+			failures, total, ..
+		})) => {
+			// The error must name at least one failing assertion to be worth anything.
+			assert!(total > 0, "an unsatisfied circuit must report a failing assertion");
+			assert_eq!(failures.len(), total.min(MAX_ASSERTION_FAILURES));
+			// No hash can fail here, so a Merkle path in this list would mean the wires that carry
+			// the statement leak into the hashing.
+			assert!(
+				failures
+					.iter()
+					.all(|failure| failure.path.contains("assert_zero")),
+				"only the protocol's own equalities may fail: {:?}",
+				failures.iter().map(|f| &f.path).collect::<Vec<_>>()
+			);
+		}
+	}
+}
+
+// The measurement
+
+/// AND and BMUL constraints one phase spends.
+#[derive(Clone, Copy, Default, Debug)]
+struct Cost {
+	/// AND constraints.
+	and: usize,
+	/// BMUL constraints.
+	bmul: usize,
+}
+
+impl Cost {
+	/// The AND and BMUL columns of a built circuit.
+	///
+	/// Pinning an output so the dead-code pass keeps it costs only ZERO constraints, which neither
+	/// column counts, so scaffolding needs no charging back out.
+	fn of(circuit: &Circuit) -> Self {
+		let stat = CircuitStat::collect(circuit);
+		Self {
+			and: stat.n_and_constraints,
+			bmul: stat.n_bmul_constraints,
+		}
+	}
+}
+
+/// Allocates `n` digests on a proof stream, byte-reversed as the channel reverses them.
+///
+/// The tape carries a digest little-endian while a compression consumes big-endian halves.
+fn read_digests(builder: &CircuitBuilder, n: usize) -> Vec<Digest> {
+	(0..n)
+		.map(|_| {
+			// One reversal per 32-bit half, which is where the real channel pays it too.
+			std::array::from_fn(|_| {
+				binius_circuits::bytes::swap_bytes_32(builder, builder.add_witness())
+			})
+		})
+		.collect()
+}
+
+/// Allocates `n` field elements on a proof stream, which need no reordering.
+fn read_elements(builder: &CircuitBuilder, n: usize) -> Vec<Element> {
+	(0..n)
+		// An element is two little-endian words on the tape and two wires in the circuit.
+		.map(|_| std::array::from_fn(|_| builder.add_witness()))
+		.collect()
+}
+
+/// Prices the Fiat-Shamir challenger alone, by replaying the schedule the verifier drove.
+///
+/// Only the schedule matters: the native challenger's block boundaries, padding and sampled-byte
+/// counter follow from the sequence of calls and never from the bytes.
+fn challenger_cost(schedule: &[ChallengerOp]) -> Cost {
+	// A fresh builder, so nothing but the challenger contributes to the count.
+	let builder = CircuitBuilder::new();
+	let mut challenger = Sha256Challenger::new(&builder);
+	let mut pins = 0;
+	for op in schedule {
+		match *op {
+			// Observed words: the values are irrelevant, so uninitialized witnesses will do.
+			ChallengerOp::Observe(n) => {
+				let words = (0..n).map(|_| builder.add_witness()).collect::<Vec<_>>();
+				challenger.observe_words(&words);
+			}
+			// A sampled challenge has to be consumed by something, or the dead-code pass removes
+			// the compressions that produced it.
+			ChallengerOp::SampleB128 => {
+				let (lo, hi) = challenger.sample_b128();
+				let claimed = [builder.add_inout(), builder.add_inout()];
+				builder.assert_eq_v(format!("sample[{pins}]"), [lo, hi], claimed);
+				pins += ELEMENT_WORDS;
+			}
+			// Same reason, and one word means one pinned equality.
+			ChallengerOp::SampleBits(bits) => {
+				let word = challenger.sample_bits(bits);
+				builder.assert_eq(format!("bits[{pins}]"), word, builder.add_inout());
+				pins += 1;
+			}
+		}
+	}
+	Cost::of(&builder.build())
+}
+
+/// Prices the Merkle work of the recorded operations `keep` selects, on a fresh builder.
+///
+/// A channel call cannot be priced in place, so this repeats what the channel emits:
+///
+/// - the digest and element reads off the tape
+/// - the fold of the decommitted layer up to the root
+/// - the per-query climb from a leaf to that layer
+/// - the tree rebuilt over a vector read in the clear
+///
+/// Observing the roots is deliberately not repeated, since that cost belongs to the challenger.
+fn merkle_cost(ops: &[MerkleOp], keep: impl Fn(&MerkleOp) -> bool) -> Cost {
+	let builder = CircuitBuilder::new();
+	// The scheme is consulted only for the layer depth it would have chosen.
+	let scheme = BinaryMerkleTreeScheme::<B128, Sha256HashSuite>::new();
+	for op in ops.iter().filter(|op| keep(op)) {
+		match *op {
+			MerkleOp::Openings {
+				leaf_size,
+				depth,
+				n_queries,
+			} => {
+				// The layer depth is what trades a wider shared layer against shorter climbs, so
+				// it must be the same choice the real channel made.
+				let layer_depth = scheme.optimal_verify_layer(n_queries, depth);
+				let root = read_digests(&builder, 1)[0];
+				let layer = read_digests(&builder, 1 << layer_depth);
+				// Paid once, whatever the query count.
+				merkle::verify_layer(&builder, root, &layer);
+				// Paid once per query: one leaf hash plus one compression per level climbed.
+				for _ in 0..n_queries {
+					let leaf = read_elements(&builder, leaf_size);
+					let branch = read_digests(&builder, depth - layer_depth);
+					merkle::verify_opening(
+						&builder,
+						builder.add_witness(),
+						&leaf,
+						layer_depth,
+						depth,
+						&layer,
+						&branch,
+					);
+				}
+			}
+			MerkleOp::Vector { leaf_size, depth } => {
+				// A vector arrives whole, so the check is the entire tree over 2^depth leaves.
+				let root = read_digests(&builder, 1)[0];
+				let data = read_elements(&builder, leaf_size << depth);
+				merkle::verify_vector(&builder, root, &data, leaf_size);
+			}
+		}
+	}
+	// Nothing here is pinned, since every read already feeds an assertion.
+	Cost::of(&builder.build())
+}
+
+/// Prices the MLE-check's own arithmetic: recover the round polynomial, evaluate it, `n_vars`
+/// times.
+fn mlecheck_cost(n_vars: usize) -> Cost {
+	let builder = CircuitBuilder::new();
+	// Every value in this loop is a fresh witness, since only the arithmetic shape is being priced.
+	let elem = || Elem::new(&builder, builder.add_witness(), builder.add_witness());
+
+	let mut sum = elem();
+	for _ in 0..n_vars {
+		// A degree-1 round proof is one truncated coefficient.
+		let round_proof = mlecheck::RoundProof(RoundCoeffs(vec![elem()]));
+		// Recovery restores the dropped coefficient from the running sum, and evaluating at the
+		// round challenge produces the sum the next round must match.
+		let coeffs = round_proof.recover(sum, elem());
+		sum = coeffs.evaluate(&elem());
+	}
+
+	// The final sum is pinned, or the whole chain is dead code.
+	let (lo, hi) = sum.words(&builder);
+	let claimed = [builder.add_inout(), builder.add_inout()];
+	builder.assert_eq_v("sum", [lo, hi], claimed);
+	Cost::of(&builder.build())
+}
+
+/// Prints the constraint table and the phase breakdown for `shape`, and returns the total.
+fn report(shape: &Shape) -> CircuitStat {
+	// The total comes from the real circuit, so the phases below are measured against something
+	// that was actually built.
+	let setup = shape.setup();
+	let verifier = VerifierCircuit::build(shape, &setup);
+	let stat = &verifier.stat;
+
+	// Each phase is rebuilt on its own, from the schedules the verifier recorded.
+	let challenger = challenger_cost(&verifier.challenger_ops);
+	let openings = merkle_cost(&verifier.merkle_ops, |op| matches!(op, MerkleOp::Openings { .. }));
+	let terminal = merkle_cost(&verifier.merkle_ops, |op| matches!(op, MerkleOp::Vector { .. }));
+	let mlecheck = mlecheck_cost(shape.n_vars);
+
+	// Whatever the four named phases do not account for is the folding and its equalities, so the
+	// rows always sum to the total.
+	let named = [
+		("Merkle openings", openings),
+		("Fiat-Shamir challenger", challenger),
+		("terminal codeword", terminal),
+		("MLE-check arithmetic", mlecheck),
+	];
+	let accounted: Cost = named.iter().fold(Cost::default(), |acc, (_, cost)| Cost {
+		and: acc.and + cost.and,
+		bmul: acc.bmul + cost.bmul,
+	});
+	// Saturating, because a phase priced in isolation can slightly overshoot what sharing achieves
+	// inside the real circuit.
+	let residual = Cost {
+		and: stat.n_and_constraints.saturating_sub(accounted.and),
+		bmul: stat.n_bmul_constraints.saturating_sub(accounted.bmul),
+	};
+
+	// The shape and the tape length, so a printed table can be traced back to what produced it.
+	println!(
+		"\n=== n_vars {} | log_inv_rate {} | {} queries | {} proof bytes ===",
+		shape.n_vars,
+		shape.log_inv_rate,
+		shape.n_test_queries,
+		verifier.layout.n_bytes(),
+	);
+	// All four columns, since which one is scarce depends on the circuit this is embedded in.
+	println!(
+		"total: {:>9} AND  {:>7} BMUL  {:>7} ZERO  {:>9} committed words",
+		stat.n_and_constraints,
+		stat.n_bmul_constraints,
+		stat.n_zero_constraints,
+		stat.committed_allocated,
+	);
+	println!("{:<26} {:>9} {:>8}   {:>6}", "phase", "AND", "BMUL", "AND %");
+	// The residual is appended last, so the named phases read in descending cost order.
+	for (name, cost) in named
+		.into_iter()
+		.chain([("FRI folding and equalities", residual)])
+	{
+		println!(
+			"{:<26} {:>9} {:>8}   {:>5.1}%",
+			name,
+			cost.and,
+			cost.bmul,
+			100.0 * cost.and as f64 / stat.n_and_constraints as f64,
+		);
+	}
+
+	verifier.stat
+}
+
+#[test]
+fn the_verifier_cost_breaks_down_by_phase() {
+	// Invariant: hashing dominates the verifier, by more than an order of magnitude.
+	//
+	// Fixture state: the native shape, printed as a total plus five phase rows.
+	let stat = report(&NATIVE_SHAPE);
+
+	// The AND column is what a Binius64 proof pays for most, and it is nearly all SHA-256 here.
+	//
+	//     AND  : Merkle climbs, the challenger, the rebuilt terminal tree
+	//     BMUL : the field arithmetic the folding and the MLE-check reduce
+	//     -> a factor of ten is a loose floor, so this catches a regression not a fluctuation
+	assert!(
+		stat.n_and_constraints > stat.n_bmul_constraints * 10,
+		"SHA-256 must dominate the field arithmetic: {} AND against {} BMUL",
+		stat.n_and_constraints,
+		stat.n_bmul_constraints
+	);
+}
+
+#[test]
+fn the_cost_surface_over_shapes() {
+	// Invariant: cost rises with the query count and with the committed size, and neither rise is
+	// the naive one.
+	//
+	// Fixture state: five shapes, each one lever off the native shape.
+	//
+	//     row 1: the native shape, 8 variables, rate 1, 32 queries
+	//     row 2: 10 variables, so four times the committed size
+	//     row 3: rate 2, so twice the codeword
+	//     row 4: 16 queries
+	//     row 5: 64 queries
+	//
+	// One parameter moves at a time, so each row isolates one lever.
+	let shapes = [
+		NATIVE_SHAPE,
+		Shape {
+			n_vars: 10,
+			..NATIVE_SHAPE
+		},
+		Shape {
+			log_inv_rate: 2,
+			..NATIVE_SHAPE
+		},
+		Shape {
+			n_test_queries: 16,
+			..NATIVE_SHAPE
+		},
+		Shape {
+			n_test_queries: 64,
+			..NATIVE_SHAPE
+		},
+	];
+
+	// Each row is printed as it is built, so the table survives a later assertion failing.
+	let mut totals = Vec::new();
+	for shape in shapes {
+		let stat = report(&shape);
+		totals.push((shape, stat.n_and_constraints));
+	}
+
+	// Pinning the variable count too, so the query rows are not confused with the deeper shape.
+	let and_of = |queries: usize| {
+		totals
+			.iter()
+			.find(|(shape, _)| {
+				shape.n_test_queries == queries && shape.n_vars == NATIVE_SHAPE.n_vars
+			})
+			.map(|&(_, and)| and)
+			.expect("the sweep covers this query count")
+	};
+
+	// Each query buys its own climb and its own leaf hash, so more of them must cost more.
+	//
+	// The rise is sublinear because the scheme deepens the shared layer as the query count grows,
+	// which shortens every climb.
+	assert!(and_of(64) > and_of(32), "more queries must cost more");
+	assert!(and_of(32) > and_of(16), "more queries must cost more");
+
+	// Two more variables deepen every tree by two levels, paid once per query.
+	//
+	// Measured at +51%, so growth in the committed size is logarithmic but far from free.
+	let deeper = totals
+		.iter()
+		.find(|(shape, _)| shape.n_vars == 10)
+		.map(|&(_, and)| and)
+		.expect("the sweep covers n_vars = 10");
+	// Doubling would mean the cost tracks the committed size rather than its logarithm.
+	assert!(
+		deeper < 2 * and_of(32),
+		"four times the committed size must not double the verifier: {deeper} against {}",
+		and_of(32)
+	);
+}

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -47,15 +47,15 @@
 //! Run them with `--nocapture` to see the output.
 //!
 //! At `n_vars = 8`, `log_inv_rate = 1` and 32 queries, over a 13,536-byte proof, the measured cost
-//! is 229,675 AND, 14,887 BMUL, 71,362 ZERO and 524,288 committed words, split as:
+//! is 229,675 AND, 15,463 BMUL, 71,362 ZERO and 524,288 committed words, split as:
 //!
 //! ```text
 //!     phase                          AND     BMUL    AND %
 //!     Merkle openings             212315     9216    92.4%
 //!     Fiat-Shamir challenger        9643        0     4.2%
 //!     terminal codeword             7773        0     3.4%
-//!     FRI folding and equalities       0     5655     0.0%
 //!     MLE-check arithmetic             0       16     0.0%
+//!     FRI folding and equalities       0     6231     0.0%
 //! ```
 //!
 //! So the verifier is SHA-256 and almost nothing else:
@@ -63,7 +63,7 @@
 //! - the three hashing phases are the whole AND column
 //! - Merkle openings alone are 92% of it
 //! - the field arithmetic that the fold and the sum-check actually reduce spends no AND at all,
-//!   only 5,671 BMUL
+//!   only 6,247 BMUL
 //!
 //! The AND column is what binds.
 //!
@@ -136,20 +136,17 @@ use binius_ip::{
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	BinarySubspace,
 	inner_product::inner_product_buffers,
 	line::extrapolate_line_packed,
 	multilinear::eq::eq_ind_partial_eval,
-	ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 	test_utils::{random_field_buffer, random_scalars},
 };
 use binius_recursion::{
+	SymbolicElem, SymbolicWord,
 	challenger::Sha256Challenger,
-	channel::{
-		ChannelWord, MerkleCommitment, MerkleVerifierChannel, ProofLayout, ProofRead, ReadKind,
-	},
-	elem::Elem,
 	merkle::{self, DIGEST_WORDS, Digest, ELEMENT_WORDS, Element, populate_element},
+	merkle_channel::{MerkleCommitment, MerkleVerifierChannel, ProofLayout, ProofRead, ReadKind},
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use binius_utils::rayon::prelude::*;
@@ -200,7 +197,7 @@ struct Setup {
 	/// The fold layout: code dimension, per-oracle shapes, fold arities and query count.
 	fri_params: FRIParams<B128>,
 	/// The additive NTT the prover encodes with.
-	ntt: NeighborsLastSingleThread<GenericOnTheFly<B128>>,
+	ntt: NeighborsLastSingleThread<GaoMateerOnTheFly<B128>>,
 }
 
 impl Shape {
@@ -217,14 +214,12 @@ impl Shape {
 
 		// The evaluation domain must span the interleaved codeword: one extra variable for the
 		// mask that buys zero-knowledge, plus the rate.
-		let subspace = BinarySubspace::with_dim(self.n_vars + 1 + self.log_inv_rate);
-		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+		let domain_context = GaoMateerOnTheFly::generate(self.n_vars + 1 + self.log_inv_rate);
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 
 		// A single zero-knowledge oracle makes the combined batch parameters valid for the masked
 		// encoder too: one interleaved batch dimension, and a code dimension of `n_vars`.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
-			ntt.domain_context(),
 			&scheme,
 			&[OracleSpec::new_zk(self.n_vars)],
 			self.log_inv_rate,
@@ -349,7 +344,6 @@ impl VerifierCircuit {
 		// Two layers of channel: the inner one emits gates, the outer one only takes notes.
 		let builder = CircuitBuilder::new();
 		let mut inner = MerkleVerifierChannel::new(&builder);
-		let mut channel = Recording::new(&mut inner);
 
 		// The statement enters on inout wires, one pair per element for the low and high halves.
 		// As build-time constants these numbers would fold into the gates, tying the circuit to one
@@ -358,11 +352,14 @@ impl VerifierCircuit {
 		let point_wires: Vec<Element> = (0..shape.n_vars)
 			.map(|_| [builder.add_inout(), builder.add_inout()])
 			.collect();
-		let eval_claim = Elem::new(&builder, claim_wires[0], claim_wires[1]);
-		let eval_point: Vec<Elem> = point_wires
+		let eval_claim = inner.elem(claim_wires[0], claim_wires[1]);
+		let eval_point: Vec<SymbolicElem> = point_wires
 			.iter()
-			.map(|&[lo, hi]| Elem::new(&builder, lo, hi))
+			.map(|&[lo, hi]| inner.elem(lo, hi))
 			.collect();
+
+		// Wrapped only once the statement is in hand, since the recorder borrows the channel.
+		let mut channel = Recording::new(&mut inner);
 
 		// The root is read first, so everything the query phase later opens is already observed.
 		let commitment = channel
@@ -518,78 +515,83 @@ impl<'a, 'b> Recording<'a, 'b> {
 }
 
 impl IPVerifierChannel<B128> for Recording<'_, '_> {
-	type Elem = Elem;
+	type Elem = SymbolicElem;
 
-	fn recv_one(&mut self) -> Result<Elem, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<SymbolicElem, binius_ip::channel::Error> {
 		// A message read is hashed as it is consumed, and one element is two proof words.
 		self.observed(ELEMENT_WORDS);
 		self.inner.recv_one()
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<Elem>, binius_ip::channel::Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<SymbolicElem>, binius_ip::channel::Error> {
 		// One read of n elements, so the words are hashed as a single contiguous run.
 		self.observed(n * ELEMENT_WORDS);
 		self.inner.recv_many(n)
 	}
 
-	fn sample(&mut self) -> Elem {
+	fn sample(&mut self) -> SymbolicElem {
 		// A 128-bit draw consumes sixteen sampler bytes, plus any refill they force.
 		self.challenger.push(ChallengerOp::SampleB128);
 		IPVerifierChannel::sample(self.inner)
 	}
 
-	fn observe_one(&mut self, val: B128) -> Elem {
+	fn observe_one(&mut self, val: B128) -> SymbolicElem {
 		// Observing always turns the channel, even with nothing to write, so it is always
 		// recorded.
 		self.challenger.push(ChallengerOp::Observe(ELEMENT_WORDS));
 		self.inner.observe_one(val)
 	}
 
-	fn observe_many(&mut self, vals: &[B128]) -> Vec<Elem> {
+	fn observe_many(&mut self, vals: &[B128]) -> Vec<SymbolicElem> {
 		// Values the verifier computed rather than read, hashed together as one run.
 		self.challenger
 			.push(ChallengerOp::Observe(vals.len() * ELEMENT_WORDS));
 		self.inner.observe_many(vals)
 	}
 
-	fn assert_zero(&mut self, val: Elem) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: SymbolicElem) -> Result<(), binius_ip::channel::Error> {
 		// An equality constraint touches neither the tape nor the Fiat-Shamir state.
 		self.inner.assert_zero(val)
 	}
 
 	fn compute_public_value(
 		&mut self,
-		inputs: &[Elem],
+		inputs: &[SymbolicElem],
 		f: impl binius_field::util::FieldFn<B128>,
-	) -> Elem {
+	) -> SymbolicElem {
 		// Arithmetic over wires the verifier already holds, so there is nothing to record.
 		self.inner.compute_public_value(inputs, f)
 	}
 }
 
 impl WordIPVerifierChannel<B128> for Recording<'_, '_> {
-	type Word = ChannelWord;
+	type Word = SymbolicWord;
 
-	fn observe_words(&mut self, words: &[ChannelWord]) {
-		// Words already in circuit form, hashed exactly as they are.
+	fn observe_words(&mut self, words: &[Word]) -> Vec<SymbolicWord> {
+		// The statement, hashed one word at a time off the inout wires it entered on.
 		self.challenger.push(ChallengerOp::Observe(words.len()));
-		self.inner.observe_words(words);
+		self.inner.observe_words(words)
 	}
 
-	fn subset_sum(&mut self, elems: &[Elem], word: &ChannelWord) -> Elem {
+	fn subset_sum(&mut self, elems: &[SymbolicElem], word: &SymbolicWord) -> SymbolicElem {
 		// A table lookup over existing elements, so it is pure gate work.
 		self.inner.subset_sum(elems, word)
 	}
 
-	fn select(&mut self, elems: &[Elem], word: &ChannelWord) -> Elem {
+	fn select(&mut self, elems: &[SymbolicElem], word: &SymbolicWord) -> SymbolicElem {
 		// Also a lookup, and also invisible to both schedules.
 		self.inner.select(elems, word)
 	}
 
-	fn sample_bits(&mut self, bits: usize) -> ChannelWord {
+	fn sample_bits(&mut self, bits: usize) -> SymbolicWord {
 		// A query index draw, which reads four sampler bytes and masks them down to `bits`.
 		self.challenger.push(ChallengerOp::SampleBits(bits));
 		self.inner.sample_bits(bits)
+	}
+
+	fn pack_words(&mut self, words: &[SymbolicWord]) -> Vec<SymbolicElem> {
+		// Pairing up wires the channel already holds, so neither schedule moves.
+		self.inner.pack_words(words)
 	}
 }
 
@@ -609,8 +611,8 @@ impl MerkleIPVerifierChannel<B128> for Recording<'_, '_> {
 	fn recv_openings(
 		&mut self,
 		commitment: &MerkleCommitment,
-		indices: &[ChannelWord],
-	) -> Result<Vec<Elem>, binius_iop::merkle_channel::Error> {
+		indices: &[SymbolicWord],
+	) -> Result<Vec<SymbolicElem>, binius_iop::merkle_channel::Error> {
 		// Pricing a climb needs all three numbers: leaf size, tree depth, and how many indices
 		// share one decommitted layer.
 		self.merkle.push(MerkleOp::Openings {
@@ -624,7 +626,7 @@ impl MerkleIPVerifierChannel<B128> for Recording<'_, '_> {
 	fn recv_committed_vector(
 		&mut self,
 		commitment: &MerkleCommitment,
-	) -> Result<Vec<Elem>, binius_iop::merkle_channel::Error> {
+	) -> Result<Vec<SymbolicElem>, binius_iop::merkle_channel::Error> {
 		// A vector read in the clear is priced by the tree rebuilt over it, which the shape fixes.
 		self.merkle.push(MerkleOp::Vector {
 			leaf_size: commitment.leaf_size,
@@ -1114,8 +1116,10 @@ fn merkle_cost(ops: &[MerkleOp], keep: impl Fn(&MerkleOp) -> bool) -> Cost {
 /// times.
 fn mlecheck_cost(n_vars: usize) -> Cost {
 	let builder = CircuitBuilder::new();
+	// A channel only for the element type it anchors: nothing is read off a proof here.
+	let channel = MerkleVerifierChannel::new(&builder);
 	// Every value in this loop is a fresh witness, since only the arithmetic shape is being priced.
-	let elem = || Elem::new(&builder, builder.add_witness(), builder.add_witness());
+	let elem = || channel.elem(builder.add_witness(), builder.add_witness());
 
 	let mut sum = elem();
 	for _ in 0..n_vars {
@@ -1128,7 +1132,7 @@ fn mlecheck_cost(n_vars: usize) -> Cost {
 	}
 
 	// The final sum is pinned, or the whole chain is dead code.
-	let (lo, hi) = sum.words(&builder);
+	let (lo, hi) = sum.to_wires(&builder);
 	let claimed = [builder.add_inout(), builder.add_inout()];
 	builder.assert_eq_v("sum", [lo, hi], claimed);
 	Cost::of(&builder.build())


### PR DESCRIPTION
Closes [BINIUS-432](https://linear.app/jimpo/issue/BINIUS-432).

The acceptance test for [BINIUS-425](https://linear.app/jimpo/issue/BINIUS-425): a polynomial-commitment opening proved natively, then verified **inside a Binius64 circuit**.
This is the first real measurement of the fold-and-Merkle share of a recursive verifier.

### What changed on the rebase

The stack this branch sat on landed in pieces while it waited, so the old "review only the second commit" note is gone — there is no longer a stack base.

| piece | landed as | on main |
|---|---|---|
| Fiat-Shamir challenger | #2103 | byte-identical |
| Merkle gadgets | #2104 | byte-identical |
| in-circuit field element | #2106 | reworked, `Elem` → `SymbolicElem` |
| **the channel that assembles them** | — | **never landed** |

That last row is why the rebase was not mechanical. `Binius64BuilderChannel` on main is still the skeleton from #2093: it records the verifier's operations but leaves the hashing out, so a replay supplies what the circuit cannot derive. The gadgets exist; nothing drives them. With no constrained channel there was nothing for this test to run against.

So the channel is carried here, as `merkle_channel`, rebuilt on main's `SymbolicElem` and `SymbolicWord` rather than on the branch's own element type:

```
skeleton (untouched):  proof -> replay -> wires the circuit could not derive
merkle_channel:        proof -> wires, and every other value is a gate output
```

Deriving those values is what costs the SHA-256, and what makes an unsatisfied circuit mean a rejected proof. The skeleton and its replay path are left exactly as they are — both channels compile, and `recursion_end_to_end.rs` still passes.

This subsumes [BINIUS-469](https://linear.app/jimpo/issue/BINIUS-469), [BINIUS-470](https://linear.app/jimpo/issue/BINIUS-470), [BINIUS-471](https://linear.app/jimpo/issue/BINIUS-471) and [BINIUS-472](https://linear.app/jimpo/issue/BINIUS-472) for the new channel, though not for the skeleton, which keeps its six `UNCONSTRAINED` markers. **If you would rather those four land incrementally against the skeleton instead, say so and I will close this and reopen the test on top of them.**

Two small additions outside the channel:

- `Shared` gains a constructor anchoring on a builder the caller already holds, which is how the statement reaches the circuit on inout wires.
- `SymbolicWord` gains a `value` accessor, so a lookup over a protocol-fixed index settles in Rust rather than spending select gates.

Three things in the test moved with main: `optimal_for_batch` takes the Merkle scheme as a type parameter, the NTT domain is Gao-Mateer rather than a naive subspace (#2094), and the channel traits grew `pack_words`.

### The two halves

The native round trip is reused at both ends:

```
prover:   native and unchanged, writing one real transcript
verifier: the same code, over a channel that emits gates instead of checking values
```

A satisfied constraint system is then the statement "this transcript opens this claim".
An outer proof can check that statement, which is what makes this one step of recursion.

### What is an input

Two things enter the circuit, and nothing else:

```
the proof byte stream   one witness wire per eight-byte proof word
the inner statement     the claimed evaluation and the point, on inout wires
```

Challenges, folded values and recomputed digests are all gate outputs.

The statement deliberately does **not** enter as a build-time constant.
A constant would fold one opening's numbers into the gates and quietly destroy the next property.

### Build once, verify many

Every shape the circuit depends on is settled before any proof exists — the code rate, the fold arities, the oracle layout, the tree depths, the query count.
So one circuit serves every opening of that shape, and the expensive compilation is paid once per protocol rather than once per proof.

A test asserts that directly: build once, then verify two different openings (different witness, different point, different transcript).

### Negative tests

Five corruption tests each flip one byte and require the system to become unsatisfiable, and each states which mechanism catches it:

| corrupted | caught by |
|---|---|
| opened value | the Merkle path to the layer |
| Merkle sibling | the Merkle path to the layer |
| layer digest | the layer fold to the root |
| terminal codeword entry | the rebuilt tree, or a fold equality |
| round polynomial | see below |

The round polynomial is the interesting one, and the reason the distinction is worth keeping.
It is an **observed** message, so corrupting it moves the Fiat-Shamir state, and therefore the sampled query indices:

```
before:  round value  -> challenge -> ... -> query indices -> the committed positions
after:   round value' -> a different challenge from that round on, indices included
```

The opened values and siblings on the tape are unchanged, but the indices addressing them are not, so every opening now climbs to the wrong entry of the decommitted layer.

A tampered statement wire is covered too.
Each test asserts on every field of the resulting error, with no discarded fields.

### The measurement

At `n_vars = 8`, `log_inv_rate = 1` and 32 queries, over a 13,536-byte proof: **229,675 AND**, 15,463 BMUL, 71,362 ZERO, 524,288 committed words.

| phase | AND | BMUL | AND % |
|---|---|---|---|
| Merkle openings | 212,315 | 9,216 | 92.4% |
| Fiat-Shamir challenger | 9,643 | 0 | 4.2% |
| terminal codeword | 7,773 | 0 | 3.4% |
| MLE-check arithmetic | 0 | 16 | 0.0% |
| fold and its equalities | 0 | 6,231 | 0.0% |

So the verifier is SHA-256 and almost nothing else:

- the three hashing phases are the whole AND column
- Merkle openings alone are 92% of it
- the field arithmetic the fold and the sum-check actually reduce spends **no AND at all**, only 6,247 BMUL

The AND column is what binds.

The AND column is unchanged from the pre-rebase measurement at every shape in the sweep below. Only BMUL moved, from 14,887 to 15,463, which is #2106 charging for the two field gadgets it constrained.

### The cost surface

One sweep, moving a single lever at a time:

| shape | AND | vs base |
|---|---|---|
| `n_vars` 8, rate 1, 32 queries | 229,675 | -- |
| `n_vars` 10, rate 1, 32 queries | 346,681 | +51% |
| `n_vars` 8, rate 2, 32 queries | 285,585 | +24% |
| `n_vars` 8, rate 1, 16 queries | 146,249 | -36% |
| `n_vars` 8, rate 1, 64 queries | 280,193 | +22% |

Two readings worth keeping, both of which contradict the estimates on the issue:

1. **Queries are sublinear** — 16 to 32 costs +57% but 32 to 64 only +22%, because the shared decommitment layer deepens as the query count grows and every climb gets shorter.
2. **Committed size is not flat** — four times the committed data costs 51% more, not "a few percent". Growth is logarithmic, but with a steep constant: every extra Merkle level is paid once per query across every tree in the fold schedule, and here the terminal codeword grew with it from 7,773 to 26,781 AND.

So doubling the query count is cheaper than it looks, and the layer depth is the reason.

### Where this sits

Against the 2.5M-5M AND estimate for a full recursive verifier, one opening of this shape is around a tenth of the lower bound.

A production shape costs more: more queries, deeper trees, several oracles, and the constraint-system checks above the opening.
The levers are the same three, in this order:

1. fewer SHA-256 compressions per Merkle level
2. fewer Merkle levels
3. the layer-depth trade-off that sets how many levels each query climbs

That last one is [BINIUS-428](https://linear.app/jimpo/issue/BINIUS-428)'s territory, and the sweep above is the surface it would be tuned against.

### Scope

3,053 insertions, 16 deletions, all inside `crates/recursion`.

| file | lines | what |
|---|---|---|
| `src/merkle_channel.rs` | +693 | the constrained channel |
| `src/merkle_channel/tests.rs` | +1018 | its unit tests, pinning it against the native channel |
| `tests/basefold_opening.rs` | +1301 | the end-to-end test and the measurement |
| `src/lib.rs` | +19/-15 | module registration, and crate docs that claimed nothing was constrained |
| `src/shared.rs` | +8/-1 | `Shared::with_builder` |
| `src/symbolic/word.rs` | +10 | `SymbolicWord::value` |
| `Cargo.toml` | +4 | `thiserror`, and three dev-dependencies for the test |

Untouched: the skeleton channel, the filler, and everything outside the crate.

Worth reading in that order — the channel is the design, the two test files are volume. Two unit tests carry most of the soundness weight:

- `a_full_script_matches_the_native_channel` runs a scripted verifier over both the in-circuit channel and the native one, and pins every sampled challenge, query index and received value between them. If the in-circuit Fiat-Shamir state ever diverged, this is what catches it.
- `only_the_root_and_prover_messages_are_observed` pins the message-versus-decommitment split, which is the load-bearing property of the module: getting it wrong does not make the circuit unsatisfiable, it makes the circuit disagree with every real transcript.

### Verification

- `cargo check -p binius-recursion --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-recursion --no-deps` — clean
- `cargo test -p binius-recursion` — 44 lib + 10 basefold + 2 channel-builds + 1 end-to-end passed

`cargo check --workspace --all-targets` fails on this machine, but it fails identically on a clean `upstream/main` checkout, so it is not from this branch.

The two measurement tests print their tables; run with `--nocapture` to see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


