### PR TITLE
Add chip composition for M4 circuits

### DIFF
--- a/crates/core/src/constraint_system/m4.rs
+++ b/crates/core/src/constraint_system/m4.rs
@@ -104,10 +104,11 @@ pub struct ChipCall {
 /// Validity invariants:
 /// - all embedded constraint systems in `chips` must have a chip_id value that indexes into `chips`
 ///
-/// [`Self::validate`] accepts any acyclic call graph, but call positions are defined by
-/// enumerating the chips in ID order, and witness generation walks them the same way — so only a
-/// system whose calls run to higher IDs is provable. The frontend's
-/// `CircuitM4::validate` is what enforces that ordering.
+/// The chips are in topological order: a chip calls only chips with a higher ID, and main, which
+/// is not one of them, calls any. Call positions are defined by enumerating the chips in ID order
+/// and witness generation walks them the same way, so every caller of a chip is reached before the
+/// chip itself. [`Self::validate`] requires it, which makes the call graph acyclic as a
+/// consequence.
 pub struct ConstraintSystemM4 {
 	/// The entry point of the system. It calls chips, but no chip ID names it, so nothing calls
 	/// it.
@@ -121,32 +122,25 @@ pub struct ConstraintSystemM4 {
 }
 
 impl ConstraintSystemM4 {
-	/// Checks every chip and every chip call, and rejects call-graph cycles.
+	/// Checks every chip and every chip call, and requires the chips to be in topological order.
 	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
-		let n_chips = self.chips.len();
-
 		self.main.validate()?;
 		self.validate_calls(None, &self.main.chip_calls)?;
 
-		// The chips each chip calls, indexed by the caller's chip ID.
-		let mut callees = vec![Vec::new(); n_chips];
 		for (chip_index, (chip, _)) in self.chips.iter().enumerate() {
 			chip.validate()?;
 			self.validate_calls(Some(chip_index), &chip.chip_calls)?;
-			callees[chip_index].extend(chip.chip_calls.iter().map(|call| call.chip_id));
-		}
-
-		if !is_acyclic(&callees) {
-			return Err(ConstraintSystemError::CyclicChipCalls);
 		}
 
 		Ok(())
 	}
 
-	/// Checks that one caller's calls name existing chips and pass no more operands than the
-	/// callee has inout values.
+	/// Checks that one caller's calls name existing chips, run only to later chips, and pass no
+	/// more operands than the callee has inout values.
 	///
 	/// A call may pass fewer: the inout values past its operands are constrained to zero.
+	///
+	/// Main is not one of the numbered chips and runs before all of them, so it may call any.
 	fn validate_calls(
 		&self,
 		chip_index: Option<usize>,
@@ -159,6 +153,14 @@ impl ConstraintSystemM4 {
 					chip_index,
 					chip_id: call.chip_id,
 					n_chips,
+				});
+			}
+			if let Some(caller) = chip_index
+				&& call.chip_id <= caller
+			{
+				return Err(ConstraintSystemError::CallOutOfOrder {
+					chip_index: caller,
+					callee: call.chip_id,
 				});
 			}
 			let n_inout = self.chips[call.chip_id].0.cs.n_inout;
@@ -318,38 +320,8 @@ impl ConstraintSystemM4 {
 	}
 }
 
-/// Checks that the call graph given by the callee list of each chip is acyclic.
-///
-/// This is Kahn's algorithm: chips with no remaining callers are removed one at a time, and any
-/// chip still left when none remain lies on a cycle. A chip that calls itself is a cycle.
-fn is_acyclic(callees: &[Vec<usize>]) -> bool {
-	let mut n_callers = vec![0usize; callees.len()];
-	for &callee in callees.iter().flatten() {
-		n_callers[callee] += 1;
-	}
-
-	let mut uncalled = (0..callees.len())
-		.filter(|&chip| n_callers[chip] == 0)
-		.collect::<Vec<_>>();
-
-	let mut n_removed = 0;
-	while let Some(chip) = uncalled.pop() {
-		n_removed += 1;
-		for &callee in &callees[chip] {
-			n_callers[callee] -= 1;
-			if n_callers[callee] == 0 {
-				uncalled.push(callee);
-			}
-		}
-	}
-
-	n_removed == callees.len()
-}
-
 #[cfg(test)]
 mod tests {
-	use proptest::prelude::*;
-
 	use super::{
 		super::{ShiftedValueIndex, ValueIndex, ValueSegment, ValueVecLayout, ZeroConstraint},
 		*,
@@ -432,34 +404,52 @@ mod tests {
 	}
 
 	#[test]
-	fn validate_accepts_an_acyclic_call_graph() {
-		// Main calls 0, which calls 1 and 2; 1 calls 2, and 2 is a leaf.
+	fn validate_accepts_calls_running_only_to_later_chips() {
+		// Main calls 0, which calls 1 and 2; 1 calls 2, and 2 is a leaf. Main is not one of the
+		// numbered chips, so its call to 0 is not a backward one.
 		let cs = system(&[0], vec![chip(&[1, 2]), chip(&[2]), chip(&[])]);
 		cs.validate().unwrap();
 	}
 
 	#[test]
 	fn validate_rejects_a_chip_that_calls_itself() {
+		// A chip is not later than itself, so self-recursion is out of order rather than a
+		// separate case.
 		let cs = system(&[0], vec![chip(&[0])]);
-		assert!(matches!(cs.validate(), Err(ConstraintSystemError::CyclicChipCalls)));
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::CallOutOfOrder {
+				chip_index: 0,
+				callee: 0,
+			})
+		));
 	}
 
 	#[test]
-	fn validate_rejects_a_cycle_reachable_from_an_uncalled_chip() {
-		// Chip 0 is called by nobody, so removing it leaves the cycle 1 -> 2 -> 1.
+	fn validate_rejects_a_chip_that_calls_an_earlier_chip() {
+		// Chip 2 calls back to chip 1, which is populated before it. The graph as a whole need not
+		// be cyclic for this to break the one pass over the chips.
 		let cs = system(&[0], vec![chip(&[1]), chip(&[2]), chip(&[1])]);
-		assert!(matches!(cs.validate(), Err(ConstraintSystemError::CyclicChipCalls)));
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::CallOutOfOrder {
+				chip_index: 2,
+				callee: 1,
+			})
+		));
 	}
 
 	#[test]
 	fn validate_rejects_a_call_to_a_chip_that_does_not_exist() {
-		let cs = system(&[0], vec![chip(&[0, 7])]);
+		// Chip 0's first call is to a later chip, so the out-of-range second one is the only
+		// fault and the range check is what has to catch it.
+		let cs = system(&[0], vec![chip(&[1, 7]), chip(&[])]);
 		assert!(matches!(
 			cs.validate(),
 			Err(ConstraintSystemError::OutOfRangeChipId {
 				chip_index: Some(0),
 				chip_id: 7,
-				n_chips: 1,
+				n_chips: 2,
 			})
 		));
 	}
@@ -587,51 +577,5 @@ mod tests {
 			),
 			"{err}"
 		);
-	}
-
-	/// Whether the call graph is acyclic, by a three-colour depth-first search.
-	///
-	/// A chip on the stack that is reached again closes a cycle. This is the independent reference
-	/// [`is_acyclic`]'s Kahn's algorithm is checked against.
-	fn acyclic_by_depth_first_search(callees: &[Vec<usize>]) -> bool {
-		#[derive(Clone, Copy, PartialEq)]
-		enum Colour {
-			Unvisited,
-			OnStack,
-			Done,
-		}
-
-		fn visit(chip: usize, callees: &[Vec<usize>], colour: &mut [Colour]) -> bool {
-			match colour[chip] {
-				Colour::OnStack => return false,
-				Colour::Done => return true,
-				Colour::Unvisited => {}
-			}
-			colour[chip] = Colour::OnStack;
-			for &callee in &callees[chip] {
-				if !visit(callee, callees, colour) {
-					return false;
-				}
-			}
-			colour[chip] = Colour::Done;
-			true
-		}
-
-		let mut colour = vec![Colour::Unvisited; callees.len()];
-		(0..callees.len()).all(|chip| visit(chip, callees, &mut colour))
-	}
-
-	proptest! {
-		// Kahn's algorithm and a depth-first search decide acyclicity by unrelated means, so
-		// agreeing on random graphs covers what the cases above are each written for one of:
-		// multi-edges, diamonds, self-loops and components nothing reaches.
-		#[test]
-		fn is_acyclic_agrees_with_a_depth_first_search(
-			graph in (1usize..7).prop_flat_map(|n_chips| {
-				prop::collection::vec(prop::collection::vec(0..n_chips, 0..4), n_chips)
-			})
-		) {
-			prop_assert_eq!(is_acyclic(&graph), acyclic_by_depth_first_search(&graph));
-		}
 	}
 }

--- a/crates/core/src/constraint_system/m4.rs
+++ b/crates/core/src/constraint_system/m4.rs
@@ -1,12 +1,46 @@
 // Copyright 2026 The Binius Developers
 
-use std::iter;
+use std::{borrow::Cow, iter};
 
 use super::{ValueVec, constraint::Operand};
 use crate::{
 	ConstraintSystem, Word,
 	error::{ConstraintSystemError, VerificationM4Error},
 };
+
+/// The chip instances of an M4 witness, addressed by chip ID and row.
+///
+/// [`ConstraintSystemM4::verify`] reads one instance at a time and never holds two, so this is all
+/// it needs of a witness. A witness that stores its instances packed — as the prover's tables do,
+/// one column per instance — can therefore serve them one at a time rather than expanding the whole
+/// witness into value vectors first, which for a system of any size is most of its memory.
+///
+/// Instances are served, not lent, because a packed witness has to build one to hand it over. One
+/// that already holds value vectors lends them and pays nothing.
+pub trait ChipInstances {
+	/// The number of chips the witness covers, which must be the number the system has.
+	fn n_chips(&self) -> usize;
+
+	/// The number of instances of the given chip, which must be at least its active-instance count.
+	fn n_instances(&self, chip_id: usize) -> usize;
+
+	/// The value vector of one instance of one chip.
+	fn instance(&self, chip_id: usize, row: usize) -> Cow<'_, ValueVec>;
+}
+
+impl ChipInstances for [Vec<ValueVec>] {
+	fn n_chips(&self) -> usize {
+		self.len()
+	}
+
+	fn n_instances(&self, chip_id: usize) -> usize {
+		self[chip_id].len()
+	}
+
+	fn instance(&self, chip_id: usize, row: usize) -> Cow<'_, ValueVec> {
+		Cow::Borrowed(&self[chip_id][row])
+	}
+}
 
 /// A constraint system that represents a single chip in a [`ConstraintSystemM4`].
 ///
