### PR TITLE
Bind the shift indicator bit index with a sumcheck

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -14,8 +14,8 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
-		monster::{build_h, build_monster_segments},
-		phase_1::{SparseShiftRows, build_g, run_phase_1_sumcheck},
+		monster::{build_h, build_monster_segments, evaluate_h},
+		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
 };
@@ -81,33 +81,30 @@ where
 		(&hidden, &key_collection.hidden.dense_shift_enc),
 	]);
 	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
-	let phase_1_output =
-		run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
+	let Phase1Output {
+		r_j,
+		r_s,
+		r_v,
+		gamma,
+	} = Phase1Output::split(run_phase_1_sumcheck::<F, F, _, _>(
+		g,
+		h,
+		prepared.batched_eval(),
+		channel,
+		alloc,
+	));
 
-	// Phase 2: split the phase-1 challenges into the bit position `r_j`, the shift amount `r_s`
-	// and the shift variant `r_v`, in increasing order of significance.
-	let SumcheckOutput {
-		challenges: mut r_j,
-		eval: gamma,
-	} = phase_1_output;
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
+	// Phase 2: the h evaluation every shift key is weighted by, then the witness folded at the
+	// bit position challenge `r_j`, per segment.
+	let h_eval = evaluate_h(domain_subspace, prepared.bitand.r_zhat_prime, &r_j, &r_s, &r_v);
+
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
-
-	// The witness folded at `r_j`, per segment.
 	// The public fold is a raw-word fold; the hidden fold contracts the already-oblong bits.
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
 
-	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
-		alloc,
-		key_collection,
-		&prepared,
-		domain_subspace,
-		&r_j,
-		&r_s,
-		&r_v,
-	);
+	let (public_monster, hidden_monster) =
+		build_monster_segments::<F, P, _>(alloc, key_collection, &prepared, h_eval, &r_s, &r_v);
 
 	run_sumcheck::<F, P, _, _>(
 		&public_folded,

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -13,8 +13,8 @@ use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
-		monster::{build_h, build_monster_segments, evaluate_h},
+		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftIndSumcheck,
+		monster::{build_h, build_monster_segments},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
@@ -96,17 +96,30 @@ where
 
 	// Phase 2: the h evaluation every shift key is weighted by, then the witness folded at the
 	// bit position challenge `r_j`, per segment.
-	let h_eval = evaluate_h(domain_subspace, prepared.bitand.r_zhat_prime, &r_j, &r_s, &r_v);
+	let shift_ind = ShiftIndSumcheck::<P, _>::new(
+		alloc,
+		domain_subspace,
+		prepared.bitand.r_zhat_prime,
+		&r_j,
+		&r_s,
+		&r_v,
+	);
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	// The public fold is a raw-word fold; the hidden fold contracts the already-oblong bits.
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
 
-	let (public_monster, hidden_monster) =
-		build_monster_segments::<F, P, _>(alloc, key_collection, &prepared, h_eval, &r_s, &r_v);
+	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
+		alloc,
+		key_collection,
+		&prepared,
+		shift_ind.h_eval(),
+		&r_s,
+		&r_v,
+	);
 
-	run_sumcheck::<F, P, _, _>(
+	let output = run_sumcheck::<F, P, _, _>(
 		&public_folded,
 		hidden_folded,
 		&public_monster,
@@ -116,7 +129,13 @@ where
 		gamma,
 		channel,
 		alloc,
-	)
+	);
+
+	// The h evaluation phase 2 was proved against is itself a sum over the bit index, which this
+	// last sumcheck binds.
+	shift_ind.prove(channel, alloc);
+
+	output
 }
 
 /// Accumulates the phase-1 "g" rows of one key segment, from instance-folded words.
@@ -378,7 +397,7 @@ mod tests {
 			&verifier_intmul,
 			&verifier_bmul,
 			&domain_subspace,
-			r_z,
+			&r_z,
 			&verifier_output,
 			&mut verifier_transcript,
 		)

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -14,8 +14,8 @@ use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		OperatorClaims, OperatorData, build_key_collection,
-		monster::{build_h, build_monster_segments, evaluate_h},
+		OperatorClaims, OperatorData, ShiftIndSumcheck, build_key_collection,
+		monster::{build_h, build_monster_segments},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 		prove,
@@ -325,7 +325,9 @@ fn bench_shift_phases(c: &mut Criterion) {
 			&GlobalAllocator,
 		))
 	};
-	let h_eval = evaluate_h(&subspace, prepared.bitand.r_zhat_prime, &r_j, &r_s, &r_v);
+	let h_eval =
+		ShiftIndSumcheck::<P, _>::new(&GlobalAllocator, &subspace, r_zhat_prime, &r_j, &r_s, &r_v)
+			.h_eval();
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -10,14 +10,13 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
-use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		OperatorClaims, OperatorData, build_key_collection,
-		monster::{build_h, build_monster_segments},
-		phase_1::{SparseShiftRows, build_g, run_phase_1_sumcheck},
+		monster::{build_h, build_monster_segments, evaluate_h},
+		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 		prove,
 	},
@@ -311,22 +310,22 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	let g = build_combined_g();
 	let h = build_h::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime);
-	let SumcheckOutput {
-		challenges: mut r_j,
-		eval: gamma,
+	let Phase1Output {
+		r_j,
+		r_s,
+		r_v,
+		gamma,
 	} = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
-		run_phase_1_sumcheck::<F, P, _, _>(
+		Phase1Output::split(run_phase_1_sumcheck::<F, P, _, _>(
 			g.clone(),
 			h.clone(),
 			prepared.batched_eval(),
 			&mut transcript,
 			&GlobalAllocator,
-		)
+		))
 	};
-	// Split the phase-1 challenges into the bit position, the shift amount and the shift variant.
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
+	let h_eval = evaluate_h(&subspace, prepared.bitand.r_zhat_prime, &r_j, &r_s, &r_v);
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());
@@ -334,8 +333,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 		&GlobalAllocator,
 		&key_collection,
 		&prepared,
-		&subspace,
-		&r_j,
+		h_eval,
 		&r_s,
 		&r_v,
 	);
@@ -376,8 +374,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 				&GlobalAllocator,
 				&key_collection,
 				&prepared,
-				&subspace,
-				&r_j,
+				h_eval,
 				&r_s,
 				&r_v,
 			)

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -29,9 +29,11 @@ pub mod phase_1;
 #[doc(hidden)]
 pub mod phase_2;
 mod prove;
+mod shift_ind;
 
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
 pub use key_collection::{
 	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
 };
 pub use prove::{OperatorData, PreparedOperatorData, prove};
+pub use shift_ind::ShiftIndSumcheck;

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -127,21 +127,37 @@ where
 	FieldBuffer::from_values_in(alloc, &data)
 }
 
+/// Evaluates the h multilinear at the phase-1 challenges, interpolated over the shift variant.
+///
+/// Phase 1 folded the variant axis into its sumcheck, so the eight h polynomials contribute this
+/// one scalar to phase 2 rather than one evaluation per variant. Every shift key of every
+/// operation is weighted by it, since all four operations share `r_zhat_prime`.
+pub fn evaluate_h<F: BinaryField>(
+	domain_subspace: &BinarySubspace<F>,
+	r_zhat_prime: F,
+	r_j: &[F],
+	r_s: &[F],
+	r_v: &[F],
+) -> F {
+	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
+	let h_ops = evaluate_h_op(l_tilde.as_ref(), r_j, r_s);
+	inner_product(h_ops, eq_ind_partial_eval::<F>(r_v).as_ref().iter().copied())
+}
+
 /// Constructs the "monster multilinear" that combines all shift operations into a single
 /// multilinear.
 ///
 /// This function builds a comprehensive multilinear polynomial that encapsulates the AND, IMUL and
 /// BMUL constraints with their associated shift operations. For each witness word, it computes the
-/// contribution from all constraints involving that word, weighted by the appropriate h-polynomial
-/// evaluations and lambda powers.
+/// contribution from all constraints involving that word, weighted by the h evaluation
+/// ([`evaluate_h`]) and lambda powers.
 ///
 /// # Construction Process
 ///
 /// 1. **Compute lambda powers**: Powers λ^(i+1) for each operand index in both operations
-/// 2. **Evaluate h-polynomials**: Compute h_op evaluations for SLL, SRL, SRA at challenge points
-/// 3. **Build scalar matrix**: Create scalars combining lambda powers, h-evaluations, and r_s
-///    tensor
-/// 4. **Process keys in parallel**: For each word, accumulate contributions from all its
+/// 2. **Build scalar matrix**: Create scalars combining lambda powers, the h evaluation, and the
+///    `r_s` and `r_v` tensors
+/// 3. **Process keys in parallel**: For each word, accumulate contributions from all its
 ///    constraints
 ///
 /// # Formula
@@ -151,9 +167,9 @@ where
 /// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor, scalars[key.dense_shift_idx])
 /// ```
 /// where `scalars[key.dense_shift_idx]` is the contiguous per-operand chunk encoding
-/// `λ^(operand_idx+1) × h_op[shift_variant] × r_s_tensor[shift_amount]` for operand index
-/// `operand_idx`, and `(shift_variant, shift_amount)` the pair the key's segment decodes its dense
-/// shift index to.
+/// `λ^(operand_idx+1) × h_eval × r_v_tensor[shift_variant] × r_s_tensor[shift_amount]` for operand
+/// index `operand_idx`, and `(shift_variant, shift_amount)` the pair the key's segment decodes its
+/// dense shift index to.
 ///
 /// # Usage
 ///
@@ -166,31 +182,14 @@ pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	key_collection: &KeyCollection,
 	prepared: &PreparedOperatorClaims<F>,
-	domain_subspace: &BinarySubspace<F>,
-	r_j: &[F],
+	h_eval: F,
 	r_s: &[F],
 	r_v: &[F],
 ) -> (FieldVec<P, A>, FieldVec<P, A>)
 where
 	F: BinaryField,
 {
-	// Phase 1 folded the variant axis into the sumcheck, so the h multilinear contributes one
-	// scalar per operation — the interpolation of its eight shift indicators at `r_v` — rather
-	// than one per variant.
 	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
-
-	let [zero_h_eval, bitand_h_eval, intmul_h_eval, binmul_h_eval] = [
-		prepared.zero.r_zhat_prime,
-		prepared.bitand.r_zhat_prime,
-		prepared.intmul.r_zhat_prime,
-		prepared.binmul.r_zhat_prime,
-	]
-	.map(|r_zhat_prime| {
-		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-		let h_ops = evaluate_h_op(l_tilde.as_ref(), r_j, r_s);
-		inner_product(h_ops, r_v_tensor.as_ref().iter().copied())
-	});
-
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
 
 	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
@@ -198,9 +197,9 @@ where
 	// can index directly by operand index.
 	//
 	// A key's shift now selects itself through a pure equality indicator over both of phase 1's
-	// shift axes, and the h evaluation is a single factor shared by every key of the operation.
+	// shift axes, and the h evaluation is a single factor shared by every key.
 	let build_scalars =
-		|arity: usize, lambda_powers: &[F], h_eval: F, dense_shift_enc: &DenseShiftEncoding| {
+		|arity: usize, lambda_powers: &[F], dense_shift_enc: &DenseShiftEncoding| {
 			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
 			for (dense_shift_idx, (variant, amount)) in dense_shift_enc.iter().enumerate() {
 				let shift_scalar = h_eval
@@ -216,25 +215,10 @@ where
 
 	// Each segment has its own dense shift encoding, so it has its own scalar tables.
 	let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
-		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, zero_h_eval, dense_shift_enc),
-		bitand: build_scalars(
-			BITAND_ARITY,
-			&prepared.bitand.lambda_powers,
-			bitand_h_eval,
-			dense_shift_enc,
-		),
-		intmul: build_scalars(
-			INTMUL_ARITY,
-			&prepared.intmul.lambda_powers,
-			intmul_h_eval,
-			dense_shift_enc,
-		),
-		binmul: build_scalars(
-			BINMUL_ARITY,
-			&prepared.binmul.lambda_powers,
-			binmul_h_eval,
-			dense_shift_enc,
-		),
+		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, dense_shift_enc),
+		bitand: build_scalars(BITAND_ARITY, &prepared.bitand.lambda_powers, dense_shift_enc),
+		intmul: build_scalars(INTMUL_ARITY, &prepared.intmul.lambda_powers, dense_shift_enc),
+		binmul: build_scalars(BINMUL_ARITY, &prepared.binmul.lambda_powers, dense_shift_enc),
 	};
 
 	// The scalar for one word of a segment: the accumulated contribution of all its keys. The

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -7,13 +7,11 @@ use binius_compute::{Allocator, VecLike};
 use binius_core::{ShiftVariant, word::Word};
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
-	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+	BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval,
+	univariate::lagrange_evals,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-use binius_verifier::protocols::shift::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY, evaluate_h_op,
-};
+use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 use bytemuck::zeroed_vec;
 use tracing::instrument;
 
