### PR TITLE
BINIUS-433: take the inner statement symbolically in IOPVerifier::verify

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -376,10 +376,12 @@ mod tests {
 			&mut verifier_transcript,
 		)
 		.unwrap();
+		// A batch hides its inout words, so the public segment is the constants the constraint
+		// system already carries.
 		check_eval(
 			&cs,
 			InoutSegment::Hidden,
-			public_words,
+			&[],
 			&verifier_zero,
 			&verifier_bitand,
 			&verifier_intmul,

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -12,6 +12,7 @@ use binius_iop::{
 	fri::{ConstantArityStrategy, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
+use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_verifier::{
 	Error,
@@ -113,7 +114,7 @@ impl IOPVerifier {
 	/// Returns an error if the reduction, the ring-switch, or the trace opening fails.
 	pub fn verify<Channel>(&self, channel: &mut Channel) -> Result<(), Error>
 	where
-		Channel: IOPVerifierChannel<B128>,
+		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 	{
 		// Receive the trace commitment.
@@ -121,14 +122,15 @@ impl IOPVerifier {
 		let trace_oracle = channel.recv_oracle(self.layout.log_witness_elems, true)?;
 
 		// Reduce every instance's constraints to one claim on the committed trace.
-		// A batch hides its inout words, so the public data is the shared constants alone.
+		// A batch hides its inout words, so the public data is the shared constants alone, which
+		// the reduction reads from the constraint system.
 		let reduction = reduce_constraints(
 			&self.cs,
 			Instances::Batch {
 				log_instances: self.layout.log_instances,
 			},
 			InoutSegment::Hidden,
-			&self.cs.constants,
+			&[],
 			channel,
 		)?;
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -24,7 +24,7 @@ use binius_utils::{
 		task_size::{IndexedParallelIteratorExt, WorkPerItem},
 	},
 };
-use binius_verifier::protocols::shift::evaluate_words_mle;
+use binius_verifier::protocols::shift::evaluate_words_mle_native;
 use tracing::instrument;
 
 use super::{
@@ -297,7 +297,8 @@ where
 	// Round the public word count up to a power of two: the segment spans that many word slots.
 	// The count itself need not be a power of two, and the MLE reads the missing words as zero.
 	let log_public_words = log2_ceil_usize(public_words.len());
-	let public_eval = evaluate_words_mle::<F, F>(public_words, &r_j, &r_y[..log_public_words]);
+	let public_eval =
+		evaluate_words_mle_native::<F, F>(public_words, &r_j, &r_y[..log_public_words]);
 	let padded_public_eval = eq_ind_zero(&r_y[log_public_words..log_half]) * public_eval;
 	let witness_eval =
 		(trace_eval - (F::ONE - r_segment) * padded_public_eval) * r_segment.invert_or_zero();

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -156,8 +156,9 @@ where
 			{
 				let inner_iop_verifier = &self.inner_iop_verifier;
 				move |replay_channel: &mut ReplayChannel<B128>| {
+					let statement = replay_channel.statement(inout_words);
 					inner_iop_verifier
-						.verify(inout_words, replay_channel)
+						.verify(&statement, replay_channel)
 						.expect("replay verification should not fail");
 				}
 			},

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -394,7 +394,7 @@ fn test_shift_prove_and_verify() {
 		check_eval(
 			&cs,
 			InoutSegment::Public,
-			value_vec.public(),
+			value_vec.inout(),
 			&verifier_zero_data,
 			&verifier_bitand_data,
 			&verifier_intmul_data,

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -39,6 +39,8 @@ pub struct Recorded {
 	pub circuit: Circuit,
 	/// The wires the witness must supply, in the order the verifier reached them.
 	pub inputs: Vec<crate::shared::Input>,
+	/// The wires holding the inner statement, which are this circuit's public input.
+	pub inout: Vec<Wire>,
 }
 
 /// A channel that records a verifier run as a Binius64 circuit.
@@ -55,21 +57,32 @@ pub struct Recorded {
 /// See the crate docs for what this does and does not constrain.
 pub struct Binius64BuilderChannel {
 	shared: Rc<Shared>,
+	inout: Vec<Wire>,
 	/// How many assertions have been recorded, so each gets a distinct name.
 	n_assertions: usize,
 }
 
 impl Binius64BuilderChannel {
-	/// Creates a channel over a fresh builder.
-	///
-	/// The inner statement is not among the circuit's inputs yet: `IOPVerifier::verify` lifts it
-	/// through `From<Word>`, so it reaches the channel already concrete and is baked in. Taking it
-	/// as inout wires is BINIUS-433.
-	pub fn new() -> Self {
+	/// Creates a channel over a fresh builder, for an inner statement of `n_inout` words.
+	pub fn new(n_inout: usize) -> Self {
+		let shared = Rc::new(Shared::new());
+		let inout = (0..n_inout).map(|_| shared.builder().add_inout()).collect();
 		Self {
-			shared: Rc::new(Shared::new()),
+			shared,
+			inout,
 			n_assertions: 0,
 		}
+	}
+
+	/// The inner statement, as this circuit's own public input.
+	///
+	/// Pass this to `IOPVerifier::verify`. The circuit it records then verifies any instance of
+	/// the inner system, since nothing about the statement is fixed while building.
+	pub fn statement(&self) -> Vec<SymbolicWord> {
+		self.inout
+			.iter()
+			.map(|&wire| SymbolicWord::wire(&self.shared, wire))
+			.collect()
 	}
 
 	/// Consumes the channel and compiles what it recorded.
@@ -77,12 +90,14 @@ impl Binius64BuilderChannel {
 	/// Every [`SymbolicElem`] and [`SymbolicWord`] derived from this channel must be dropped first:
 	/// they hold weak handles to the builder, and using one afterwards panics.
 	pub fn build(self) -> Recorded {
-		let shared = Rc::try_unwrap(self.shared).unwrap_or_else(|_| {
+		let Self { shared, inout, .. } = self;
+		let shared = Rc::try_unwrap(shared).unwrap_or_else(|_| {
 			panic!("SymbolicElem and SymbolicWord values hold only weak handles")
 		});
 		Recorded {
 			inputs: shared.inputs(),
 			circuit: shared.builder().build(),
+			inout,
 		}
 	}
 
@@ -91,12 +106,6 @@ impl Binius64BuilderChannel {
 		let lo = self.shared.input_wire(kind);
 		let hi = self.shared.input_wire(kind);
 		SymbolicElem::wires(&self.shared, lo, hi)
-	}
-}
-
-impl Default for Binius64BuilderChannel {
-	fn default() -> Self {
-		Self::new()
 	}
 }
 

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -31,7 +31,10 @@
 //!   right value but nothing pins them to their inputs.
 //!
 //! What *is* constrained is the verifier's arithmetic: the sumcheck folding, the eq-indicator and
-//! Lagrange evaluations, the monster multilinear, and every `assert_zero` along the way.
+//! Lagrange evaluations, the monster multilinear, and every `assert_zero` along the way. The inner
+//! statement is this circuit's public input, so the circuit is about the inner system rather than
+//! about one proof of it, and the shift reduction's public-value check is what ties a proof to the
+//! statement it is offered against.
 //!
 //! So a circuit built here accepts proofs it should reject. It is useful for measuring that
 //! arithmetic and for keeping the pipeline honest while the gadgets are written, not for proving

--- a/crates/recursion/tests/channel_builds.rs
+++ b/crates/recursion/tests/channel_builds.rs
@@ -12,7 +12,7 @@ use binius_recursion::Binius64BuilderChannel;
 
 #[test]
 fn records_received_arithmetic_as_constraints() {
-	let mut channel = Binius64BuilderChannel::new();
+	let mut channel = Binius64BuilderChannel::new(0);
 
 	// Read `a`, `b` and `c` off the proof and record that `a * b == c`.
 	let a = channel.recv_one().unwrap();
@@ -35,7 +35,7 @@ fn records_received_arithmetic_as_constraints() {
 
 #[test]
 fn folds_constants_without_constraints() {
-	let mut channel = Binius64BuilderChannel::new();
+	let mut channel = Binius64BuilderChannel::new(0);
 
 	// A product of build-time constants is decided while building, so it records nothing, and
 	// asserting a zero constant succeeds without a constraint.

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -16,9 +16,11 @@
 //! one verifier runs over both channels, reaching the same operations in the same order, and the
 //! circuit the first produced is satisfied by the witness the second filled.
 
+use std::iter;
+
 use binius_core::{constraint_system::ValueVec, word::Word};
 use binius_field::arch::OptimalPackedB128;
-use binius_frontend::{Circuit, CircuitBuilder, CircuitStat, Wire};
+use binius_frontend::{Circuit, CircuitBuilder, CircuitStat, PopulateError, Wire};
 use binius_hash::StdHashSuite;
 use binius_prover::Prover;
 use binius_recursion::{Binius64BuilderChannel, WitnessFillerChannel};
@@ -97,6 +99,34 @@ fn crc64_witness(crc64: &Crc64, message: &[u64; N_INPUT_WORDS]) -> ValueVec {
 
 #[test]
 fn recursive_circuit_is_satisfied_by_a_real_proof() {
+	run_recursion(|inout| inout.to_vec()).expect("the replayed witness satisfies the circuit");
+}
+
+/// The statement is the circuit's public input, and the proof is about one statement, so a
+/// circuit given a different one must fail. This is what says the statement wires are wired in
+/// rather than merely present.
+#[test]
+fn a_statement_the_proof_is_not_about_fails() {
+	let failure = run_recursion(|inout| {
+		let mut corrupted = inout.to_vec();
+		corrupted[0] = corrupted[0] ^ Word::ONE;
+		corrupted
+	})
+	.expect_err("a statement the proof is not about leaves the circuit unsatisfied");
+
+	// The shift reduction's consistency check is where the statement enters the arithmetic.
+	assert!(
+		failure
+			.failures
+			.iter()
+			.all(|f| f.path.starts_with(".assert_zero[")),
+		"the failure should be an assertion, not a missing value: {failure:?}",
+	);
+}
+
+/// Runs the pipeline end to end, filling the recursive circuit's statement wires with what
+/// `statement` returns for the inner circuit's inout words.
+fn run_recursion(statement: impl Fn(&[Word]) -> Vec<Word>) -> Result<(), PopulateError> {
 	// --- the inner circuit and its proof -------------------------------------------------------
 	let crc64 = crc64_circuit();
 	let message = [0x0123456789abcdef, 0xfedcba9876543210, 1, u64::MAX];
@@ -121,12 +151,15 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 	// --- the recursive circuit -----------------------------------------------------------------
 	// The verifier runs over the builder channel, wrapped in the same BaseFold layer the transcript
 	// channel gets, and what it records becomes the circuit.
+	// The statement enters as wires, so the circuit is about the inner system rather than about
+	// this one message.
 	let recorded = {
-		let builder_channel = Binius64BuilderChannel::new();
+		let builder_channel = Binius64BuilderChannel::new(witness.inout().len());
+		let statement = builder_channel.statement();
 		let mut channel = verifier.iop_compiler().create_channel(builder_channel);
 		verifier
 			.iop_verifier()
-			.verify(witness.inout(), &mut channel)
+			.verify(&statement, &mut channel)
 			.expect("the symbolic run records rather than checks, so it cannot fail");
 		let builder_channel = channel.finish().unwrap();
 		builder_channel.build()
@@ -147,6 +180,12 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 	// The same verifier runs again over the real transcript, and every value the circuit cannot
 	// derive is written into the wire the build recorded for it.
 	let mut filler = recorded.circuit.new_witness_filler();
+
+	// The statement is this circuit's public input, so it is given rather than replayed.
+	for (&wire, word) in iter::zip(&recorded.inout, statement(witness.inout())) {
+		filler[wire] = word;
+	}
+
 	{
 		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
 		let filler_channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
@@ -162,8 +201,5 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 		channel.finish().unwrap().finish();
 	}
 
-	recorded
-		.circuit
-		.populate_wire_witness(&mut filler)
-		.expect("the recorded circuit is satisfied by the replayed witness");
+	recorded.circuit.populate_wire_witness(&mut filler)
 }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -11,14 +11,14 @@ use std::{
 };
 
 use binius_core::word::Word;
-use binius_field::{Field, util::FieldFn};
+use binius_field::{BinaryField1b as B1, ExtensionField, Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, WireAllocator, WitnessError, WitnessGenerator},
 	constraint_system::{WireKind, Witness, WitnessLayout},
 };
-use binius_spartan_verifier::wrapper::circuit_elem::{CircuitElem, hinted_subset_sum};
+use binius_spartan_verifier::wrapper::{circuit_elem::CircuitElem, circuit_word::CircuitWord};
 
 /// A channel that replays recorded interaction values through a [`WitnessGenerator`], filling
 /// both inout and private wires in the outer witness.
@@ -69,6 +69,29 @@ impl<F: Field> ReplayChannel<F> {
 		let wire = self.inout_alloc.alloc();
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
 		CircuitElem::wire(&self.witness_gen, witness_wire)
+	}
+
+	/// Allocates the inner statement as the outer circuit's public input, holding `words`.
+	///
+	/// This matches
+	/// [`IronSpartanBuilderChannel::statement`](binius_spartan_verifier::wrapper::IronSpartanBuilderChannel::statement),
+	/// which allocated the same wires with no values, and must be called at the same point: before
+	/// the verifier this channel replays.
+	pub fn statement(&mut self, words: &[Word]) -> Vec<CircuitWord<F, WitnessGenerator<F>>>
+	where
+		F: ExtensionField<B1>,
+	{
+		words
+			.iter()
+			.map(|&word| {
+				let wire = self.inout_alloc.alloc();
+				let witness_wire = self
+					.witness_gen
+					.borrow_mut()
+					.write_inout(wire, CircuitWord::<F, WitnessGenerator<F>>::embed(word));
+				CircuitWord::from_wire(&self.witness_gen, witness_wire)
+			})
+			.collect()
 	}
 
 	fn next_precommit_elem(&mut self) -> CircuitElem<F, WitnessGenerator<F>> {
@@ -144,23 +167,22 @@ impl<F: Field> IPVerifierChannel<F> for ReplayChannel<F> {
 }
 
 impl<F: Field> WordIPVerifierChannel<F> for ReplayChannel<F> {
-	type Word = Word;
+	type Word = CircuitWord<F, WitnessGenerator<F>>;
 
 	// The recorded interaction already holds whatever the Fiat-Shamir state produced, so replaying
 	// observes nothing. This mirrors `IronSpartanBuilderChannel::observe_words`.
-	fn observe_words(&mut self, _words: &[Word]) {}
+	fn observe_words(&mut self, _words: &[Self::Word]) {}
 
-	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		// Hinted to match the symbolic build, which reached this with a dummy statement.
-		hinted_subset_sum(&self.witness_gen, elems, *word)
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		word.subset_sum(elems)
 	}
 
-	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		select_word(elems, *word)
+	fn select(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		word.select(elems)
 	}
 
-	fn sample_bits(&mut self, _bits: usize) -> Word {
-		Word::ZERO
+	fn sample_bits(&mut self, _bits: usize) -> Self::Word {
+		CircuitWord::Constant(Word::ZERO)
 	}
 }
 

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -13,12 +13,12 @@ use std::{
 use binius_core::word::Word;
 use binius_field::{Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, WireAllocator, WitnessError, WitnessGenerator},
 	constraint_system::{WireKind, Witness, WitnessLayout},
 };
-use binius_spartan_verifier::wrapper::circuit_elem::CircuitElem;
+use binius_spartan_verifier::wrapper::circuit_elem::{CircuitElem, hinted_subset_sum};
 
 /// A channel that replays recorded interaction values through a [`WitnessGenerator`], filling
 /// both inout and private wires in the outer witness.
@@ -151,7 +151,8 @@ impl<F: Field> WordIPVerifierChannel<F> for ReplayChannel<F> {
 	fn observe_words(&mut self, _words: &[Word]) {}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		subset_sum_word(elems, *word)
+		// Hinted to match the symbolic build, which reached this with a dummy statement.
+		hinted_subset_sum(&self.witness_gen, elems, *word)
 	}
 
 	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -11,10 +11,10 @@ use std::{
 use binius_core::word::Word;
 use binius_field::{Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word};
 use binius_spartan_frontend::circuit_builder::{CircuitBuilder, ConstraintBuilder};
 
-use super::circuit_elem::CircuitElem;
+use super::circuit_elem::{CircuitElem, hinted_subset_sum};
 
 /// A channel that symbolically executes a verifier, building up an IronSpartan constraint system.
 ///
@@ -132,10 +132,14 @@ impl<F: Field> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	fn observe_words(&mut self, _words: &[Word]) {}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		// The word is concrete, so which elements the sum runs over is settled while building.
-		subset_sum_word(elems, *word)
+		// Hinted rather than folded: the statement is a dummy while building. See
+		// `hinted_subset_sum`.
+		hinted_subset_sum(&self.builder, elems, *word)
 	}
 
+	// Folded rather than hinted, unlike `subset_sum`: the only words reaching this are a code
+	// proximity test's query indices, and that test is not run symbolically here — which is also
+	// why `sample_bits` below can answer with zero.
 	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
 		select_word(elems, *word)
 	}

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -9,12 +9,12 @@ use std::{
 };
 
 use binius_core::word::Word;
-use binius_field::{Field, util::FieldFn};
+use binius_field::{BinaryField1b as B1, ExtensionField, Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_spartan_frontend::circuit_builder::{CircuitBuilder, ConstraintBuilder};
 
-use super::circuit_elem::{CircuitElem, hinted_subset_sum};
+use super::{circuit_elem::CircuitElem, circuit_word::CircuitWord};
 
 /// A channel that symbolically executes a verifier, building up an IronSpartan constraint system.
 ///
@@ -46,6 +46,23 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 	fn alloc_inout_elem(&self) -> CircuitElem<F, ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_inout();
 		CircuitElem::wire(&self.builder, wire)
+	}
+
+	/// Allocates the inner statement as this circuit's public input.
+	///
+	/// Pass the result to the verifier this channel drives. The words are wires, so what is
+	/// recorded is a circuit about the inner system rather than about one statement — which it
+	/// could not be anyway, since the build precedes every instance.
+	pub fn statement(&mut self, n_inout: usize) -> Vec<CircuitWord<F, ConstraintBuilder<F>>>
+	where
+		F: ExtensionField<B1>,
+	{
+		(0..n_inout)
+			.map(|_| {
+				let wire = self.builder.borrow_mut().alloc_inout();
+				CircuitWord::from_wire(&self.builder, wire)
+			})
+			.collect()
 	}
 
 	fn alloc_precommit_elem(&self) -> CircuitElem<F, ConstraintBuilder<F>> {
@@ -126,26 +143,23 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 }
 
 impl<F: Field> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
-	type Word = Word;
+	type Word = CircuitWord<F, ConstraintBuilder<F>>;
 
 	// The outer verifier rebinds the public inputs, so the wrapper records no Fiat-Shamir state.
-	fn observe_words(&mut self, _words: &[Word]) {}
+	fn observe_words(&mut self, _words: &[Self::Word]) {}
 
-	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		// Hinted rather than folded: the statement is a dummy while building. See
-		// `hinted_subset_sum`.
-		hinted_subset_sum(&self.builder, elems, *word)
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		word.subset_sum(elems)
 	}
 
-	// Folded rather than hinted, unlike `subset_sum`: the only words reaching this are a code
-	// proximity test's query indices, and that test is not run symbolically here — which is also
-	// why `sample_bits` below can answer with zero.
-	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		select_word(elems, *word)
+	fn select(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		word.select(elems)
 	}
 
-	fn sample_bits(&mut self, _bits: usize) -> Word {
-		Word::ZERO
+	// A code proximity test's query indices are the only words that reach this, and that test runs
+	// against the inner channel rather than symbolically here, so nothing reads what it returns.
+	fn sample_bits(&mut self, _bits: usize) -> Self::Word {
+		CircuitWord::Constant(Word::ZERO)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -28,13 +28,11 @@ use std::{
 	rc::{Rc, Weak},
 };
 
-use binius_core::word::Word;
 use binius_field::{
 	ExtensionField, Field,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
 };
-use binius_ip::channel::subset_sum_word;
 use binius_spartan_frontend::circuit_builder::CircuitBuilder;
 
 use super::gadgets;
@@ -216,40 +214,6 @@ where
 			result.into_iter().map(Self::Constant).collect()
 		}
 	}
-}
-
-/// [`WordIPVerifierChannel::subset_sum`] as a single derived wire.
-///
-/// A concrete word decides *which* elements the sum runs over, so folding it at build time would
-/// write the word's value into the circuit's shape. The wrapper is built once from a dummy
-/// statement and then run again on the real one, so the two runs would allocate different wires
-/// and the second would not fit the first's layout.
-///
-/// A hint keeps the shape fixed and the value free, which is sound here for the same reason
-/// [`IPVerifierChannel::compute_public_value`] is: the outer verifier holds the statement and the
-/// challenges, so it recomputes this itself. Every input is public-derivable, so the output is
-/// too, and it costs no constraint.
-///
-/// [`WordIPVerifierChannel::subset_sum`]: binius_ip::channel::WordIPVerifierChannel::subset_sum
-/// [`IPVerifierChannel::compute_public_value`]: binius_ip::channel::IPVerifierChannel::compute_public_value
-pub fn hinted_subset_sum<F, B>(
-	builder: &Rc<RefCell<B>>,
-	elems: &[CircuitElem<F, B>],
-	word: Word,
-) -> CircuitElem<F, B>
-where
-	F: Field,
-	B: CircuitBuilder<Field = F>,
-{
-	let out_wire = {
-		let mut builder = builder.borrow_mut();
-		let input_wires = elems
-			.iter()
-			.map(|elem| elem.to_wire(&mut builder))
-			.collect::<Vec<_>>();
-		builder.hint_varsize(&input_wires, 1, move |vals| vec![subset_sum_word(vals, word)])[0]
-	};
-	CircuitElem::wire(builder, out_wire)
 }
 
 // In characteristic 2, negation is identity.

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -28,11 +28,13 @@ use std::{
 	rc::{Rc, Weak},
 };
 
+use binius_core::word::Word;
 use binius_field::{
 	ExtensionField, Field,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
 };
+use binius_ip::channel::subset_sum_word;
 use binius_spartan_frontend::circuit_builder::CircuitBuilder;
 
 use super::gadgets;
@@ -214,6 +216,40 @@ where
 			result.into_iter().map(Self::Constant).collect()
 		}
 	}
+}
+
+/// [`WordIPVerifierChannel::subset_sum`] as a single derived wire.
+///
+/// A concrete word decides *which* elements the sum runs over, so folding it at build time would
+/// write the word's value into the circuit's shape. The wrapper is built once from a dummy
+/// statement and then run again on the real one, so the two runs would allocate different wires
+/// and the second would not fit the first's layout.
+///
+/// A hint keeps the shape fixed and the value free, which is sound here for the same reason
+/// [`IPVerifierChannel::compute_public_value`] is: the outer verifier holds the statement and the
+/// challenges, so it recomputes this itself. Every input is public-derivable, so the output is
+/// too, and it costs no constraint.
+///
+/// [`WordIPVerifierChannel::subset_sum`]: binius_ip::channel::WordIPVerifierChannel::subset_sum
+/// [`IPVerifierChannel::compute_public_value`]: binius_ip::channel::IPVerifierChannel::compute_public_value
+pub fn hinted_subset_sum<F, B>(
+	builder: &Rc<RefCell<B>>,
+	elems: &[CircuitElem<F, B>],
+	word: Word,
+) -> CircuitElem<F, B>
+where
+	F: Field,
+	B: CircuitBuilder<Field = F>,
+{
+	let out_wire = {
+		let mut builder = builder.borrow_mut();
+		let input_wires = elems
+			.iter()
+			.map(|elem| elem.to_wire(&mut builder))
+			.collect::<Vec<_>>();
+		builder.hint_varsize(&input_wires, 1, move |vals| vec![subset_sum_word(vals, word)])[0]
+	};
+	CircuitElem::wire(builder, out_wire)
 }
 
 // In characteristic 2, negation is identity.

--- a/crates/spartan-verifier/src/wrapper/circuit_word.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_word.rs
@@ -1,0 +1,258 @@
+// Copyright 2026 The Binius Developers
+
+//! The 64-bit word the wrapper channels carry.
+
+use std::{cell::RefCell, iter, ops::Shr, rc::Rc};
+
+use binius_core::word::Word;
+use binius_field::{BinaryField1b as B1, ExtensionField, Field};
+use binius_ip::channel::{select_word, subset_sum_word};
+use binius_spartan_frontend::circuit_builder::CircuitBuilder;
+
+use super::circuit_elem::CircuitElem;
+
+/// A 64-bit word that is either fixed while the circuit is built or carried by wires.
+///
+/// This is the `Word` associated type of the wrapper channels. The statement a wrapped verifier
+/// checks arrives this way, and it has to: the wrapper's circuit is built once, before any
+/// statement exists, so an operation reading a concrete word's bits would settle its answer from
+/// whatever stood in for the statement at build time, and the run on the real one would not fit
+/// the circuit that produced.
+///
+/// A word the protocol fixes — a constraint system constant — is the same in every run, so it
+/// stays a `Constant` and folds for free.
+pub enum CircuitWord<F: Field, B: CircuitBuilder<Field = F>> {
+	Constant(Word),
+	/// The word's bits, low first, each holding zero or one.
+	Bits(Rc<Vec<CircuitElem<F, B>>>),
+}
+
+// Manual `Clone` that does not require `B: Clone`, as on [`CircuitElem`].
+impl<F: Field, B: CircuitBuilder<Field = F>> Clone for CircuitWord<F, B> {
+	fn clone(&self) -> Self {
+		match self {
+			Self::Constant(word) => Self::Constant(*word),
+			Self::Bits(bits) => Self::Bits(Rc::clone(bits)),
+		}
+	}
+}
+
+impl<F, B> CircuitWord<F, B>
+where
+	F: Field + ExtensionField<B1>,
+	B: CircuitBuilder<Field = F>,
+{
+	/// The field element a word is carried as: its bits as the `B1` coefficients.
+	pub fn embed(word: Word) -> F {
+		F::from_bases((0..Word::BITS).map(|bit| {
+			if word.extract_bit(bit) {
+				B1::ONE
+			} else {
+				B1::ZERO
+			}
+		}))
+	}
+
+	/// Reads the word `wire` carries as its bits.
+	///
+	/// The bits are hinted rather than constrained. A hint over public inputs is not a value a
+	/// prover chooses: the wire is public, so the outer verifier recomputes the bits for itself,
+	/// and they cost no constraint for the same reason.
+	pub fn from_wire(builder: &Rc<RefCell<B>>, wire: B::Wire) -> Self {
+		let bit_wires =
+			builder
+				.borrow_mut()
+				.hint_varsize(std::slice::from_ref(&wire), Word::BITS, |vals| {
+					(0..Word::BITS)
+						.map(|bit| F::from(vals[0].get_base(bit)))
+						.collect()
+				});
+		Self::Bits(Rc::new(
+			bit_wires
+				.into_iter()
+				.map(|bit| CircuitElem::wire(builder, bit))
+				.collect(),
+		))
+	}
+}
+
+impl<F, B> CircuitWord<F, B>
+where
+	F: Field,
+	B: CircuitBuilder<Field = F>,
+{
+	/// The sum of the `elems` selected by this word's low bits, low bit first.
+	///
+	/// This is [`WordIPVerifierChannel::subset_sum`](binius_ip::channel::WordIPVerifierChannel::subset_sum)
+	/// over one word. Every term is a product of public-derivable values, so the sub-circuit it
+	/// builds emits no constraint; the outer verifier evaluates it.
+	///
+	/// ## Preconditions
+	///
+	/// * `elems.len()` must be at most 64.
+	pub fn subset_sum(&self, elems: &[CircuitElem<F, B>]) -> CircuitElem<F, B> {
+		assert!(elems.len() <= Word::BITS); // precondition
+
+		match self {
+			Self::Constant(word) => subset_sum_word(elems, *word),
+			// A bit is zero or one, so multiplying by it keeps or drops its element.
+			Self::Bits(bits) => iter::zip(elems, bits.iter())
+				.map(|(elem, bit)| elem.clone() * bit)
+				.sum(),
+		}
+	}
+
+	/// The element of `elems` at the index in this word's low bits.
+	///
+	/// ## Preconditions
+	///
+	/// * `elems` must be non-empty and its length must be a power of two.
+	pub fn select(&self, elems: &[CircuitElem<F, B>]) -> CircuitElem<F, B> {
+		assert!(!elems.is_empty() && elems.len().is_power_of_two()); // precondition
+
+		match self {
+			Self::Constant(word) => select_word(elems, *word),
+			Self::Bits(bits) => {
+				// Halve the layer at each index bit, low bit first: `lo + b * (lo + hi)`, which is
+				// `(1 - b) * lo + b * hi` in characteristic two.
+				let mut layer = elems.to_vec();
+				for bit in bits.iter().take(elems.len().ilog2() as usize) {
+					layer = layer
+						.chunks_exact(2)
+						.map(|pair| {
+							let (lo, hi) = (&pair[0], &pair[1]);
+							lo.clone() + bit.clone() * (lo.clone() + hi)
+						})
+						.collect();
+				}
+				layer
+					.pop()
+					.expect("halving a power-of-two layer ends at one element")
+			}
+		}
+	}
+}
+
+impl<F: Field, B: CircuitBuilder<Field = F>> From<Word> for CircuitWord<F, B> {
+	fn from(word: Word) -> Self {
+		Self::Constant(word)
+	}
+}
+
+impl<F: Field, B: CircuitBuilder<Field = F>> Shr<u32> for CircuitWord<F, B> {
+	type Output = Self;
+
+	fn shr(self, rhs: u32) -> Self {
+		match self {
+			Self::Constant(word) => Self::Constant(word >> rhs),
+			Self::Bits(bits) => Self::Bits(Rc::new(
+				bits.iter()
+					.skip(rhs as usize)
+					.cloned()
+					.chain(iter::repeat_with(|| CircuitElem::Constant(F::ZERO)))
+					.take(Word::BITS)
+					.collect(),
+			)),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField128bGhash as B128;
+	use binius_spartan_frontend::circuit_builder::ConstraintBuilder;
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	type TestWord = CircuitWord<B128, ConstraintBuilder<B128>>;
+	type TestElem = CircuitElem<B128, ConstraintBuilder<B128>>;
+
+	/// The bits of `word` as constant elements.
+	///
+	/// A `Bits` word normally holds wires, but the arithmetic over them does not care which, so
+	/// constants exercise it while staying readable: every result folds to a value.
+	fn bits_of(word: Word) -> TestWord {
+		CircuitWord::Bits(Rc::new(
+			(0..Word::BITS)
+				.map(|bit| {
+					CircuitElem::Constant(if word.extract_bit(bit) {
+						B128::ONE
+					} else {
+						B128::ZERO
+					})
+				})
+				.collect(),
+		))
+	}
+
+	fn value(elem: &TestElem) -> B128 {
+		match elem {
+			CircuitElem::Constant(value) => *value,
+			CircuitElem::Wire { .. } => panic!("constant inputs should fold to a constant"),
+		}
+	}
+
+	fn random_elems(rng: &mut StdRng, n: usize) -> Vec<TestElem> {
+		(0..n)
+			.map(|_| CircuitElem::Constant(B128::new(rng.random::<u128>())))
+			.collect()
+	}
+
+	#[test]
+	fn test_subset_sum_over_bits_matches_the_concrete_word() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let elems = random_elems(&mut rng, 40);
+
+		for _ in 0..8 {
+			let word = Word::from_u64(rng.random::<u64>());
+			assert_eq!(
+				value(&bits_of(word).subset_sum(&elems)),
+				value(&TestWord::Constant(word).subset_sum(&elems)),
+			);
+		}
+	}
+
+	#[test]
+	fn test_select_over_bits_matches_the_concrete_word() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let elems = random_elems(&mut rng, 16);
+
+		for _ in 0..8 {
+			let word = Word::from_u64(rng.random::<u64>());
+			assert_eq!(
+				value(&bits_of(word).select(&elems)),
+				value(&TestWord::Constant(word).select(&elems)),
+			);
+		}
+	}
+
+	#[test]
+	fn test_shift_over_bits_matches_the_concrete_word() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let elems = random_elems(&mut rng, 40);
+
+		for shift in [0, 1, 7, 63] {
+			let word = Word::from_u64(rng.random::<u64>());
+			assert_eq!(
+				value(&(bits_of(word) >> shift).subset_sum(&elems)),
+				value(&TestWord::Constant(word >> shift).subset_sum(&elems)),
+			);
+		}
+	}
+
+	/// The bits a statement wire is read as are the bits of the word it was written from.
+	#[test]
+	fn test_embed_round_trips_through_the_bases() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		for _ in 0..8 {
+			let word = Word::from_u64(rng.random::<u64>());
+			let embedded = TestWord::embed(word);
+			for bit in 0..Word::BITS {
+				let base = <B128 as ExtensionField<B1>>::get_base(&embedded, bit);
+				assert_eq!(base == B1::ONE, word.extract_bit(bit));
+			}
+		}
+	}
+}

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -11,10 +11,12 @@
 
 pub mod builder_channel;
 pub mod circuit_elem;
+pub mod circuit_word;
 pub mod gadgets;
 pub mod zk_wrapped_channel;
 
 pub use builder_channel::IronSpartanBuilderChannel;
+pub use circuit_word::CircuitWord;
 pub use zk_wrapped_channel::ZKWrappedVerifierChannel;
 
 #[cfg(test)]

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -14,13 +14,13 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, util::FieldFn};
+use binius_field::{BinaryField, BinaryField1b as B1, ExtensionField, Field, util::FieldFn};
 use binius_iop::{
 	basefold::channel::{BaseFoldOracle, BaseFoldVerifierChannel},
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	merkle_channel::MerkleIPVerifierChannel,
 };
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
@@ -28,8 +28,31 @@ use binius_spartan_frontend::{
 
 use crate::{
 	Error, IOPVerifier,
-	wrapper::circuit_elem::{CircuitElem, hinted_subset_sum},
+	wrapper::{circuit_elem::CircuitElem, circuit_word::CircuitWord},
 };
+
+/// The word a statement entry carries.
+///
+/// This channel is the run that has the values, so it reads them back off the wires it wrote them
+/// to. They leave the circuit here — they feed the inner Fiat-Shamir state, which lives outside it.
+fn word_value<F: Field>(word: &CircuitWord<F, InstanceGenerator<F>>) -> Word {
+	match word {
+		CircuitWord::Constant(word) => *word,
+		CircuitWord::Bits(bits) => {
+			let set = |bit: &CircuitElem<F, InstanceGenerator<F>>| match bit {
+				CircuitElem::Constant(value) => *value == F::ONE,
+				CircuitElem::Wire { wire, .. } => wire.value() == Some(F::ONE),
+			};
+			Word::from_u64(
+				bits.iter()
+					.enumerate()
+					.filter(|(_, bit)| set(bit))
+					.map(|(index, _)| 1u64 << index)
+					.sum(),
+			)
+		}
+	}
+}
 
 /// A verifier channel that wraps a [`BaseFoldVerifierChannel`] and an [`IOPVerifier`].
 ///
@@ -137,6 +160,29 @@ where
 		CircuitElem::wire(&self.instance_gen, public_wire)
 	}
 
+	/// Allocates the inner statement as the outer circuit's public input, holding `words`.
+	///
+	/// This matches
+	/// [`IronSpartanBuilderChannel::statement`](super::builder_channel::IronSpartanBuilderChannel::statement),
+	/// which allocated the same wires with no values, and must be called at the same point: before
+	/// the verifier this channel drives.
+	pub fn statement(&mut self, words: &[Word]) -> Vec<CircuitWord<F, InstanceGenerator<F>>>
+	where
+		F: ExtensionField<B1>,
+	{
+		words
+			.iter()
+			.map(|&word| {
+				let wire = self.inout_alloc.alloc();
+				let public_wire = self
+					.instance_gen
+					.borrow_mut()
+					.write_inout(wire, CircuitWord::<F, InstanceGenerator<F>>::embed(word));
+				CircuitWord::from_wire(&self.instance_gen, public_wire)
+			})
+			.collect()
+	}
+
 	/// Allocates the next precommit wire (value-less to the verifier) as an element.
 	fn alloc_precommit_elem(&mut self) -> CircuitElem<F, InstanceGenerator<F>> {
 		let wire = self.precommit_alloc.alloc();
@@ -236,25 +282,29 @@ where
 	F: BinaryField,
 	Channel: MerkleIPVerifierChannel<F, Elem = F, Word = Word>,
 {
-	type Word = Word;
+	type Word = CircuitWord<F, InstanceGenerator<F>>;
 
-	fn observe_words(&mut self, words: &[Word]) {
+	fn observe_words(&mut self, words: &[Self::Word]) {
 		// The inner channel holds the Fiat-Shamir state the inner prover mirrors, so the words go
-		// there. The outer verifier recomputes what depends on them from the public segment.
-		self.inner_channel.observe_words(words);
+		// there as the values they carry — which this run has, being the one with a real statement.
+		// Those values feed a hash outside the circuit and decide nothing the circuit contains,
+		// which is what lets the circuit be built before any statement exists.
+		let values = words.iter().map(word_value).collect::<Vec<_>>();
+		self.inner_channel.observe_words(&values);
 	}
 
-	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		// Hinted to match the symbolic build, which reached this with a dummy statement.
-		hinted_subset_sum(&self.instance_gen, elems, *word)
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		word.subset_sum(elems)
 	}
 
-	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		select_word(elems, *word)
+	fn select(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		word.select(elems)
 	}
 
-	fn sample_bits(&mut self, bits: usize) -> Word {
-		self.inner_channel.sample_bits(bits)
+	// The query indices a code proximity test samples reach this, and that test runs against the
+	// inner channel rather than symbolically, so the value is read outside the circuit.
+	fn sample_bits(&mut self, bits: usize) -> Self::Word {
+		CircuitWord::Constant(self.inner_channel.sample_bits(bits))
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -20,13 +20,16 @@ use binius_iop::{
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	merkle_channel::MerkleIPVerifierChannel,
 };
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
 };
 
-use crate::{Error, IOPVerifier, wrapper::circuit_elem::CircuitElem};
+use crate::{
+	Error, IOPVerifier,
+	wrapper::circuit_elem::{CircuitElem, hinted_subset_sum},
+};
 
 /// A verifier channel that wraps a [`BaseFoldVerifierChannel`] and an [`IOPVerifier`].
 ///
@@ -242,7 +245,8 @@ where
 	}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
-		subset_sum_word(elems, *word)
+		// Hinted to match the symbolic build, which reached this with a dummy statement.
+		hinted_subset_sum(&self.instance_gen, elems, *word)
 	}
 
 	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -20,4 +20,6 @@ mod error;
 mod verify;
 
 pub use error::Error;
-pub use verify::{OperatorData, VerifyOutput, check_eval, evaluate_words_mle, verify};
+pub use verify::{
+	OperatorData, VerifyOutput, check_eval, evaluate_words_mle, evaluate_words_mle_native, verify,
+};

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -9,7 +9,7 @@ use binius_core::{
 };
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
 use binius_ip::{
-	channel::IPVerifierChannel,
+	channel::{IPVerifierChannel, WordIPVerifierChannel, subset_sum_word},
 	sumcheck::{SumcheckOutput, verify as verify_sumcheck},
 };
 use binius_math::{
@@ -34,6 +34,9 @@ use super::{
 /// bit within a word and the high variables index the word. Words past `words.len()` (up to
 /// `2^r_y.len()`) are treated as zero.
 ///
+/// A verifier reaches its words through a channel, so it uses the `channel_words_mle` sibling
+/// below; this is for a prover mirroring the same evaluation over native words.
+///
 /// ## Preconditions
 ///
 /// * `r_j` has exactly `Word::LOG_BITS` entries
@@ -49,13 +52,37 @@ where
 	let r_j_tensor = eq_ind_partial_eval_scalars(r_j);
 	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
 	iter::zip(words, r_y_tensor)
-		.map(|(word, weight)| {
-			let word_eval = (0..Word::BITS)
-				.filter(|bit| (word.as_u64() >> bit) & 1 == 1)
-				.map(|bit| &r_j_tensor[bit])
-				.sum::<E>();
-			weight * word_eval
-		})
+		.map(|(&word, weight)| weight * subset_sum_word(&r_j_tensor, word))
+		.sum()
+}
+
+/// [`evaluate_words_mle`] over a channel's own words.
+///
+/// A word's contribution is the sum of the bit-index tensor over its set bits, which is what
+/// [`WordIPVerifierChannel::subset_sum`] computes — over concrete bits for a verifier reading a
+/// transcript, and over a sub-circuit for one building a recursive circuit.
+///
+/// ## Preconditions
+///
+/// * `r_j` has exactly `Word::LOG_BITS` entries
+/// * `words` has at most `2^r_y.len()` entries
+fn channel_words_mle<F, C>(
+	channel: &mut C,
+	words: &[C::Word],
+	r_j: &[C::Elem],
+	r_y: &[C::Elem],
+) -> C::Elem
+where
+	F: BinaryField,
+	C: WordIPVerifierChannel<F>,
+{
+	assert_eq!(r_j.len(), Word::LOG_BITS); // precondition
+	assert!(words.len() <= 1 << r_y.len()); // precondition
+
+	let r_j_tensor = eq_ind_partial_eval_scalars(r_j);
+	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
+	iter::zip(words, r_y_tensor)
+		.map(|(word, weight)| weight * channel.subset_sum(&r_j_tensor, word))
 		.sum()
 }
 
@@ -274,7 +301,7 @@ where
 pub fn check_eval<F, C>(
 	constraint_system: &ConstraintSystem,
 	inout: InoutSegment,
-	public: &[Word],
+	inout_words: &[C::Word],
 	zero_data: &OperatorData<C::Elem, ZERO_ARITY>,
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
@@ -286,9 +313,16 @@ pub fn check_eval<F, C>(
 ) -> Result<(), Error>
 where
 	F: BinaryField,
-	C: IPVerifierChannel<F>,
+	C: WordIPVerifierChannel<F>,
 	C::Elem: FieldOps<Scalar = F> + From<F>,
 {
+	// The inout words are public only when they sit in the public segment; a batch hides them and
+	// passes none.
+	assert_eq!(
+		inout_words.len(),
+		constraint_system.n_public_words(inout) - constraint_system.n_const()
+	); // precondition
+
 	let VerifyOutput {
 		zero_lambda,
 		bitand_lambda,
@@ -351,17 +385,21 @@ where
 		channel.compute_public_value(&inputs, eval_fn)
 	};
 
-	// The public-half evaluation is a function of the verifier's public words (plaintext) and
-	// public-channel-derived challenges, so it is computed the same way as `monster_eval`.
+	// The public segment is the constraint system's constants followed by the inout words, in the
+	// order the value vector places them. The constants are fixed by the system, so they are
+	// lifted into the channel's word type here rather than being restated by the caller.
+	//
+	// This runs symbolically rather than through `compute_public_value`, unlike `monster_eval`
+	// above: the public segment is small, so a channel that builds a circuit can afford to derive
+	// it, and one that carries the statement as wires has to.
 	let log_public_words = constraint_system.log_public_words(inout);
-	let public_eval = {
-		let inputs: Vec<C::Elem> = r_j
-			.iter()
-			.chain(&r_y[..log_public_words])
-			.cloned()
-			.collect();
-		channel.compute_public_value(&inputs, PublicWordsEvalFn { public })
-	};
+	let public = constraint_system
+		.constants
+		.iter()
+		.map(|&word| C::Word::from(word))
+		.chain(inout_words.iter().cloned())
+		.collect::<Vec<_>>();
+	let public_eval = channel_words_mle(channel, &public, r_j, &r_y[..log_public_words]);
 
 	// Reconstruct the witness evaluation from its two segments. The public segment is
 	// zero-padded up to the hidden segment length, contributing the eq-zero padding factor.
@@ -377,21 +415,6 @@ where
 	channel.assert_zero(expected_eval - eval)?;
 
 	Ok(())
-}
-
-/// The bit-level MLE evaluation of the public words, as a [`FieldFn`] over the inputs
-/// `r_j.. | r_y_low..`: the word-bit challenges followed by the low `log_public_words`
-/// word-index challenges. Computed via the same public-value mechanism as [`MonsterEvalFn`].
-struct PublicWordsEvalFn<'a> {
-	/// The public words of the value vector.
-	public: &'a [Word],
-}
-
-impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
-	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
-		let (r_j, r_y_low) = vals.split_at(Word::LOG_BITS);
-		evaluate_words_mle(self.public, r_j, r_y_low)
-	}
 }
 
 /// The monster multilinear evaluation, as a [`FieldFn`] over public-channel-derived inputs.
@@ -651,13 +674,14 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 mod tests {
 	use binius_field::Field;
 	use binius_math::test_utils::random_scalars;
+	use binius_transcript::VerifierTranscript;
 	use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::config::B128;
+	use crate::config::{B128, StdChallenger};
 
-	#[test]
-	fn test_evaluate_words_mle_matches_naive() {
+	/// Words, challenges, and the evaluation a naive reader of the definition gets.
+	fn words_mle_case() -> (Vec<Word>, Vec<B128>, Vec<B128>, B128) {
 		let mut rng = StdRng::seed_from_u64(0);
 		let log_words = 3;
 		// A non-power-of-two word count exercises the implicit zero padding.
@@ -679,6 +703,23 @@ mod tests {
 			}
 		}
 
+		(words, r_j, r_y, expected)
+	}
+
+	#[test]
+	fn test_evaluate_words_mle_matches_naive() {
+		let (words, r_j, r_y, expected) = words_mle_case();
 		assert_eq!(evaluate_words_mle::<B128, B128>(&words, &r_j, &r_y), expected);
+	}
+
+	/// The two must agree: the verifier evaluates the public words through its channel and the
+	/// prover mirrors it natively.
+	#[test]
+	fn test_channel_words_mle_matches_the_native_one() {
+		let (words, r_j, r_y, expected) = words_mle_case();
+
+		// A transcript carries concrete words, so this is the same arithmetic reached the long way.
+		let mut channel = VerifierTranscript::new(StdChallenger::default(), Vec::new());
+		assert_eq!(channel_words_mle(&mut channel, &words, &r_j, &r_y), expected);
 	}
 }

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -34,14 +34,14 @@ use super::{
 /// bit within a word and the high variables index the word. Words past `words.len()` (up to
 /// `2^r_y.len()`) are treated as zero.
 ///
-/// A verifier reaches its words through a channel, so it uses the `channel_words_mle` sibling
-/// below; this is for a prover mirroring the same evaluation over native words.
+/// A verifier reaches its words through a channel and so uses [`evaluate_words_mle`]; this is the
+/// same evaluation over native words, for a prover mirroring the check.
 ///
 /// ## Preconditions
 ///
 /// * `r_j` has exactly `Word::LOG_BITS` entries
 /// * `words` has at most `2^r_y.len()` entries
-pub fn evaluate_words_mle<F, E>(words: &[Word], r_j: &[E], r_y: &[E]) -> E
+pub fn evaluate_words_mle_native<F, E>(words: &[Word], r_j: &[E], r_y: &[E]) -> E
 where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
@@ -56,7 +56,7 @@ where
 		.sum()
 }
 
-/// [`evaluate_words_mle`] over a channel's own words.
+/// [`evaluate_words_mle_native`] over a channel's own words.
 ///
 /// A word's contribution is the sum of the bit-index tensor over its set bits, which is what
 /// [`WordIPVerifierChannel::subset_sum`] computes — over concrete bits for a verifier reading a
@@ -66,7 +66,7 @@ where
 ///
 /// * `r_j` has exactly `Word::LOG_BITS` entries
 /// * `words` has at most `2^r_y.len()` entries
-fn channel_words_mle<F, C>(
+pub fn evaluate_words_mle<F, C>(
 	channel: &mut C,
 	words: &[C::Word],
 	r_j: &[C::Elem],
@@ -399,7 +399,7 @@ where
 		.map(|&word| C::Word::from(word))
 		.chain(inout_words.iter().cloned())
 		.collect::<Vec<_>>();
-	let public_eval = channel_words_mle(channel, &public, r_j, &r_y[..log_public_words]);
+	let public_eval = evaluate_words_mle(channel, &public, r_j, &r_y[..log_public_words]);
 
 	// Reconstruct the witness evaluation from its two segments. The public segment is
 	// zero-padded up to the hidden segment length, contributing the eq-zero padding factor.
@@ -707,19 +707,19 @@ mod tests {
 	}
 
 	#[test]
-	fn test_evaluate_words_mle_matches_naive() {
+	fn test_evaluate_words_mle_native_matches_naive() {
 		let (words, r_j, r_y, expected) = words_mle_case();
-		assert_eq!(evaluate_words_mle::<B128, B128>(&words, &r_j, &r_y), expected);
+		assert_eq!(evaluate_words_mle_native::<B128, B128>(&words, &r_j, &r_y), expected);
 	}
 
 	/// The two must agree: the verifier evaluates the public words through its channel and the
 	/// prover mirrors it natively.
 	#[test]
-	fn test_channel_words_mle_matches_the_native_one() {
+	fn test_evaluate_words_mle_matches_the_native_one() {
 		let (words, r_j, r_y, expected) = words_mle_case();
 
 		// A transcript carries concrete words, so this is the same arithmetic reached the long way.
 		let mut channel = VerifierTranscript::new(StdChallenger::default(), Vec::new());
-		assert_eq!(channel_words_mle(&mut channel, &words, &r_j, &r_y), expected);
+		assert_eq!(evaluate_words_mle(&mut channel, &words, &r_j, &r_y), expected);
 	}
 }

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -26,7 +26,7 @@ use binius_core::{
 use binius_field::{AESTowerField8b as B8, FieldOps};
 use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::{
-	channel::IPVerifierChannel,
+	channel::{IPVerifierChannel, WordIPVerifierChannel},
 	sumcheck::{BatchSumcheckOutput, batch_verify},
 };
 use binius_math::{
@@ -132,7 +132,8 @@ impl<F: Clone> ReductionOutput<F> {
 /// - `cs`: the single-instance constraint system every instance satisfies.
 /// - `instances`: whether this is the monolithic reduction or a batch, and how wide.
 /// - `inout`: which value segment the inout words sit in.
-/// - `public`: the declared public values, unpadded — the constants, then the inout values.
+/// - `inout_words`: the declared inout values, and nothing when they are hidden. The constants are
+///   part of the constraint system, so the caller does not restate them.
 /// - `channel`: the verifier channel that reads messages and redraws Fiat-Shamir challenges.
 ///
 /// # Errors
@@ -150,11 +151,11 @@ pub fn reduce_constraints<Channel>(
 	cs: &ConstraintSystem,
 	instances: Instances,
 	inout: InoutSegment,
-	public: &[Word],
+	inout_words: &[Channel::Word],
 	channel: &mut Channel,
 ) -> Result<ReductionOutput<Channel::Elem>, Error>
 where
-	Channel: IOPVerifierChannel<B128>,
+	Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 	Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 {
 	let log_instances = instances.log_count();
@@ -290,7 +291,7 @@ where
 		shift::check_eval::<B128, _>(
 			cs,
 			inout,
-			public,
+			inout_words,
 			&zero,
 			&bitand,
 			&intmul,

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -125,7 +125,15 @@ impl IOPVerifier {
 	///
 	/// This is the core verification logic, independent of the specific IOP compilation strategy.
 	/// For most users, [`Verifier::verify`] is the simpler interface.
-	pub fn verify<Channel>(&self, inout: &[Word], channel: &mut Channel) -> Result<(), Error>
+	///
+	/// The statement arrives as the channel's own word type. A channel over concrete values takes
+	/// [`Word`]s; a channel that builds a recursive circuit takes wires, so the circuit verifies
+	/// every instance of the system rather than the one statement it was built with.
+	pub fn verify<Channel>(
+		&self,
+		inout: &[Channel::Word],
+		channel: &mut Channel,
+	) -> Result<(), Error>
 	where
 		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
@@ -142,19 +150,7 @@ impl IOPVerifier {
 
 		// Only the inout values go into Fiat-Shamir: they are what varies per instance, and the
 		// constants are fixed by the constraint system the transcript is already bound to.
-		//
-		// The words are lifted into the channel's own word type, so a channel that carries words
-		// as wires still receives them. They arrive here concrete, so such a channel sees the
-		// statement as fixed; taking it symbolically is BINIUS-433.
-		let observed = inout
-			.iter()
-			.map(|&word| Channel::Word::from(word))
-			.collect::<Vec<_>>();
-		channel.observe_words(&observed);
-
-		// The shift reduction reads the whole public segment, which is the constants followed by
-		// the inout values — the order the value vector places them in.
-		let public = [self.constraint_system.constants.as_slice(), inout].concat();
+		channel.observe_words(inout);
 
 		let _verify_guard =
 			tracing::info_span!("Verify", operation = "verify", perfetto_category = "operation")
@@ -169,7 +165,7 @@ impl IOPVerifier {
 			self.constraint_system(),
 			Instances::Single,
 			InoutSegment::Public,
-			&public,
+			inout,
 			channel,
 		)?;
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -72,15 +72,16 @@ where
 
 		let inner_iop_verifier = IOPVerifier::new(constraint_system, log_public_words);
 
-		// Symbolically execute the inner verifier to build the outer constraint system.
-		let dummy_inout_words =
-			vec![Word::from_u64(0); inner_iop_verifier.constraint_system().n_inout];
-
+		// Symbolically execute the inner verifier to build the outer constraint system. The
+		// statement is wires, so the circuit is about the inner system rather than about any one
+		// instance — it is built here, before any instance exists.
 		let outer_builder = {
 			let _guard = tracing::debug_span!("Build ZK wrapper circuit").entered();
 			let mut builder_channel = IronSpartanBuilderChannel::new();
+			let statement =
+				builder_channel.statement(inner_iop_verifier.constraint_system().n_inout);
 			inner_iop_verifier
-				.verify(&dummy_inout_words, &mut builder_channel)
+				.verify(&statement, &mut builder_channel)
 				.expect("symbolic verify should not fail");
 			builder_channel.finish()
 		};
@@ -206,8 +207,11 @@ where
 			)
 			.entered();
 
+			// The statement fills the wires the wrapper circuit was built with, so the outer
+			// verification is about this instance.
+			let statement = wrapped_channel.statement(inout);
 			self.inner_iop_verifier
-				.verify(inout, &mut wrapped_channel)?;
+				.verify(&statement, &mut wrapped_channel)?;
 		};
 
 		// Finish runs the outer spartan verification.


### PR DESCRIPTION
Next in the recursion stack, on top of #2093. Closes [BINIUS-433](https://linear.app/jimpo/issue/BINIUS-433/take-the-inner-statement-symbolically-in-iopverifierverify).

`IOPVerifier::verify` took `inout: &[Word]`, so a channel that builds a circuit received the statement already concrete and baked it in as constants. The circuit then verified one instance of the inner system — the one it happened to be built with. It now takes `&[Channel::Word]`, and a builder channel hands back wires that are its circuit's own public input.

Two places read the statement.

**Fiat-Shamir** — `observe_words` already took the channel's word type, so the `From<Word>` lift at the call site just goes away.

**The public-words MLE** — `shift::check_eval` evaluated the public segment through `compute_public_value`, which carries field elements and so cannot carry symbolic words; the old code smuggled the words past it by capturing them in `PublicWordsEvalFn`. It now runs the algorithm symbolically, over `subset_sum`. `compute_public_value` is for values too slow to rebuild — the monster multilinear, proportional to the inner circuit's size. The public segment is small, so it is not one of them, and `PublicWordsEvalFn` is gone.

## The Spartan wrapper carries its statement symbolically too

That wrapper built its circuit from `dummy_inout_words`, which worked only while nothing in the circuit read a statement word's bits. `subset_sum` does, and a concrete word decides *which* elements the sum runs over, so folding it would write the dummy into the circuit's shape.

So the wrapper channels carry a `CircuitWord`: either a `Constant`, for a word the protocol fixes, or the word's bits. `subset_sum` is `Σ bits[i]·elems[i]` and `select` a mux over them, built the same way whatever the statement is. The statement enters as inout wires whose bits are hinted — a hint over a public input is not a value a prover chooses, since the outer verifier recomputes it — and `dummy_inout_words` is gone.

The cost is exactly the statement. On the sha256 preimage test:

| | before | after |
|---|---|---|
| inout wires | 324 | **332** |
| derived wires | 129 | 129 |
| public (padded) | 1024 | 1024 |
| mul constraints | 49,366 | 49,366 |

Every operation over the bits is public-derivable, so `ConstraintBuilder::mul` emits no constraint, and the intermediates feed only other derived wires, so `WitnessLayout::sparse` gives them no slot. Outer proof bytes change, since the outer constraint system does.

`ZKWrappedVerifierChannel::observe_words` is the one place a value still leaves the circuit: it reads the words back off the wires to feed the inner Fiat-Shamir state, which lives outside the circuit and which the inner prover mirrors. A read, not a decision — nothing the circuit contains depends on it.

## Also in here

- `reduce_constraints` and `check_eval` take the **inout words** rather than the whole public segment, reading the constants off the constraint system. The M4 verifier was passing `&cs.constants` for a batch that hides its inout words; it passes nothing now. A caller can no longer restate the constants wrongly — which the existing comment in `verify` already said was the point.
- `evaluate_words_mle` is the channel-generic one; the native form the prover needs (`WordIPProverChannel` has no `subset_sum`, so a prover only ever has native words) is `evaluate_words_mle_native`, the suffix `subset_sum_word` and `select_word` already use.

## Cost, recursion side

On the crc64 end-to-end test the recursive circuit goes from 129,959 to 130,599 BMUL and 3,912 to 4,259 ZERO: the statement's four words at one `subset_sum` each (64 selects over the `(lo, hi)` pair), plus the eq-indicator tensor over the word index.

```
recursive circuit: 166312 gates, 0 AND, 130599 BMUL, 4259 ZERO, 3336 recorded inputs
```

## Testing

`a_statement_the_proof_is_not_about_fails` is what says the recursion wires are wired in rather than merely present: filling them with a corrupted statement leaves the shift reduction's consistency check unsatisfied (`.assert_zero[1].lo`) instead of passing regardless. `CircuitWord`'s bit arithmetic is tested against the concrete helpers — `subset_sum`, `select`, `>>`, and the word/element embedding.

`cargo test --workspace --exclude binius-arith-bench`: **1454 passed, 0 failed, 21 ignored** across 58 binaries. Clippy clean on every crate touched; rustdoc clean; `fmt --check` clean.

Pre-existing breakages on this machine, excluded and confirmed against pristine `main`: `binius-arith-bench` does not compile here (aarch64 `poly64x2_t: Underlier`), and `cargo clippy --all-features` fails in `binius-ip-prover` (`Data cannot be shared between threads safely`) and `binius-examples` (a `needless_borrow` from a newer clippy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)