### PR TITLE
BINIUS-466: ring-switch the public segment's evaluation

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -314,20 +314,24 @@ impl IOPProver {
 			)
 		};
 
+		// Split the shift's final point `r_j || r_y || r_segment` into its three parts.
+		// The bit index `r_j` is the low coordinates addressing a bit within a 64-bit word.
+		// The segment selector `r_segment` is the last coordinate, choosing public or hidden
+		// words. The hidden-only trace drops it.
+		// The word index `r_y` is everything in between.
+		let challenges = &witness_claim.challenges;
+		let r_j = &challenges[..Word::LOG_BITS];
+		let r_y = &challenges[Word::LOG_BITS..challenges.len() - 1];
+
+		// Prove the public segment's evaluation claim, which the verifier's public-input check
+		// consumes.
+		ring_switch::prove_public_eval::<_, P, _>(alloc, &public_words, r_j, r_y, channel);
+
 		let RingSwitchOutput {
 			rs_eq_ind,
 			sumcheck_claim,
 		} = {
 			let _scope = tracing::debug_span!("Ring-switching reduction").entered();
-
-			// Split the shift's final point `r_j || r_y || r_segment` into its three parts.
-			// The bit index `r_j` is the low coordinates addressing a bit within a 64-bit word.
-			// The segment selector `r_segment` is the last coordinate, choosing public or hidden
-			// words. The hidden-only trace drops it.
-			// The word index `r_y` is everything in between.
-			let challenges = &witness_claim.challenges;
-			let r_j = &challenges[..Word::LOG_BITS];
-			let r_y = &challenges[Word::LOG_BITS..challenges.len() - 1];
 
 			// Ring-switch the reduced claim onto the committed trace.
 			// The point is `r_j || r_rho || r_y`.

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -212,7 +212,9 @@ mod tests {
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
-		protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
+		protocols::shift::{
+			OperatorData as VerifierOperatorData, check_eval, evaluate_words_mle, verify,
+		},
 	};
 	use rand::prelude::*;
 
@@ -372,10 +374,19 @@ mod tests {
 			&mut verifier_transcript,
 		)
 		.unwrap();
+		// The public segment over the shift's whole index space. The full reduction reads this
+		// from the prover and ties it to the constants with a ring-switch; driving the shift
+		// alone, evaluate it here.
+		let public_eval = evaluate_words_mle::<B128, B128>(
+			public_words,
+			verifier_output.r_j(),
+			verifier_output.r_y(),
+		);
+
 		check_eval(
 			&cs,
 			InoutSegment::Hidden,
-			public_words,
+			public_eval,
 			&verifier_zero,
 			&verifier_bitand,
 			&verifier_intmul,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -303,6 +303,16 @@ impl IOPProver {
 		);
 		drop(shift_guard);
 
+		// Split the shift's final point `r_j || r_y || r_segment` into its three parts. The bit
+		// index `r_j` addresses a bit within a 64-bit word, the segment selector `r_segment` is
+		// the last coordinate, and the word index `r_y` is everything in between.
+		let witness_point = &eval_point[..eval_point.len() - 1];
+		let (r_j, r_y) = witness_point.split_at(Word::LOG_BITS);
+
+		// Prove the public segment's evaluation claim, which the verifier's public-input check
+		// consumes.
+		ring_switch::prove_public_eval::<_, P, _>(alloc, witness.public(), r_j, r_y, &mut *channel);
+
 		// [phase] Ring-Switching + PCS Opening
 		let pcs_guard = tracing::info_span!(
 			"[phase] PCS Opening",
@@ -311,10 +321,8 @@ impl IOPProver {
 		)
 		.entered();
 
-		// Ring-switching reduction of the witness claim. The top challenge is the witness's
-		// segment selector, which the verifier consumes when reconstructing the full witness
-		// evaluation.
-		let witness_point = &eval_point[..eval_point.len() - 1];
+		// Ring-switching reduction of the witness claim, at the point above less its segment
+		// selector — the verifier consumes that when reconstructing the full witness evaluation.
 		let ring_switch::RingSwitchOutput {
 			rs_eq_ind,
 			sumcheck_claim,

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -4,6 +4,7 @@
 use std::{iter, ops::Deref};
 
 use binius_compute::{Allocator, VecLike};
+use binius_core::word::Word;
 use binius_field::{
 	ExtensionField, Field, PackedBinaryField128x1b, PackedField, cast_base,
 	linear_transformation::{
@@ -11,16 +12,25 @@ use binius_field::{
 		LinearTransformationFactory, OutputWrappingTransformationFactory, Transformation,
 	},
 };
-use binius_ip_prover::channel::IPProverChannel;
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{bivariate_product_prover, prove_single},
+};
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec, inner_product::inner_product,
 	multilinear::eq::eq_ind_partial_eval, tensor_algebra::TensorAlgebra,
 };
-use binius_utils::rayon::prelude::*;
-use binius_verifier::config::{B1, B128};
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_verifier::{
+	config::{B1, B128, LOG_WORDS_PER_ELEM},
+	protocols::shift::evaluate_words_mle,
+};
 use itertools::izip;
 
-use crate::fold_word::{fold_row_group, row_fold_tables};
+use crate::{
+	fold_word::{fold_row_group, row_fold_tables},
+	prove::pack_witness,
+};
 
 /// Base-2 log of the row group one subset-sum table covers.
 ///
@@ -324,6 +334,62 @@ where
 		rs_eq_ind,
 		sumcheck_claim,
 	}
+}
+
+/// Proves the public segment's evaluation claim.
+///
+/// The shift closes over the public segment as a bit matrix, at `r_j` over the bit within a word
+/// and the low coordinates of `r_y` over the word index. The verifier holds the segment but not
+/// its bits, so the claim is stated here and reduced in two steps:
+///
+/// 1. a ring-switch onto the segment's packed form, leaving the claim `sum_x P(x) A(x)` against the
+///    ring-switching indicator;
+/// 2. a sumcheck over the packed segment's own variables, leaving one evaluation of each factor.
+///
+/// Nothing here is committed, so the verifier finishes on its own: it evaluates the packed
+/// segment's multilinear from the words it holds, and the indicator from its succinct formula.
+///
+/// ## Arguments
+///
+/// * `alloc` - the allocator the packed segment and the indicator are drawn from
+/// * `public_words` - the public segment, unpadded
+/// * `r_j` - the bit-index challenges
+/// * `r_y` - the word-index challenges, of which the segment spans the low ones
+/// * `channel` - the prover channel for sending/sampling
+///
+/// ## Preconditions
+///
+/// * `r_y` must have at least as many coordinates as the packed segment spans words
+pub fn prove_public_eval<A, P, Channel>(
+	alloc: &A,
+	public_words: &[Word],
+	r_j: &[B128],
+	r_y: &[B128],
+	channel: &mut Channel,
+) where
+	A: Allocator,
+	P: PackedField<Scalar = B128>,
+	Channel: IPProverChannel<B128>,
+{
+	// The claim is over the packed segment, so it spans whole field elements: a segment shorter
+	// than one still spans one, reading the words past its end as zero.
+	let log_public_elems = log2_ceil_usize(public_words.len()).saturating_sub(LOG_WORDS_PER_ELEM);
+	let r_y_public = &r_y[..log_public_elems + LOG_WORDS_PER_ELEM];
+
+	channel.send_one(evaluate_words_mle::<B128, B128>(public_words, r_j, r_y_public));
+
+	let packed = pack_witness::<P, _>(alloc, log_public_elems, public_words)
+		.expect("the element count is derived from the words being packed");
+	let RingSwitchOutput {
+		rs_eq_ind,
+		sumcheck_claim,
+	} = prove(alloc, packed.to_ref(), &[r_j, r_y_public].concat(), channel);
+
+	// The reduced claim is the sum of the two multilinears' product over the hypercube, which is
+	// what the trace's opening hands to BaseFold. Here it is discharged by the sumcheck alone: the
+	// final evaluations need no message, since the verifier computes both itself.
+	let prover = bivariate_product_prover(alloc, [packed, rs_eq_ind], sumcheck_claim);
+	prove_single(prover, channel);
 }
 
 #[cfg(test)]

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -27,7 +27,9 @@ use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::StdChallenger,
-	protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
+	protocols::shift::{
+		OperatorData as VerifierOperatorData, check_eval, evaluate_words_mle, verify,
+	},
 };
 use itertools::Itertools;
 use rand::{SeedableRng, rngs::StdRng};