@@ -127,30 +125,13 @@ where
 	FieldBuffer::from_values_in(alloc, &data)
 }
 
-/// Evaluates the h multilinear at the phase-1 challenges, interpolated over the shift variant.
-///
-/// Phase 1 folded the variant axis into its sumcheck, so the eight h polynomials contribute this
-/// one scalar to phase 2 rather than one evaluation per variant. Every shift key of every
-/// operation is weighted by it, since all four operations share `r_zhat_prime`.
-pub fn evaluate_h<F: BinaryField>(
-	domain_subspace: &BinarySubspace<F>,
-	r_zhat_prime: F,
-	r_j: &[F],
-	r_s: &[F],
-	r_v: &[F],
-) -> F {
-	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-	let h_ops = evaluate_h_op(l_tilde.as_ref(), r_j, r_s);
-	inner_product(h_ops, eq_ind_partial_eval::<F>(r_v).as_ref().iter().copied())
-}
-
 /// Constructs the "monster multilinear" that combines all shift operations into a single
 /// multilinear.
 ///
 /// This function builds a comprehensive multilinear polynomial that encapsulates the AND, IMUL and
 /// BMUL constraints with their associated shift operations. For each witness word, it computes the
-/// contribution from all constraints involving that word, weighted by the h evaluation
-/// ([`evaluate_h`]) and lambda powers.
+/// contribution from all constraints involving that word, weighted by the h evaluation and lambda
+/// powers.
 ///
 /// # Construction Process
 ///
@@ -169,7 +150,8 @@ pub fn evaluate_h<F: BinaryField>(
 /// where `scalars[key.dense_shift_idx]` is the contiguous per-operand chunk encoding
 /// `λ^(operand_idx+1) × h_eval × r_v_tensor[shift_variant] × r_s_tensor[shift_amount]` for operand
 /// index `operand_idx`, and `(shift_variant, shift_amount)` the pair the key's segment decodes its
-/// dense shift index to.
+/// dense shift index to. The h evaluation comes from
+/// [`ShiftIndSumcheck`](super::ShiftIndSumcheck), which proves it.
 ///
 /// # Usage
 ///
@@ -296,16 +278,17 @@ mod tests {
 		inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval,
 		test_utils::random_scalars,
 	};
-	use binius_verifier::protocols::shift::{LOG_SHIFT_VARIANT_COUNT, evaluate_h_op};
+	use binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT;
 	use rand::{SeedableRng, rngs::StdRng};
 
-	use super::*;
+	use super::{super::ShiftIndSumcheck, *};
 
-	/// The built h multilinear and the succinct `evaluate_h_op` must agree.
+	/// Phase 1's h multilinear and the h evaluation the last sumcheck claims must agree.
 	///
-	/// The variant axis is folded by the sumcheck now, so evaluating the whole multilinear at
-	/// `(r_j, r_s, r_v)` gives the interpolation of the eight succinct evaluations over `r_v` —
-	/// which is exactly the single scalar phase 2 weights its keys by.
+	/// The claim sums the shift indicators over the bit index, weighted by the Lagrange
+	/// evaluations; the multilinear holds those sums over the whole shift axis. So evaluating the
+	/// multilinear at `(r_j, r_s, r_v)` must give the claim — which is the single scalar phase 2
+	/// weights its keys by.
 	#[test]
 	fn h_op_consistency() {
 		type F = BinaryField128bGhash;
@@ -322,12 +305,17 @@ mod tests {
 			let r_s = random_scalars::<F>(&mut rng, Word::LOG_BITS);
 			let r_v = random_scalars::<F>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
 
-			// Method 1: the succinct per-variant evaluations, interpolated over the variant axis.
+			// Method 1: the sum the last sumcheck claims.
 			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
-			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
-			let succinct_evaluations = evaluate_h_op(l_tilde.as_ref(), &r_j, &r_s);
-			let r_v_tensor = eq_ind_partial_eval::<F>(&r_v);
-			let succinct = inner_product(succinct_evaluations, r_v_tensor.as_ref().iter().copied());
+			let claimed = ShiftIndSumcheck::<P, _>::new(
+				&GlobalAllocator,
+				&subspace,
+				r_zhat_prime,
+				&r_j,
+				&r_s,
+				&r_v,
+			)
+			.h_eval();
 
 			// Method 2: evaluate the built multilinear at the whole point.
 			let h = build_h(&GlobalAllocator, &subspace, r_zhat_prime);
@@ -336,8 +324,8 @@ mod tests {
 			let direct = inner_product_buffers(&h, &tensor);
 
 			assert_eq!(
-				succinct, direct,
-				"H-op evaluation mismatch (test_case={test_case}): succinct != direct",
+				claimed, direct,
+				"H-op evaluation mismatch (test_case={test_case}): claimed != direct",
 			);
 		}
 	}

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -50,6 +50,42 @@ pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_V
 /// amount, then the shift variant.
 pub const LOG_SHIFT_ROWS: usize = PHASE_1_LOG_LEN - Word::LOG_BITS;
 
+/// What phase 1 leaves phase 2: its sumcheck's challenge point, split into the axes it binds,
+/// and the evaluation claim it reduced to.
+#[derive(Debug, Clone)]
+pub struct Phase1Output<F> {
+	/// The bit position within a word.
+	pub r_j: Vec<F>,
+	/// The shift amount.
+	pub r_s: Vec<F>,
+	/// The shift variant.
+	pub r_v: Vec<F>,
+	/// The evaluation claim phase 2 proves, called gamma in the paper.
+	pub gamma: F,
+}
+
+impl<F> Phase1Output<F> {
+	/// Splits the phase-1 sumcheck's output into the axes its challenge point binds: the bit
+	/// position within a word, then the shift amount, then the shift variant, in increasing order
+	/// of significance.
+	pub fn split(output: SumcheckOutput<F>) -> Self {
+		let SumcheckOutput {
+			challenges: mut r_j,
+			eval: gamma,
+		} = output;
+		assert_eq!(r_j.len(), PHASE_1_LOG_LEN);
+
+		let r_v = r_j.split_off(Word::LOG_BITS * 2);
+		let r_s = r_j.split_off(Word::LOG_BITS);
+		Self {
+			r_j,
+			r_s,
+			r_v,
+			gamma,
+		}
+	}
+}
+
 /// Proves the first phase of the shift reduction.
 ///
 /// Builds the g and h multilinears and runs one sumcheck over their product.
@@ -61,7 +97,7 @@ pub fn prove_phase_1<F, P, Channel, A>(
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F>
+) -> Phase1Output<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -80,7 +116,7 @@ where
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
 	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 
-	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
+	Phase1Output::split(run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc))
 }
 
 /// The number of packed elements one row of `Word::BITS` scalars occupies.

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -14,7 +14,7 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec,
+	FieldBuffer, FieldVec,
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
 };
 use binius_utils::{
@@ -29,7 +29,7 @@ use tracing::instrument;
 
 use super::{
 	SegmentWords, claims::PreparedOperatorClaims, key_collection::KeyCollection,
-	monster::build_monster_segments,
+	monster::build_monster_segments, phase_1::Phase1Output,
 };
 use crate::fold_word::fold_words;
 
@@ -40,11 +40,10 @@ use crate::fold_word::fold_words;
 /// the witness and the monster multilinear polynomial.
 ///
 /// # Protocol Steps
-/// 1. **Challenge Splitting**: Splits phase 1 challenges into `r_j` and `r_s` components
-/// 2. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
-/// 3. **Monster Multilinear Construction**: Builds the monster segments from the key collection and
+/// 1. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
+/// 2. **Monster Multilinear Construction**: Builds the monster segments from the key collection and
 ///    the prepared claims
-/// 4. **Sumcheck Execution**: Runs the bivariate product sumcheck with a sparse first round over
+/// 3. **Sumcheck Execution**: Runs the bivariate product sumcheck with a sparse first round over
 ///    the segment selector
 ///
 /// # Parameters
@@ -52,6 +51,7 @@ use crate::fold_word::fold_words;
 /// - `words`: The value vector words
 /// - `prepared`: The prepared claim of each operation, indexed by the operation a key names
 /// - `phase_1_output`: Challenges and evaluation from the first phase
+/// - `h_eval`: The h evaluation weighting every shift key, from [`evaluate_h`]
 /// - `channel`: The prover's channel
 ///
 /// # Returns
@@ -62,8 +62,8 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
 	key_collection: &KeyCollection,
 	words: SegmentWords<'_>,
 	prepared: &PreparedOperatorClaims<F>,
-	domain_subspace: &BinarySubspace<F>,
-	phase_1_output: SumcheckOutput<F>,
+	phase_1_output: Phase1Output<F>,
+	h_eval: F,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F>
@@ -72,14 +72,12 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	let SumcheckOutput {
-		challenges: mut r_j,
-		eval: gamma,
+	let Phase1Output {
+		r_j,
+		r_s,
+		r_v,
+		gamma,
 	} = phase_1_output;
-	// Split the challenges as `r_j, r_s, r_v`: the bit position, then the shift amount, then the
-	// shift variant, in increasing order of significance.
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
@@ -89,7 +87,7 @@ where
 	let hidden_folded = fold_words::<_, P, _>(alloc, words.hidden, r_j_tensor.as_ref());
 
 	let (public_monster, hidden_monster) =
-		build_monster_segments(alloc, key_collection, prepared, domain_subspace, &r_j, &r_s, &r_v);
+		build_monster_segments(alloc, key_collection, prepared, h_eval, &r_s, &r_v);
 
 	// Both halves of the sumcheck share one word-index address space, spanning the wider of the
 	// two segments. The hidden segment is normally the wider one, but a system with more public

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -51,7 +51,8 @@ use crate::fold_word::fold_words;
 /// - `words`: The value vector words
 /// - `prepared`: The prepared claim of each operation, indexed by the operation a key names
 /// - `phase_1_output`: Challenges and evaluation from the first phase
-/// - `h_eval`: The h evaluation weighting every shift key, from [`evaluate_h`]
+/// - `h_eval`: The h evaluation weighting every shift key, from
+///   [`ShiftIndSumcheck`](super::ShiftIndSumcheck)
 /// - `channel`: The prover's channel
 ///
 /// # Returns

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -10,8 +10,8 @@ use binius_math::{
 };
 
 use super::{
-	SegmentWords, claims::OperatorClaims, key_collection::KeyCollection, phase_1::prove_phase_1,
-	phase_2::prove_phase_2,
+	SegmentWords, claims::OperatorClaims, key_collection::KeyCollection, monster::evaluate_h,
+	phase_1::prove_phase_1, phase_2::prove_phase_2,
 };
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
@@ -173,7 +173,7 @@ where
 		claims.prepare(|| channel.sample())
 	};
 
-	// Phase 1 outputs challenges `r_j || r_s`, and `gamma` as its evaluation (see paper).
+	// Phase 1 outputs challenges `r_j || r_s || r_v`, and `gamma` as its evaluation (see paper).
 	let phase_1_output = prove_phase_1::<_, P, _, _>(
 		key_collection,
 		words,
@@ -183,14 +183,24 @@ where
 		alloc,
 	);
 
+	// The h evaluation phase 2 weights every shift key by. All four operations share
+	// `r_zhat_prime`, so it is drawn from the BitAnd claim, as phase 1's h multilinear is.
+	let h_eval = evaluate_h(
+		domain_subspace,
+		prepared.bitand.r_zhat_prime,
+		&phase_1_output.r_j,
+		&phase_1_output.r_s,
+		&phase_1_output.r_v,
+	);
+
 	// Phase 2 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
 	// the univariate variable `r_j` and the multilinear variable `r_y`.
 	prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
-		domain_subspace,
 		phase_1_output,
+		h_eval,
 		channel,
 		alloc,
 	)

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -10,8 +10,8 @@ use binius_math::{
 };
 
 use super::{
-	SegmentWords, claims::OperatorClaims, key_collection::KeyCollection, monster::evaluate_h,
-	phase_1::prove_phase_1, phase_2::prove_phase_2,
+	SegmentWords, claims::OperatorClaims, key_collection::KeyCollection, phase_1::prove_phase_1,
+	phase_2::prove_phase_2, shift_ind::ShiftIndSumcheck,
 };
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
@@ -183,9 +183,11 @@ where
 		alloc,
 	);
 