@@ -157,38 +191,42 @@ impl ConstraintSystemM4 {
 	/// This is the reference the proving protocol's argument is checked against, in the manner of
 	/// [`ConstraintSystem::verify`].
 	///
-	/// Malformed systems are [`Self::validate`]'s to reject; verifying one may panic or
-	/// misreport.
+	/// Instances are read through [`ChipInstances`] one at a time, so a witness that stores them
+	/// packed is never expanded whole. The price is that an instance serving a call is built again
+	/// when the call is checked, having already been built for its own constraints.
+	///
+	/// Malformed systems are [`Self::validate`]'s to reject; verifying one may panic, misreport, or
+	/// pass. In particular a call passing more operands than the callee has inout values — which
+	/// [`Self::validate`] rejects — has the operands past them ignored here.
 	///
 	/// # Errors
 	///
 	/// Reports the first failure found, in the order listed above.
-	pub fn verify(
+	pub fn verify<I: ChipInstances + ?Sized>(
 		&self,
 		main: &ValueVec,
-		chip_instances: &[Vec<ValueVec>],
+		chip_instances: &I,
 	) -> Result<(), VerificationM4Error> {
-		if chip_instances.len() != self.chips.len() {
+		if chip_instances.n_chips() != self.chips.len() {
 			return Err(VerificationM4Error::WrongChipCount {
-				n_witness_chips: chip_instances.len(),
+				n_witness_chips: chip_instances.n_chips(),
 				n_chips: self.chips.len(),
 			});
 		}
 
 		self.main.cs.verify(main)?;
-		for (chip_id, ((chip, n_active), instances)) in
-			iter::zip(&self.chips, chip_instances).enumerate()
-		{
-			if instances.len() < *n_active {
+		for (chip_id, (chip, n_active)) in self.chips.iter().enumerate() {
+			let n_instances = chip_instances.n_instances(chip_id);
+			if n_instances < *n_active {
 				return Err(VerificationM4Error::MissingInstances {
 					chip_id,
-					n_instances: instances.len(),
+					n_instances,
 					n_active: *n_active,
 				});
 			}
-			for (instance, values) in instances.iter().enumerate() {
+			for instance in 0..n_instances {
 				chip.cs
-					.verify(values)
+					.verify(&chip_instances.instance(chip_id, instance))
 					.map_err(|source| VerificationM4Error::ChipInstance {
 						chip_id,
 						instance,
@@ -203,10 +241,11 @@ impl ConstraintSystemM4 {
 		self.check_caller(None, &self.main.chip_calls, main, &mut cursor, chip_instances)?;
 		for (caller_chip, (chip, n_active)) in self.chips.iter().enumerate() {
 			for caller_instance in 0..*n_active {
+				let values = chip_instances.instance(caller_chip, caller_instance);
 				self.check_caller(
 					Some((caller_chip, caller_instance)),
 					&chip.chip_calls,
-					&chip_instances[caller_chip][caller_instance],
+					&values,
 					&mut cursor,
 					chip_instances,
 				)?;
@@ -234,18 +273,14 @@ impl ConstraintSystemM4 {
 	/// `values` is that caller's value vector, which the call operands are evaluated on. A call
 	/// past its chip's active instances is counted but compared to nothing; the caller reports the
 	/// overshoot when the cursors are read back.
-	fn check_caller(
+	fn check_caller<I: ChipInstances + ?Sized>(
 		&self,
 		caller: Option<(usize, usize)>,
 		calls: &[ChipCall],
 		values: &ValueVec,
 		cursor: &mut [usize],
-		chip_instances: &[Vec<ValueVec>],
+		chip_instances: &I,
 	) -> Result<(), VerificationM4Error> {
-		let (caller_chip, caller_instance) = match caller {
-			Some((chip, instance)) => (Some(chip), instance),
-			None => (None, 0),
-		};
 		for (call_index, call) in calls.iter().enumerate() {
 			let chip_id = call.chip_id;
 			let (chip, n_active) = &self.chips[chip_id];
@@ -255,8 +290,11 @@ impl ConstraintSystemM4 {
 				continue;
 			}
 
+			// Only the callee's own inout values are compared. An operand past them is one
+			// `validate` rejects, and nothing here would have a word to compare it to.
 			let n_inout = chip.cs.n_inout;
-			let served = chip_instances[chip_id][row].inout();
+			let instance = chip_instances.instance(chip_id, row);
+			let served = instance.inout();
 			for word in 0..n_inout {
 				let passed = call
 					.inout
@@ -267,8 +305,7 @@ impl ConstraintSystemM4 {
 					return Err(VerificationM4Error::CallMismatch {
 						chip_id,
 						row,
-						caller_chip,
-						caller_instance,
+						caller,
 						call_index,
 						word,
 						passed: passed.as_u64(),
@@ -311,23 +348,27 @@ fn is_acyclic(callees: &[Vec<usize>]) -> bool {
 
 #[cfg(test)]
 mod tests {
+	use proptest::prelude::*;
+
 	use super::{
-		super::{ShiftedValueIndex, ValueIndex, ValueSegment, ValueVecLayout},
+		super::{ShiftedValueIndex, ValueIndex, ValueSegment, ValueVecLayout, ZeroConstraint},
 		*,
 	};
-	use crate::error::OperandFault;
+	use crate::error::{OperandFault, VerificationError};
+
+	/// The value-vector layout every chip in these tests is shaped by.
+	const LAYOUT: ValueVecLayout = ValueVecLayout {
+		n_const: 0,
+		n_inout: 8,
+		n_witness: 8,
+		n_internal: 0,
+		n_scratch: 0,
+	};
 
 	/// A chip that calls each of `callees` once, over a value vector of 8 inout and 8 private
 	/// words.
 	fn chip(callees: &[usize]) -> EmbeddedConstraintSystem {
-		let cs = ValueVecLayout {
-			n_const: 0,
-			n_inout: 8,
-			n_witness: 8,
-			n_internal: 0,
-			n_scratch: 0,
-		}
-		.constraint_system_shape(vec![]);
+		let cs = LAYOUT.constraint_system_shape(vec![]);
 		let chip_calls = callees
 			.iter()
 			.map(|&chip_id| ChipCall {
@@ -336,6 +377,11 @@ mod tests {
 			})
 			.collect();
 		EmbeddedConstraintSystem { cs, chip_calls }
+	}
+
+	/// An all-zero instance of a chip, which satisfies one with no constraints of its own.
+	fn instance() -> ValueVec {
+		ValueVec::new(&LAYOUT)
 	}
 
 	/// A system whose main chip calls each of `main_callees` once, over the given chips.
@@ -429,5 +475,163 @@ mod tests {
 				n_chips: 1,
 			})
 		));
+	}
+
+	// A call passing fewer operands than the callee has inout values constrains the rest to zero,
+	// so an all-zero instance serves a call that passes nothing at all.
+	#[test]
+	fn verify_constrains_the_inout_values_a_call_passes_no_operand_for() {
+		let cs = system(&[0], vec![chip(&[])]);
+		let main = instance();
+		cs.verify(&main, &[vec![instance()]][..]).unwrap();
+
+		// Give the instance a nonzero word where the call passes nothing, and the zero-fill is what
+		// it stops matching.
+		let mut served = instance();
+		served[ValueIndex::inout(3)] = Word::from_u64(0xdead);
+		let err = cs.verify(&main, &[vec![served]][..]).unwrap_err();
+		assert!(
+			matches!(
+				err,
+				VerificationM4Error::CallMismatch {
+					chip_id: 0,
+					row: 0,
+					caller: None,
+					word: 3,
+					passed: 0,
+					served: 0xdead,
+					..
+				}
+			),
+			"{err}"
+		);
+	}
+
+	#[test]
+	fn verify_rejects_a_witness_covering_the_wrong_number_of_chips() {
+		let cs = system(&[0], vec![chip(&[])]);
+		let err = cs.verify(&instance(), &[][..]).unwrap_err();
+		assert!(
+			matches!(
+				err,
+				VerificationM4Error::WrongChipCount {
+					n_witness_chips: 0,
+					n_chips: 1,
+				}
+			),
+			"{err}"
+		);
+	}
+
+	#[test]
+	fn verify_rejects_a_chip_with_fewer_instances_than_active_ones() {
+		let cs = system(&[0], vec![chip(&[])]);
+		let err = cs.verify(&instance(), &[vec![]][..]).unwrap_err();
+		assert!(
+			matches!(
+				err,
+				VerificationM4Error::MissingInstances {
+					chip_id: 0,
+					n_instances: 0,
+					n_active: 1,
+				}
+			),
+			"{err}"
+		);
+	}
+
+	// The call-to-instance map is a bijection, not just an injection: a chip reached by more
+	// invocations than it has active instances has calls that no row answers for.
+	#[test]
+	fn verify_rejects_more_invocations_than_a_chip_has_active_instances() {
+		// Main calls chip 0 twice, but the chip declares one active instance.
+		let cs = system(&[0, 0], vec![chip(&[])]);
+		let err = cs.verify(&instance(), &[vec![instance()]][..]).unwrap_err();
+		assert!(
+			matches!(
+				err,
+				VerificationM4Error::WrongInvocationCount {
+					chip_id: 0,
+					n_invocations: 2,
+					n_active: 1,
+				}
+			),
+			"{err}"
+		);
+	}
+
+	#[test]
+	fn verify_reports_the_instance_whose_own_constraints_fail() {
+		let mut cs = system(&[0], vec![chip(&[])]);
+		// The chip requires its first inout value to vanish, and the padding instance holds a word
+		// that does not. Every instance is committed, so padding is checked like the rest.
+		cs.chips[0]
+			.0
+			.cs
+			.zero_constraints
+			.push(ZeroConstraint::plain([ValueIndex::inout(0)]));
+
+		let mut padding = instance();
+		padding[ValueIndex::inout(0)] = Word::ONE;
+		let err = cs
+			.verify(&instance(), &[vec![instance(), padding]][..])
+			.unwrap_err();
+		assert!(
+			matches!(
+				err,
+				VerificationM4Error::ChipInstance {
+					chip_id: 0,
+					instance: 1,
+					source: VerificationError::Unsatisfied { .. },
+				}
+			),
+			"{err}"
+		);
+	}
+
+	/// Whether the call graph is acyclic, by a three-colour depth-first search.
+	///
+	/// A chip on the stack that is reached again closes a cycle. This is the independent reference
+	/// [`is_acyclic`]'s Kahn's algorithm is checked against.
+	fn acyclic_by_depth_first_search(callees: &[Vec<usize>]) -> bool {
+		#[derive(Clone, Copy, PartialEq)]
+		enum Colour {
+			Unvisited,
+			OnStack,
+			Done,
+		}
+
+		fn visit(chip: usize, callees: &[Vec<usize>], colour: &mut [Colour]) -> bool {
+			match colour[chip] {
+				Colour::OnStack => return false,
+				Colour::Done => return true,
+				Colour::Unvisited => {}
+			}
+			colour[chip] = Colour::OnStack;
+			for &callee in &callees[chip] {
+				if !visit(callee, callees, colour) {
+					return false;
+				}
+			}
+			colour[chip] = Colour::Done;
+			true
+		}
+
+		let mut colour = vec![Colour::Unvisited; callees.len()];
+		(0..callees.len()).all(|chip| visit(chip, callees, &mut colour))
+	}
+
+	proptest! {
+		// Kahn's algorithm and a depth-first search decide acyclicity by unrelated means, so
+		// agreeing on random graphs covers what the cases above are each written for one of:
+		// multi-edges, diamonds, self-loops and components nothing reaches.
+		#[test]
+		fn is_acyclic_agrees_with_a_depth_first_search(
+			graph in (1usize..7).prop_flat_map(|n_chips| {
+				prop::collection::vec(prop::collection::vec(0..n_chips, 0..4), n_chips)
+			})
+		) {
+			prop_assert_eq!(is_acyclic(&graph), acyclic_by_depth_first_search(&graph));
+		}
 	}
 }

--- a/crates/core/src/constraint_system/m4.rs
+++ b/crates/core/src/constraint_system/m4.rs
@@ -1,0 +1,433 @@
+// Copyright 2026 The Binius Developers
+
+use std::iter;
+
+use super::{ValueVec, constraint::Operand};
+use crate::{
+	ConstraintSystem, Word,
+	error::{ConstraintSystemError, VerificationM4Error},
+};
+
+/// A constraint system that represents a single chip in a [`ConstraintSystemM4`].
+///
+/// The [`crate::constraint_system::ShiftedValueIndex`] values in the constraints and in the chip
+/// calls name words of the embedded constraint system's value vector, each index counting within
+/// its own segment. See [`ConstraintSystem`] for the exact layout.
+///
+/// ## Validity criteria
+/// * every operand of every chip call in `chip_calls` references a value of this chip
+///
+/// The `chip_id` of a chip call names a chip of the enclosing system, which this type does not
+/// know; [`ConstraintSystemM4::validate`] is what range-checks it.
+#[derive(Debug, Clone)]
+pub struct EmbeddedConstraintSystem {
+	/// The constraints one instance of the chip must satisfy.
+	pub cs: ConstraintSystem,
+	/// The chips this one delegates subrelations to, one entry per call per instance.
+	pub chip_calls: Vec<ChipCall>,
+}
+
+impl EmbeddedConstraintSystem {
+	/// Checks the constraint system and the chip-call operands over it.
+	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
+		self.cs.validate()?;
+
+		for (call_index, chip_call) in self.chip_calls.iter().enumerate() {
+			for (operand_index, operand) in chip_call.inout.iter().enumerate() {
+				if let Some(source) = self.cs.operand_fault(operand) {
+					return Err(ConstraintSystemError::ChipCallOperand {
+						call_index,
+						operand_index,
+						source,
+					});
+				}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+/// One invocation of a chip by the constraint system holding this call.
+#[derive(Debug, Clone)]
+pub struct ChipCall {
+	/// The ID of the chip being called: its index in [`ConstraintSystemM4::chips`].
+	pub chip_id: usize,
+	/// The words passed as the callee's inout values, positionally, as operands over the caller's
+	/// value vector.
+	///
+	/// There is at most one operand per inout value of the callee; the values past them are
+	/// constrained to zero.
+	pub inout: Vec<Operand>,
+}
+
+/// An M4 constraint system.
+///
+/// An M4 constraint system is essentially defined by the composition of chips, each of which
+/// validates a relation on its local inout values. Chips can delegate subrelation constraints to
+/// other chips via chip calls.
+///
+/// Validity invariants:
+/// - all embedded constraint systems in `chips` must have a chip_id value that indexes into `chips`
+///
+/// [`Self::validate`] accepts any acyclic call graph, but call positions are defined by
+/// enumerating the chips in ID order, and witness generation walks them the same way — so only a
+/// system whose calls run to higher IDs is provable. The frontend's
+/// `CircuitM4::validate` is what enforces that ordering.
+pub struct ConstraintSystemM4 {
+	/// The entry point of the system. It calls chips, but no chip ID names it, so nothing calls
+	/// it.
+	pub main: EmbeddedConstraintSystem,
+	/// The chips, indexed by chip ID, each paired with its number of active instances.
+	///
+	/// A chip runs once per call that reaches it, and those instances are the active ones: only
+	/// they have their own chip calls enforced. The instances past them pad the count and are
+	/// matched by no call.
+	pub chips: Vec<(EmbeddedConstraintSystem, usize)>,
+}
+
+impl ConstraintSystemM4 {
+	/// Checks every chip and every chip call, and rejects call-graph cycles.
+	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
+		let n_chips = self.chips.len();
+
+		self.main.validate()?;
+		self.validate_calls(None, &self.main.chip_calls)?;
+
+		// The chips each chip calls, indexed by the caller's chip ID.
+		let mut callees = vec![Vec::new(); n_chips];
+		for (chip_index, (chip, _)) in self.chips.iter().enumerate() {
+			chip.validate()?;
+			self.validate_calls(Some(chip_index), &chip.chip_calls)?;
+			callees[chip_index].extend(chip.chip_calls.iter().map(|call| call.chip_id));
+		}
+
+		if !is_acyclic(&callees) {
+			return Err(ConstraintSystemError::CyclicChipCalls);
+		}
+
+		Ok(())
+	}
+
+	/// Checks that one caller's calls name existing chips and pass no more operands than the
+	/// callee has inout values.
+	///
+	/// A call may pass fewer: the inout values past its operands are constrained to zero.
+	fn validate_calls(
+		&self,
+		chip_index: Option<usize>,
+		calls: &[ChipCall],
+	) -> Result<(), ConstraintSystemError> {
+		let n_chips = self.chips.len();
+		for (call_index, call) in calls.iter().enumerate() {
+			if call.chip_id >= n_chips {
+				return Err(ConstraintSystemError::OutOfRangeChipId {
+					chip_index,
+					chip_id: call.chip_id,
+					n_chips,
+				});
+			}
+			let n_inout = self.chips[call.chip_id].0.cs.n_inout;
+			if call.inout.len() > n_inout {
+				return Err(ConstraintSystemError::WrongCallArity {
+					chip_index,
+					call_index,
+					chip_id: call.chip_id,
+					arity: call.inout.len(),
+					n_inout,
+				});
+			}
+		}
+		Ok(())
+	}
+
+	/// Checks that a witness satisfies this system.
+	///
+	/// The witness is the main chip's value vector and, per chip, one value vector per instance.
+	/// It must satisfy:
+	///
+	/// - the main chip's constraints, on `main`;
+	/// - each chip's constraints, on every one of its instances — the instances past the active
+	///   ones included, since every instance is committed;
+	/// - every chip call, by the instance at the call's position: counting main's calls first and
+	///   then the calls of each chip's active instances in ID, instance and call order, invocation
+	///   `i` of a chip passes exactly the inout words its instance `i` holds. An inout value the
+	///   call has no operand for must hold zero.
+	///
+	/// This is the reference the proving protocol's argument is checked against, in the manner of
+	/// [`ConstraintSystem::verify`].
+	///
+	/// Malformed systems are [`Self::validate`]'s to reject; verifying one may panic or
+	/// misreport.
+	///
+	/// # Errors
+	///
+	/// Reports the first failure found, in the order listed above.
+	pub fn verify(
+		&self,
+		main: &ValueVec,
+		chip_instances: &[Vec<ValueVec>],
+	) -> Result<(), VerificationM4Error> {
+		if chip_instances.len() != self.chips.len() {
+			return Err(VerificationM4Error::WrongChipCount {
+				n_witness_chips: chip_instances.len(),
+				n_chips: self.chips.len(),
+			});
+		}
+
+		self.main.cs.verify(main)?;
+		for (chip_id, ((chip, n_active), instances)) in
+			iter::zip(&self.chips, chip_instances).enumerate()
+		{
+			if instances.len() < *n_active {
+				return Err(VerificationM4Error::MissingInstances {
+					chip_id,
+					n_instances: instances.len(),
+					n_active: *n_active,
+				});
+			}
+			for (instance, values) in instances.iter().enumerate() {
+				chip.cs
+					.verify(values)
+					.map_err(|source| VerificationM4Error::ChipInstance {
+						chip_id,
+						instance,
+						source,
+					})?;
+			}
+		}
+
+		// The next instance each chip's calls are served by, advanced call by call so that
+		// invocation `i` lands on instance `i`.
+		let mut cursor = vec![0usize; self.chips.len()];
+		self.check_caller(None, &self.main.chip_calls, main, &mut cursor, chip_instances)?;
+		for (caller_chip, (chip, n_active)) in self.chips.iter().enumerate() {
+			for caller_instance in 0..*n_active {
+				self.check_caller(
+					Some((caller_chip, caller_instance)),
+					&chip.chip_calls,
+					&chip_instances[caller_chip][caller_instance],
+					&mut cursor,
+					chip_instances,
+				)?;
+			}
+		}
+
+		for (chip_id, ((_, n_active), &n_invocations)) in
+			iter::zip(&self.chips, &cursor).enumerate()
+		{
+			if n_invocations != *n_active {
+				return Err(VerificationM4Error::WrongInvocationCount {
+					chip_id,
+					n_invocations,
+					n_active: *n_active,
+				});
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Checks one caller's calls against the instances at their positions, advancing the cursors.
+	///
+	/// `caller` names the caller for diagnostics: a chip instance, or `None` for the main chip.
+	/// `values` is that caller's value vector, which the call operands are evaluated on. A call
+	/// past its chip's active instances is counted but compared to nothing; the caller reports the
+	/// overshoot when the cursors are read back.
+	fn check_caller(
+		&self,
+		caller: Option<(usize, usize)>,
+		calls: &[ChipCall],
+		values: &ValueVec,
+		cursor: &mut [usize],
+		chip_instances: &[Vec<ValueVec>],
+	) -> Result<(), VerificationM4Error> {
+		let (caller_chip, caller_instance) = match caller {
+			Some((chip, instance)) => (Some(chip), instance),
+			None => (None, 0),
+		};
+		for (call_index, call) in calls.iter().enumerate() {
+			let chip_id = call.chip_id;
+			let (chip, n_active) = &self.chips[chip_id];
+			let row = cursor[chip_id];
+			cursor[chip_id] += 1;
+			if row >= *n_active {
+				continue;
+			}
+
+			let n_inout = chip.cs.n_inout;
+			let served = chip_instances[chip_id][row].inout();
+			for word in 0..n_inout {
+				let passed = call
+					.inout
+					.get(word)
+					.map(|operand| values.eval_operand(operand))
+					.unwrap_or(Word::ZERO);
+				if served[word] != passed {
+					return Err(VerificationM4Error::CallMismatch {
+						chip_id,
+						row,
+						caller_chip,
+						caller_instance,
+						call_index,
+						word,
+						passed: passed.as_u64(),
+						served: served[word].as_u64(),
+					});
+				}
+			}
+		}
+		Ok(())
+	}
+}
+
+/// Checks that the call graph given by the callee list of each chip is acyclic.
+///
+/// This is Kahn's algorithm: chips with no remaining callers are removed one at a time, and any
+/// chip still left when none remain lies on a cycle. A chip that calls itself is a cycle.
+fn is_acyclic(callees: &[Vec<usize>]) -> bool {
+	let mut n_callers = vec![0usize; callees.len()];
+	for &callee in callees.iter().flatten() {
+		n_callers[callee] += 1;
+	}
+
+	let mut uncalled = (0..callees.len())
+		.filter(|&chip| n_callers[chip] == 0)
+		.collect::<Vec<_>>();
+
+	let mut n_removed = 0;
+	while let Some(chip) = uncalled.pop() {
+		n_removed += 1;
+		for &callee in &callees[chip] {
+			n_callers[callee] -= 1;
+			if n_callers[callee] == 0 {
+				uncalled.push(callee);
+			}
+		}
+	}
+
+	n_removed == callees.len()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		super::{ShiftedValueIndex, ValueIndex, ValueSegment, ValueVecLayout},
+		*,
+	};
+	use crate::error::OperandFault;
+
+	/// A chip that calls each of `callees` once, over a value vector of 8 inout and 8 private
+	/// words.
+	fn chip(callees: &[usize]) -> EmbeddedConstraintSystem {
+		let cs = ValueVecLayout {
+			n_const: 0,
+			n_inout: 8,
+			n_witness: 8,
+			n_internal: 0,
+			n_scratch: 0,
+		}
+		.constraint_system_shape(vec![]);
+		let chip_calls = callees
+			.iter()
+			.map(|&chip_id| ChipCall {
+				chip_id,
+				inout: vec![],
+			})
+			.collect();
+		EmbeddedConstraintSystem { cs, chip_calls }
+	}
+
+	/// A system whose main chip calls each of `main_callees` once, over the given chips.
+	///
+	/// The active-instance counts are not what `validate` checks, so every chip declares one.
+	fn system(main_callees: &[usize], chips: Vec<EmbeddedConstraintSystem>) -> ConstraintSystemM4 {
+		ConstraintSystemM4 {
+			main: chip(main_callees),
+			chips: chips.into_iter().map(|chip| (chip, 1)).collect(),
+		}
+	}
+
+	#[test]
+	fn validate_rejects_a_chip_call_operand_past_its_own_segment() {
+		// Inout index 8 is the word after the chip's eight inout values. Its position in the value
+		// vector is one a private value occupies, so only a per-segment check catches it.
+		let mut cs = system(&[0], vec![chip(&[])]);
+		cs.main.chip_calls[0].inout = vec![vec![ShiftedValueIndex::plain(ValueIndex::inout(8))]];
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::ChipCallOperand {
+				call_index: 0,
+				operand_index: 0,
+				source: OperandFault::OutOfRangeValueIndex {
+					segment: ValueSegment::InOut,
+					value_index: 8,
+					segment_len: 8,
+				},
+			})
+		));
+	}
+
+	#[test]
+	fn validate_rejects_a_call_passing_more_operands_than_the_callee_takes() {
+		// The chips have eight inout values; nine operands leave one with no value to land in.
+		let mut cs = system(&[0], vec![chip(&[])]);
+		cs.main.chip_calls[0].inout = vec![vec![]; 9];
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::WrongCallArity {
+				chip_index: None,
+				call_index: 0,
+				chip_id: 0,
+				arity: 9,
+				n_inout: 8,
+			})
+		));
+	}
+
+	#[test]
+	fn validate_accepts_an_acyclic_call_graph() {
+		// Main calls 0, which calls 1 and 2; 1 calls 2, and 2 is a leaf.
+		let cs = system(&[0], vec![chip(&[1, 2]), chip(&[2]), chip(&[])]);
+		cs.validate().unwrap();
+	}
+
+	#[test]
+	fn validate_rejects_a_chip_that_calls_itself() {
+		let cs = system(&[0], vec![chip(&[0])]);
+		assert!(matches!(cs.validate(), Err(ConstraintSystemError::CyclicChipCalls)));
+	}
+
+	#[test]
+	fn validate_rejects_a_cycle_reachable_from_an_uncalled_chip() {
+		// Chip 0 is called by nobody, so removing it leaves the cycle 1 -> 2 -> 1.
+		let cs = system(&[0], vec![chip(&[1]), chip(&[2]), chip(&[1])]);
+		assert!(matches!(cs.validate(), Err(ConstraintSystemError::CyclicChipCalls)));
+	}
+
+	#[test]
+	fn validate_rejects_a_call_to_a_chip_that_does_not_exist() {
+		let cs = system(&[0], vec![chip(&[0, 7])]);
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::OutOfRangeChipId {
+				chip_index: Some(0),
+				chip_id: 7,
+				n_chips: 1,
+			})
+		));
+	}
+
+	#[test]
+	fn validate_rejects_a_main_call_to_a_chip_that_does_not_exist() {
+		let cs = system(&[7], vec![chip(&[])]);
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::OutOfRangeChipId {
+				chip_index: None,
+				chip_id: 7,
+				n_chips: 1,
+			})
+		));
+	}
+}

--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -1,8 +1,10 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Constraint system and related definitions.
 
 mod constraint;
 mod layout;
+pub mod m4;
 mod proof;
 mod shift;
 mod system;

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -327,56 +327,11 @@ impl ConstraintSystem {
 	) -> Result<(), ConstraintSystemError> {
 		match self.operand_fault(operand) {
 			None => Ok(()),
-			Some(OperandFault::NonCanonicalShift) => {
-				Err(ConstraintSystemError::NonCanonicalShift {
-					constraint_kind,
-					constraint_index,
-					operand_name,
-				})
-			}
-			Some(OperandFault::ShiftAmountTooLarge {
-				shift_amount,
-				max_amount,
-			}) => Err(ConstraintSystemError::ShiftAmountTooLarge {
+			Some(source) => Err(ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
-				shift_amount,
-				max_amount,
-			}),
-			Some(OperandFault::NonCanonicalShiftSequence) => {
-				Err(ConstraintSystemError::NonCanonicalShiftSequence {
-					constraint_kind,
-					constraint_index,
-					operand_name,
-				})
-			}
-			Some(OperandFault::CollapsibleShiftSequence { composition }) => {
-				Err(ConstraintSystemError::CollapsibleShiftSequence {
-					constraint_kind,
-					constraint_index,
-					operand_name,
-					composition,
-				})
-			}
-			Some(OperandFault::ScratchValueIndex) => {
-				Err(ConstraintSystemError::ScratchValueIndex {
-					constraint_kind,
-					constraint_index,
-					operand_name,
-				})
-			}
-			Some(OperandFault::OutOfRangeValueIndex {
-				segment,
-				value_index,
-				segment_len,
-			}) => Err(ConstraintSystemError::OutOfRangeValueIndex {
-				constraint_kind,
-				constraint_index,
-				operand_name,
-				segment,
-				value_index,
-				segment_len,
+				source,
 			}),
 		}
 	}
@@ -386,7 +341,7 @@ impl ConstraintSystem {
 	///
 	/// The fault says nothing about where the operand sits, so a constraint operand and a chip-call
 	/// operand can both report it under their own naming.
-	pub(crate) fn operand_fault(&self, operand: &Operand) -> Option<OperandFault> {
+	pub fn operand_fault(&self, operand: &Operand) -> Option<OperandFault> {
 		operand.iter().find_map(|term| {
 			for shift in term.shift_seq {
 				// check canonicity. SLL is the canonical form of the identity.
@@ -833,8 +788,10 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::ScratchValueIndex {
-				constraint_kind, ..
+			ConstraintSystemError::ConstraintOperand {
+				constraint_kind,
+				source: OperandFault::ScratchValueIndex,
+				..
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
 			}
@@ -855,10 +812,13 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::OutOfRangeValueIndex {
-				segment,
-				value_index,
-				segment_len,
+			ConstraintSystemError::ConstraintOperand {
+				source:
+					OperandFault::OutOfRangeValueIndex {
+						segment,
+						value_index,
+						segment_len,
+					},
 				..
 			} => {
 				assert_eq!(segment, ValueSegment::Constant);
@@ -919,11 +879,15 @@ mod tests {
 			.push(ZeroConstraint::plain([ValueIndex::constant(0), ValueIndex::private(100)]));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::OutOfRangeValueIndex {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				operand_name,
-				value_index,
-				segment_len,
+				source:
+					OperandFault::OutOfRangeValueIndex {
+						value_index,
+						segment_len,
+						..
+					},
 				..
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::Zero);
@@ -973,11 +937,15 @@ mod tests {
 		assert!(result.is_err(), "Should reject constraint with out-of-range index");
 
 		match result.unwrap_err() {
-			ConstraintSystemError::OutOfRangeValueIndex {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				operand_name,
-				value_index,
-				segment_len,
+				source:
+					OperandFault::OutOfRangeValueIndex {
+						value_index,
+						segment_len,
+						..
+					},
 				..
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
@@ -1005,11 +973,15 @@ mod tests {
 		assert!(result.is_err(), "Should reject IMUL constraint with out-of-range index");
 
 		match result.unwrap_err() {
-			ConstraintSystemError::OutOfRangeValueIndex {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				operand_name,
-				value_index,
-				segment_len,
+				source:
+					OperandFault::OutOfRangeValueIndex {
+						value_index,
+						segment_len,
+						..
+					},
 				..
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::Imul);
@@ -1039,11 +1011,15 @@ mod tests {
 		assert!(result.is_err(), "Should reject BMUL constraint with out-of-range index");
 
 		match result.unwrap_err() {
-			ConstraintSystemError::OutOfRangeValueIndex {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				operand_name,
-				value_index,
-				segment_len,
+				source:
+					OperandFault::OutOfRangeValueIndex {
+						value_index,
+						segment_len,
+						..
+					},
 				..
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::Bmul);
@@ -1076,12 +1052,15 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::ShiftAmountTooLarge {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
-				shift_amount,
-				max_amount,
+				source:
+					OperandFault::ShiftAmountTooLarge {
+						shift_amount,
+						max_amount,
+					},
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(constraint_index, 0);
@@ -1116,12 +1095,15 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::ShiftAmountTooLarge {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
-				shift_amount,
-				max_amount,
+				source:
+					OperandFault::ShiftAmountTooLarge {
+						shift_amount,
+						max_amount,
+					},
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(constraint_index, 0);
@@ -1149,10 +1131,11 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::NonCanonicalShiftSequence {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
+				source: OperandFault::NonCanonicalShiftSequence,
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(constraint_index, 0);
@@ -1178,11 +1161,11 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::CollapsibleShiftSequence {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
-				composition,
+				source: OperandFault::CollapsibleShiftSequence { composition },
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(constraint_index, 0);
@@ -1210,11 +1193,11 @@ mod tests {
 		));
 
 		match cs.validate().unwrap_err() {
-			ConstraintSystemError::CollapsibleShiftSequence {
+			ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
-				composition,
+				source: OperandFault::CollapsibleShiftSequence { composition },
 			} => {
 				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(constraint_index, 0);

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -13,7 +13,7 @@ use super::{
 	ValueIndex, ValueSegment, ValueVec, ZeroConstraint,
 };
 use crate::{
-	error::{ConstraintSystemError, VerificationError},
+	error::{ConstraintSystemError, OperandFault, VerificationError},
 	word::Word,
 };
 
@@ -325,25 +325,80 @@ impl ConstraintSystem {
 		constraint_index: usize,
 		operand_name: &'static str,
 	) -> Result<(), ConstraintSystemError> {
-		for term in operand {
+		match self.operand_fault(operand) {
+			None => Ok(()),
+			Some(OperandFault::NonCanonicalShift) => {
+				Err(ConstraintSystemError::NonCanonicalShift {
+					constraint_kind,
+					constraint_index,
+					operand_name,
+				})
+			}
+			Some(OperandFault::ShiftAmountTooLarge {
+				shift_amount,
+				max_amount,
+			}) => Err(ConstraintSystemError::ShiftAmountTooLarge {
+				constraint_kind,
+				constraint_index,
+				operand_name,
+				shift_amount,
+				max_amount,
+			}),
+			Some(OperandFault::NonCanonicalShiftSequence) => {
+				Err(ConstraintSystemError::NonCanonicalShiftSequence {
+					constraint_kind,
+					constraint_index,
+					operand_name,
+				})
+			}
+			Some(OperandFault::CollapsibleShiftSequence { composition }) => {
+				Err(ConstraintSystemError::CollapsibleShiftSequence {
+					constraint_kind,
+					constraint_index,
+					operand_name,
+					composition,
+				})
+			}
+			Some(OperandFault::ScratchValueIndex) => {
+				Err(ConstraintSystemError::ScratchValueIndex {
+					constraint_kind,
+					constraint_index,
+					operand_name,
+				})
+			}
+			Some(OperandFault::OutOfRangeValueIndex {
+				segment,
+				value_index,
+				segment_len,
+			}) => Err(ConstraintSystemError::OutOfRangeValueIndex {
+				constraint_kind,
+				constraint_index,
+				operand_name,
+				segment,
+				value_index,
+				segment_len,
+			}),
+		}
+	}
+
+	/// Returns the first way a term of an operand is malformed, or `None` when every term is
+	/// well-formed.
+	///
+	/// The fault says nothing about where the operand sits, so a constraint operand and a chip-call
+	/// operand can both report it under their own naming.
+	pub(crate) fn operand_fault(&self, operand: &Operand) -> Option<OperandFault> {
+		operand.iter().find_map(|term| {
 			for shift in term.shift_seq {
 				// check canonicity. SLL is the canonical form of the identity.
 				if !shift.is_canonical() {
-					return Err(ConstraintSystemError::NonCanonicalShift {
-						constraint_kind,
-						constraint_index,
-						operand_name,
-					});
+					return Some(OperandFault::NonCanonicalShift);
 				}
 				// Half-word (*32) variants cap at 32, full-width at 64. `Shift::new` and the
 				// deserializer both enforce this, but the fields are public, so a hand-built term
 				// can still carry an amount the variant cannot represent.
 				let max_amount = shift.variant.max_amount();
 				if usize::from(shift.amount) >= max_amount {
-					return Err(ConstraintSystemError::ShiftAmountTooLarge {
-						constraint_kind,
-						constraint_index,
-						operand_name,
+					return Some(OperandFault::ShiftAmountTooLarge {
 						shift_amount: shift.amount as usize,
 						max_amount,
 					});
@@ -353,11 +408,7 @@ impl ConstraintSystem {
 			// Were the outer slot allowed to carry the lone shift, one map would have two
 			// spellings and two terms denoting the same shifted word would not compare equal.
 			if term.is_unshifted() && term.is_doubly_shifted() {
-				return Err(ConstraintSystemError::NonCanonicalShiftSequence {
-					constraint_kind,
-					constraint_index,
-					operand_name,
-				});
+				return Some(OperandFault::NonCanonicalShiftSequence);
 			}
 			// A genuine pair must not collapse. `Single` means the frontend failed to merge two
 			// shifts that compose into one; `Zero` means it emitted a term whose every bit is
@@ -365,39 +416,26 @@ impl ConstraintSystem {
 			if term.is_doubly_shifted() {
 				let composition = Shift::compose(term.inner(), term.outer());
 				if composition != Composition::Pair {
-					return Err(ConstraintSystemError::CollapsibleShiftSequence {
-						constraint_kind,
-						constraint_index,
-						operand_name,
-						composition,
-					});
+					return Some(OperandFault::CollapsibleShiftSequence { composition });
 				}
 			}
 			// Scratch words are uncommitted temporaries of the circuit that produced this system,
 			// so no constraint may name one.
 			let segment = term.value_index.segment();
 			if !segment.is_referenceable() {
-				return Err(ConstraintSystemError::ScratchValueIndex {
-					constraint_kind,
-					constraint_index,
-					operand_name,
-				});
+				return Some(OperandFault::ScratchValueIndex);
 			}
 			// An index is checked against its own segment, so it can only name a declared value.
-			// Padding follows the values of a segment, and no index reaches it.
 			let segment_len = self.segment_len(segment);
 			if term.value_index.index() as usize >= segment_len {
-				return Err(ConstraintSystemError::OutOfRangeValueIndex {
-					constraint_kind,
-					constraint_index,
-					operand_name,
+				return Some(OperandFault::OutOfRangeValueIndex {
 					segment,
 					value_index: term.value_index.index(),
 					segment_len,
 				});
 			}
-		}
-		Ok(())
+			None
+		})
 	}
 
 	/// Returns the number of ZERO constraints in the system.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -90,6 +90,16 @@ pub enum ConstraintSystemError {
 	CyclicChipCalls,
 }
 
+/// Names the chip of an M4 constraint system that a diagnostic is about.
+///
+/// The main chip is not one of the numbered chips, so it has no index.
+fn chip_name(chip_index: Option<usize>) -> String {
+	match chip_index {
+		Some(chip_index) => format!("chip #{chip_index}"),
+		None => "the main chip".to_string(),
+	}
+}
+
 /// The way one term of an operand is malformed, said without naming where the operand sits.
 ///
 /// A diagnostic pairs this with the position of the operand it checked, which differs between a
@@ -115,79 +125,6 @@ pub enum OperandFault {
 		segment: ValueSegment,
 		value_index: u32,
 		segment_len: usize,
-	},
-}
-
-/// Names the chip of an M4 constraint system that a diagnostic is about.
-///
-/// The main chip is not one of the numbered chips, so it has no index.
-fn chip_name(chip_index: Option<usize>) -> String {
-	match chip_index {
-		Some(chip_index) => format!("chip #{chip_index}"),
-		None => "the main chip".to_string(),
-	}
-}
-
-/// Names the chip instance an M4 diagnostic blames a call on.
-///
-/// The main chip runs once, so only a numbered chip's instance is worth naming.
-fn caller_name(chip_index: Option<usize>, instance: usize) -> String {
-	match chip_index {
-		Some(chip_index) => format!("chip #{chip_index} instance #{instance}"),
-		None => "the main chip".to_string(),
-	}
-}
-
-/// Reason a witness fails to satisfy an M4 constraint system.
-///
-/// A witness is the main chip's value vector and one list of instance value vectors per chip.
-/// It must satisfy every chip's local constraints on every instance, and serve every chip call
-/// with the instance at the call's position.
-#[allow(missing_docs)] // errors are self-documenting
-#[derive(Debug, thiserror::Error)]
-pub enum VerificationM4Error {
-	#[error("the witness covers {n_witness_chips} chips, but the system has {n_chips}")]
-	WrongChipCount {
-		n_witness_chips: usize,
-		n_chips: usize,
-	},
-	#[error("the main chip is not satisfied: {0}")]
-	Main(#[from] VerificationError),
-	#[error("chip #{chip_id} instance #{instance} is not satisfied: {source}")]
-	ChipInstance {
-		chip_id: usize,
-		instance: usize,
-		#[source]
-		source: VerificationError,
-	},
-	#[error("chip #{chip_id} has {n_instances} instances, fewer than its {n_active} active ones")]
-	MissingInstances {
-		chip_id: usize,
-		n_instances: usize,
-		n_active: usize,
-	},
-	#[error(
-		"{n_invocations} invocations reach chip #{chip_id}, which has {n_active} active instances"
-	)]
-	WrongInvocationCount {
-		chip_id: usize,
-		n_invocations: usize,
-		n_active: usize,
-	},
-	#[error(
-		"call #{call_index} of {} reaches chip #{chip_id} as invocation #{row}, passing {passed:016x} \
-		 as inout value {word}, but the instance holds {served:016x}",
-		caller_name(*caller_chip, *caller_instance)
-	)]
-	CallMismatch {
-		chip_id: usize,
-		row: usize,
-		caller_chip: Option<usize>,
-		caller_instance: usize,
-		call_index: usize,
-		word: usize,
-		passed: u64,
-		served: u64,
 	},
 }
 
@@ -285,5 +222,68 @@ pub enum VerificationError {
 		constraint_index: usize,
 		/// The relation that failed, carrying the words that failed it.
 		source: ConstraintViolation,
+	},
+}
+
+/// Names the chip instance an M4 diagnostic blames a call on.
+///
+/// The main chip runs once, so only a numbered chip's instance is worth naming.
+fn caller_name(chip_index: Option<usize>, instance: usize) -> String {
+	match chip_index {
+		Some(chip_index) => format!("chip #{chip_index} instance #{instance}"),
+		None => "the main chip".to_string(),
+	}
+}
+
+/// Reason a witness fails to satisfy an M4 constraint system.
+///
+/// A witness is the main chip's value vector and one list of instance value vectors per chip.
+/// It must satisfy every chip's local constraints on every instance, and serve every chip call
+/// with the instance at the call's position.
+#[allow(missing_docs)] // errors are self-documenting
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationM4Error {
+	#[error("the witness covers {n_witness_chips} chips, but the system has {n_chips}")]
+	WrongChipCount {
+		n_witness_chips: usize,
+		n_chips: usize,
+	},
+	#[error("the main chip is not satisfied: {0}")]
+	Main(#[from] VerificationError),
+	#[error("chip #{chip_id} instance #{instance} is not satisfied: {source}")]
+	ChipInstance {
+		chip_id: usize,
+		instance: usize,
+		#[source]
+		source: VerificationError,
+	},
+	#[error("chip #{chip_id} has {n_instances} instances, fewer than its {n_active} active ones")]
+	MissingInstances {
+		chip_id: usize,
+		n_instances: usize,
+		n_active: usize,
+	},
+	#[error(
+		"{n_invocations} invocations reach chip #{chip_id}, which has {n_active} active instances"
+	)]
+	WrongInvocationCount {
+		chip_id: usize,
+		n_invocations: usize,
+		n_active: usize,
+	},
+	#[error(
+		"call #{call_index} of {} reaches chip #{chip_id} as invocation #{row}, passing {passed:016x} \
+		 as inout value {word}, but the instance holds {served:016x}",
+		caller_name(*caller_chip, *caller_instance)
+	)]
+	CallMismatch {
+		chip_id: usize,
+		row: usize,
+		caller_chip: Option<usize>,
+		caller_instance: usize,
+		call_index: usize,
+		word: usize,
+		passed: u64,
+		served: u64,
 	},
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -42,8 +42,8 @@ pub enum ConstraintSystemError {
 		arity: usize,
 		n_inout: usize,
 	},
-	#[error("the chip call graph has a cycle")]
-	CyclicChipCalls,
+	#[error("chip #{chip_index} calls chip {callee}, which is not a later chip")]
+	CallOutOfOrder { chip_index: usize, callee: usize },
 }
 
 /// Names the chip of an M4 system that a diagnostic is about: `chip #3`, or `the main chip`.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -2,65 +2,21 @@
 // Copyright 2026 The Binius Developers
 //! Hosts error definitions for the core crate.
 
+use std::fmt;
+
 use crate::constraint_system::{Composition, ConstraintKind, ValueSegment};
 
 /// Constraint system related error.
 #[allow(missing_docs)] // errors are self-documenting
 #[derive(Debug, thiserror::Error)]
 pub enum ConstraintSystemError {
-	#[error(
-		"{constraint_kind} #{constraint_index} uses non canonical shift in its {operand_name} operand"
-	)]
-	NonCanonicalShift {
+	#[error("{constraint_kind} #{constraint_index} operand {operand_name} is malformed: {source}")]
+	ConstraintOperand {
 		constraint_kind: ConstraintKind,
 		constraint_index: usize,
 		operand_name: &'static str,
-	},
-	#[error(
-		"{constraint_kind} #{constraint_index} puts a lone shift in the outer slot of its {operand_name} operand; the canonical form places it inner"
-	)]
-	NonCanonicalShiftSequence {
-		constraint_kind: ConstraintKind,
-		constraint_index: usize,
-		operand_name: &'static str,
-	},
-	#[error(
-		"{constraint_kind} #{constraint_index} uses a shift pair in its {operand_name} operand that composes to {composition:?} rather than staying a pair"
-	)]
-	CollapsibleShiftSequence {
-		constraint_kind: ConstraintKind,
-		constraint_index: usize,
-		operand_name: &'static str,
-		composition: Composition,
-	},
-	#[error(
-		"{constraint_kind} #{constraint_index} refers to a scratch value in its {operand_name} operand"
-	)]
-	ScratchValueIndex {
-		constraint_kind: ConstraintKind,
-		operand_name: &'static str,
-		constraint_index: usize,
-	},
-	#[error(
-		"{constraint_kind} #{constraint_index} uses shift amount n={shift_amount}>={max_amount} in {operand_name} operand"
-	)]
-	ShiftAmountTooLarge {
-		constraint_kind: ConstraintKind,
-		constraint_index: usize,
-		operand_name: &'static str,
-		shift_amount: usize,
-		max_amount: usize,
-	},
-	#[error(
-		"{constraint_kind} #{constraint_index} refers to out-of-range value index in {operand_name} operand ({segment:?} index {value_index} >= segment length {segment_len})"
-	)]
-	OutOfRangeValueIndex {
-		constraint_kind: ConstraintKind,
-		constraint_index: usize,
-		operand_name: &'static str,
-		segment: ValueSegment,
-		value_index: u32,
-		segment_len: usize,
+		#[source]
+		source: OperandFault,
 	},
 	#[error("chip call #{call_index} has a malformed operand #{operand_index}: {source}")]
 	ChipCallOperand {
@@ -69,7 +25,7 @@ pub enum ConstraintSystemError {
 		#[source]
 		source: OperandFault,
 	},
-	#[error("{} calls chip {chip_id}, but the system has {n_chips} chips", chip_name(*chip_index))]
+	#[error("{} calls chip {chip_id}, but the system has {n_chips} chips", ChipName(*chip_index))]
 	OutOfRangeChipId {
 		chip_index: Option<usize>,
 		chip_id: usize,
@@ -77,7 +33,7 @@ pub enum ConstraintSystemError {
 	},
 	#[error(
 		"{}'s call #{call_index} passes {arity} operands to chip {chip_id}, which has {n_inout} inout values",
-		chip_name(*chip_index)
+		ChipName(*chip_index)
 	)]
 	WrongCallArity {
 		chip_index: Option<usize>,
@@ -90,13 +46,19 @@ pub enum ConstraintSystemError {
 	CyclicChipCalls,
 }
 
-/// Names the chip of an M4 constraint system that a diagnostic is about.
+/// Names the chip of an M4 system that a diagnostic is about: `chip #3`, or `the main chip`.
 ///
-/// The main chip is not one of the numbered chips, so it has no index.
-fn chip_name(chip_index: Option<usize>) -> String {
-	match chip_index {
-		Some(chip_index) => format!("chip #{chip_index}"),
-		None => "the main chip".to_string(),
+/// The main chip is not one of the numbered chips, so it has no index. The frontend's circuit form
+/// numbers its chips the same way, so its diagnostics name them through this too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChipName(pub Option<usize>);
+
+impl fmt::Display for ChipName {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self.0 {
+			Some(chip_index) => write!(f, "chip #{chip_index}"),
+			None => f.write_str("the main chip"),
+		}
 	}
 }
 
@@ -225,13 +187,18 @@ pub enum VerificationError {
 	},
 }
 
-/// Names the chip instance an M4 diagnostic blames a call on.
+/// Names the chip instance an M4 diagnostic blames a call on, by chip index and instance.
 ///
-/// The main chip runs once, so only a numbered chip's instance is worth naming.
-fn caller_name(chip_index: Option<usize>, instance: usize) -> String {
-	match chip_index {
-		Some(chip_index) => format!("chip #{chip_index} instance #{instance}"),
-		None => "the main chip".to_string(),
+/// The main chip runs once, so only a numbered chip's instance is worth naming. Unlike
+/// [`ChipName`], nothing outside this module names a caller, so this stays private to it.
+struct CallerName(Option<(usize, usize)>);
+
+impl fmt::Display for CallerName {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self.0 {
+			Some((chip_index, instance)) => write!(f, "chip #{chip_index} instance #{instance}"),
+			None => f.write_str("the main chip"),
+		}
 	}
 }
 
@@ -274,13 +241,13 @@ pub enum VerificationM4Error {
 	#[error(
 		"call #{call_index} of {} reaches chip #{chip_id} as invocation #{row}, passing {passed:016x} \
 		 as inout value {word}, but the instance holds {served:016x}",
-		caller_name(*caller_chip, *caller_instance)
+		CallerName(*caller)
 	)]
 	CallMismatch {
 		chip_id: usize,
 		row: usize,
-		caller_chip: Option<usize>,
-		caller_instance: usize,
+		/// The calling chip instance, or `None` for the main chip.
+		caller: Option<(usize, usize)>,
 		call_index: usize,
 		word: usize,
 		passed: u64,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -62,6 +62,133 @@ pub enum ConstraintSystemError {
 		value_index: u32,
 		segment_len: usize,
 	},
+	#[error("chip call #{call_index} has a malformed operand #{operand_index}: {source}")]
+	ChipCallOperand {
+		call_index: usize,
+		operand_index: usize,
+		#[source]
+		source: OperandFault,
+	},
+	#[error("{} calls chip {chip_id}, but the system has {n_chips} chips", chip_name(*chip_index))]
+	OutOfRangeChipId {
+		chip_index: Option<usize>,
+		chip_id: usize,
+		n_chips: usize,
+	},
+	#[error(
+		"{}'s call #{call_index} passes {arity} operands to chip {chip_id}, which has {n_inout} inout values",
+		chip_name(*chip_index)
+	)]
+	WrongCallArity {
+		chip_index: Option<usize>,
+		call_index: usize,
+		chip_id: usize,
+		arity: usize,
+		n_inout: usize,
+	},
+	#[error("the chip call graph has a cycle")]
+	CyclicChipCalls,
+}
+
+/// The way one term of an operand is malformed, said without naming where the operand sits.
+///
+/// A diagnostic pairs this with the position of the operand it checked, which differs between a
+/// constraint and a chip call.
+#[allow(missing_docs)] // errors are self-documenting
+#[derive(Debug, thiserror::Error)]
+pub enum OperandFault {
+	#[error("the shift is not canonical")]
+	NonCanonicalShift,
+	#[error("the shift amount n={shift_amount}>={max_amount}")]
+	ShiftAmountTooLarge {
+		shift_amount: usize,
+		max_amount: usize,
+	},
+	#[error("a lone shift sits in the outer slot; the canonical form places it inner")]
+	NonCanonicalShiftSequence,
+	#[error("a shift pair composes to {composition:?} rather than staying a pair")]
+	CollapsibleShiftSequence { composition: Composition },
+	#[error("it refers to a scratch value")]
+	ScratchValueIndex,
+	#[error("it refers to {segment:?} index {value_index} >= segment length {segment_len}")]
+	OutOfRangeValueIndex {
+		segment: ValueSegment,
+		value_index: u32,
+		segment_len: usize,
+	},
+}
+
+/// Names the chip of an M4 constraint system that a diagnostic is about.
+///
+/// The main chip is not one of the numbered chips, so it has no index.
+fn chip_name(chip_index: Option<usize>) -> String {
+	match chip_index {
+		Some(chip_index) => format!("chip #{chip_index}"),
+		None => "the main chip".to_string(),
+	}
+}
+
+/// Names the chip instance an M4 diagnostic blames a call on.
+///
+/// The main chip runs once, so only a numbered chip's instance is worth naming.
+fn caller_name(chip_index: Option<usize>, instance: usize) -> String {
+	match chip_index {
+		Some(chip_index) => format!("chip #{chip_index} instance #{instance}"),
+		None => "the main chip".to_string(),
+	}
+}
+
+/// Reason a witness fails to satisfy an M4 constraint system.
+///
+/// A witness is the main chip's value vector and one list of instance value vectors per chip.
+/// It must satisfy every chip's local constraints on every instance, and serve every chip call
+/// with the instance at the call's position.
+#[allow(missing_docs)] // errors are self-documenting
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationM4Error {
+	#[error("the witness covers {n_witness_chips} chips, but the system has {n_chips}")]
+	WrongChipCount {
+		n_witness_chips: usize,
+		n_chips: usize,
+	},
+	#[error("the main chip is not satisfied: {0}")]
+	Main(#[from] VerificationError),
+	#[error("chip #{chip_id} instance #{instance} is not satisfied: {source}")]
+	ChipInstance {
+		chip_id: usize,
+		instance: usize,
+		#[source]
+		source: VerificationError,
+	},
+	#[error("chip #{chip_id} has {n_instances} instances, fewer than its {n_active} active ones")]
+	MissingInstances {
+		chip_id: usize,
+		n_instances: usize,
+		n_active: usize,
+	},
+	#[error(
+		"{n_invocations} invocations reach chip #{chip_id}, which has {n_active} active instances"
+	)]
+	WrongInvocationCount {
+		chip_id: usize,
+		n_invocations: usize,
+		n_active: usize,
+	},
+	#[error(
+		"call #{call_index} of {} reaches chip #{chip_id} as invocation #{row}, passing {passed:016x} \
+		 as inout value {word}, but the instance holds {served:016x}",
+		caller_name(*caller_chip, *caller_instance)
+	)]
+	CallMismatch {
+		chip_id: usize,
+		row: usize,
+		caller_chip: Option<usize>,
+		caller_instance: usize,
+		call_index: usize,
+		word: usize,
+		passed: u64,
+		served: u64,
+	},
 }
 
 /// The arithmetic by which a single constraint fails on a value vector.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Core datatypes common to prover and verifier of Binius64.
 //!
 //! Most imporantly it hosts the definition of a [`ConstraintSystem`].
@@ -10,5 +11,7 @@ pub mod error;
 pub mod word;
 
 pub use constraint_system::*;
-pub use error::{ConstraintSystemError, ConstraintViolation, VerificationError};
+pub use error::{
+	ConstraintSystemError, ConstraintViolation, VerificationError, VerificationM4Error,
+};
 pub use word::Word;

--- a/crates/frontend/src/chip.rs
+++ b/crates/frontend/src/chip.rs
@@ -28,29 +28,6 @@ pub struct EmbeddedCircuit {
 	pub chip_calls: Vec<ChipCall>,
 }
 
-/// A chip of the system a [`CircuitBuilder`](crate::CircuitBuilder) is building.
-///
-/// [`CircuitBuilder::add_chip`](crate::CircuitBuilder::add_chip) returns one for each chip it
-/// registers, and a call site names its callee by it. Registering further chips never moves a chip
-/// already registered, so a reference stays good for the rest of the build.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct ChipRef(usize);
-
-impl ChipRef {
-	/// Names the chip at the given index of [`CircuitM4::chips`].
-	pub(crate) const fn new(chip_id: usize) -> Self {
-		Self(chip_id)
-	}
-
-	/// Returns the chip's index in [`CircuitM4::chips`], which is what a [`ChipCall`] names it by.
-	///
-	/// Reading the index out is the only direction: a reference cannot be made from one, so every
-	/// reference names a chip that was registered.
-	pub const fn chip_id(self) -> usize {
-		self.0
-	}
-}
-
 /// A circuit composed of chips, as the circuits that generate their witnesses.
 ///
 /// `main` is the entry point: it calls chips, but no chip ID names it, so nothing calls it. The
@@ -200,6 +177,29 @@ impl CircuitM4 {
 				.map(|(chip, n_active)| (lower(chip), *n_active))
 				.collect(),
 		}
+	}
+}
+
+/// A chip of the system a [`CircuitBuilder`](crate::CircuitBuilder) is building.
+///
+/// [`CircuitBuilder::add_chip`](crate::CircuitBuilder::add_chip) returns one for each chip it
+/// registers, and a call site names its callee by it. Registering further chips never moves a chip
+/// already registered, so a reference stays good for the rest of the build.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ChipRef(usize);
+
+impl ChipRef {
+	/// Names the chip at the given index of [`CircuitM4::chips`].
+	pub(crate) const fn new(chip_id: usize) -> Self {
+		Self(chip_id)
+	}
+
+	/// Returns the chip's index in [`CircuitM4::chips`], which is what a [`ChipCall`] names it by.
+	///
+	/// Reading the index out is the only direction: a reference cannot be made from one, so every
+	/// reference names a chip that was registered.
+	pub const fn chip_id(self) -> usize {
+		self.0
 	}
 }
 

--- a/crates/frontend/src/chip.rs
+++ b/crates/frontend/src/chip.rs
@@ -75,11 +75,10 @@ impl CircuitM4 {
 	///   chip is left uncalled, and no count outgrows a `usize`.
 	///
 	/// A system that passes here lowers to one that passes
-	/// [`ConstraintSystemM4::validate`](binius_core::m4::ConstraintSystemM4::validate). That check
-	/// additionally rejects call-graph cycles, which the ordering requirement here already rules
-	/// out, and validates each chip's compiled constraint system, which the compiler is what keeps
-	/// well-formed. Nothing downstream of this therefore has to run the lowered check to know its
-	/// preconditions hold.
+	/// [`ConstraintSystemM4::validate`](binius_core::m4::ConstraintSystemM4::validate), which
+	/// requires the same ordering and additionally validates each chip's compiled constraint
+	/// system — the one thing here the compiler rather than this check keeps well-formed. Nothing
+	/// downstream therefore has to run the lowered check to know its preconditions hold.
 	pub fn validate(&self) -> Result<(), CircuitM4Error> {
 		let n_chips = self.chips.len();
 

--- a/crates/frontend/src/chip.rs
+++ b/crates/frontend/src/chip.rs
@@ -2,7 +2,10 @@
 
 //! Circuits composed out of chips, each generating the witness of one M4 chip.
 
-use binius_core::m4::{ChipCall, ConstraintSystemM4, EmbeddedConstraintSystem};
+use binius_core::{
+	error::{ChipName, OperandFault},
+	m4::{ChipCall, ConstraintSystemM4, EmbeddedConstraintSystem},
+};
 
 use crate::Circuit;
 
@@ -64,32 +67,26 @@ impl CircuitM4 {
 	///
 	/// Specifically checks that:
 	///
-	/// - every chip call names a chip of this system;
+	/// - every chip call names a chip of this system, passes no more operands than that chip has
+	///   inout values, and reads only committed words of its own caller;
 	/// - the chips are in topological order, each calling only chips with a higher ID, so every
 	///   caller of a chip is populated before the chip itself;
-	/// - each chip's declared active-instance count is the number of invocations that reach it, and
-	///   no chip is left uncalled.
+	/// - each chip's declared active-instance count is the number of invocations that reach it, no
+	///   chip is left uncalled, and no count outgrows a `usize`.
+	///
+	/// A system that passes here lowers to one that passes
+	/// [`ConstraintSystemM4::validate`](binius_core::m4::ConstraintSystemM4::validate). That check
+	/// additionally rejects call-graph cycles, which the ordering requirement here already rules
+	/// out, and validates each chip's compiled constraint system, which the compiler is what keeps
+	/// well-formed. Nothing downstream of this therefore has to run the lowered check to know its
+	/// preconditions hold.
 	pub fn validate(&self) -> Result<(), CircuitM4Error> {
 		let n_chips = self.chips.len();
 
-		for call in &self.main.chip_calls {
-			if call.chip_id >= n_chips {
-				return Err(CircuitM4Error::OutOfRangeChipId {
-					chip_index: None,
-					chip_id: call.chip_id,
-					n_chips,
-				});
-			}
-		}
+		self.validate_calls(None, &self.main)?;
 		for (chip_index, (chip, _)) in self.chips.iter().enumerate() {
+			self.validate_calls(Some(chip_index), chip)?;
 			for call in &chip.chip_calls {
-				if call.chip_id >= n_chips {
-					return Err(CircuitM4Error::OutOfRangeChipId {
-						chip_index: Some(chip_index),
-						chip_id: call.chip_id,
-						n_chips,
-					});
-				}
 				if call.chip_id <= chip_index {
 					return Err(CircuitM4Error::CallOutOfOrder {
 						chip_index,
@@ -102,7 +99,7 @@ impl CircuitM4 {
 		// The invocations reaching each chip, counted the way witness generation gathers them. Only
 		// main and lower-numbered chips call a chip, so a single pass in ID order sees every caller
 		// of chip `i` before it reads chip `i`'s own total.
-		let mut n_calls = vec![0; n_chips];
+		let mut n_calls = vec![0usize; n_chips];
 		for call in &self.main.chip_calls {
 			n_calls[call.chip_id] += 1;
 		}
@@ -120,11 +117,70 @@ impl CircuitM4 {
 
 			// Only the active instances of this chip have their calls enforced, so only they
 			// demand an instance of the callee.
+			//
+			// The counts multiply down the call graph — a chain whose every chip calls the next
+			// twice reaches `2^depth` — so a system of a few dozen chips can outgrow a `usize`.
+			// Counting it out unchecked would wrap to a small total that then agrees with a
+			// `recompute_n_active` that wrapped the same way, and the system would go on to be
+			// populated against a count that is not the number of calls.
 			for call in &chip.chip_calls {
-				n_calls[call.chip_id] += n_active;
+				n_calls[call.chip_id] = n_calls[call.chip_id].checked_add(*n_active).ok_or(
+					CircuitM4Error::TooManyInstances {
+						chip_index: call.chip_id,
+					},
+				)?;
 			}
 		}
 
+		Ok(())
+	}
+
+	/// Checks one caller's calls: that each names a chip of this system, passes no more operands
+	/// than that chip has inout values, and reads only committed words of the caller's own value
+	/// vector.
+	///
+	/// A call may pass fewer operands than the callee takes: the inout values past them are
+	/// constrained to zero.
+	fn validate_calls(
+		&self,
+		chip_index: Option<usize>,
+		caller: &EmbeddedCircuit,
+	) -> Result<(), CircuitM4Error> {
+		let n_chips = self.chips.len();
+		let cs = caller.circuit.constraint_system();
+		for (call_index, call) in caller.chip_calls.iter().enumerate() {
+			if call.chip_id >= n_chips {
+				return Err(CircuitM4Error::OutOfRangeChipId {
+					chip_index,
+					chip_id: call.chip_id,
+					n_chips,
+				});
+			}
+			let n_inout = self.chips[call.chip_id]
+				.0
+				.circuit
+				.constraint_system()
+				.n_inout;
+			if call.inout.len() > n_inout {
+				return Err(CircuitM4Error::WrongCallArity {
+					chip_index,
+					call_index,
+					chip_id: call.chip_id,
+					arity: call.inout.len(),
+					n_inout,
+				});
+			}
+			for (operand_index, operand) in call.inout.iter().enumerate() {
+				if let Some(source) = cs.operand_fault(operand) {
+					return Err(CircuitM4Error::CallOperand {
+						chip_index,
+						call_index,
+						operand_index,
+						source,
+					});
+				}
+			}
+		}
 		Ok(())
 	}
 
@@ -136,13 +192,16 @@ impl CircuitM4 {
 	/// This is what [`Self::validate`] checks the declared counts against, so a system whose call
 	/// sites have just been written or rewritten passes it here rather than counting by hand.
 	///
+	/// A count that outgrows a `usize` saturates rather than wrapping, so it stays too large for
+	/// the invocations that reach the chip and [`Self::validate`] reports it.
+	///
 	/// # Panics
 	///
 	/// Panics if a chip call names a chip this system does not have. Chips out of topological
 	/// order are not detected here: a call to a lower ID counts against a total already written
 	/// back, and [`Self::validate`] is what rejects the result.
 	pub fn recompute_n_active(&mut self) {
-		let mut n_calls = vec![0; self.chips.len()];
+		let mut n_calls = vec![0usize; self.chips.len()];
 		for call in &self.main.chip_calls {
 			n_calls[call.chip_id] += 1;
 		}
@@ -155,7 +214,7 @@ impl CircuitM4 {
 			// Only the active instances of this chip have their calls enforced, so only they
 			// demand an instance of the callee.
 			for call in &self.chips[chip_index].0.chip_calls {
-				n_calls[call.chip_id] += n_active;
+				n_calls[call.chip_id] = n_calls[call.chip_id].saturating_add(n_active);
 			}
 		}
 	}
@@ -203,25 +262,37 @@ impl ChipRef {
 	}
 }
 
-/// Names the circuit of an M4 system that a diagnostic is about.
-///
-/// The main circuit is not one of the numbered chips, so it has no index.
-fn circuit_name(chip_index: Option<usize>) -> String {
-	match chip_index {
-		Some(chip_index) => format!("chip #{chip_index}"),
-		None => "the main circuit".to_string(),
-	}
-}
-
 /// Reason an M4 circuit cannot be populated as it stands.
 #[allow(missing_docs)] // errors are self-documenting
 #[derive(Debug, thiserror::Error)]
 pub enum CircuitM4Error {
-	#[error("{} calls chip {chip_id}, but the system has {n_chips} chips", circuit_name(*chip_index))]
+	#[error("{} calls chip {chip_id}, but the system has {n_chips} chips", ChipName(*chip_index))]
 	OutOfRangeChipId {
 		chip_index: Option<usize>,
 		chip_id: usize,
 		n_chips: usize,
+	},
+	#[error(
+		"{}'s call #{call_index} passes {arity} operands to chip {chip_id}, which has {n_inout} inout values",
+		ChipName(*chip_index)
+	)]
+	WrongCallArity {
+		chip_index: Option<usize>,
+		call_index: usize,
+		chip_id: usize,
+		arity: usize,
+		n_inout: usize,
+	},
+	#[error(
+		"{}'s call #{call_index} has a malformed operand #{operand_index}: {source}",
+		ChipName(*chip_index)
+	)]
+	CallOperand {
+		chip_index: Option<usize>,
+		call_index: usize,
+		operand_index: usize,
+		#[source]
+		source: OperandFault,
 	},
 	#[error("chip #{chip_index} calls chip {callee}, which is not a later chip")]
 	CallOutOfOrder { chip_index: usize, callee: usize },
@@ -233,4 +304,6 @@ pub enum CircuitM4Error {
 	},
 	#[error("chip #{chip_index} is never called")]
 	NeverCalled { chip_index: usize },
+	#[error("more invocations reach chip #{chip_index} than a usize can count")]
+	TooManyInstances { chip_index: usize },
 }

--- a/crates/frontend/src/chip.rs
+++ b/crates/frontend/src/chip.rs
@@ -1,0 +1,236 @@
+// Copyright 2026 The Binius Developers
+
+//! Circuits composed out of chips, each generating the witness of one M4 chip.
+
+use binius_core::m4::{ChipCall, ConstraintSystemM4, EmbeddedConstraintSystem};
+
+use crate::Circuit;
+
+/// One chip of a [`CircuitM4`], as the circuit that generates its witness.
+///
+/// The chip's interface is its circuit's inout segment: a call site supplies those words
+/// positionally, and every value the chip holds beyond them is derived from them. An inout wire the
+/// call does not reach is filled with zero.
+///
+/// A wire promoted with [`CircuitBuilder::mark_inout`](crate::CircuitBuilder::mark_inout) serves
+/// as well as one declared with [`CircuitBuilder::add_inout`](crate::CircuitBuilder::add_inout).
+/// Witness generation assigns every inout wire from the call data, then evaluation recomputes the
+/// promoted ones over it. Nothing checks that the two agree, and nothing has to: where they
+/// disagree the row stops matching the call site, which is what the chip call itself enforces.
+///
+/// That is what lets a caller pass a chip's output. The caller is populated whole before its calls
+/// are read, so it holds the output already — generally from a hint, whose correctness the chip
+/// call is what constrains.
+pub struct EmbeddedCircuit {
+	/// The circuit generating one instance of the chip.
+	pub circuit: Circuit,
+	/// The chips this one delegates subrelations to, one entry per call per instance.
+	pub chip_calls: Vec<ChipCall>,
+}
+
+/// A chip of the system a [`CircuitBuilder`](crate::CircuitBuilder) is building.
+///
+/// [`CircuitBuilder::add_chip`](crate::CircuitBuilder::add_chip) returns one for each chip it
+/// registers, and a call site names its callee by it. Registering further chips never moves a chip
+/// already registered, so a reference stays good for the rest of the build.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ChipRef(usize);
+
+impl ChipRef {
+	/// Names the chip at the given index of [`CircuitM4::chips`].
+	pub(crate) const fn new(chip_id: usize) -> Self {
+		Self(chip_id)
+	}
+
+	/// Returns the chip's index in [`CircuitM4::chips`], which is what a [`ChipCall`] names it by.
+	///
+	/// Reading the index out is the only direction: a reference cannot be made from one, so every
+	/// reference names a chip that was registered.
+	pub const fn chip_id(self) -> usize {
+		self.0
+	}
+}
+
+/// A circuit composed of chips, as the circuits that generate their witnesses.
+///
+/// `main` is the entry point: it calls chips, but no chip ID names it, so nothing calls it. The
+/// chips have an ID equal to their index in `chips`.
+pub struct CircuitM4 {
+	/// The entry point, which runs once.
+	pub main: EmbeddedCircuit,
+	/// The chips, indexed by chip ID, each paired with its number of active instances.
+	///
+	/// A chip runs once per call that reaches it, and those instances are the active ones: only
+	/// they have their own chip calls enforced. The instances past them pad the count up to a
+	/// power of two.
+	///
+	/// The count is denormalized — it says what the call graph already says, and
+	/// [`Self::recompute_n_active`] derives it. [`Self::validate`] holds the two to each other.
+	pub chips: Vec<(EmbeddedCircuit, usize)>,
+}
+
+impl From<Circuit> for CircuitM4 {
+	/// Makes a circuit the whole system, as a main that calls no chips.
+	fn from(circuit: Circuit) -> Self {
+		Self {
+			main: EmbeddedCircuit {
+				circuit,
+				chip_calls: Vec::new(),
+			},
+			chips: Vec::new(),
+		}
+	}
+}
+
+impl CircuitM4 {
+	/// Checks that this system can be populated in one pass over the chips, in ID order.
+	///
+	/// Specifically checks that:
+	///
+	/// - every chip call names a chip of this system;
+	/// - the chips are in topological order, each calling only chips with a higher ID, so every
+	///   caller of a chip is populated before the chip itself;
+	/// - each chip's declared active-instance count is the number of invocations that reach it, and
+	///   no chip is left uncalled.
+	pub fn validate(&self) -> Result<(), CircuitM4Error> {
+		let n_chips = self.chips.len();
+
+		for call in &self.main.chip_calls {
+			if call.chip_id >= n_chips {
+				return Err(CircuitM4Error::OutOfRangeChipId {
+					chip_index: None,
+					chip_id: call.chip_id,
+					n_chips,
+				});
+			}
+		}
+		for (chip_index, (chip, _)) in self.chips.iter().enumerate() {
+			for call in &chip.chip_calls {
+				if call.chip_id >= n_chips {
+					return Err(CircuitM4Error::OutOfRangeChipId {
+						chip_index: Some(chip_index),
+						chip_id: call.chip_id,
+						n_chips,
+					});
+				}
+				if call.chip_id <= chip_index {
+					return Err(CircuitM4Error::CallOutOfOrder {
+						chip_index,
+						callee: call.chip_id,
+					});
+				}
+			}
+		}
+
+		// The invocations reaching each chip, counted the way witness generation gathers them. Only
+		// main and lower-numbered chips call a chip, so a single pass in ID order sees every caller
+		// of chip `i` before it reads chip `i`'s own total.
+		let mut n_calls = vec![0; n_chips];
+		for call in &self.main.chip_calls {
+			n_calls[call.chip_id] += 1;
+		}
+		for (chip_index, (chip, n_active)) in self.chips.iter().enumerate() {
+			if n_calls[chip_index] != *n_active {
+				return Err(CircuitM4Error::WrongActiveInstanceCount {
+					chip_index,
+					declared: *n_active,
+					actual: n_calls[chip_index],
+				});
+			}
+			if *n_active == 0 {
+				return Err(CircuitM4Error::NeverCalled { chip_index });
+			}
+
+			// Only the active instances of this chip have their calls enforced, so only they
+			// demand an instance of the callee.
+			for call in &chip.chip_calls {
+				n_calls[call.chip_id] += n_active;
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Sets each chip's active-instance count to the number of invocations that reach it.
+	///
+	/// A chip is invoked once per call site naming it, per active instance of the caller. Main runs
+	/// once, so each of its call sites counts for one.
+	///
+	/// This is what [`Self::validate`] checks the declared counts against, so a system whose call
+	/// sites have just been written or rewritten passes it here rather than counting by hand.
+	///
+	/// # Panics
+	///
+	/// Panics if a chip call names a chip this system does not have. Chips out of topological
+	/// order are not detected here: a call to a lower ID counts against a total already written
+	/// back, and [`Self::validate`] is what rejects the result.
+	pub fn recompute_n_active(&mut self) {
+		let mut n_calls = vec![0; self.chips.len()];
+		for call in &self.main.chip_calls {
+			n_calls[call.chip_id] += 1;
+		}
+		// Only main and lower-numbered chips call a chip, so one pass in ID order settles chip
+		// `i`'s own total before reading it.
+		for chip_index in 0..self.chips.len() {
+			let n_active = n_calls[chip_index];
+			self.chips[chip_index].1 = n_active;
+
+			// Only the active instances of this chip have their calls enforced, so only they
+			// demand an instance of the callee.
+			for call in &self.chips[chip_index].0.chip_calls {
+				n_calls[call.chip_id] += n_active;
+			}
+		}
+	}
+
+	/// Lowers this system to the constraint-system form the proving protocol consumes.
+	///
+	/// Each circuit contributes its compiled constraint system; the chip calls and the
+	/// active-instance counts carry over unchanged.
+	pub fn to_constraint_system(&self) -> ConstraintSystemM4 {
+		let lower = |chip: &EmbeddedCircuit| EmbeddedConstraintSystem {
+			cs: chip.circuit.constraint_system().clone(),
+			chip_calls: chip.chip_calls.clone(),
+		};
+		ConstraintSystemM4 {
+			main: lower(&self.main),
+			chips: self
+				.chips
+				.iter()
+				.map(|(chip, n_active)| (lower(chip), *n_active))
+				.collect(),
+		}
+	}
+}
+
+/// Names the circuit of an M4 system that a diagnostic is about.
+///
+/// The main circuit is not one of the numbered chips, so it has no index.
+fn circuit_name(chip_index: Option<usize>) -> String {
+	match chip_index {
+		Some(chip_index) => format!("chip #{chip_index}"),
+		None => "the main circuit".to_string(),
+	}
+}
+
+/// Reason an M4 circuit cannot be populated as it stands.
+#[allow(missing_docs)] // errors are self-documenting
+#[derive(Debug, thiserror::Error)]
+pub enum CircuitM4Error {
+	#[error("{} calls chip {chip_id}, but the system has {n_chips} chips", circuit_name(*chip_index))]
+	OutOfRangeChipId {
+		chip_index: Option<usize>,
+		chip_id: usize,
+		n_chips: usize,
+	},
+	#[error("chip #{chip_index} calls chip {callee}, which is not a later chip")]
+	CallOutOfOrder { chip_index: usize, callee: usize },
+	#[error("chip #{chip_index} declares {declared} active instances, but {actual} calls reach it")]
+	WrongActiveInstanceCount {
+		chip_index: usize,
+		declared: usize,
+		actual: usize,
+	},
+	#[error("chip #{chip_index} is never called")]
+	NeverCalled { chip_index: usize },
+}

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -149,6 +149,7 @@ pub struct Circuit {
 	constraint_system: ConstraintSystem,
 	value_vec_layout: ValueVecLayout,
 	wire_mapping: SecondaryMap<Wire, ValueIndex>,
+	inout: Vec<Wire>,
 	eval_form: EvalForm,
 	scratch_peak_live: usize,
 }
@@ -161,6 +162,7 @@ impl Circuit {
 		constraint_system: ConstraintSystem,
 		value_vec_layout: ValueVecLayout,
 		wire_mapping: SecondaryMap<Wire, ValueIndex>,
+		inout: Vec<Wire>,
 		eval_form: EvalForm,
 		scratch_peak_live: usize,
 	) -> Self {
@@ -169,9 +171,24 @@ impl Circuit {
 			constraint_system,
 			value_vec_layout,
 			wire_mapping,
+			inout,
 			eval_form,
 			scratch_peak_live,
 		}
+	}
+
+	/// Returns the wires forming the circuit's public interface, in inout segment order.
+	///
+	/// Inout value `i` of the value vector is the word wire `inout()[i]` holds, so this is the
+	/// reverse of [`Self::witness_index`] over that segment. A caller assembling the positional
+	/// public-input vector a verifier takes reads it straight off this slice.
+	///
+	/// The segment is ordered by wire creation, so a wire promoted with
+	/// [`CircuitBuilder::mark_inout`](super::CircuitBuilder::mark_inout) follows the declared inout
+	/// wires only if its gate created it later; among promotions the order is the one their gates
+	/// ran in, not the order they were promoted in.
+	pub fn inout(&self) -> &[Wire] {
+		&self.inout
 	}
 
 	/// Returns the smallest scratch segment this circuit could run with.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -2,22 +2,27 @@
 // Copyright 2025 Irreducible Inc.
 use std::{
 	cell::{RefCell, RefMut},
+	iter, mem,
 	rc::Rc,
 };
 
 use binius_core::{
-	constraint_system::{ConstraintSystem, ShiftVariant, ValueSegment},
+	constraint_system::{ConstraintSystem, ShiftVariant, ShiftedValueIndex, ValueSegment},
+	m4::ChipCall,
 	word::Word,
 };
 use cranelift_entity::EntitySet;
 use itertools::chain;
 
-use crate::compiler::{
-	circuit::Circuit,
-	constraint_builder::ConstraintBuilder,
-	gate_graph::{GateGraph, WireKind},
-	hints::{Hint, HintRegistry},
-	pathspec::PathSpec,
+use crate::{
+	chip::{ChipRef, CircuitM4, EmbeddedCircuit},
+	compiler::{
+		circuit::Circuit,
+		constraint_builder::ConstraintBuilder,
+		gate_graph::{GateGraph, WireKind},
+		hints::{Hint, HintRegistry},
+		pathspec::PathSpec,
+	},
 };
 
 mod gate;
@@ -95,6 +100,19 @@ pub(crate) struct Shared {
 	pub(crate) opts: Options,
 	pub(crate) force_committed: EntitySet<Wire>,
 	pub(crate) hint_registry: HintRegistry,
+	/// The chips registered on the builder, indexed by chip ID.
+	pub(crate) chips: Vec<EmbeddedCircuit>,
+	/// The calls the built circuit makes, in the order they were emitted.
+	pub(crate) chip_calls: Vec<PendingCall>,
+}
+
+/// A chip call named by the wires it passes, before the build assigns them value indices.
+///
+/// A [`ChipCall`] reads its words out of the value vector, and which word a wire holds is only
+/// settled once the circuit is built.
+pub(crate) struct PendingCall {
+	chip: ChipRef,
+	inout: Vec<Wire>,
 }
 
 /// Circuit builder for constructing zero-knowledge proof circuits.
@@ -208,8 +226,90 @@ impl CircuitBuilder {
 				opts,
 				force_committed: EntitySet::new(),
 				hint_registry: HintRegistry::new(),
+				chips: Vec::new(),
+				chip_calls: Vec::new(),
 			}))),
 		}
+	}
+
+	/// Registers a chip the built circuit can delegate subrelations to, and returns a reference
+	/// naming it.
+	///
+	/// The registered system is flattened into the builder's own: its main circuit becomes the
+	/// chip the returned reference names, and the chips it calls follow, with the IDs inside it
+	/// shifted to their new slots. Each system occupies one contiguous run of IDs and calls only
+	/// into its own run, so the chips stay in the topological order [`CircuitM4::validate`]
+	/// requires.
+	///
+	/// The registered system's active-instance counts are dropped. They say how often its own main
+	/// reached each chip, which says nothing about how often this circuit will;
+	/// [`Self::build_m4`] recounts the whole graph.
+	///
+	/// Only [`Self::build_m4`] returns the registered chips; [`Self::build`] rejects a builder
+	/// carrying any.
+	pub fn add_chip(&self, chip: CircuitM4) -> ChipRef {
+		let mut shared = self.shared.borrow_mut();
+		let chips = &mut shared
+			.as_mut()
+			.expect("CircuitBuilder used after build")
+			.chips;
+
+		let chip_id = chips.len();
+		// The system's main takes the next slot and its own chips follow it, so an ID naming its
+		// chip `i` now names the slot one past main's.
+		let offset = chip_id + 1;
+		let CircuitM4 {
+			main,
+			chips: nested,
+		} = chip;
+		chips.extend(
+			iter::once(main)
+				.chain(nested.into_iter().map(|(embedded, _)| embedded))
+				.map(|mut embedded| {
+					for call in &mut embedded.chip_calls {
+						call.chip_id += offset;
+					}
+					embedded
+				}),
+		);
+		ChipRef::new(chip_id)
+	}
+
+	/// Calls a registered chip, passing the given wires as the inout words of one invocation.
+	///
+	/// The chip gains an instance serving this call, and that instance's inout values are these
+	/// wires' words. The chip's own constraints are what relate them, so this is how a circuit
+	/// delegates a relation rather than constraining it inline.
+	///
+	/// A chip does not say which of its inout words are inputs and which are outputs; a call
+	/// constrains them all alike. The expected shape computes the outputs from the inputs with a
+	/// hint and passes both: the hint hands the witness its values, and the call is the
+	/// constraint that makes them correct.
+	///
+	/// The build treats a call as a constraint on the words it names. Each wire passed takes a
+	/// committed word of the value vector, and the gate defining it stays live however little
+	/// else reads it. A call names words rather than expressions, though, so a linear argument
+	/// such as `a ^ b` is committed together with the ZERO constraint defining it, where a
+	/// constraint operand would have fused it in for free.
+	///
+	/// The wires are matched positionally against the callee's
+	/// [`Circuit::inout`](Circuit::inout), so they are given in that order and there is one per
+	/// inout word.
+	///
+	/// # Panics
+	///
+	/// Panics if the wire count differs from the callee's inout word count.
+	pub fn call_chip(&self, chip: ChipRef, inout: &[Wire]) {
+		let mut shared = self.shared.borrow_mut();
+		let shared = shared.as_mut().expect("CircuitBuilder used after build");
+
+		let n_inout = shared.chips[chip.chip_id()].circuit.inout().len();
+		assert_eq!(inout.len(), n_inout, "chip #{} takes {n_inout} inout words", chip.chip_id());
+
+		shared.chip_calls.push(PendingCall {
+			chip,
+			inout: inout.to_vec(),
+		});
 	}
 
 	/// Returns the circuit built by this builder.
@@ -219,14 +319,81 @@ impl CircuitBuilder {
 	///
 	/// # Preconditions
 	///
-	/// Must be called only once.
+	/// Must be called only once, on a builder with no chip registered by [`Self::add_chip`].
 	pub fn build(&self) -> Circuit {
-		let shared = self.shared.borrow_mut().take();
+		let shared = self.take_shared();
+		assert!(
+			shared.chips.is_empty(),
+			"a builder carrying chips builds with CircuitBuilder::build_m4"
+		);
+		Self::compile(shared, &[])
+	}
 
+	/// Returns the chip-composed circuit built by this builder.
+	///
+	/// The built circuit is the main one, over the chips registered with [`Self::add_chip`] and
+	/// making the calls emitted by [`Self::call_chip`]. Each call's wires resolve to the value
+	/// indices the build assigned them, and each chip's active-instance count is counted off the
+	/// resulting call graph.
+	///
+	/// # Preconditions
+	///
+	/// Must be called only once.
+	pub fn build_m4(&self) -> CircuitM4 {
+		let mut shared = self.take_shared();
+		let chips = mem::take(&mut shared.chips);
+		let pending = mem::take(&mut shared.chip_calls);
+		let circuit = Self::compile(shared, &pending);
+
+		let chip_calls = pending
+			.into_iter()
+			.map(|call| ChipCall {
+				chip_id: call.chip.chip_id(),
+				inout: call
+					.inout
+					.iter()
+					.map(|&wire| vec![ShiftedValueIndex::plain(circuit.witness_index(wire))])
+					.collect(),
+			})
+			.collect();
+
+		let mut circuit = CircuitM4 {
+			main: EmbeddedCircuit {
+				circuit,
+				chip_calls,
+			},
+			chips: chips.into_iter().map(|chip| (chip, 0)).collect(),
+		};
+		circuit.recompute_n_active();
+		circuit
+	}
+
+	/// Takes the builder's state, leaving it spent.
+	///
+	/// # Panics
+	///
+	/// Panics if the state was already taken, which is what makes building a one-shot operation.
+	fn take_shared(&self) -> Shared {
+		let shared = self.shared.borrow_mut().take();
 		let Some(shared) = shared else {
 			panic!("CircuitBuilder::build called twice");
 		};
+		shared
+	}
+
+	/// Compiles the builder's state into a circuit, running every optimization pass it enables.
+	fn compile(shared: Shared, chip_calls: &[PendingCall]) -> Circuit {
 		let mut graph = shared.graph;
+
+		// A chip call is a constraint on the words its wires hold, but the compiler passes have
+		// no notion of a call. Folding its wires into the pinned set gives them the treatment a
+		// constraint's wires get: dead-code elimination keeps the gates defining them,
+		// common-subexpression elimination keeps them distinct, and gate fusion keeps a linear
+		// definition committed rather than inlining it away.
+		let mut pinned = shared.force_committed;
+		for wire in chip_calls.iter().flat_map(|call| &call.inout) {
+			pinned.insert(*wire);
+		}
 
 		// The all-one wire is seeded as the first constant when the graph is constructed.
 		let all_one = graph.all_one;
@@ -241,7 +408,7 @@ impl CircuitBuilder {
 		// Zero propagation: drop the gates a zero operand turns into the identity.
 		// This runs before the dead-code pass, which is what removes the gates it strands.
 		if shared.opts.enable_zero_propagation {
-			zero_fold::zero_propagation(&mut graph, &shared.force_committed, &shared.hint_registry);
+			zero_fold::zero_propagation(&mut graph, &pinned, &shared.hint_registry);
 		}
 
 		// Common-subexpression elimination: collapse structurally-identical gates.
@@ -249,7 +416,7 @@ impl CircuitBuilder {
 		let dead_gates = shared
 			.opts
 			.enable_common_subexpression_elimination
-			.then(|| cse::dedup_gates(&mut graph, &shared.force_committed, &shared.hint_registry));
+			.then(|| cse::dedup_gates(&mut graph, &pinned, &shared.hint_registry));
 
 		// Dead-code elimination: the gates that can affect the constraint system.
 		// A gate outside this set emits no constraint and no committed wire, so it is skipped
@@ -257,7 +424,7 @@ impl CircuitBuilder {
 		let live_gates = shared
 			.opts
 			.enable_dead_code_elimination
-			.then(|| dce::live_gates(&mut graph, &shared.force_committed, &shared.hint_registry));
+			.then(|| dce::live_gates(&mut graph, &pinned, &shared.hint_registry));
 
 		let mut builder = ConstraintBuilder::new();
 		for (gate_id, _) in graph.gates.iter() {
@@ -278,10 +445,17 @@ impl CircuitBuilder {
 
 		// Perform fusion if the corresponding feature flag is turned on.
 		if shared.opts.enable_gate_fusion {
-			gate_fusion::run_pass(&mut builder, &shared.force_committed);
+			gate_fusion::run_pass(&mut builder, &pinned);
 		}
 
-		let constrained_wires = builder.mark_used_wires();
+		let mut constrained_wires = builder.mark_used_wires();
+
+		// A chip call reads its words out of the value vector just as a constraint operand does,
+		// so the wires it names are committed on the same footing. This is what commits a hint
+		// output: no constraint defines it, and constraining it is the call's purpose.
+		for wire in chip_calls.iter().flat_map(|call| &call.inout) {
+			constrained_wires.insert(*wire);
+		}
 
 		// Collect the values no constraint operand mentions.
 		//
@@ -315,6 +489,7 @@ impl CircuitBuilder {
 			wire_mapping,
 			value_vec_layout,
 			constants,
+			inout,
 		} = {
 			let mut value_vec_alloc = value_vec_alloc::Alloc::new(scratch_alloc.n_slots());
 			for (wire, kind) in graph.wires.iter() {
@@ -398,6 +573,7 @@ impl CircuitBuilder {
 			cs,
 			value_vec_layout,
 			wire_mapping,
+			inout,
 			eval_form,
 			scratch_alloc.peak_live(),
 		)

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -95,6 +95,15 @@ impl Default for Options {
 	}
 }
 
+/// A chip call named by the wires it passes, before the build assigns them value indices.
+///
+/// A [`ChipCall`] reads its words out of the value vector, and which word a wire holds is only
+/// settled once the circuit is built.
+pub(crate) struct PendingCall {
+	chip: ChipRef,
+	inout: Vec<Wire>,
+}
+
 pub(crate) struct Shared {
 	pub(crate) graph: GateGraph,
 	pub(crate) opts: Options,
@@ -104,15 +113,6 @@ pub(crate) struct Shared {
 	pub(crate) chips: Vec<EmbeddedCircuit>,
 	/// The calls the built circuit makes, in the order they were emitted.
 	pub(crate) chip_calls: Vec<PendingCall>,
-}
-
-/// A chip call named by the wires it passes, before the build assigns them value indices.
-///
-/// A [`ChipCall`] reads its words out of the value vector, and which word a wire holds is only
-/// settled once the circuit is built.
-pub(crate) struct PendingCall {
-	chip: ChipRef,
-	inout: Vec<Wire>,
 }
 
 /// Circuit builder for constructing zero-knowledge proof circuits.

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -1091,3 +1091,171 @@ fn mark_inout_wire_is_derived_by_population() {
 		);
 	}
 }
+
+// `inout()` is the reverse of `witness_index` over the inout segment, so it must agree with it
+// position by position. The segment is ordered by wire creation, which for a promoted wire is when
+// its gate ran rather than when it was promoted: `and` is created before `xor` is promoted, yet
+// follows it here.
+#[test]
+fn inout_lists_the_public_wires_in_segment_order() {
+	let builder = CircuitBuilder::new();
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let xor = builder.bxor(a, b);
+	let and = builder.band(xor, a);
+	builder.mark_inout(and);
+	builder.mark_inout(xor);
+	let circuit = builder.build();
+
+	assert_eq!(circuit.inout(), [a, b, xor, and]);
+	for (index, &wire) in circuit.inout().iter().enumerate() {
+		assert_eq!(circuit.witness_index(wire), ValueIndex::inout(index as u32));
+	}
+}
+
+/// A chip taking no inout words, as a whole system of its own.
+fn empty_chip() -> CircuitM4 {
+	CircuitM4::from(CircuitBuilder::new().build())
+}
+
+/// A one-chip system, as a leaf chip a main circuit calls once.
+fn leaf_caller() -> CircuitM4 {
+	let builder = CircuitBuilder::new();
+	let chip = builder.add_chip(empty_chip());
+	builder.call_chip(chip, &[]);
+	builder.build_m4()
+}
+
+// Registering a system splices its chips in behind its main, so the IDs inside it have to move
+// with them. Nesting two levels puts a call at every depth: main's calls to the two systems, each
+// outer main's call to its own leaf.
+//
+// Calling one system twice and the other once also separates the counts the registered systems
+// declared, where each leaf served one call, from the counts here.
+#[test]
+fn add_chip_remaps_the_ids_of_a_nested_system() {
+	let builder = CircuitBuilder::new();
+	let twice = builder.add_chip(leaf_caller());
+	let once = builder.add_chip(leaf_caller());
+	for chip in [twice, twice, once] {
+		builder.call_chip(chip, &[]);
+	}
+	let circuit = builder.build_m4();
+
+	// Each system takes two slots, its main then its leaf, and its call names the leaf's new slot.
+	assert_eq!((twice.chip_id(), once.chip_id()), (0, 2));
+	let callees = |(chip, _): &(EmbeddedCircuit, usize)| {
+		chip.chip_calls
+			.iter()
+			.map(|call| call.chip_id)
+			.collect::<Vec<_>>()
+	};
+	assert_eq!(
+		circuit.chips.iter().map(callees).collect::<Vec<_>>(),
+		[vec![1], vec![], vec![3], vec![]]
+	);
+
+	// The twice-called system's leaf serves both of its main's instances, not the one call it
+	// declared before being registered.
+	assert_eq!(circuit.chips.iter().map(|&(_, n)| n).collect::<Vec<_>>(), [2, 2, 1, 1]);
+	circuit.validate().unwrap();
+}
+
+// `build` returns a plain circuit, which has nowhere to carry the chips its calls would name.
+#[test]
+#[should_panic(expected = "builds with CircuitBuilder::build_m4")]
+fn build_rejects_a_builder_carrying_chips() {
+	let builder = CircuitBuilder::new();
+	builder.add_chip(empty_chip());
+	builder.build();
+}
+
+// A call passes its words positionally against the callee's inout segment, so a call of the wrong
+// length would silently shift every word past the gap.
+#[test]
+#[should_panic(expected = "chip #0 takes 2 inout words")]
+fn call_chip_rejects_the_wrong_number_of_words() {
+	let chip = CircuitBuilder::new();
+	chip.assert_eq("eq", chip.add_inout(), chip.add_inout());
+
+	let builder = CircuitBuilder::new();
+	let chip = builder.add_chip(CircuitM4::from(chip.build()));
+	builder.call_chip(chip, &[builder.add_witness()]);
+}
+
+// A call reads its words out of the value vector, so the wires it names have to survive the build
+// as committed words. Nothing else here reads the conjunction, so the call is what keeps it.
+#[test]
+fn call_chip_resolves_and_pins_the_wires_it_passes() {
+	let chip = CircuitBuilder::new();
+	chip.assert_eq("eq", chip.add_inout(), chip.add_inout());
+
+	let builder = CircuitBuilder::new();
+	let chip_ref = builder.add_chip(CircuitM4::from(chip.build()));
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let and = builder.band(a, b);
+	builder.call_chip(chip_ref, &[and, a]);
+	let circuit = builder.build_m4();
+
+	// The call names one word per wire, at the index the build gave that wire.
+	let main = &circuit.main.circuit;
+	let operands = circuit.main.chip_calls[0]
+		.inout
+		.iter()
+		.map(|operand| operand.as_slice())
+		.collect::<Vec<_>>();
+	assert_eq!(
+		operands,
+		[
+			[ShiftedValueIndex::plain(main.witness_index(and))].as_slice(),
+			[ShiftedValueIndex::plain(main.witness_index(a))].as_slice(),
+		]
+	);
+
+	// The conjunction is a committed private word rather than an uncommitted temporary, and the
+	// AND constraint defining it survives. Nothing but the call reads it, so the call is what
+	// keeps that definition — a committed word without one would be a prover's to choose.
+	assert_eq!(main.witness_index(and).segment(), ValueSegment::Private);
+	let cs = main.constraint_system();
+	assert_eq!(cs.and_constraints.len(), 1);
+	assert!(
+		cs.and_constraints[0]
+			.0
+			.iter()
+			.flatten()
+			.any(|term| term.value_index == main.witness_index(and))
+	);
+
+	circuit.validate().unwrap();
+}
+
+// What a linear argument costs. `a ^ b` reaching a constraint fuses into its operand and occupies
+// no word, but a chip call reads its words out of the value vector, so passing the same expression
+// commits it and keeps the equation defining it.
+#[test]
+fn call_chip_commits_a_linear_argument() {
+	// The XOR reaching a constraint fuses into its operand, so it holds no word of the value
+	// vector: it stays an uncommitted temporary of the circuit.
+	let builder = CircuitBuilder::new();
+	let (a, b) = (builder.add_inout(), builder.add_inout());
+	let xor = builder.bxor(a, b);
+	builder.mark_inout(builder.band(xor, b));
+	let fused = builder.build();
+	assert_eq!(fused.witness_index(xor).segment(), ValueSegment::Scratch);
+
+	// The same XOR passed to a chip call instead.
+	let chip = CircuitBuilder::new();
+	chip.assert_eq("eq", chip.add_inout(), chip.add_inout());
+
+	let builder = CircuitBuilder::new();
+	let chip_ref = builder.add_chip(CircuitM4::from(chip.build()));
+	let (a, b) = (builder.add_inout(), builder.add_inout());
+	let xor = builder.bxor(a, b);
+	builder.call_chip(chip_ref, &[xor, a]);
+	let called = builder.build_m4().main.circuit;
+
+	assert_eq!(called.witness_index(xor).segment(), ValueSegment::Private);
+	assert_eq!(called.value_vec_layout().n_private(), 1);
+	assert_eq!(called.constraint_system().n_zero_constraints(), 1);
+}

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -9,6 +9,11 @@ pub struct Assignment {
 	pub wire_mapping: SecondaryMap<Wire, ValueIndex>,
 	pub value_vec_layout: ValueVecLayout,
 	pub constants: Vec<Word>,
+	/// The inout wires in segment order, so inout value `i` is the word `inout[i]` holds.
+	///
+	/// `wire_mapping` only looks up a wire, so this is the way back from a position to the wire
+	/// at it.
+	pub inout: Vec<Wire>,
 }
 
 /// A structure that provides you assignments of value indices for wires and get a
@@ -95,7 +100,7 @@ impl Alloc {
 			wire_mapping[wire] = ValueIndex::constant(index as u32);
 			constants.push(value);
 		}
-		for (index, wire) in self.w_inout.into_iter().enumerate() {
+		for (index, &wire) in self.w_inout.iter().enumerate() {
 			wire_mapping[wire] = ValueIndex::inout(index as u32);
 		}
 		for (index, wire) in self
@@ -128,6 +133,7 @@ impl Alloc {
 			wire_mapping,
 			value_vec_layout,
 			constants,
+			inout: self.w_inout,
 		}
 	}
 }

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -26,10 +26,12 @@
 
 #![warn(rustdoc::missing_crate_level_docs)]
 
+pub mod chip;
 mod compiler;
 pub mod ops;
 pub mod stat;
 
+pub use chip::{ChipRef, CircuitM4, CircuitM4Error, EmbeddedCircuit};
 pub use compiler::{
 	CircuitBuilder, Options, Wire,
 	circuit::{AssertionFailure, Circuit, PopulateError, WitnessFiller},

--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -23,6 +23,7 @@ binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
 bytemuck.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Witness table and prover for the data-parallel Binius64 M4 proof system.
 
+mod m4_witness;
 mod prove;
 mod shift;
 #[cfg(test)]
@@ -10,6 +11,7 @@ mod test_utils;
 mod value_table;
 mod witness;
 
+pub use m4_witness::{PopulateM4Error, WitnessM4};
 pub use prove::{IOPProver, Prover};
 pub use value_table::{BatchWitnessFiller, ValueTable};
 pub use witness::OperandColumns;

--- a/crates/m4-prover/src/m4_witness.rs
+++ b/crates/m4-prover/src/m4_witness.rs
@@ -2,11 +2,11 @@
 
 //! The witness for an M4 circuit: the main circuit's values and one table per chip.
 
-use std::iter;
+use std::{borrow::Cow, mem};
 
 use binius_core::{
 	ValueVec, VerificationM4Error, Word,
-	m4::{ChipCall, ConstraintSystemM4},
+	m4::{ChipCall, ChipInstances, ConstraintSystemM4},
 };
 use binius_frontend::{BatchPopulateError, CircuitM4, PopulateError, WitnessFiller};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -38,7 +38,8 @@ impl WitnessM4 {
 	///
 	/// # Panics
 	///
-	/// Panics if the system does not pass [`CircuitM4::validate`].
+	/// Panics if the system does not pass [`CircuitM4::validate`], which covers both the ordering
+	/// this walks the chips in and the well-formedness of the operands it evaluates.
 	pub fn generate<F>(circuit: &CircuitM4, fill_main: F) -> Result<Self, PopulateM4Error>
 	where
 		F: FnOnce(&mut WitnessFiller<'_>),
@@ -52,33 +53,17 @@ impl WitnessM4 {
 
 		let main_values = main_witness_filler.into_value_vec();
 
+		// The invocations awaiting each chip, in the order the calls run: main's first, then the
+		// calls of each chip in ID order, instance-major and call-minor. Calls only run to higher
+		// IDs, so a chip's list is complete by the time the pass below reaches it.
+		let mut pending = vec![Vec::new(); circuit.chips.len()];
+		for call in &circuit.main.chip_calls {
+			pending[call.chip_id].push(eval_call(&main_values, call));
+		}
+
 		let mut tables = Vec::<ValueTable>::with_capacity(circuit.chips.len());
 		for (chip_id, (chip, n_active)) in circuit.chips.iter().enumerate() {
-			let mut call_data = Vec::with_capacity(*n_active);
-
-			// Push main's calls.
-			for call in &circuit.main.chip_calls {
-				if call.chip_id == chip_id {
-					call_data.push(eval_call(&main_values, call));
-				}
-			}
-
-			// Push the calls of the chips populated so far. Calls only run to higher IDs, so
-			// zipping against the tables built up to here yields exactly this chip's callers.
-			for ((caller, caller_active), table) in iter::zip(&circuit.chips, &tables) {
-				if !caller.chip_calls.iter().any(|call| call.chip_id == chip_id) {
-					continue;
-				}
-				let constants = &caller.circuit.constraint_system().constants;
-				for instance in 0..*caller_active {
-					let values = table.instance_value_vec(instance, constants);
-					for call in &caller.chip_calls {
-						if call.chip_id == chip_id {
-							call_data.push(eval_call(&values, call));
-						}
-					}
-				}
-			}
+			let call_data = mem::take(&mut pending[chip_id]);
 
 			// Invariants checked in `CircuitM4::validate()`
 			assert_eq!(call_data.len(), *n_active);
@@ -95,6 +80,20 @@ impl WitnessM4 {
 				})
 				.map_err(|source| PopulateM4Error::Chip { chip_id, source })?;
 
+			// Read this chip's own calls off each active instance, for the chips after it to
+			// serve. Building the instance is what costs here — a value vector allocated and
+			// gathered word by word — so each is built once and every call it makes is read off
+			// it, rather than once per callee.
+			if !chip.chip_calls.is_empty() {
+				let constants = &chip.circuit.constraint_system().constants;
+				for instance in 0..*n_active {
+					let values = table.instance_value_vec(instance, constants);
+					for call in &chip.chip_calls {
+						pending[call.chip_id].push(eval_call(&values, call));
+					}
+				}
+			}
+
 			tables.push(table);
 		}
 
@@ -106,24 +105,42 @@ impl WitnessM4 {
 
 	/// Checks that this witness satisfies an M4 constraint system.
 	///
-	/// Each table's instances are materialized as value vectors and handed to
-	/// [`ConstraintSystemM4::verify`], which checks the local constraints of every instance and
-	/// matches every chip call against the instance serving it.
+	/// [`ConstraintSystemM4::verify`] checks the local constraints of every instance and matches
+	/// every chip call against the instance serving it. It reads the instances one at a time, so a
+	/// table is never expanded into value vectors whole: the tables are the witness, and they stay
+	/// the only copy of it.
 	pub fn verify(&self, cs: &ConstraintSystemM4) -> Result<(), VerificationM4Error> {
-		if self.tables.len() != cs.chips.len() {
-			return Err(VerificationM4Error::WrongChipCount {
-				n_witness_chips: self.tables.len(),
-				n_chips: cs.chips.len(),
-			});
-		}
-		let chip_instances = iter::zip(&cs.chips, &self.tables)
-			.map(|((chip, _), table)| {
-				(0..table.n_instances())
-					.map(|instance| table.instance_value_vec(instance, &chip.cs.constants))
-					.collect()
-			})
-			.collect::<Vec<_>>();
-		cs.verify(&self.main, &chip_instances)
+		cs.verify(
+			&self.main,
+			&TableInstances {
+				tables: &self.tables,
+				cs,
+			},
+		)
+	}
+}
+
+/// A witness's tables read as chip instances, each built when it is asked for.
+///
+/// The constants are the one part of an instance a table does not store, so the system is held
+/// alongside to supply them.
+struct TableInstances<'a> {
+	tables: &'a [ValueTable],
+	cs: &'a ConstraintSystemM4,
+}
+
+impl ChipInstances for TableInstances<'_> {
+	fn n_chips(&self) -> usize {
+		self.tables.len()
+	}
+
+	fn n_instances(&self, chip_id: usize) -> usize {
+		self.tables[chip_id].n_instances()
+	}
+
+	fn instance(&self, chip_id: usize, row: usize) -> Cow<'_, ValueVec> {
+		let constants = &self.cs.chips[chip_id].0.cs.constants;
+		Cow::Owned(self.tables[chip_id].instance_value_vec(row, constants))
 	}
 }
 
@@ -151,7 +168,9 @@ pub enum PopulateM4Error {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::ShiftedValueIndex;
+	use std::iter;
+
+	use binius_core::{ShiftedValueIndex, ValueIndex, error::OperandFault};
 	use binius_frontend::{Circuit, CircuitBuilder, CircuitM4Error, EmbeddedCircuit, Wire};
 
 	use super::*;
@@ -172,6 +191,26 @@ mod tests {
 				inout: vec![forward_c.clone(), forward_c],
 			}],
 			circuit,
+		}
+	}
+
+	/// A chip whose inout words are `(a, b, c)`, constrained by `c == a & b`.
+	///
+	/// It calls chip `callee` twice per instance, forwarding `(a, a)` and then `(b, b)`.
+	fn twice_calling_and_chip(callee: usize) -> EmbeddedCircuit {
+		let builder = CircuitBuilder::new();
+		let (a, b, c) = (builder.add_inout(), builder.add_inout(), builder.add_inout());
+		builder.assert_eq("and", builder.band(a, b), c);
+		let circuit = builder.build();
+
+		let call = |wire| ChipCall {
+			chip_id: callee,
+			inout: vec![operand(&circuit, wire), operand(&circuit, wire)],
+		};
+		let chip_calls = vec![call(a), call(b)];
+		EmbeddedCircuit {
+			circuit,
+			chip_calls,
 		}
 	}
 
@@ -372,13 +411,52 @@ mod tests {
 				VerificationM4Error::CallMismatch {
 					chip_id: 0,
 					row: 0,
-					caller_chip: None,
+					caller: None,
 					word: 2,
 					..
 				}
 			),
 			"{err}"
 		);
+	}
+
+	// A caller with several instances making several calls to one callee is what pins the order
+	// generation and verification both walk the calls in: instance-major, call-minor. With one
+	// call per callee the two orders coincide and neither side would notice the other drifting.
+	#[test]
+	fn generate_interleaves_a_callers_instances_before_its_calls() {
+		let (main, inputs) = main_circuit(2);
+		let mut circuit = CircuitM4 {
+			main,
+			chips: vec![(twice_calling_and_chip(1), 0), (eq_chip(), 0)],
+		};
+		circuit.recompute_n_active();
+		circuit.validate().unwrap();
+
+		// Chip 0 serves main's two calls, and each of its instances calls chip 1 twice.
+		assert_eq!(circuit.chips[0].1, 2);
+		assert_eq!(circuit.chips[1].1, 4);
+
+		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0)];
+		let witness = WitnessM4::generate(&circuit, |filler| {
+			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+				filler[a] = Word(a_word);
+				filler[b] = Word(b_word);
+			}
+		})
+		.unwrap();
+
+		// Instance 0's two calls come before instance 1's, each forwarding `(a, a)` then `(b, b)`.
+		let expected = [words[0].0, words[0].1, words[1].0, words[1].1];
+		assert_eq!(witness.tables[1].n_instances(), 4);
+		for (instance, &word) in expected.iter().enumerate() {
+			assert_eq!(
+				instance_inout(&circuit.chips[1].0, &witness.tables[1], instance),
+				vec![word, word]
+			);
+		}
+
+		witness.verify(&circuit.to_constraint_system()).unwrap();
 	}
 
 	#[test]
@@ -473,5 +551,88 @@ mod tests {
 		circuit.main.chip_calls.clear();
 		circuit.recompute_n_active();
 		assert!(matches!(circuit.validate(), Err(CircuitM4Error::NeverCalled { chip_index: 0 })));
+	}
+
+	// An operand past the callee's interface has nowhere to land: generation drops it and
+	// verification never looks at it, so nothing downstream would report it.
+	#[test]
+	fn validate_rejects_a_call_passing_more_operands_than_the_callee_takes() {
+		let (mut circuit, inputs) = system(1);
+		let extra = operand(&circuit.main.circuit, inputs[0].0);
+		circuit.main.chip_calls[0].inout.push(extra);
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::WrongCallArity {
+				chip_index: None,
+				call_index: 0,
+				chip_id: 0,
+				arity: 4,
+				n_inout: 3,
+			})
+		));
+	}
+
+	// Scratch words are uncommitted temporaries, so a call reading one names a word no instance
+	// holds. `call_chip` pins its wires out of scratch, but `ChipCall` is built by hand too.
+	#[test]
+	fn validate_rejects_a_call_operand_naming_a_scratch_value() {
+		let (mut circuit, _) = system(1);
+		circuit.main.chip_calls[0].inout[2] =
+			vec![ShiftedValueIndex::plain(ValueIndex::scratch(0))];
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::CallOperand {
+				chip_index: None,
+				call_index: 0,
+				operand_index: 2,
+				source: OperandFault::ScratchValueIndex,
+			})
+		));
+	}
+
+	// Instance counts multiply down the call graph, so a chain of a few dozen chips outgrows a
+	// `usize`. Counting it out unchecked would wrap to a plausible-looking total.
+	#[test]
+	fn validate_rejects_an_instance_count_that_outgrows_a_usize() {
+		// A chain of 70 chips, each calling the next twice, so chip `i` is reached 2^i times.
+		let chip = |callee: Option<usize>| {
+			let builder = CircuitBuilder::new();
+			builder.add_inout();
+			EmbeddedCircuit {
+				circuit: builder.build(),
+				chip_calls: callee
+					.into_iter()
+					.flat_map(|chip_id| {
+						iter::repeat_with(move || ChipCall {
+							chip_id,
+							inout: vec![],
+						})
+						.take(2)
+					})
+					.collect(),
+			}
+		};
+
+		const DEPTH: usize = 70;
+		let mut circuit = CircuitM4 {
+			main: EmbeddedCircuit {
+				circuit: CircuitBuilder::new().build(),
+				chip_calls: vec![ChipCall {
+					chip_id: 0,
+					inout: vec![],
+				}],
+			},
+			chips: (0..DEPTH)
+				.map(|i| (chip((i + 1 < DEPTH).then_some(i + 1)), 0))
+				.collect(),
+		};
+		circuit.recompute_n_active();
+
+		// Chip 63 is reached 2^63 times and calls chip 64 twice, which is where the count leaves
+		// the range.
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::TooManyInstances { chip_index: 64 })
+		));
 	}
 }

--- a/crates/m4-prover/src/m4_witness.rs
+++ b/crates/m4-prover/src/m4_witness.rs
@@ -1,0 +1,477 @@
+// Copyright 2026 The Binius Developers
+
+//! The witness for an M4 circuit: the main circuit's values and one table per chip.
+
+use std::iter;
+
+use binius_core::{
+	ValueVec, VerificationM4Error, Word,
+	m4::{ChipCall, ConstraintSystemM4},
+};
+use binius_frontend::{BatchPopulateError, CircuitM4, PopulateError, WitnessFiller};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
+
+use crate::value_table::ValueTable;
+
+/// A full M4 witness: the main circuit's values and one [`ValueTable`] per chip of a
+/// [`CircuitM4`].
+///
+/// The tables are indexed by chip ID, so `tables[i]` holds every instance of chip `i`. One row of a
+/// table is one invocation of that chip: the chip's local constraints must hold on the row, and the
+/// row's inout values must be matched by exactly one chip call elsewhere in the system.
+#[derive(Debug)]
+pub struct WitnessM4 {
+	/// The values of the main circuit, which runs once.
+	pub main: ValueVec,
+	/// The instances of each chip, indexed by chip ID.
+	pub tables: Vec<ValueTable>,
+}
+
+impl WitnessM4 {
+	/// Generates the witness for a whole system from the main circuit's inputs.
+	///
+	/// `fill_main` assigns the witness inputs of the main circuit; every other value in the system
+	/// is derived from them. Each chip's table holds one instance per invocation that reaches it,
+	/// ordered by caller: main's calls first, then the calls of each chip in ID order, and within a
+	/// chip by instance. The instance count is rounded up to a power of two by repeating the last
+	/// invocation, which satisfies the chip because the invocation it copies does.
+	///
+	/// # Panics
+	///
+	/// Panics if the system does not pass [`CircuitM4::validate`].
+	pub fn generate<F>(circuit: &CircuitM4, fill_main: F) -> Result<Self, PopulateM4Error>
+	where
+		F: FnOnce(&mut WitnessFiller<'_>),
+	{
+		let mut main_witness_filler = circuit.main.circuit.new_witness_filler();
+		fill_main(&mut main_witness_filler);
+		circuit
+			.main
+			.circuit
+			.populate_wire_witness(&mut main_witness_filler)?;
+
+		let main_values = main_witness_filler.into_value_vec();
+
+		let mut tables = Vec::<ValueTable>::with_capacity(circuit.chips.len());
+		for (chip_id, (chip, n_active)) in circuit.chips.iter().enumerate() {
+			let mut call_data = Vec::with_capacity(*n_active);
+
+			// Push main's calls.
+			for call in &circuit.main.chip_calls {
+				if call.chip_id == chip_id {
+					call_data.push(eval_call(&main_values, call));
+				}
+			}
+
+			// Push the calls of the chips populated so far. Calls only run to higher IDs, so
+			// zipping against the tables built up to here yields exactly this chip's callers.
+			for ((caller, caller_active), table) in iter::zip(&circuit.chips, &tables) {
+				if !caller.chip_calls.iter().any(|call| call.chip_id == chip_id) {
+					continue;
+				}
+				let constants = &caller.circuit.constraint_system().constants;
+				for instance in 0..*caller_active {
+					let values = table.instance_value_vec(instance, constants);
+					for call in &caller.chip_calls {
+						if call.chip_id == chip_id {
+							call_data.push(eval_call(&values, call));
+						}
+					}
+				}
+			}
+
+			// Invariants checked in `CircuitM4::validate()`
+			assert_eq!(call_data.len(), *n_active);
+			assert!(*n_active > 0, "chip {chip_id} is never called");
+
+			let log_instances = log2_ceil_usize(call_data.len());
+			let table =
+				ValueTable::populate_parallel(&chip.circuit, log_instances, |instance, filler| {
+					// Instances past the last invocation repeat it.
+					let inout = &call_data[instance.min(call_data.len() - 1)];
+					for (i, &wire) in chip.circuit.inout().iter().enumerate() {
+						filler[wire] = inout.get(i).copied().unwrap_or(Word::ZERO);
+					}
+				})
+				.map_err(|source| PopulateM4Error::Chip { chip_id, source })?;
+
+			tables.push(table);
+		}
+
+		Ok(Self {
+			main: main_values,
+			tables,
+		})
+	}
+
+	/// Checks that this witness satisfies an M4 constraint system.
+	///
+	/// Each table's instances are materialized as value vectors and handed to
+	/// [`ConstraintSystemM4::verify`], which checks the local constraints of every instance and
+	/// matches every chip call against the instance serving it.
+	pub fn verify(&self, cs: &ConstraintSystemM4) -> Result<(), VerificationM4Error> {
+		if self.tables.len() != cs.chips.len() {
+			return Err(VerificationM4Error::WrongChipCount {
+				n_witness_chips: self.tables.len(),
+				n_chips: cs.chips.len(),
+			});
+		}
+		let chip_instances = iter::zip(&cs.chips, &self.tables)
+			.map(|((chip, _), table)| {
+				(0..table.n_instances())
+					.map(|instance| table.instance_value_vec(instance, &chip.cs.constants))
+					.collect()
+			})
+			.collect::<Vec<_>>();
+		cs.verify(&self.main, &chip_instances)
+	}
+}
+
+/// Evaluates the inout operands of one chip call against the caller's values.
+fn eval_call(values: &ValueVec, call: &ChipCall) -> Vec<Word> {
+	call.inout
+		.iter()
+		.map(|operand| values.eval_operand(operand))
+		.collect()
+}
+
+/// Reason the witness of an M4 circuit could not be generated.
+#[allow(missing_docs)] // errors are self-documenting
+#[derive(Debug, thiserror::Error)]
+pub enum PopulateM4Error {
+	#[error("the main circuit is not satisfied: {0}")]
+	Main(#[from] PopulateError),
+	#[error("chip #{chip_id} is not satisfied: {source}")]
+	Chip {
+		chip_id: usize,
+		#[source]
+		source: BatchPopulateError,
+	},
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::ShiftedValueIndex;
+	use binius_frontend::{Circuit, CircuitBuilder, CircuitM4Error, EmbeddedCircuit, Wire};
+
+	use super::*;
+
+	/// A chip whose inout words are `(a, b, c)`, constrained by `c == a & b`.
+	///
+	/// It calls chip `callee` once per instance, forwarding `(c, c)`.
+	fn and_chip(callee: usize) -> EmbeddedCircuit {
+		let builder = CircuitBuilder::new();
+		let (a, b, c) = (builder.add_inout(), builder.add_inout(), builder.add_inout());
+		builder.assert_eq("and", builder.band(a, b), c);
+		let circuit = builder.build();
+
+		let forward_c = operand(&circuit, c);
+		EmbeddedCircuit {
+			chip_calls: vec![ChipCall {
+				chip_id: callee,
+				inout: vec![forward_c.clone(), forward_c],
+			}],
+			circuit,
+		}
+	}
+
+	/// A leaf chip whose inout words are `(a, b, a & b)`, the conjunction promoted rather than
+	/// declared and asserted against.
+	fn promoting_and_chip() -> EmbeddedCircuit {
+		let builder = CircuitBuilder::new();
+		let (a, b) = (builder.add_inout(), builder.add_inout());
+		builder.mark_inout(builder.band(a, b));
+		EmbeddedCircuit {
+			circuit: builder.build(),
+			chip_calls: vec![],
+		}
+	}
+
+	/// A leaf chip whose two inout words must be equal.
+	fn eq_chip() -> EmbeddedCircuit {
+		let builder = CircuitBuilder::new();
+		let (x, y) = (builder.add_inout(), builder.add_inout());
+		builder.assert_eq("eq", x, y);
+		EmbeddedCircuit {
+			circuit: builder.build(),
+			chip_calls: vec![],
+		}
+	}
+
+	/// The operand reading a single wire of a circuit's value vector.
+	fn operand(circuit: &Circuit, wire: Wire) -> Vec<ShiftedValueIndex> {
+		vec![ShiftedValueIndex::plain(circuit.witness_index(wire))]
+	}
+
+	/// A main circuit passing `n_calls` triples of its own witness wires to chip 0.
+	///
+	/// Triple `i` is `(a_i, b_i, a_i & b_i)`, so every call satisfies the chip it reaches.
+	fn main_circuit(n_calls: usize) -> (EmbeddedCircuit, Vec<(Wire, Wire)>) {
+		let builder = CircuitBuilder::new();
+		let inputs = (0..n_calls)
+			.map(|_| (builder.add_witness(), builder.add_witness()))
+			.collect::<Vec<_>>();
+		let conjunctions = inputs
+			.iter()
+			.map(|&(a, b)| {
+				let and = builder.band(a, b);
+				builder.mark_inout(and);
+				and
+			})
+			.collect::<Vec<_>>();
+		let circuit = builder.build();
+
+		let chip_calls = iter::zip(&inputs, &conjunctions)
+			.map(|(&(a, b), &and)| ChipCall {
+				chip_id: 0,
+				inout: vec![
+					operand(&circuit, a),
+					operand(&circuit, b),
+					operand(&circuit, and),
+				],
+			})
+			.collect();
+
+		let main = EmbeddedCircuit {
+			circuit,
+			chip_calls,
+		};
+		(main, inputs)
+	}
+
+	/// A system whose main circuit calls chip 0 `n_calls` times, and whose chip 0 calls chip 1
+	/// once per instance.
+	fn system(n_calls: usize) -> (CircuitM4, Vec<(Wire, Wire)>) {
+		let (main, inputs) = main_circuit(n_calls);
+		let mut circuit = CircuitM4 {
+			main,
+			chips: vec![(and_chip(1), 0), (eq_chip(), 0)],
+		};
+		circuit.recompute_n_active();
+		(circuit, inputs)
+	}
+
+	/// The inout words of one instance of a chip, read back off its table.
+	fn instance_inout(chip: &EmbeddedCircuit, table: &ValueTable, instance: usize) -> Vec<u64> {
+		let constants = &chip.circuit.constraint_system().constants;
+		let values = table.instance_value_vec(instance, constants);
+		chip.circuit
+			.inout()
+			.iter()
+			.map(|&wire| values[chip.circuit.witness_index(wire)].as_u64())
+			.collect()
+	}
+
+	// The whole path with nothing hand-assembled: a chip built by one builder, registered and
+	// called by another, and a witness generated off the result.
+	#[test]
+	fn generate_serves_the_calls_a_builder_emitted() {
+		// The chip constrains its third inout word to be the conjunction of the first two.
+		let chip = CircuitBuilder::new();
+		let (x, y, z) = (chip.add_inout(), chip.add_inout(), chip.add_inout());
+		chip.assert_eq("and", chip.band(x, y), z);
+
+		// Main delegates two conjunctions to it, passing each result alongside its operands.
+		let builder = CircuitBuilder::new();
+		let chip_ref = builder.add_chip(CircuitM4::from(chip.build()));
+		let inputs = (0..2)
+			.map(|_| (builder.add_witness(), builder.add_witness()))
+			.collect::<Vec<_>>();
+		for &(a, b) in &inputs {
+			builder.call_chip(chip_ref, &[a, b, builder.band(a, b)]);
+		}
+		let circuit = builder.build_m4();
+
+		assert_eq!(circuit.chips[0].1, 2);
+		circuit.validate().unwrap();
+
+		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0)];
+		let witness = WitnessM4::generate(&circuit, |filler| {
+			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+				filler[a] = Word(a_word);
+				filler[b] = Word(b_word);
+			}
+		})
+		.unwrap();
+
+		assert_eq!(witness.tables[0].n_instances(), 2);
+		for (instance, &(a, b)) in words.iter().enumerate() {
+			assert_eq!(
+				instance_inout(&circuit.chips[0].0, &witness.tables[0], instance),
+				vec![a, b, a & b]
+			);
+		}
+	}
+
+	#[test]
+	fn generate_fills_one_instance_per_call() {
+		let (circuit, inputs) = system(2);
+		circuit.validate().unwrap();
+
+		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0)];
+		let witness = WitnessM4::generate(&circuit, |filler| {
+			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+				filler[a] = Word(a_word);
+				filler[b] = Word(b_word);
+			}
+		})
+		.unwrap();
+
+		// Chip 0 serves main's two calls, in call order.
+		let (chip_0, chip_1) = (&circuit.chips[0].0, &circuit.chips[1].0);
+		assert_eq!(witness.tables[0].n_instances(), 2);
+		for (instance, &(a, b)) in words.iter().enumerate() {
+			assert_eq!(instance_inout(chip_0, &witness.tables[0], instance), vec![a, b, a & b]);
+		}
+
+		// Chip 1 serves chip 0's call from each of those instances, which forwards `(c, c)`.
+		assert_eq!(witness.tables[1].n_instances(), 2);
+		for (instance, &(a, b)) in words.iter().enumerate() {
+			assert_eq!(instance_inout(chip_1, &witness.tables[1], instance), vec![a & b, a & b]);
+		}
+
+		witness.verify(&circuit.to_constraint_system()).unwrap();
+	}
+
+	// A chip may promote an inout word instead of declaring it, which is what lets a chip return a
+	// result. Generation assigns every inout wire from the call data and evaluation then recomputes
+	// the promoted ones, so a row holds the chip's own word whatever the call passed. Nothing here
+	// checks the two agree; where they do not, the row stops matching the call site.
+	#[test]
+	fn generate_recomputes_a_promoted_inout_word() {
+		let (main, inputs) = main_circuit(1);
+		let mut circuit = CircuitM4 {
+			main,
+			chips: vec![(promoting_and_chip(), 1)],
+		};
+		circuit.validate().unwrap();
+
+		let (a, b) = inputs[0];
+		let fill = |filler: &mut WitnessFiller<'_>| {
+			filler[a] = Word(0b1100);
+			filler[b] = Word(0b1010);
+		};
+		let row = |circuit: &CircuitM4, witness: &WitnessM4| {
+			instance_inout(&circuit.chips[0].0, &witness.tables[0], 0)
+		};
+
+		let witness = WitnessM4::generate(&circuit, fill).unwrap();
+		assert_eq!(row(&circuit, &witness), vec![0b1100, 0b1010, 0b1000]);
+		witness.verify(&circuit.to_constraint_system()).unwrap();
+
+		// Pass `a` as the third word, which the chip's conjunction disagrees with. Generation still
+		// succeeds, and the row still holds the conjunction rather than what the call passed — so
+		// the call no longer matches its instance, which is exactly what verification rejects.
+		circuit.main.chip_calls[0].inout[2] = operand(&circuit.main.circuit, a);
+		let witness = WitnessM4::generate(&circuit, fill).unwrap();
+		assert_eq!(row(&circuit, &witness), vec![0b1100, 0b1010, 0b1000]);
+		let err = witness.verify(&circuit.to_constraint_system()).unwrap_err();
+		assert!(
+			matches!(
+				err,
+				VerificationM4Error::CallMismatch {
+					chip_id: 0,
+					row: 0,
+					caller_chip: None,
+					word: 2,
+					..
+				}
+			),
+			"{err}"
+		);
+	}
+
+	#[test]
+	fn generate_pads_the_instance_count_by_repeating_the_last_call() {
+		let (circuit, inputs) = system(3);
+		circuit.validate().unwrap();
+
+		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0), (0xabcd, 0xdcba)];
+		let witness = WitnessM4::generate(&circuit, |filler| {
+			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+				filler[a] = Word(a_word);
+				filler[b] = Word(b_word);
+			}
+		})
+		.unwrap();
+
+		// Three calls round up to four instances, the fourth repeating the third.
+		let chip_0 = &circuit.chips[0].0;
+		assert_eq!(witness.tables[0].n_instances(), 4);
+		let (a, b) = words[2];
+		assert_eq!(instance_inout(chip_0, &witness.tables[0], 3), vec![a, b, a & b]);
+
+		// The padding instances pass verification too: their local constraints hold, and no call
+		// claims them.
+		witness.verify(&circuit.to_constraint_system()).unwrap();
+	}
+
+	#[test]
+	fn generate_reports_the_chip_whose_calls_do_not_satisfy_it() {
+		let (mut circuit, inputs) = system(1);
+
+		// Pass `a` where chip 0 expects `a & b`, so no witness can serve the call.
+		let (a, b) = inputs[0];
+		circuit.main.chip_calls[0].inout[2] = operand(&circuit.main.circuit, a);
+
+		let err = WitnessM4::generate(&circuit, |filler| {
+			filler[a] = Word(0b1100);
+			filler[b] = Word(0b1010);
+		})
+		.unwrap_err();
+		assert!(matches!(err, PopulateM4Error::Chip { chip_id: 0, .. }), "{err}");
+	}
+
+	#[test]
+	fn validate_rejects_a_call_to_a_chip_that_does_not_exist() {
+		let (mut circuit, _) = system(1);
+		circuit.main.chip_calls[0].chip_id = 2;
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::OutOfRangeChipId {
+				chip_index: None,
+				chip_id: 2,
+				n_chips: 2,
+			})
+		));
+	}
+
+	#[test]
+	fn validate_rejects_chips_out_of_topological_order() {
+		let (mut circuit, _) = system(1);
+		// Chip 1 is a leaf; make it call chip 0, which is populated before it.
+		circuit.chips[1].0.chip_calls.push(ChipCall {
+			chip_id: 0,
+			inout: vec![],
+		});
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::CallOutOfOrder {
+				chip_index: 1,
+				callee: 0,
+			})
+		));
+	}
+
+	#[test]
+	fn validate_rejects_a_wrong_active_instance_count() {
+		let (mut circuit, _) = system(2);
+		circuit.chips[1].1 = 1;
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::WrongActiveInstanceCount {
+				chip_index: 1,
+				declared: 1,
+				actual: 2,
+			})
+		));
+	}
+
+	#[test]
+	fn validate_rejects_a_chip_nothing_calls() {
+		let (mut circuit, _) = system(1);
+		circuit.main.chip_calls.clear();
+		circuit.recompute_n_active();
+		assert!(matches!(circuit.validate(), Err(CircuitM4Error::NeverCalled { chip_index: 0 })));
+	}
+}