@@ -390,11 +392,20 @@ fn test_shift_prove_and_verify() {
 		)
 		.unwrap();
 
+		// The public segment over the shift's whole index space. The full reduction reads this
+		// from the prover and ties it to the public words with a ring-switch; driving the shift
+		// alone, evaluate it here.
+		let public_eval = evaluate_words_mle::<F, F>(
+			value_vec.public(),
+			verifier_output.r_j(),
+			verifier_output.r_y(),
+		);
+
 		// Check consistency with verifier output
 		check_eval(
 			&cs,
 			InoutSegment::Public,
-			value_vec.public(),
+			public_eval,
 			&verifier_zero_data,
 			&verifier_bitand_data,
 			&verifier_intmul_data,

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -260,11 +260,14 @@ where
 /// where `monster_eval` is the sum of evaluations for AND, IMUL and BMUL constraint polynomials,
 /// and `trace_eval` is the witness evaluation reconstructed from its two segments:
 /// ```text
-/// trace_eval = (1 - r_segment) * prod_{k <= i} (1 - r_y_i) * public_eval + r_segment * witness_eval
+/// trace_eval = (1 - r_segment) * public_eval + r_segment * witness_eval
 /// ```
-/// The public half is evaluated over the *verifier's* public words, so a prover that used
-/// different public values fails this check with high probability; this subsumes the former
-/// standalone public input check.
+///
+/// `public_eval` is the public segment over the shift's whole index space — `r_j` over the bit
+/// within a word and all of `r_y` over the word — so it already carries the zero-padding above the
+/// segment's own length. Tying it to the public values is the caller's job: the caller reads it
+/// from the prover and reduces it onto the packed public segment, so a prover that used different
+/// public values fails there rather than here.
 ///
 /// # Errors
 ///
@@ -274,7 +277,7 @@ where
 pub fn check_eval<F, C>(
 	constraint_system: &ConstraintSystem,
 	inout: InoutSegment,
-	public: &[Word],
+	public_eval: C::Elem,
 	zero_data: &OperatorData<C::Elem, ZERO_ARITY>,
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
@@ -351,22 +354,8 @@ where
 		channel.compute_public_value(&inputs, eval_fn)
 	};
 
-	// The public-half evaluation is a function of the verifier's public words (plaintext) and
-	// public-channel-derived challenges, so it is computed the same way as `monster_eval`.
-	let log_public_words = constraint_system.log_public_words(inout);
-	let public_eval = {
-		let inputs: Vec<C::Elem> = r_j
-			.iter()
-			.chain(&r_y[..log_public_words])
-			.cloned()
-			.collect();
-		channel.compute_public_value(&inputs, PublicWordsEvalFn { public })
-	};
-
-	// Reconstruct the witness evaluation from its two segments. The public segment is
-	// zero-padded up to the hidden segment length, contributing the eq-zero padding factor.
-	let padded_public_eval = eq_ind_zero(&r_y[log_public_words..]) * public_eval;
-	let trace_eval = extrapolate_line(padded_public_eval, witness_eval.clone(), r_segment.clone());
+	// Reconstruct the witness evaluation from its two segments.
+	let trace_eval = extrapolate_line(public_eval, witness_eval.clone(), r_segment.clone());
 
 	// Check if the reconstructed trace value is satisfying.
 	//
@@ -377,21 +366,6 @@ where
 	channel.assert_zero(expected_eval - eval)?;
 
 	Ok(())
-}
-
-/// The bit-level MLE evaluation of the public words, as a [`FieldFn`] over the inputs
-/// `r_j.. | r_y_low..`: the word-bit challenges followed by the low `log_public_words`
-/// word-index challenges. Computed via the same public-value mechanism as [`MonsterEvalFn`].
-struct PublicWordsEvalFn<'a> {
-	/// The public words of the value vector.
-	public: &'a [Word],
-}
-
-impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
-	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
-		let (r_j, r_y_low) = vals.split_at(Word::LOG_BITS);
-		evaluate_words_mle(self.public, r_j, r_y_low)
-	}
 }
 
 /// The monster multilinear evaluation, as a [`FieldFn`] over public-channel-derived inputs.

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -17,28 +17,31 @@
 //! A batch of one instance still runs that sumcheck, over no rounds.
 //! It is the batched protocol either way, because its prover folds a batched witness.
 