-	// The h evaluation phase 2 weights every shift key by. All four operations share
-	// `r_zhat_prime`, so it is drawn from the BitAnd claim, as phase 1's h multilinear is.
-	let h_eval = evaluate_h(
+	// The h evaluation phase 2 weights every shift key by, with the multilinears the final
+	// sumcheck proves it from. All four operations share `r_zhat_prime`, so it is drawn from the
+	// BitAnd claim, as phase 1's h multilinear is.
+	let shift_ind = ShiftIndSumcheck::<P, _>::new(
+		alloc,
 		domain_subspace,
 		prepared.bitand.r_zhat_prime,
 		&phase_1_output.r_j,
@@ -195,13 +197,19 @@ where
 
 	// Phase 2 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
 	// the univariate variable `r_j` and the multilinear variable `r_y`.
-	prove_phase_2::<_, P, _, _>(
+	let output = prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
 		phase_1_output,
-		h_eval,
+		shift_ind.h_eval(),
 		channel,
 		alloc,
-	)
+	);
+
+	// The h evaluation phase 2 was proved against is itself a sum over the bit index, which this
+	// last sumcheck binds.
+	shift_ind.prove(channel, alloc);
+
+	output
 }

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -1,0 +1,393 @@
+// Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+//! The sumcheck binding the bit index the h polynomials sum over, and the shift indicator
+//! partial evaluations it runs over.
+
+use binius_compute::Allocator;
+use binius_core::word::Word;
+use binius_field::{BinaryField, FieldOps, PackedField};
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{bivariate_product_prover, prove_single},
+};
+use binius_math::{
+	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
+	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+};
+
+/// The number of bit variables a half-word (`*32`) shift variant acts over.
+const HALF_WORD_LOG_BITS: usize = Word::LOG_BITS - 1;
+
+/// The shift reduction's last sumcheck, over the bit index the h polynomials sum over.
+///
+/// The scalar phase 2 weights every shift key by is that sum, at the phase-1 challenges:
+///
+/// $$
+/// h(r_j, r_s, r_v) = \sum_i \widetilde{L}(i) \cdot
+///     \sum_{\text{op}} \widetilde{eq}(r_v, \text{op}) \cdot \text{ind}_{\text{op}}(i, r_j, r_s)
+/// $$
+///
+/// Proving it as a sumcheck over the two multilinears in `i` leaves the verifier one evaluation
+/// of each at a random point, which it computes directly with
+/// [`evaluate_shift_inds`](binius_verifier::protocols::shift::evaluate_shift_inds) — no
+/// summation over the bit index, and no partial evaluation.
+pub struct ShiftIndSumcheck<P: PackedField, A: Allocator> {
+	/// The Lagrange evaluations at the univariate challenge, over the bit index.
+	l_tilde: FieldVec<P, A>,
+	/// The shift indicators interpolated over the shift variant, over the bit index.
+	shift_ind: FieldVec<P, A>,
+	/// The claimed sum of their product: the h evaluation.
+	h_eval: P::Scalar,
+}
+
+impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<P, A> {
+	/// Builds the two multilinears the sumcheck runs over, and their claimed sum.
+	///
+	/// # Arguments
+	///
+	/// - `domain_subspace`: the univariate evaluation domain.
+	/// - `r_zhat_prime`: the univariate challenge, shared by every operation.
+	/// - `r_j`, `r_s`, `r_v`: phase 1's challenges — the input bit position, the shift amount and
+	///   the shift variant.
+	pub fn new(
+		alloc: &A,
+		domain_subspace: &BinarySubspace<F>,
+		r_zhat_prime: F,
+		r_j: &[F],
+		r_s: &[F],
+		r_v: &[F],
+	) -> Self {
+		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
+		let l_tilde = l_tilde.as_ref();
+
+		let shift_ind = build_shift_ind(r_j, r_s, r_v);
+		let h_eval = inner_product(l_tilde.iter().copied(), shift_ind.iter().copied());
+
+		Self {
+			l_tilde: FieldBuffer::from_values_in(alloc, l_tilde),
+			shift_ind: FieldBuffer::from_values_in(alloc, &shift_ind),
+			h_eval,
+		}
+	}
+
+	/// The h evaluation, which phase 2 weights every shift key by.
+	pub const fn h_eval(&self) -> F {
+		self.h_eval
+	}
+
+	/// Sends the h evaluation and proves it, in the [`Word::LOG_BITS`] rounds that bind the bit
+	/// index.
+	///
+	/// The reduced evaluations the sumcheck ends at are dropped: the verifier evaluates both
+	/// multilinears at the challenge point itself.
+	pub fn prove(self, channel: &mut impl IPProverChannel<F>, alloc: &A) {
+		channel.send_one(self.h_eval);
+		let prover = bivariate_product_prover(alloc, [self.l_tilde, self.shift_ind], self.h_eval);
+		prove_single(prover, channel);
+	}
+}
+
+/// Builds the shift indicators over the bit index, interpolated over the shift variant, at the
+/// phase-1 challenges: one scalar per bit index.
+///
+/// Phase 1 folded the variant axis into its own sumcheck, so the eight indicators contribute a
+/// single multilinear here rather than one each.
+fn build_shift_ind<F: BinaryField>(r_j: &[F], r_s: &[F], r_v: &[F]) -> Vec<F> {
+	let (sigma, sigma_prime) = partial_eval_sigmas(r_j, r_s);
+	let sigma_transpose = partial_eval_sigmas_transpose(r_j, r_s);
+	let phi = partial_eval_phi(r_s);
+	// The equality indicator selecting the sign position, the top input bit.
+	let sign_position: F = r_j.iter().copied().product();
+
+	// A half-word variant applies the same four rules to each 32-bit half, reading only the low
+	// bits of the shift amount. The two halves never mix, so each indicator also carries the
+	// equality of the halves the two bit indices fall in.
+	let (sigma32, sigma32_prime) =
+		partial_eval_sigmas(&r_j[..HALF_WORD_LOG_BITS], &r_s[..HALF_WORD_LOG_BITS]);
+	let sigma32_transpose =
+		partial_eval_sigmas_transpose(&r_j[..HALF_WORD_LOG_BITS], &r_s[..HALF_WORD_LOG_BITS]);
+	let phi32 = partial_eval_phi(&r_s[..HALF_WORD_LOG_BITS]);
+	let sign_position32: F = r_j[..HALF_WORD_LOG_BITS].iter().copied().product();
+	let same_half = eq_ind_partial_eval::<F>(&r_j[HALF_WORD_LOG_BITS..]);
+
+	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
+	(0..Word::BITS)
+		.map(|index| {
+			let (half, low) = (index >> HALF_WORD_LOG_BITS, index % (1 << HALF_WORD_LOG_BITS));
+			let same_half = same_half.as_ref()[half];
+			// The eight indicators at this bit index, in `ShiftVariant` order.
+			let shift_inds = [
+				sigma_transpose[index],
+				sigma[index],
+				sigma[index] + sign_position * phi[index],
+				sigma[index] + sigma_prime[index],
+				same_half * sigma32_transpose[low],
+				same_half * sigma32[low],
+				same_half * (sigma32[low] + sign_position32 * phi32[low]),
+				same_half * (sigma32[low] + sigma32_prime[low]),
+			];
+			inner_product(shift_inds, r_v_tensor.as_ref().iter().copied())
+		})
+		.collect()
+}
+
+/// Partial evaluation of the shift indicator helper polynomials $\sigma, \sigma'$ over all i on the
+/// hypercube.
+///
+/// Given fixed j and s, computes sigma and sigma_prime for all possible i values.
+/// Returns (sigma, sigma_prime) as Vecs of length `1 << r_j.len()`.
+fn partial_eval_sigmas<E: FieldOps>(r_j: &[E], r_s: &[E]) -> (Vec<E>, Vec<E>) {
+	assert_eq!(r_j.len(), r_s.len(), "r_j and r_s must have the same length");
+
+	let n = r_j.len();
+	let mut sigma = vec![E::zero(); 1 << n];
+	let mut sigma_prime = vec![E::zero(); 1 << n];
+	sigma[0] = E::one();
+
+	// Process each bit position
+	for k in 0..n {
+		let j_k = r_j[k].clone();
+		let s_k = r_s[k].clone();
+
+		// Precompute boolean combinations for this bit
+		let both = j_k.clone() * &s_k;
+		let j_one_s = j_k.clone() - &both; // j_k * (1 - s_k)
+		let one_j_s = s_k.clone() - &both; // (1 - j_k) * s_k
+		let xor = j_k + s_k;
+		let eq = E::one() + &xor;
+
+		// Update arrays for this bit position
+		for i in 0..(1 << k) {
+			// Update upper halves first (i_k = 1)
+			sigma[(1 << k) | i] = j_one_s.clone() * &sigma[i];
+			sigma_prime[(1 << k) | i] = one_j_s.clone() * &sigma[i] + eq.clone() * &sigma_prime[i];
+
+			// Update lower halves (i_k = 0)
+			let sigma_i = sigma[i].clone();
+			let sigma_prime_i = sigma_prime[i].clone();
+			sigma[i] = eq.clone() * &sigma_i + j_one_s.clone() * &sigma_prime_i;
+			sigma_prime[i] = sigma_prime_i * &one_j_s;
+		}
+	}
+
+	(sigma, sigma_prime)
+}
+
+/// Partial evaluation of the shift indicator helper polynomial $\phi$ over all i on the hypercube.
+///
+/// Given fixed s, computes phi for all possible i values.
+fn partial_eval_phi<E: FieldOps>(r_s: &[E]) -> Vec<E> {
+	let n = r_s.len();
+	let mut phi = vec![E::zero(); 1 << n];
+
+	// Process each bit position
+	for k in 0..n {
+		let s_k = r_s[k].clone();
+
+		// Update arrays for this bit position
+		for i in 0..(1 << k) {
+			// Update for i_k = 1
+			phi[(1 << k) | i] = s_k.clone() + (E::one() + &s_k) * &phi[i];
+			let temp = phi[(1 << k) | i].clone() - &s_k;
+			phi[i] += &temp;
+		}
+	}
+
+	phi
+}
+
+/// Partial evaluation of transposed sigma for SLL.
+///
+/// Since sll_ind(i, j, s) = srl_ind(j, i, s), this computes sigma with i and j swapped.
+fn partial_eval_sigmas_transpose<E: FieldOps>(r_j: &[E], r_s: &[E]) -> Vec<E> {
+	assert_eq!(r_j.len(), r_s.len(), "r_j and r_s must have the same length");
+
+	let n = r_j.len();
+	let mut sigma_transpose = vec![E::zero(); 1 << n];
+	let mut sigma_transpose_prime = vec![E::zero(); 1 << n];
+	sigma_transpose[0] = E::one();
+
+	// Process each bit position
+	for k in 0..n {
+		let j_k = r_j[k].clone();
+		let s_k = r_s[k].clone();
+
+		// Precompute boolean combinations for this bit (with i and j swapped)
+		let both = j_k.clone() * &s_k;
+		let xor = j_k + s_k;
+		let eq = E::one() + &xor;
+		let zero = eq.clone() + &both;
+
+		// Update arrays for this bit position
+		for i in 0..(1 << k) {
+			// Update for i_k = 1
+			sigma_transpose[(1 << k) | i] =
+				xor.clone() * &sigma_transpose[i] + zero.clone() * &sigma_transpose_prime[i];
+			sigma_transpose_prime[(1 << k) | i] = both.clone() * &sigma_transpose_prime[i];
+
+			// Update for i_k = 0
+			let sigma_t = sigma_transpose[i].clone();
+			sigma_transpose_prime[i] =
+				both.clone() * &sigma_t + xor.clone() * &sigma_transpose_prime[i];
+			sigma_transpose[i] = zero.clone() * &sigma_t;
+		}
+	}
+
+	sigma_transpose
+}
+
+#[cfg(test)]
+mod tests {
+	use std::array;
+
+	use binius_field::{BinaryField128bGhash as B128, Field};
+	use binius_math::{
+		multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars,
+		univariate::lagrange_evals_scalars,
+	};
+	use binius_verifier::protocols::shift::{LOG_SHIFT_VARIANT_COUNT, evaluate_shift_inds};
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	// Ground truth for a shift-indicator MLE, independent of the recurrence under test.
+	//
+	// Fix j, s to the challenges r_j, r_s.
+	//
+	// Over the hypercube in i, the indicator's MLE expands over the (j, s) cube as:
+	//     mle[i] = sum_{j, s in {0,1}^n : cond(i, j, s)} eq(r_j, j) * eq(r_s, s)
+	fn reference_indicator(
+		r_j: &[B128],
+		r_s: &[B128],
+		cond: impl Fn(usize, usize, usize) -> bool,
+	) -> Vec<B128> {
+		let n = r_j.len();
+		// eq_j[j] = eq(r_j, j), eq_s[s] = eq(r_s, s).
+		//
+		// Both index little-endian, matching the recurrence's bit order.
+		let eq_j = eq_ind_partial_eval_scalars(r_j);
+		let eq_s = eq_ind_partial_eval_scalars(r_s);
+
+		(0..1 << n)
+			.map(|i| {
+				let mut acc = B128::ZERO;
+				for j in 0..1 << n {
+					for s in 0..1 << n {
+						if cond(i, j, s) {
+							acc += eq_j[j] * eq_s[s];
+						}
+					}
+				}
+				acc
+			})
+			.collect()
+	}
+
+	// Draw a pseudo-random challenge (r_j, r_s).
+	// The fixed seed keeps failures reproducible.
+	fn challenges(n: usize) -> (Vec<B128>, Vec<B128>) {
+		let mut rng = StdRng::seed_from_u64(0);
+		(random_scalars(&mut rng, n), random_scalars(&mut rng, n))
+	}
+
+	#[test]
+	fn srl_matches_reference() {
+		// srl: output bit i reads input bit j = i + s.
+		// Bits shifted past the top vanish, since no such j is in range.
+		let (r_j, r_s) = challenges(6);
+		let (sigma, _) = partial_eval_sigmas(&r_j, &r_s);
+		assert_eq!(sigma, reference_indicator(&r_j, &r_s, |i, j, s| j == i + s));
+	}
+
+	#[test]
+	fn sll_matches_reference() {
+		// sll is the transpose of srl.
+		// Output bit i = j + s reads input bit j.
+		let (r_j, r_s) = challenges(6);
+		let sigma_transpose = partial_eval_sigmas_transpose(&r_j, &r_s);
+		assert_eq!(sigma_transpose, reference_indicator(&r_j, &r_s, |i, j, s| i == j + s));
+	}
+
+	#[test]
+	fn sra_matches_reference() {
+		// sra behaves like srl within range.
+		// Past the shift, the sign bit j = 2^n - 1 fills every position.
+		let (r_j, r_s) = challenges(6);
+		let n = r_j.len();
+		let (sigma, _) = partial_eval_sigmas(&r_j, &r_s);
+		let phi = partial_eval_phi(&r_s);
+		// prod(r_j) is the eq-indicator selecting the all-ones sign position j = 2^n - 1.
+		let j_product: B128 = r_j.iter().copied().product();
+		let sra: Vec<_> = (0..1 << n).map(|i| sigma[i] + j_product * phi[i]).collect();
+		assert_eq!(sra, reference_indicator(&r_j, &r_s, |i, j, s| j == (i + s).min((1 << n) - 1)));
+	}
+
+	#[test]
+	fn rotr_matches_reference() {
+		// rotr wraps bits leaving the bottom back to the top.
+		// So j = (i + s) mod 2^n.
+		let (r_j, r_s) = challenges(6);
+		let n = r_j.len();
+		let (sigma, sigma_prime) = partial_eval_sigmas(&r_j, &r_s);
+		let rotr: Vec<_> = (0..1 << n).map(|i| sigma[i] + sigma_prime[i]).collect();
+		assert_eq!(rotr, reference_indicator(&r_j, &r_s, |i, j, s| j == (i + s) % (1 << n)));
+	}
+
+	/// The multilinear the prover sums over and the point evaluation the verifier checks it
+	/// against must be the same polynomial: over the bit-index hypercube, the two agree.
+	#[test]
+	fn build_matches_the_verifier_point_evaluation() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let r_j = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
+		let r_s = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
+		let r_v = random_scalars::<B128>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
+
+		let shift_ind = build_shift_ind(&r_j, &r_s, &r_v);
+		let r_v_tensor = eq_ind_partial_eval_scalars(&r_v);
+
+		for (index, &value) in shift_ind.iter().enumerate() {
+			// The bit-index hypercube vertex at `index`.
+			let r_i: [B128; Word::LOG_BITS] = array::from_fn(|bit| {
+				if (index >> bit) & 1 == 1 {
+					B128::ONE
+				} else {
+					B128::ZERO
+				}
+			});
+			let expected =
+				inner_product(evaluate_shift_inds(&r_i, &r_j, &r_s), r_v_tensor.iter().copied());
+			assert_eq!(value, expected, "bit index {index}");
+		}
+	}
+
+	/// The claimed sum is the h evaluation: the Lagrange weights contracted against the
+	/// indicator multilinear.
+	#[test]
+	fn claimed_sum_is_the_weighted_indicator_sum() {
+		use binius_compute::GlobalAllocator;
+		use binius_field::{AESTowerField8b, PackedBinaryGhash2x128b, Random};
+
+		type P = PackedBinaryGhash2x128b;
+
+		let mut rng = StdRng::seed_from_u64(1);
+		let r_zhat_prime = B128::random(&mut rng);
+		let r_j = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
+		let r_s = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
+		let r_v = random_scalars::<B128>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
+
+		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let sumcheck = ShiftIndSumcheck::<P, _>::new(
+			&GlobalAllocator,
+			&subspace,
+			r_zhat_prime,
+			&r_j,
+			&r_s,
+			&r_v,
+		);
+
+		let l_tilde = lagrange_evals_scalars(&subspace, &r_zhat_prime);
+		let expected = inner_product(l_tilde, build_shift_ind(&r_j, &r_s, &r_v));
+		assert_eq!(sumcheck.h_eval(), expected);
+	}
+}

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -400,7 +400,7 @@ fn test_shift_prove_and_verify() {
 			&verifier_intmul_data,
 			&verifier_binmul_data,
 			&subspace,
-			r_zhat_prime,
+			&r_zhat_prime,
 			&verifier_output,
 			&mut verifier_transcript,
 		)

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -20,4 +20,5 @@ mod error;
 mod verify;
 
 pub use error::Error;