--- a/crates/m4-prover/tests/crc64_chip.rs
+++ b/crates/m4-prover/tests/crc64_chip.rs
@@ -1,0 +1,148 @@
+// Copyright 2026 The Binius Developers
+
+//! A chip-accelerated CRC-64/GO-ISO circuit, exercising the chip path end to end.
+//!
+//! Mixing one message word into the register is a chip; the main circuit calls it once per word.
+//! Main learns each register state from a hint rather than computing it, so its own constraints
+//! say nothing about the CRC at all — the chip calls are what tie the states together.
+//!
+//! The plain circuit this mirrors is the CRC-64 fixture in this crate's `test_utils`.
+
+use std::iter;
+
+use binius_core::Word;
+use binius_frontend::{CircuitBuilder, CircuitM4, Wire, hints::Hint};
+use binius_m4_prover::WitnessM4;
+
+/// The CRC-64/GO-ISO generator polynomial, in reflected form.
+const POLY_REFLECTED: u64 = 0xd800_0000_0000_0000;
+/// The register is preset to all ones before absorbing the message.
+const INIT: u64 = 0xffff_ffff_ffff_ffff;
+/// The final register is XORed with all ones before being returned.
+const XOR_OUT: u64 = 0xffff_ffff_ffff_ffff;
+
+/// Mixes one message word into the register, absorbing its bits from bit 0 up.
+fn mix_word(mut crc: u64, word: u64) -> u64 {
+	for i in 0..64 {
+		let bit = (word >> i) & 1;
+		let mix = (crc ^ bit) & 1;
+		crc >>= 1;
+		if mix != 0 {
+			crc ^= POLY_REFLECTED;
+		}
+	}
+	crc
+}
+
+/// Computes CRC-64/GO-ISO over `words`, absorbing them in index order.
+fn crc64_iso_reference(words: &[u64]) -> u64 {
+	words.iter().fold(INIT, |crc, &word| mix_word(crc, word)) ^ XOR_OUT
+}
+
+/// Mixes one message word into the register in gates, mirroring [`mix_word`] round for round.
+fn mix_word_gates(builder: &CircuitBuilder, mut crc: Wire, word: Wire) -> Wire {
+	let poly = builder.add_constant_64(POLY_REFLECTED);
+	for i in 0..64 {
+		// Isolate message bit `i` into the low bit; the higher bits are junk we discard.
+		let bit = if i == 0 { word } else { builder.shr(word, i) };
+
+		// The low bit that decides whether the polynomial is mixed in this round.
+		let mixed = builder.bxor(crc, bit);
+
+		// Broadcast that low bit across the whole word: all ones iff it is set, else zero.
+		let to_msb = builder.shl(mixed, 63);
+		let mask = builder.sar(to_msb, 63);
+		let poly_term = builder.band(mask, poly);
+
+		// Advance the register: shift right by one, then conditionally mix the polynomial.
+		crc = builder.bxor(builder.shr(crc, 1), poly_term);
+	}
+	crc
+}
+
+/// The register state one call produces, which main takes on trust and the call constrains.
+struct MixWord;
+
+impl Hint for MixWord {
+	const NAME: &'static str = "crc64_iso_mix_word";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(2, 1)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		outputs[0] = Word(mix_word(inputs[0].as_u64(), inputs[1].as_u64()));
+	}
+}
+
+/// The chip, as a system of its own: inout words `(crc_in, word, crc_out)`.
+///
+/// `crc_out` is promoted rather than declared, so the chip states the relation in the words it
+/// already computes rather than paying for a fourth and an assertion.
+fn mix_chip() -> CircuitM4 {
+	let builder = CircuitBuilder::new();
+	let crc_in = builder.add_inout();
+	let word = builder.add_inout();
+	builder.mark_inout(mix_word_gates(&builder, crc_in, word));
+	builder.build_m4()
+}
+
+/// A chip-accelerated CRC-64/GO-ISO circuit over message words.
+struct Crc64ChipCircuit {
+	circuit: CircuitM4,
+	input: Vec<Wire>,
+	output: Wire,
+}
+
+/// Builds the circuit over `n_words` message words: one chip, called once per word.
+fn crc64_chip_circuit(n_words: usize) -> Crc64ChipCircuit {
+	let builder = CircuitBuilder::new();
+	let chip = builder.add_chip(mix_chip());
+
+	let input = (0..n_words)
+		.map(|_| builder.add_inout())
+		.collect::<Vec<_>>();
+
+	// Each round hands the register state to the chip and takes the next one back from the hint.
+	// Nothing in this circuit computes the mixing, so the call is the only thing tying the two.
+	let mut crc = builder.add_constant_64(INIT);
+	for &word in &input {
+		let next = builder.call_hint(MixWord, &[], &[crc, word])[0];
+		builder.call_chip(chip, &[crc, word, next]);
+		crc = next;
+	}
+
+	let output = builder.bxor(crc, builder.add_constant_64(XOR_OUT));
+	builder.mark_inout(output);
+
+	Crc64ChipCircuit {
+		circuit: builder.build_m4(),
+		input,
+		output,
+	}
+}
+
+#[test]
+fn chip_accelerated_crc64_matches_the_reference() {
+	let words = [0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210, 0, u64::MAX];
+	let c = crc64_chip_circuit(words.len());
+	c.circuit.validate().unwrap();
+	let cs = c.circuit.to_constraint_system();
+	cs.validate().unwrap();
+
+	let witness = WitnessM4::generate(&c.circuit, |filler| {
+		for (&wire, &word) in iter::zip(&c.input, &words) {
+			filler[wire] = Word(word);
+		}
+	})
+	.unwrap();
+
+	// The hints carried the whole computation, and they carried it correctly.
+	let main = &c.circuit.main.circuit;
+	assert_eq!(witness.main[main.witness_index(c.output)].as_u64(), crc64_iso_reference(&words));
+
+	// Everything else is the verifier's: main's constraints, every chip instance's, and the calls
+	// each instance serves. The calls are what hold the hints to the mixing — a hint returning the
+	// wrong state leaves its instance's recomputed word disagreeing with the call.
+	witness.verify(&cs).unwrap();
+}