-use std::array;
+use std::{array, iter};
 
 use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
 	word::Word,
 };
-use binius_field::{AESTowerField8b as B8, FieldOps};
+use binius_field::{AESTowerField8b as B8, ExtensionField, FieldOps};
 use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::{
 	channel::IPVerifierChannel,
-	sumcheck::{BatchSumcheckOutput, batch_verify},
+	sumcheck::{BatchSumcheckOutput, SumcheckOutput, batch_verify, verify as verify_sumcheck},
 };
 use binius_math::{
 	BinarySubspace,
 	inner_product::inner_product_scalars,
-	multilinear::eq::eq_ind,
+	multilinear::{
+		eq::{eq_ind, eq_ind_zero},
+		evaluate::evaluate_inplace_scalars,
+	},
 	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
 
 use crate::{
 	Error,
-	config::B128,
+	config::{B1, B128, LOG_WORDS_PER_ELEM},
 	protocols::{
 		binmul::{BinMulOutput, verify as verify_binmul_reduction},
 		bitand::AndCheckOutput,
@@ -46,6 +49,7 @@ use crate::{
 		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperatorData},
 		zero,
 	},
+	ring_switch::{self, RingSwitchVerifyOutput, eval_rs_eq},
 	verify_bitand_reduction,
 };
 
@@ -278,7 +282,7 @@ where
 	};
 
 	// Tie in the public values through the public-input consistency check.