+pub use shift_ind::evaluate_shift_inds;
 pub use verify::{OperatorData, VerifyOutput, check_eval, evaluate_words_mle, verify};

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -8,15 +8,10 @@ use binius_field::{
 	BinaryField, FieldOps, WideMul,
 	util::{FieldFn, powers},
 };
-use binius_math::{
-	inner_product::inner_product_scalars, multilinear::eq::eq_ind_partial_eval_scalars,
-};
+use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
-use super::{
-	SHIFT_VARIANT_COUNT,
-	shift_ind::{partial_eval_phi, partial_eval_sigmas, partial_eval_sigmas_transpose},
-};
+use super::SHIFT_VARIANT_COUNT;
 
 /// Why a term's outer shift slot must hold the identity in the two-phase reduction.
 ///
@@ -24,76 +19,6 @@ use super::{
 /// A term carrying both would verify against the wrong shifted word.
 const DOUBLE_SHIFT_UNSUPPORTED: &str =
 	"the two-phase shift reduction reads only the inner shift of a term";
-
-/// Evaluates the three h multilinear polynomials (corresponding to SLL, SRL, SRA) at challenge
-/// points.
-///
-/// This is the verifier's version of the h-parts evaluation - instead of building
-/// full multilinear polynomials, it directly computes their evaluations.
-pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SHIFT_VARIANT_COUNT] {
-	assert_eq!(l_tilde.len(), Word::BITS);
-	assert_eq!(r_j.len(), Word::LOG_BITS);
-	assert_eq!(r_s.len(), Word::LOG_BITS);
-
-	// Use helper functions to compute shift indicator helpers for 64-bit shifts
-	let (sigma, sigma_prime) = partial_eval_sigmas(r_j, r_s);
-	let sigma_transpose = partial_eval_sigmas_transpose(r_j, r_s);
-	let phi = partial_eval_phi(r_s);
-	let j_product: E = r_j.iter().cloned().product();
-
-	// Use helper functions to compute shift indicator helpers for 32-bit shifts
-	let (sigma32, sigma32_prime) = partial_eval_sigmas(&r_j[..5], &r_s[..5]);
-	let sigma32_transpose = partial_eval_sigmas_transpose(&r_j[..5], &r_s[..5]);
-	let phi32 = partial_eval_phi(&r_s[..5]);
-	let j_product32: E = r_j[..5].iter().cloned().product();
-
-	// Compute final results
-	let sll = inner_product_scalars(l_tilde.iter().cloned(), sigma_transpose);
-	let srl = inner_product_scalars(l_tilde.iter().cloned(), sigma.iter().cloned());
-	// sra == ∑ᵢ L̃(i) ⋅ (srlᵢ + ∏ₖ rⱼ[k] ⋅ φᵢ)
-	//     == ∑ᵢ L̃(i) ⋅ srlᵢ + ∏ₖ rⱼ[k] ⋅ [ ∑ᵢ L̃(i) ⋅ φᵢ ]
-	//     == srl + ∏ₖ rⱼ[k] ⋅ [ ∑ᵢ L̃(i) ⋅ φᵢ ]
-	let sra = srl.clone() + j_product * inner_product_scalars(l_tilde.iter().cloned(), phi);
-	let rotr = inner_product_scalars(
-		l_tilde.iter().cloned(),
-		iter::zip(&sigma, &sigma_prime).map(|(s_i, s_prime_i)| s_i.clone() + s_prime_i),
-	);
-
-	let r_j_rest_tensor = eq_ind_partial_eval_scalars(&r_j[5..]);
-	let chunk_size = 1 << 5; // 32
-
-	let sll32 = inner_product_scalars(
-		l_tilde.chunks(chunk_size).map(|chunk| {
-			inner_product_scalars(chunk.iter().cloned(), sigma32_transpose.iter().cloned())
-		}),
-		r_j_rest_tensor.iter().cloned(),
-	);
-	let srl32 = inner_product_scalars(
-		l_tilde
-			.chunks(chunk_size)
-			.map(|chunk| inner_product_scalars(chunk.iter().cloned(), sigma32.iter().cloned())),
-		r_j_rest_tensor.iter().cloned(),
-	);
-	let sra32 = srl32.clone()
-		+ inner_product_scalars(
-			l_tilde.chunks(chunk_size).map(|chunk| {
-				j_product32.clone()
-					* inner_product_scalars(chunk.iter().cloned(), phi32.iter().cloned())
-			}),
-			r_j_rest_tensor.iter().cloned(),
-		);
-	let rotr32 = inner_product_scalars(
-		l_tilde.chunks(chunk_size).map(|chunk| {
-			inner_product_scalars(
-				chunk.iter().cloned(),
-				iter::zip(&sigma32, &sigma32_prime).map(|(s_i, s_prime_i)| s_i.clone() + s_prime_i),
-			)
-		}),
-		r_j_rest_tensor,
-	);
-
-	[sll, srl, sra, rotr, sll32, srl32, sra32, rotr32]
-}
 
 /// A [`FieldFn`] evaluating one operation's monster multilinear polynomial.
 ///