### PR DESCRIPTION
## Overview

An M4 constraint system is a composition of chips. Each chip is an embedded constraint system validating a relation on its local inout values, and runs once per call that reaches it; a distinguished main chip runs once and nothing calls it. A chip call names a callee and passes operands over the caller&#39;s value vector, one per inout value of the callee, and is served by the callee instance at the call&#39;s position.

Four commits: the feature, a pure item-relocation pass (verified: added and removed line multisets are identical), then the two review rounds.

## What each crate gains

**binius-core** — the constraint-system form: `ConstraintSystemM4`, built from `EmbeddedConstraintSystem` and `ChipCall`.
- `validate` checks call operands the way constraint operands are checked (the per-term body of `validate_operand` moves to `operand_fault`, which both wrap under their own naming), range-checks callee IDs and call arity, and requires the chips to be in topological order.
- `verify` is the reference checker for the composition, in the manner of `ConstraintSystem::verify`: the main chip&#39;s constraints, every instance&#39;s (padding instances included, since every instance is committed), and every call positionally against the instance serving it. Instances are read through the `ChipInstances` accessor, one at a time.

**binius-frontend** — the circuit form: a `chip` module with `EmbeddedCircuit` and `CircuitM4`, and a builder API.
- `CircuitBuilder::add_chip` registers a system and returns an opaque `ChipRef`, flattening nested systems into one topologically ordered chip list.
- `call_chip` takes a `ChipRef` and the wires of one invocation.
- `build_m4` compiles, resolves each call&#39;s wires to value indices, and counts each chip&#39;s active instances off the call graph. `CircuitM4::to_constraint_system` lowers to the form the protocol consumes.
- `Circuit` now carries its inout wires in segment order, so a chip&#39;s interface is its circuit&#39;s inout segment.