-	// The shift evaluates them over the layout's power-of-two word count.
+	// The reduction reads them over the layout's power-of-two word count.
 	// Their count need not be a power of two, so they are passed unpadded.
 	{
 		let _guard = tracing::info_span!(
@@ -287,10 +291,11 @@ where
 			perfetto_category = "phase"
 		)
 		.entered();
+		let public_eval = verify_public_eval(cs, inout, public, &shift, channel)?;
 		shift::check_eval::<B128, _>(
 			cs,
 			inout,
-			public,
+			public_eval,
 			&zero,
 			&bitand,
 			&intmul,
@@ -303,6 +308,105 @@ where
 	}
 
 	Ok(ReductionOutput { r_rho, shift })
+}
+
+/// Reads the public segment's evaluation and reduces it onto the segment's packed form.
+///
+/// The shift closes over the public segment as a bit matrix: its multilinear is claimed at `r_j`
+/// over the bit within a word and the low coordinates of `r_y` over the word index. Evaluating
+/// that here would cost the verifier the bits of every public word. So the prover states the
+/// evaluation instead, and it is reduced in two steps:
+///
+/// 1. a ring-switch onto the packed segment — two words to a field element — leaving the claim
+///    `sum_x P(x) A(x)` against the ring-switching indicator;
+/// 2. a sumcheck over the packed segment's own variables, leaving one evaluation of each factor.
+///
+/// Nothing here is committed, so the verifier finishes on its own, with field arithmetic and no
+/// word bits: it evaluates the packed segment's multilinear from the words it holds, and the
+/// indicator from its succinct formula.
+///
+/// The reduction stands on its own, sharing nothing with the trace's: that one ends in a committed
+/// opening, this one in two evaluations the verifier computes from values it already has.
+///
+/// # Returns
+///
+/// The public segment over the shift's whole index space, which is what [`shift::check_eval`]
+/// reconstructs the trace evaluation from: the claim scaled by the eq-zero factors of the
+/// word-index coordinates above the segment's span.
+///
+/// # Preconditions
+///
+/// * `r_y` must have at least as many coordinates as the packed segment spans words
+fn verify_public_eval<Channel>(
+	cs: &ConstraintSystem,
+	inout: InoutSegment,
+	public: &[Word],
+	shift: &shift::VerifyOutput<Channel::Elem>,
+	channel: &mut Channel,
+) -> Result<Channel::Elem, Error>
+where
+	Channel: IPVerifierChannel<B128>,
+	Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
+{
+	// The claim is over the packed segment, so it spans whole field elements: a segment shorter
+	// than one still spans one, reading the words past its end as zero.
+	let log_public_elems = cs
+		.log_public_words(inout)
+		.saturating_sub(LOG_WORDS_PER_ELEM);
+	let log_packed_words = log_public_elems + LOG_WORDS_PER_ELEM;
+
+	// The claimed evaluation's point: the bit within a word, then the words the segment spans.
+	let r_y = shift.r_y();
+	let eval_point = [shift.r_j(), &r_y[..log_packed_words]].concat();
+
+	let public_eval = channel.recv_one()?;
+	let RingSwitchVerifyOutput {
+		eq_r_double_prime,
+		sumcheck_claim,
+	} = ring_switch::verify(public_eval.clone(), &eval_point, channel)?;
+
+	// Reduce the ring-switched claim to one evaluation of each factor.
+	let SumcheckOutput {
+		eval,
+		challenges: mut r_public,
+	} = verify_sumcheck(log_public_elems, 2, sumcheck_claim, channel)?;
+	r_public.reverse();
+
+	// Close it out against the two factors, both of which the verifier computes: the packed
+	// segment's multilinear, over the words it already holds, and the ring-switching indicator.
+	let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
+	let packed_public = pack_words(public)
+		.into_iter()
+		.map(Channel::Elem::from)
+		// The words past the segment's end read as zero, so the elements past its packed length do
+		// too, up to the power-of-two span the sumcheck ran over.
+		.chain(iter::repeat_with(Channel::Elem::zero))
+		.take(1 << log_public_elems)
+		.collect::<Vec<_>>();
+	let packed_eval = evaluate_inplace_scalars(packed_public, &r_public);
+	let rs_eq_eval = eval_rs_eq(&eval_point[log_packing..], &r_public, &eq_r_double_prime);
+	channel.assert_zero(packed_eval * rs_eq_eval - eval)?;
+
+	// Extend the claim from the segment's own span to the shift's whole word-index space. Every
+	// word above the segment is zero, so each extra coordinate contributes its eq-zero factor.
+	Ok(eq_ind_zero(&r_y[log_packed_words..]) * public_eval)
+}
+
+/// Packs words into field elements, two words to an element.
+///
+/// Word `2i` takes the low half of element `i` and word `2i + 1` the high half. That is the layout
+/// the committed trace is packed in, so a bit of the packed segment sits where the shift's
+/// bit-index challenges address it: `r_j` over the bit within a word, then the word's parity.
+///
+/// An odd word count leaves a final element whose high half is zero, which is the missing word read
+/// as zero — the same reading the shift gives the words past the segment's end.
+fn pack_words(words: &[Word]) -> Vec<B128> {
+	let (pairs, remainder) = words.as_chunks::<2>();
+	pairs
+		.iter()
+		.map(|[w0, w1]| B128::new(((w1.as_u64() as u128) << 64) | w0.as_u64() as u128))
+		.chain(remainder.iter().map(|w0| B128::new(w0.as_u64() as u128)))
+		.collect()
 }
 
 /// An operation's operand data, or a zero claim at an empty point when it is absent.