@@ -309,12 +234,8 @@ mod tests {
 		ShiftVariant,
 		constraint_system::{AndConstraint, Shift, ShiftedValueIndex, ValueIndex},
 	};
-	use binius_field::{BinaryField128bGhash, Field, Random};
-	use binius_math::{
-		BinarySubspace,
-		test_utils::{index_to_hypercube_point, random_scalars},
-		univariate::lagrange_evals_scalars,
-	};
+	use binius_field::{BinaryField128bGhash, Random};
+	use binius_math::test_utils::random_scalars;
 	use rand::prelude::*;
 
 	use super::*;
@@ -427,109 +348,5 @@ mod tests {
 			OperationEvalFn::new(&constraints, 0, 0, n_words).call_native(&input),
 			OperationEvalFn::new(&padded, 0, 0, n_words).call_native(&input)
 		);
-	}
-
-	#[test]
-	fn test_evaluate_h_op_hypercube_vertices() {
-		// Property-based test: for random i, j, s in {0..63}, with challenge being
-		// the i-th element of the subspace, the outputs must match indicator relations
-		// over integers:
-		// - sll == 1 iff j + s == i
-		// - srl == 1 iff i + s == j
-		// - sra == 1 iff i + s == j || i + s >= 64 && j == 63
-		// - rotr == 1 iff (i + s) % 64 == j
-		let mut rng = StdRng::seed_from_u64(0);
-		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(Word::LOG_BITS);
-
-		// Run a reasonable number of random trials
-		for _trial in 0..1024 {
-			let i = rng.random_range(0..64);
-			let j = rng.random_range(0..64);
-			let s = rng.random_range(0..64);
-
-			let challenge = subspace.get(i);
-			let l_tilde = lagrange_evals_scalars(&subspace, &challenge);
-
-			let r_j = index_to_hypercube_point::<BinaryField128bGhash>(Word::LOG_BITS, j);
-			let r_s = index_to_hypercube_point::<BinaryField128bGhash>(Word::LOG_BITS, s);
-
-			let [sll, srl, sra, rotr, sll32, srl32, sra32, rotr32] =
-				evaluate_h_op(&l_tilde, &r_j, &r_s);
-
-			let expected_sll = j + s == i;
-			let expected_srl = i + s == j;
-			let expected_sra = (i + s).min(63) == j;
-			let expected_rotr = (i + s) % 64 == j;
-
-			let i_hi = i / 32;
-			let i_lo = i % 32;
-			let j_hi = j / 32;
-			let j_lo = j % 32;
-			let s_lo = s % 32;
-
-			let expected_sll32 = i_hi == j_hi && j_lo + s_lo == i_lo;
-			let expected_srl32 = i_hi == j_hi && i_lo + s_lo == j_lo;
-			let expected_sra32 = i_hi == j_hi && (i_lo + s_lo).min(31) == j_lo;
-			let expected_rotr32 = i_hi == j_hi && (i_lo + s_lo) % 32 == j_lo;
-
-			let to_field = |b: bool| {
-				if b {
-					BinaryField128bGhash::ONE
-				} else {
-					BinaryField128bGhash::ZERO
-				}
-			};
-
-			assert_eq!(sll, to_field(expected_sll), "sll failed for i={i}, j={j}, s={s}");
-			assert_eq!(srl, to_field(expected_srl), "srl failed for i={i}, j={j}, s={s}");
-			assert_eq!(sra, to_field(expected_sra), "sra failed for i={i}, j={j}, s={s}");
-			assert_eq!(rotr, to_field(expected_rotr), "rotr failed for i={i}, j={j}, s={s}");
-			assert_eq!(sll32, to_field(expected_sll32), "sll32 failed for i={i}, j={j}, s={s}");
-			assert_eq!(srl32, to_field(expected_srl32), "srl32 failed for i={i}, j={j}, s={s}");
-			assert_eq!(sra32, to_field(expected_sra32), "sra32 failed for i={i}, j={j}, s={s}");
-			assert_eq!(rotr32, to_field(expected_rotr32), "rotr32 failed for i={i}, j={j}, s={s}");
-		}
-	}
-
-	#[test]
-	fn test_evaluate_h_op_multilinearity() {
-		// Test that the function is multilinear in each variable
-		let mut rng = StdRng::seed_from_u64(0);
-
-		// Generate random evaluation points
-		let challenge = BinaryField128bGhash::random(&mut rng);
-		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(Word::LOG_BITS);
-		let l_tilde = lagrange_evals_scalars(&subspace, &challenge);
-		let r_j = random_scalars::<BinaryField128bGhash>(&mut rng, Word::LOG_BITS);
-		let r_s = random_scalars::<BinaryField128bGhash>(&mut rng, Word::LOG_BITS);
-
-		// Check linearity in each variable
-		for i in 0..Word::LOG_BITS {
-			// Check r_j[i]
-			let mut r_j_at_0 = r_j.clone();
-			r_j_at_0[i] = BinaryField128bGhash::ZERO;
-			let mut r_j_at_1 = r_j.clone();
-			r_j_at_1[i] = BinaryField128bGhash::ONE;
-			let [result_0, result_1, result_y] = [&r_j_at_0, &r_j_at_1, &r_j]
-				.map(|r_j_variant| evaluate_h_op(&l_tilde, r_j_variant, &r_s));
-			for variant in 0..SHIFT_VARIANT_COUNT {
-				let expected = result_0[variant] * (BinaryField128bGhash::ONE - r_j[i])
-					+ result_1[variant] * r_j[i];
-				assert_eq!(result_y[variant], expected, "Not linear in r_j[{i}]");
-			}
-
-			// Check r_s[i]
-			let mut r_s_at_0 = r_s.clone();
-			r_s_at_0[i] = BinaryField128bGhash::ZERO;
-			let mut r_s_at_1 = r_s.clone();
-			r_s_at_1[i] = BinaryField128bGhash::ONE;
-			let [result_0, result_1, result_y] = [&r_s_at_0, &r_s_at_1, &r_s]
-				.map(|r_s_variant| evaluate_h_op(&l_tilde, &r_j, r_s_variant));
-			for variant in 0..SHIFT_VARIANT_COUNT {
-				let expected = result_0[variant] * (BinaryField128bGhash::ONE - r_s[i])
-					+ result_1[variant] * r_s[i];
-				assert_eq!(result_y[variant], expected, "Not linear in r_s[{i}]");
-			}
-		}
 	}
 }

--- a/crates/verifier/src/protocols/shift/shift_ind.rs
+++ b/crates/verifier/src/protocols/shift/shift_ind.rs
@@ -2,10 +2,6 @@
 // Copyright 2026 The Binius Developers
 
 //! Evaluation of the shift indicator multilinear extensions.
-//!
-//! A shift indicator can be evaluated at an arbitrary point with
-//! [`evaluate_shift_inds`], or partially evaluated over the bit-index hypercube with the two
-//! shift axes fixed, which is what the helper polynomial recurrences below do.
 
 use std::iter;
 
@@ -142,123 +138,17 @@ fn evaluate_overflow_ind<E: FieldOps>(r_i: &[E], r_s: &[E]) -> E {
 	})
 }
 
-/// Partial evaluation of the shift indicator helper polynomials $\sigma, \sigma'$ over all i on the
-/// hypercube.
-///
-/// Given fixed j and s, computes sigma and sigma_prime for all possible i values.
-/// Returns (sigma, sigma_prime) as Vecs of length `1 << r_j.len()`.
-pub fn partial_eval_sigmas<E: FieldOps>(r_j: &[E], r_s: &[E]) -> (Vec<E>, Vec<E>) {
-	assert_eq!(r_j.len(), r_s.len(), "r_j and r_s must have the same length");
-
-	let n = r_j.len();
-	let mut sigma = vec![E::zero(); 1 << n];
-	let mut sigma_prime = vec![E::zero(); 1 << n];
-	sigma[0] = E::one();
-
-	// Process each bit position
-	for k in 0..n {
-		let j_k = r_j[k].clone();
-		let s_k = r_s[k].clone();
-
-		// Precompute boolean combinations for this bit
-		let both = j_k.clone() * &s_k;
-		let j_one_s = j_k.clone() - &both; // j_k * (1 - s_k)
-		let one_j_s = s_k.clone() - &both; // (1 - j_k) * s_k
-		let xor = j_k + s_k;
-		let eq = E::one() + &xor;
-
-		// Update arrays for this bit position
-		for i in 0..(1 << k) {
-			// Update upper halves first (i_k = 1)
-			sigma[(1 << k) | i] = j_one_s.clone() * &sigma[i];
-			sigma_prime[(1 << k) | i] = one_j_s.clone() * &sigma[i] + eq.clone() * &sigma_prime[i];
-
-			// Update lower halves (i_k = 0)
-			let sigma_i = sigma[i].clone();
-			let sigma_prime_i = sigma_prime[i].clone();
-			sigma[i] = eq.clone() * &sigma_i + j_one_s.clone() * &sigma_prime_i;
-			sigma_prime[i] = sigma_prime_i * &one_j_s;
-		}
-	}
-
-	(sigma, sigma_prime)
-}
-
-/// Partial evaluation of the shift indicator helper polynomial $\phi$ over all i on the hypercube.
-///
-/// Given fixed s, computes phi for all possible i values.
-pub fn partial_eval_phi<E: FieldOps>(r_s: &[E]) -> Vec<E> {
-	let n = r_s.len();
-	let mut phi = vec![E::zero(); 1 << n];
-
-	// Process each bit position
-	for k in 0..n {
-		let s_k = r_s[k].clone();
-
-		// Update arrays for this bit position
-		for i in 0..(1 << k) {
-			// Update for i_k = 1
-			phi[(1 << k) | i] = s_k.clone() + (E::one() + &s_k) * &phi[i];
-			let temp = phi[(1 << k) | i].clone() - &s_k;
-			phi[i] += &temp;
-		}
-	}
-
-	phi
-}
-
-/// Partial evaluation of transposed sigma for SLL.
-///
-/// Since sll_ind(i, j, s) = srl_ind(j, i, s), this computes sigma with i and j swapped.
-pub fn partial_eval_sigmas_transpose<E: FieldOps>(r_j: &[E], r_s: &[E]) -> Vec<E> {
-	assert_eq!(r_j.len(), r_s.len(), "r_j and r_s must have the same length");
-
-	let n = r_j.len();
-	let mut sigma_transpose = vec![E::zero(); 1 << n];
-	let mut sigma_transpose_prime = vec![E::zero(); 1 << n];
-	sigma_transpose[0] = E::one();
-
-	// Process each bit position
-	for k in 0..n {
-		let j_k = r_j[k].clone();
-		let s_k = r_s[k].clone();
-
-		// Precompute boolean combinations for this bit (with i and j swapped)
-		let both = j_k.clone() * &s_k;
-		let xor = j_k + s_k;
-		let eq = E::one() + &xor;
-		let zero = eq.clone() + &both;
-
-		// Update arrays for this bit position
-		for i in 0..(1 << k) {
-			// Update for i_k = 1
-			sigma_transpose[(1 << k) | i] =
-				xor.clone() * &sigma_transpose[i] + zero.clone() * &sigma_transpose_prime[i];
-			sigma_transpose_prime[(1 << k) | i] = both.clone() * &sigma_transpose_prime[i];
-
-			// Update for i_k = 0
-			let sigma_t = sigma_transpose[i].clone();
-			sigma_transpose_prime[i] =
-				both.clone() * &sigma_t + xor.clone() * &sigma_transpose_prime[i];
-			sigma_transpose[i] = zero.clone() * &sigma_t;
-		}
-	}
-
-	sigma_transpose
-}
-
 #[cfg(test)]
 mod tests {
 	use std::array;
 
 	use binius_field::{BinaryField128bGhash as B128, Field};
-	use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars};
+	use binius_math::test_utils::random_scalars;
 	use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 	use super::*;
 