**binius-m4-prover** — `WitnessM4`. `generate` populates the main circuit and one `ValueTable` per chip, one instance per invocation in caller order, the count padded to a power of two by repeating the last invocation. `verify` hands the tables to the core checker, which reads their instances one at a time.

## The model

A chip call is a constraint on the words its wires hold. The compiler passes have no notion of a call, so `compile` folds call wires into the pinned set they do understand and counts them as constraint-read when the value vector is laid out. The expected usage computes a chip&#39;s outputs from its inputs with a hint and passes both: the hint hands the witness its values, and the call is the constraint that makes them correct. A chip does not say which of its inout words are inputs and which are outputs; a call constrains them all alike.

The chip-accelerated CRC-64 test (`crates/m4-prover/tests/crc64_chip.rs`) drives the whole path: a chip mixes one message word into the register, main calls it once per word on hinted states, and the witness verifies whole. A hint returning a wrong register state fails verification with a `CallMismatch` naming the call, instance and word.

## Ordering

The chips are in topological order: a chip calls only chips with a higher ID, and main, which is not one of them, calls any. Call positions are defined by enumerating the chips in ID order, and both witness generation and `verify` walk them that way, so every caller of a chip is reached before the chip itself.

Both `CircuitM4::validate` and `ConstraintSystemM4::validate` require it, as one comparison per call. Acyclicity follows, and is not separately checked: an acyclic graph is not enough, because a backward call between two chips that never form a cycle is still served by an instance the walk has already passed.