### PR DESCRIPTION
Closes [BINIUS-466](https://linear.app/jimpo/issue/BINIUS-466/ring-switching-for-the-public-segment), the first step of [BINIUS-465](https://linear.app/jimpo/issue/BINIUS-465/remove-wordipchannel-requirement-for-binius64-iopverifier).

> **Revised.** The first version summed the ring-switched claim over the hypercube and hid that behind `compute_public_value`. @jimpo asked for the sumcheck instead, which removes both that sum and the escape hatch. The description below is the current design.

The shift closes over the public segment as a **bit matrix**: its multilinear is claimed at `r_j` over the bit within a word and the low coordinates of `r_y` over the word index. `check_eval` evaluated that itself, from the verifier's public words — which costs the verifier the bits of every one of them.

Now the prover states that evaluation, and it is reduced in two steps.

## The reduction

```
prover                                    verifier
  public_eval ------------------------->  reads the claim
  s_hat_v (128 elems) ----------------->  ring_switch::verify: partial eval at r_j || r_y[0]
  <--------------------------- r''        row-batching query
                                          claim: sum_x P(x) A(x)
  log_public_elems sumcheck rounds <-->   verify_sumcheck(.., degree 2, ..)
                                          claim: P(r) * A(r), both computed by the verifier
```

1. The **ring-switch** moves the claim onto the segment's *packed* form, two words to a field element, leaving `sum_x P(x) A(x)` against the ring-switching indicator.
2. The **sumcheck** over the packed segment's own variables leaves one evaluation of each factor.

Nothing here is committed, so the verifier finishes on its own, with field arithmetic and **no word bits**:

```rust
let packed_eval = evaluate_inplace_scalars(packed_public, &r_public);
let rs_eq_eval = eval_rs_eq(&eval_point[log_packing..], &r_public, &eq_r_double_prime);
channel.assert_zero(packed_eval * rs_eq_eval - eval)?;
```

Entirely separate from the trace's ring-switch: its own partial evaluations, its own row-batching query, its own sumcheck, drawn between the shift and the trace's reduction.

## What changed

- **`shift::check_eval`** takes `public_eval` in place of `public: &[Word]`. It is the segment over the shift's *whole* word-index space, so the eq-zero padding above the segment's own length moves out to the caller with the rest of the segment's layout — `check_eval` no longer knows `log_public_words` at all, and `PublicWordsEvalFn` is gone.
- **`reduction::verify_public_eval`** reads the claim, ring-switches it, verifies the sumcheck, and closes against the two evaluations it computes itself.
- **`pack_words`** brings back [`encode_inout`](https://github.com/binius-zk/binius64/pull/2083/files#diff-29768aff84a68cb55d0379fea96a6827e0483e2530f5078ffb68efca40e04819L374), over the public segment rather than just the inout words: word `2i` low, word `2i + 1` high, matching how the trace is packed, so a bit of the packed segment sits where the shift's bit-index challenges address it.
- **`ring_switch::prove_public_eval`** on the prover side, which reuses `ring_switch::prove` and then runs the sumcheck on the shared `bivariate_product_prover`. The final multilinear evaluations need no message, since the verifier computes both.

### Whole field elements

The claim spans whole field elements, so a public segment shorter than one still spans one and reads the words past its end as zero. This is not hypothetical: an M4 system's public half is the shared constants alone, so `log_public_elems` is 0 there and this runs a zero-round sumcheck. That path is covered by the M4 round trips.

### No new channel method

The issue anticipated a `WordIPVerifierChannel` method for packing words into `Elem`s. It is not needed yet: the statement still arrives as concrete `Word`s, so packing natively and lifting through the `From<B128>` bound `reduce_constraints` already carries produces the same constants a wrapper channel would build, with no new trait surface. That method becomes necessary when the statement goes symbolic ([BINIUS-433](https://linear.app/jimpo/issue/BINIUS-433)). Happy to add it now if you'd rather have the seam in place.

`observe` is untouched — the inout words still enter Fiat-Shamir as words.

## Verification

Tests for the four affected crates, `cargo clippy --all --tests --benches --examples -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` are clean.

The end-to-end round trips cover the reduction: `prove_verify` (15 cases, including the ZK and the public-wider-than-hidden ones) and the M4 protocol round trips exercise both sides of the new messages.

The check is **non-vacuous**, verified by mutation rather than assumed. Two independent mutations each fail `test_prove_verify_sha256_preimage`:

- swapping the word order inside `pack_words` — so the packed values are really bound;
- dropping the sumcheck challenge reversal — so the sumcheck's variable order is really exercised, not incidentally satisfied.

The two shift-protocol tests drive the shift alone, with no reduction around it, so they evaluate the public segment directly where the full reduction reads it from the prover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)