-	/// The bit-index hypercube vertex at `index`, as one of the points [`evaluate_shift_inds`]
-	/// takes.
+	/// The bit-index hypercube vertex at `index`.
 	fn bit_index_vertex(index: usize) -> [B128; Word::LOG_BITS] {
 		array::from_fn(|bit| {
 			if (index >> bit) & 1 == 1 {
@@ -342,109 +232,6 @@ mod tests {
 					"variant {variant} is not linear in coordinate {coordinate}"
 				);
 			}
-		}
-	}
-
-	// Ground truth for a shift-indicator MLE, independent of the recurrence under test.
-	//
-	// Fix j, s to the challenges r_j, r_s.
-	//
-	// Over the hypercube in i, the indicator's MLE expands over the (j, s) cube as:
-	//     mle[i] = sum_{j, s in {0,1}^n : cond(i, j, s)} eq(r_j, j) * eq(r_s, s)
-	fn reference_indicator(
-		r_j: &[B128],
-		r_s: &[B128],
-		cond: impl Fn(usize, usize, usize) -> bool,
-	) -> Vec<B128> {
-		let n = r_j.len();
-		// eq_j[j] = eq(r_j, j), eq_s[s] = eq(r_s, s).
-		//
-		// Both index little-endian, matching the recurrence's bit order.
-		let eq_j = eq_ind_partial_eval_scalars(r_j);
-		let eq_s = eq_ind_partial_eval_scalars(r_s);
-
-		(0..1 << n)
-			.map(|i| {
-				let mut acc = B128::ZERO;
-				for j in 0..1 << n {
-					for s in 0..1 << n {
-						if cond(i, j, s) {
-							acc += eq_j[j] * eq_s[s];
-						}
-					}
-				}
-				acc
-			})
-			.collect()
-	}
-
-	// Draw a pseudo-random challenge (r_j, r_s).
-	// The fixed seed keeps failures reproducible.
-	fn challenges(n: usize) -> (Vec<B128>, Vec<B128>) {
-		let mut rng = StdRng::seed_from_u64(0);
-		(random_scalars(&mut rng, n), random_scalars(&mut rng, n))
-	}
-
-	#[test]
-	fn srl_matches_reference() {
-		// srl: output bit i reads input bit j = i + s.
-		// Bits shifted past the top vanish, since no such j is in range.
-		let (r_j, r_s) = challenges(6);
-		let (sigma, _) = partial_eval_sigmas(&r_j, &r_s);
-		assert_eq!(sigma, reference_indicator(&r_j, &r_s, |i, j, s| j == i + s));
-	}
-
-	#[test]
-	fn sll_matches_reference() {
-		// sll is the transpose of srl.
-		// Output bit i = j + s reads input bit j.
-		let (r_j, r_s) = challenges(6);
-		let sigma_transpose = partial_eval_sigmas_transpose(&r_j, &r_s);
-		assert_eq!(sigma_transpose, reference_indicator(&r_j, &r_s, |i, j, s| i == j + s));
-	}
-
-	#[test]
-	fn sra_matches_reference() {
-		// sra behaves like srl within range.
-		// Past the shift, the sign bit j = 2^n - 1 fills every position.
-		let (r_j, r_s) = challenges(6);
-		let n = r_j.len();
-		let (sigma, _) = partial_eval_sigmas(&r_j, &r_s);
-		let phi = partial_eval_phi(&r_s);
-		// prod(r_j) is the eq-indicator selecting the all-ones sign position j = 2^n - 1.
-		let j_product: B128 = r_j.iter().copied().product();
-		let sra: Vec<_> = (0..1 << n).map(|i| sigma[i] + j_product * phi[i]).collect();
-		assert_eq!(sra, reference_indicator(&r_j, &r_s, |i, j, s| j == (i + s).min((1 << n) - 1)));
-	}
-
-	#[test]
-	fn rotr_matches_reference() {
-		// rotr wraps bits leaving the bottom back to the top.
-		// So j = (i + s) mod 2^n.
-		let (r_j, r_s) = challenges(6);
-		let n = r_j.len();
-		let (sigma, sigma_prime) = partial_eval_sigmas(&r_j, &r_s);
-		let rotr: Vec<_> = (0..1 << n).map(|i| sigma[i] + sigma_prime[i]).collect();
-		assert_eq!(rotr, reference_indicator(&r_j, &r_s, |i, j, s| j == (i + s) % (1 << n)));
-	}
-
-	/// The point evaluation and the partial evaluations must agree wherever both are defined: at
-	/// a hypercube vertex of the bit index, with the two shift axes at the same challenges.
-	#[test]
-	fn point_evaluation_matches_the_partial_evaluations() {
-		let (r_j, r_s) = challenges(Word::LOG_BITS);
-
-		let (sigma, sigma_prime) = partial_eval_sigmas(&r_j, &r_s);
-		let sigma_transpose = partial_eval_sigmas_transpose(&r_j, &r_s);
-		let phi = partial_eval_phi(&r_s);
-		let j_product: B128 = r_j.iter().copied().product();
-
-		for i in 0..Word::BITS {
-			let [sll, srl, sra, rotr, ..] = evaluate_shift_inds(&bit_index_vertex(i), &r_j, &r_s);
-			assert_eq!(sll, sigma_transpose[i], "sll at i={i}");
-			assert_eq!(srl, sigma[i], "srl at i={i}");
-			assert_eq!(sra, sigma[i] + j_product * phi[i], "sra at i={i}");
-			assert_eq!(rotr, sigma[i] + sigma_prime[i], "rotr at i={i}");
 		}
 	}
 }

--- a/crates/verifier/src/protocols/shift/shift_ind.rs
+++ b/crates/verifier/src/protocols/shift/shift_ind.rs
@@ -1,11 +1,146 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
-//! Shift indicator partial evaluation functions.
+//! Evaluation of the shift indicator multilinear extensions.
 //!
-//! This module provides functions for computing partial evaluations of shift indicator
-//! multilinear extensions and their helper polynomials.
+//! A shift indicator can be evaluated at an arbitrary point with
+//! [`evaluate_shift_inds`], or partially evaluated over the bit-index hypercube with the two
+//! shift axes fixed, which is what the helper polynomial recurrences below do.
 
+use std::iter;
+
+use binius_core::word::Word;
 use binius_field::FieldOps;
+use binius_math::{line::extrapolate_line, multilinear::eq::eq_one_var};
+
+use super::SHIFT_VARIANT_COUNT;
+
+/// The number of bit variables a half-word (`*32`) shift variant acts over.
+const HALF_WORD_LOG_BITS: usize = Word::LOG_BITS - 1;
+
+/// Evaluates the eight shift indicator multilinear extensions at one point.
+///
+/// A shift indicator is the 3·[`Word::LOG_BITS`]-variate multilinear extension of the predicate
+/// relating an output bit index `i`, an input bit index `j` and a shift amount `s`:
+///
+/// ```text
+/// sll   i == j + s            sll32   i / 32 == j / 32 and i % 32 == j % 32 + s % 32
+/// srl   j == i + s            srl32   likewise, over each half independently
+/// sra   j == min(i + s, 63)   sra32
+/// rotr  j == (i + s) % 64     rotr32
+/// ```
+///
+/// The results are ordered by [`ShiftVariant`](binius_core::ShiftVariant), so the array indexes
+/// straight by variant.
+///
+/// ## Preconditions
+///
+/// * `r_i`, `r_j` and `r_s` each have exactly [`Word::LOG_BITS`] entries
+pub fn evaluate_shift_inds<E: FieldOps>(
+	r_i: &[E],
+	r_j: &[E],
+	r_s: &[E],
+) -> [E; SHIFT_VARIANT_COUNT] {
+	assert_eq!(r_i.len(), Word::LOG_BITS); // precondition
+	assert_eq!(r_j.len(), Word::LOG_BITS); // precondition
+	assert_eq!(r_s.len(), Word::LOG_BITS); // precondition
+
+	let [sll, srl, sra, rotr] = evaluate_variants(r_i, r_j, r_s);
+
+	// A half-word variant applies the same four rules to each 32-bit half, reading only the low
+	// bits of the shift amount. The two halves never mix, so the indicator also carries the
+	// equality of the halves the two bit indices fall in.
+	let [sll32, srl32, sra32, rotr32] = evaluate_variants(
+		&r_i[..HALF_WORD_LOG_BITS],
+		&r_j[..HALF_WORD_LOG_BITS],
+		&r_s[..HALF_WORD_LOG_BITS],
+	);
+	let same_half = eq_one_var(r_i[HALF_WORD_LOG_BITS].clone(), r_j[HALF_WORD_LOG_BITS].clone());
+
+	[
+		sll,
+		srl,
+		sra,
+		rotr,
+		same_half.clone() * sll32,
+		same_half.clone() * srl32,
+		same_half.clone() * sra32,
+		same_half * rotr32,
+	]
+}
+
+/// Evaluates the four shift indicators over `r_i.len()` bit variables, in variant order.
+///
+/// All four are built from the indicators of the addition `i + s`: whether it equals `j`, and
+/// whether it equals `j` only after wrapping past the top bit.
+fn evaluate_variants<E: FieldOps>(r_i: &[E], r_j: &[E], r_s: &[E]) -> [E; 4] {
+	let (srl, wrapped) = evaluate_sum_inds(r_i, r_j, r_s);
+
+	// A left shift is a right shift with the two bit indices exchanged: `i == j + s`.
+	let (sll, _) = evaluate_sum_inds(r_j, r_i, r_s);
+
+	// An arithmetic right shift agrees with the logical one until the sum overflows, past which
+	// every output bit reads the sign bit. The product of the `r_j` coordinates is the equality
+	// indicator selecting that top position.
+	let sign_position: E = r_j.iter().cloned().product();
+	let sra = srl.clone() + sign_position * evaluate_overflow_ind(r_i, r_s);
+
+	// A rotation keeps the bits the sum carries past the top, wrapping them around instead.
+	let rotr = srl.clone() + wrapped;
+
+	[sll, srl, sra, rotr]
+}
+
+/// Evaluates the multilinear extensions of the two indicators of the addition `i + s`:
+/// `i + s == j`, and `i + s == j + 2^n` — the sum wrapped around the top bit.
+///
+/// The addition is checked one bit position at a time, carrying between positions, so the state
+/// is the pair of indicators that the positions below sum correctly with a carry out of 0 and of
+/// 1 respectively. Both start certain: the empty sum is correct and carries nothing.
+fn evaluate_sum_inds<E: FieldOps>(r_i: &[E], r_j: &[E], r_s: &[E]) -> (E, E) {
+	iter::zip(iter::zip(r_i, r_j), r_s).fold(
+		(E::one(), E::zero()),
+		|(no_carry, carry), ((i, j), s)| {
+			// A position's transition reads `j` and `s` through three weights only: the two agree,
+			// only `j` is set, or only `s` is set.
+			let both = j.clone() * s;
+			let j_only = j.clone() - &both;
+			let s_only = s.clone() - &both;
+			let agree = eq_one_var(j.clone(), s.clone());
+
+			// The transitions at `i = 0` and at `i = 1`, interpolated at the coordinate. With
+			// `i = 0` the position sums correctly either when `j` agrees with `s` and nothing
+			// carries in, or when only `j` is set and the carry coming in fills it; it carries out
+			// only when `s` absorbs a carry in. With `i = 1` the position carries out whenever `s`
+			// is set or a carry comes in, and sums correctly against the `j` those leave.
+			(
+				extrapolate_line(
+					agree.clone() * &no_carry + j_only.clone() * &carry,
+					j_only * &no_carry,
+					i.clone(),
+				),
+				extrapolate_line(
+					s_only.clone() * &carry,
+					s_only * &no_carry + agree * &carry,
+					i.clone(),
+				),
+			)
+		},
+	)
+}
+
+/// Evaluates the multilinear extension of the indicator that the addition `i + s` overflows past
+/// the top bit, `i + s >= 2^n`.
+///
+/// This is [`evaluate_sum_inds`]'s carry state with the input bit index summed out: exactly one
+/// `j` completes the addition for each `(i, s)`, so summing over `j` leaves the carry alone.
+fn evaluate_overflow_ind<E: FieldOps>(r_i: &[E], r_s: &[E]) -> E {
+	iter::zip(r_i, r_s).fold(E::zero(), |carry, (i, s)| {
+		// With `i = 0` only a carry in that `s` propagates survives; with `i = 1` the position
+		// carries out whenever `s` is set or a carry comes in.
+		extrapolate_line(s.clone() * &carry, s.clone() + (E::one() - s) * &carry, i.clone())
+	})
+}
 
 /// Partial evaluation of the shift indicator helper polynomials $\sigma, \sigma'$ over all i on the
 /// hypercube.