## Validation

`CircuitM4::validate` is the single check on the circuit form. It rejects a call naming a chip the system does not have, a call passing more operands than the callee has inout values, an operand reading an uncommitted word of its caller, a call to an earlier chip, a declared active-instance count that disagrees with the calls reaching the chip, a chip nothing calls, and an instance count that outgrows a `usize`.

A system that passes it lowers to one that passes `ConstraintSystemM4::validate`, which requires the same ordering and additionally validates each chip&#39;s compiled constraint system — the one thing the compiler rather than that check keeps well-formed. So nothing downstream has to run the lowered check to know its preconditions hold, and that check remains the one for a hand-built `ConstraintSystemM4` that never went through the frontend.

## Instance access

`ConstraintSystemM4::verify` reads chip instances through `ChipInstances`, which serves one instance at a time by `(chip_id, row)`. A witness that stores its instances packed — as the prover&#39;s `ValueTable` does, one column per instance — is therefore never expanded into value vectors whole. For a chip of 451 words at 2^20 instances, expanding it was several gigabytes on top of the table itself, for a check whose working set is one value vector. The cost is that an instance serving a call is rebuilt when the call is checked, having already been built for its own constraints: roughly 2x the materializations for O(1) live instead of O(total).

`[Vec<ValueVec>]` implements the trait, so a hand-built witness still passes a slice.

## Known deferrals and open questions

- **Fusion rewrite site**: a chip call is not yet a rewrite site of gate fusion, so a linear argument such as `a ^ b` is committed together with its defining ZERO constraint rather than fusing into the call operand.
- **Protocol gap**: nothing proves a `WitnessM4` yet; positional matching is the reference stand-in for the eventual permutation/lookup argument. Core M4 types have no serialization yet.
- **`build_m4` does not validate its result**: a registered-but-never-called chip surfaces as a `generate` panic instead of `CircuitM4Error::NeverCalled`. Every test calls `validate()` by hand right after `build_m4()`; the call may belong inside.
- **Chip circuits with `add_witness` wires** compile but fail late in generation (only `circuit.inout()` is assigned). A build-time check that a chip declares its whole interface as inout could catch this earlier.
- **Cross-builder `ChipRef`**: a ref from one builder used on another either panics on an index or silently names the wrong chip. Fixing needs builder provenance inside `ChipRef`.
- **Naming**: `m4::ConstraintSystemM4` repeats the module in the identifier, unlike its siblings `EmbeddedConstraintSystem`/`ChipCall`; kept for symmetry with `CircuitM4`/`WitnessM4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)