@@ -114,11 +249,101 @@ pub fn partial_eval_sigmas_transpose<E: FieldOps>(r_j: &[E], r_s: &[E]) -> Vec<E
 
 #[cfg(test)]
 mod tests {
+	use std::array;
+
 	use binius_field::{BinaryField128bGhash as B128, Field};
 	use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars};
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 	use super::*;
+
+	/// The bit-index hypercube vertex at `index`, as one of the points [`evaluate_shift_inds`]
+	/// takes.
+	fn bit_index_vertex(index: usize) -> [B128; Word::LOG_BITS] {
+		array::from_fn(|bit| {
+			if (index >> bit) & 1 == 1 {
+				B128::ONE
+			} else {
+				B128::ZERO
+			}
+		})
+	}
+
+	/// Over the hypercube the eight evaluations must be the indicators of the integer relations
+	/// the shift variants are defined by.
+	#[test]
+	fn hypercube_vertices_match_the_shift_relations() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		for _trial in 0..1024 {
+			let i = rng.random_range(0..Word::BITS);
+			let j = rng.random_range(0..Word::BITS);
+			let s = rng.random_range(0..Word::BITS);
+
+			let evals = evaluate_shift_inds(
+				&bit_index_vertex(i),
+				&bit_index_vertex(j),
+				&bit_index_vertex(s),
+			);
+
+			let (i_lo, j_lo, s_lo) = (i % 32, j % 32, s % 32);
+			let same_half = i / 32 == j / 32;
+			let expected = [
+				i == j + s,
+				j == i + s,
+				j == (i + s).min(Word::BITS - 1),
+				j == (i + s) % Word::BITS,
+				same_half && i_lo == j_lo + s_lo,
+				same_half && j_lo == i_lo + s_lo,
+				same_half && j_lo == (i_lo + s_lo).min(31),
+				same_half && j_lo == (i_lo + s_lo) % 32,
+			];
+
+			for (variant, (eval, expected)) in iter::zip(evals, expected).enumerate() {
+				let expected = if expected { B128::ONE } else { B128::ZERO };
+				assert_eq!(eval, expected, "variant {variant} at i={i}, j={j}, s={s}");
+			}
+		}
+	}
+
+	/// The evaluations must be multilinear in every coordinate: their hypercube values pin the
+	/// polynomials down only together with this.
+	#[test]
+	fn evaluations_are_multilinear_in_every_coordinate() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let point = [
+			random_scalars::<B128>(&mut rng, Word::LOG_BITS),
+			random_scalars::<B128>(&mut rng, Word::LOG_BITS),
+			random_scalars::<B128>(&mut rng, Word::LOG_BITS),
+		]
+		.concat();
+
+		let evaluate = |point: &[B128]| {
+			let (r_i, rest) = point.split_at(Word::LOG_BITS);
+			let (r_j, r_s) = rest.split_at(Word::LOG_BITS);
+			evaluate_shift_inds(r_i, r_j, r_s)
+		};
+
+		// Every coordinate of all three points, restricted to 0 and to 1.
+		for coordinate in 0..point.len() {
+			let restrict = |value| {
+				let mut restricted = point.clone();
+				restricted[coordinate] = value;
+				evaluate(&restricted)
+			};
+
+			for (variant, ((eval, at_zero), at_one)) in
+				iter::zip(iter::zip(evaluate(&point), restrict(B128::ZERO)), restrict(B128::ONE))
+					.enumerate()
+			{
+				assert_eq!(
+					eval,
+					extrapolate_line(at_zero, at_one, point[coordinate]),
+					"variant {variant} is not linear in coordinate {coordinate}"
+				);
+			}
+		}
+	}
 
 	// Ground truth for a shift-indicator MLE, independent of the recurrence under test.
 	//
@@ -201,5 +426,25 @@ mod tests {
 		let (sigma, sigma_prime) = partial_eval_sigmas(&r_j, &r_s);
 		let rotr: Vec<_> = (0..1 << n).map(|i| sigma[i] + sigma_prime[i]).collect();
 		assert_eq!(rotr, reference_indicator(&r_j, &r_s, |i, j, s| j == (i + s) % (1 << n)));
+	}
+
+	/// The point evaluation and the partial evaluations must agree wherever both are defined: at
+	/// a hypercube vertex of the bit index, with the two shift axes at the same challenges.
+	#[test]
+	fn point_evaluation_matches_the_partial_evaluations() {
+		let (r_j, r_s) = challenges(Word::LOG_BITS);
+
+		let (sigma, sigma_prime) = partial_eval_sigmas(&r_j, &r_s);
+		let sigma_transpose = partial_eval_sigmas_transpose(&r_j, &r_s);
+		let phi = partial_eval_phi(&r_s);
+		let j_product: B128 = r_j.iter().copied().product();
+
+		for i in 0..Word::BITS {
+			let [sll, srl, sra, rotr, ..] = evaluate_shift_inds(&bit_index_vertex(i), &r_j, &r_s);
+			assert_eq!(sll, sigma_transpose[i], "sll at i={i}");
+			assert_eq!(srl, sigma[i], "srl at i={i}");
+			assert_eq!(sra, sigma[i] + j_product * phi[i], "sra at i={i}");
+			assert_eq!(rotr, sigma[i] + sigma_prime[i], "rotr at i={i}");
+		}
 	}
 }

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -25,7 +25,8 @@ use getset::Getters;
 
 use super::{
 	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, OperationEvalFn,
-	SHIFT_VARIANT_COUNT, ZERO_ARITY, encode_operation_input, error::Error, evaluate_h_op,
+	SHIFT_VARIANT_COUNT, ZERO_ARITY, encode_operation_input, error::Error,
+	shift_ind::evaluate_shift_inds,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -122,6 +123,13 @@ pub struct VerifyOutput<F> {
 	/// The claimed witness evaluation at the challenge point.
 	#[getset(get = "pub")]
 	pub witness_eval: F,
+	/// The claimed h evaluation, which the monster multilinear is scaled by.
+	h_eval: F,
+	/// Challenge point for the bit index variables the h sumcheck binds (length
+	/// `Word::LOG_BITS`).
+	pub r_i: Vec<F>,
+	/// Final evaluation claim from the h sumcheck.
+	h_sumcheck_eval: F,
 }
 
 impl<F> VerifyOutput<F> {
@@ -158,7 +166,9 @@ impl<F> VerifyOutput<F> {
 /// 2. **First Sumcheck**: Verifies the batched evaluation claim over `Word::LOG_BITS * 2` variables
 /// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j`, `r_s` and `r_v` components
 /// 4. **Second Sumcheck**: Verifies the gamma claim over `log_word_count` variables
-/// 5. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
+/// 5. **Shift Indicator Sumcheck**: Verifies the h evaluation the monster multilinear is scaled by,
+///    over the `Word::LOG_BITS` bit-index variables it sums over
+/// 6. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
 ///    monster multilinear evaluations for AND constraints (bitand), IMUL constraints (intmul) and
 ///    BMUL constraints (binmul)
 ///
@@ -228,6 +238,16 @@ where
 
 	let witness_eval = channel.recv_one()?;
 
+	// The monster multilinear is scaled by one h evaluation, which is itself a sum over the bit
+	// index the shift indicators read. A last sumcheck binds that index, leaving `check_eval` an
+	// evaluation to compute rather than a summation to run.
+	let h_eval = channel.recv_one()?;
+	let SumcheckOutput {
+		eval: h_sumcheck_eval,
+		challenges: mut r_i,
+	} = verify_sumcheck(Word::LOG_BITS, 2, h_eval.clone(), channel)?;
+	r_i.reverse();
+
 	Ok(VerifyOutput {
 		zero_lambda,
 		bitand_lambda,
@@ -240,6 +260,9 @@ where
 		r_v,
 		eval,
 		witness_eval,
+		h_eval,
+		r_i,
+		h_sumcheck_eval,
 	})
 }
 
@@ -258,7 +281,10 @@ where
 /// ```
 ///
 /// where `monster_eval` is the sum of evaluations for AND, IMUL and BMUL constraint polynomials,
-/// and `trace_eval` is the witness evaluation reconstructed from its two segments:
+/// scaled by the h evaluation the shift indicator sumcheck reduced. That sumcheck's own claim is
+/// checked here too, against the two evaluations it reduced to.
+///
+/// `trace_eval` is the witness evaluation reconstructed from its two segments:
 /// ```text
 /// trace_eval = (1 - r_segment) * prod_{k <= i} (1 - r_y_i) * public_eval + r_segment * witness_eval
 /// ```
@@ -280,7 +306,7 @@ pub fn check_eval<F, C>(
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
 	binmul_data: &OperatorData<C::Elem, BINMUL_ARITY>,
 	subspace: &BinarySubspace<F>,
-	r_zhat_prime: C::Elem,
+	r_zhat_prime: &C::Elem,
 	output: &VerifyOutput<C::Elem>,
 	channel: &mut C,
 ) -> Result<(), Error>
@@ -301,26 +327,38 @@ where
 		r_y,
 		r_segment,
 		witness_eval,
+		h_eval,
+		r_i,
+		h_sumcheck_eval,
 	} = output;
 
+	// The h sumcheck reduced its claim to the product of two evaluations at `r_i`: the Lagrange
+	// weights of the univariate challenge, and the shift indicators interpolated over the variant
+	// axis.
+	let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime);
+	let l_tilde_eval = inner_product_scalars(l_tilde, eq_ind_partial_eval_scalars(r_i));
+	let shift_ind_eval =
+		inner_product_scalars(evaluate_shift_inds(r_i, r_j, r_s), eq_ind_partial_eval_scalars(r_v));
+	channel.assert_zero(h_sumcheck_eval.clone() - l_tilde_eval * shift_ind_eval)?;
+
 	// `monster_eval` is a function of purely public-channel-derived elements
-	// (`r_zhat_prime`, `bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime`
-	// vectors, `r_j`, `r_s`, `r_y`) plus the constant `subspace` and `constraint_system`.
-	// Trade those Elems for plain field values, run the MLE evaluation in plaintext, and
-	// materialize the result as a single inout wire instead of building the entire
-	// sub-circuit in wrapper channels.
+	// (`bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime` vectors, `r_s`, `r_v`,
+	// `r_y`) plus the constant `constraint_system`. Trade those Elems for plain field values, run
+	// the MLE evaluation in plaintext, and materialize the result as a single inout wire instead
+	// of building the entire sub-circuit in wrapper channels.
+	//
+	// The h evaluation, which every shift scalar of the monster is scaled by, is a prover message
+	// rather than a public value, so it multiplies the result out here instead.
 	let monster_eval = {
 		let zero_r_x_prime_len = zero_data.r_x_prime.len();
 		let bitand_r_x_prime_len = bitand_data.r_x_prime.len();
 		let intmul_r_x_prime_len = intmul_data.r_x_prime.len();
 		let binmul_r_x_prime_len = binmul_data.r_x_prime.len();
-		let r_j_len = r_j.len();
 		let r_s_len = r_s.len();
 		let r_v_len = r_v.len();
 		let r_y_len = r_y.len();
 
-		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime)
-			.chain(iter::once(zero_lambda.clone()))
+		let inputs: Vec<C::Elem> = iter::once(zero_lambda.clone())
 			.chain(iter::once(bitand_lambda.clone()))
 			.chain(iter::once(intmul_lambda.clone()))
 			.chain(iter::once(binmul_lambda.clone()))
@@ -328,7 +366,6 @@ where
 			.chain(bitand_data.r_x_prime.iter().cloned())
 			.chain(intmul_data.r_x_prime.iter().cloned())
 			.chain(binmul_data.r_x_prime.iter().cloned())
-			.chain(r_j.iter().cloned())
 			.chain(r_s.iter().cloned())
 			.chain(r_v.iter().cloned())
 			.chain(r_y.iter().cloned())
@@ -336,19 +373,17 @@ where
 			.collect();
 
 		let eval_fn = MonsterEvalFn {
-			subspace,
 			constraint_system,
 			inout,
 			zero_r_x_prime_len,
 			bitand_r_x_prime_len,
 			intmul_r_x_prime_len,
 			binmul_r_x_prime_len,
-			r_j_len,
 			r_s_len,
 			r_v_len,
 			r_y_len,
 		};
-		channel.compute_public_value(&inputs, eval_fn)
+		h_eval.clone() * channel.compute_public_value(&inputs, eval_fn)
 	};
 
 	// The public-half evaluation is a function of the verifier's public words (plaintext) and
@@ -399,13 +434,14 @@ impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
 /// The inputs are the flat concatenation of these sections, in order:
 ///
 /// ```text
-/// r_zhat_prime | zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_j.. | r_s.. | r_v.. | r_y..
+/// zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_s.. | r_v.. | r_y..
 /// ```
 ///
 /// The stored lengths recover each variable-length section from that flat slice.
-struct MonsterEvalFn<'a, F: BinaryField> {
-	/// The evaluation subspace for the Lagrange basis over the word bits.
-	subspace: &'a BinarySubspace<F>,
+///
+/// The h evaluation every shift scalar is scaled by is left out: it is a prover message, so
+/// [`check_eval`] multiplies it in outside.
+struct MonsterEvalFn<'a> {
 	/// The AND, IMUL and BMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,
 	/// Which segment holds the inout values, which fixes where the word-index tensor is cut.
@@ -418,8 +454,6 @@ struct MonsterEvalFn<'a, F: BinaryField> {
 	intmul_r_x_prime_len: usize,
 	/// Length of the BinMul operator's `r_x_prime` section.
 	binmul_r_x_prime_len: usize,
-	/// Length of the `r_j` section (the low-order word-bit challenges).
-	r_j_len: usize,
 	/// Length of the `r_s` section (the shift-amount challenges).
 	r_s_len: usize,
 	/// Length of the `r_v` section (the shift-variant challenges).
@@ -438,7 +472,7 @@ struct OperationInputs<E> {
 	binmul: Option<Vec<E>>,
 }
 
-impl<F: BinaryField> MonsterEvalFn<'_, F> {
+impl MonsterEvalFn<'_> {
 	/// Shared setup for [`FieldFn::call`] and [`FieldFn::call_native`]: splits the flat `vals`
 	/// slice, builds the shared shift-scalar and word-index tensors, and re-encodes them (with each
 	/// operation's `r_x'` and `lambda`) into the per-operation [`OperationEvalFn`] input via
@@ -446,10 +480,7 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 	///
 	/// The Zero and BitAnd inputs are always present; the IntMul and BinMul inputs are `None` when
 	/// that operation has no constraints and is skipped.
-	fn operation_inputs<E>(&self, vals: &[E]) -> OperationInputs<E>
-	where
-		E: FieldOps<Scalar = F> + From<F>,
-	{
+	fn operation_inputs<E: FieldOps>(&self, vals: &[E]) -> OperationInputs<E> {
 		// Each operation's `r_x'` section is as long as its reduction has constraint variables, and
 		// [`OperationEvalFn::split_input`] re-derives that length from the constraint count alone.
 		// The two derivations must agree or both sides mis-split the same input. An absent IntMul
@@ -474,12 +505,11 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		);
 
 		// Split the flat input back into its sections, in the order they were concatenated.
-		let r_zhat_prime_v = vals[0].clone();
-		let zero_lambda_v = vals[1].clone();
-		let bitand_lambda_v = vals[2].clone();
-		let intmul_lambda_v = vals[3].clone();
-		let binmul_lambda_v = vals[4].clone();
-		let mut off = 5;
+		let zero_lambda_v = vals[0].clone();
+		let bitand_lambda_v = vals[1].clone();
+		let intmul_lambda_v = vals[2].clone();
+		let binmul_lambda_v = vals[3].clone();
+		let mut off = 4;
 		let zero_r_x_prime_v = &vals[off..off + self.zero_r_x_prime_len];
 		off += self.zero_r_x_prime_len;
 		let bitand_r_x_prime_v = &vals[off..off + self.bitand_r_x_prime_len];
@@ -488,8 +518,6 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		off += self.intmul_r_x_prime_len;
 		let binmul_r_x_prime_v = &vals[off..off + self.binmul_r_x_prime_len];
 		off += self.binmul_r_x_prime_len;
-		let r_j_v = &vals[off..off + self.r_j_len];
-		off += self.r_j_len;
 		let r_s_v = &vals[off..off + self.r_s_len];
 		off += self.r_s_len;
 		let r_v_v = &vals[off..off + self.r_v_len];
@@ -537,22 +565,15 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 				&hidden_tensor[cs.n_inout..cs.n_inout + cs.n_private],
 			],
 		};
-		let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
-		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
-
-		// Phase 1 folded the shift variant into its sumcheck, so the h multilinear contributes a
-		// single evaluation here: the multilinear interpolation of the eight shift indicators over
-		// the variant axis.
+		// A key's shift selects itself through a pure equality indicator over both of phase 1's
+		// shift axes. Built once, so the Zero, BitAnd, IntMul and BinMul monster evaluations share
+		// it. Indexed by `variant * Word::BITS + amount`. The h evaluation scaling all of them is
+		// left for `check_eval` to multiply in.
 		let eq_r_v = eq_ind_partial_eval_scalars(r_v_v);
-		let h_eval = inner_product_scalars(h_op_evals, eq_r_v.iter().cloned());
-
-		// A key's shift now selects itself through a pure equality indicator over both shift axes,
-		// scaled by that one h evaluation. Built once, so the Zero, BitAnd, IntMul and BinMul
-		// monster evaluations share it. Indexed by `variant * Word::BITS + amount`.
 		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
 		let shift_scalars =
 			Box::new(array::from_fn::<_, { SHIFT_VARIANT_COUNT * Word::BITS }, _>(|i| {
-				h_eval.clone() * &eq_r_v[i / Word::BITS] * &eq_r_s[i % Word::BITS]
+				eq_r_v[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
 			}));
 
 		// Re-encode the shared tensors with each operation's `r_x'` and `lambda`. IntMul and BinMul
@@ -577,7 +598,7 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 	}
 }
 
-impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
+impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_> {
 	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
 		let OperationInputs {
 			zero: zero_input,

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -296,7 +296,7 @@ where
 			&intmul,
 			&binmul,
 			&shift_domain,
-			z_challenge,
+			&z_challenge,
 			&shift,
 			channel,
 		)?;


### PR DESCRIPTION
Closes [BINIUS-464](https://linear.app/jimpo/issue/BINIUS-464/shift-sumcheck-to-bind-the-i-variables).

The shift verifier computed the h evaluation itself, summing the shift indicators over the output bit index `i` through the partial-evaluation recurrences. A sumcheck over that index replaces the summation: the prover claims the h evaluation and proves it in `Word::LOG_BITS` rounds, leaving the verifier one evaluation of the Lagrange weights and one of the eight shift indicators, both at a single point. The recurrences move to the prover crate along with the summation they serve.

### Commits

1. **Evaluate the shift indicators at a point** — adds a closed-form evaluation of all eight indicator multilinears at an arbitrary point, alongside the existing recurrences. It is built from the two carry indicators of `i + s`: `sll` is `srl` with the two bit indices exchanged, `rotr` adds the wrapped carry, `sra` adds the overflow indicator at the sign position, and the `*32` variants are the same four rules over five variables times the equality of the halves the indices fall in. Purely additive — nothing else changes.
2. **Compute the shift h evaluation once, before phase 2** — the h evaluation was computed inside `build_monster_segments`, once per operation, from four `r_zhat_prime` values that are always the same one (phase 1 already builds its h multilinear from the BitAnd claim's challenge alone). It moves up to `prove`, and `Phase1Output` replaces the raw `SumcheckOutput` at the phase boundary so the challenge axes are split once.
3. **Bind the shift indicator bit index with a sumcheck** — the protocol change. The prover sends the h evaluation after phase 2 and proves it with a bivariate-product sumcheck over the Lagrange weights and the shift indicators; the verifier verifies the sumcheck and checks its reduced claim against its own evaluation of both. `partial_eval_sigmas` / `partial_eval_sigmas_transpose` / `partial_eval_phi` move to `binius-prover`, where `build_shift_ind` assembles the eight indicators from them into the multilinear the sumcheck runs over.

Two tests tie the prover's and verifier's definitions together: `build_matches_the_verifier_point_evaluation` checks the assembled multilinear against `evaluate_shift_inds` at every bit-index vertex, and `claimed_sum_is_the_weighted_indicator_sum` checks the claimed sum. The recurrences keep their `*_matches_reference` tests against a brute-force indicator.

### Verifier cost

The verifier drops the eight partial-evaluation recurrences over the 64-point bit-index cube (and the `r_j` section of the monster evaluation's input) in exchange for six sumcheck rounds, one extra transcript element, and two 64-element evaluations. The `h_eval` factor is pulled out of the monster `FieldFn` and multiplied in by `check_eval`, because it is a prover message and `compute_public_value` may only take public inputs; the reduced-claim check is a plain function, not a `compute_public_value` call.

### Testing

`binius-verifier` and `binius-prover` shift tests, the `shift` prove/verify integration test, `binius-m4-prover`, `binius-recursion`, rustdoc, and clippy over the touched crates. The full workspace run is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)