### PR TITLE
Present the shift reduction as one sumcheck, phased in the prover

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -86,13 +86,8 @@ where
 		r_s,
 		r_v,
 		gamma,
-	} = Phase1Output::split(run_phase_1_sumcheck::<F, F, _, _>(
-		g,
-		h,
-		prepared.batched_eval(),
-		channel,
-		alloc,
-	));
+		g_eval: _,
+	} = run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
 
 	// Phase 2: the h evaluation every shift key is weighted by, then the witness folded at the
 	// bit position challenge `r_j`, per segment.

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -13,7 +13,8 @@ use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftIndSumcheck,
+		KeyCollection, KeySegment, OperatorClaims, Phase3Output, PreparedOperatorClaims,
+		ShiftIndSumcheck,
 		monster::{build_h, build_monster_segments},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
@@ -86,19 +87,27 @@ where
 		r_s,
 		r_v,
 		gamma,
-		g_eval: _,
+		g_eval,
 	} = run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
 
-	// Phase 2: the h evaluation every shift key is weighted by, then the witness folded at the
-	// bit position challenge `r_j`, per segment.
-	let shift_ind = ShiftIndSumcheck::<P, _>::new(
+	// Phase 3 binds the bit index the shift indicators read, carrying phase 1's `g` evaluation
+	// through its rounds as a constant.
+	let phase_3 = ShiftIndSumcheck::<P, _>::new(
 		alloc,
 		domain_subspace,
 		prepared.bitand.r_zhat_prime,
 		&r_j,
 		&r_s,
 		&r_v,
+		g_eval,
 	);
+	debug_assert_eq!(phase_3.beta(), gamma);
+	let Phase3Output {
+		shift_ind_eval,
+		eval: epsilon,
+	} = phase_3.prove(channel, alloc);
+
+	// Phase 4: the witness folded at the bit position challenge `r_j`, per segment.
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	// The public fold is a raw-word fold; the hidden fold contracts the already-oblong bits.
@@ -109,28 +118,22 @@ where
 		alloc,
 		key_collection,
 		&prepared,
-		shift_ind.h_eval(),
+		shift_ind_eval,
 		&r_s,
 		&r_v,
 	);
 
-	let output = run_sumcheck::<F, P, _, _>(
+	run_sumcheck::<F, P, _, _>(
 		&public_folded,
 		hidden_folded,
 		&public_monster,
 		hidden_monster,
 		public_words,
 		r_j,
-		gamma,
+		epsilon,
 		channel,
 		alloc,
-	);
-
-	// The h evaluation phase 2 was proved against is itself a sum over the bit index, which this
-	// last sumcheck binds.
-	shift_ind.prove(channel, alloc);
-
-	output
+	)
 }
 
 /// Accumulates the phase-1 "g" rows of one key segment, from instance-folded words.

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -315,15 +315,16 @@ fn bench_shift_phases(c: &mut Criterion) {
 		r_s,
 		r_v,
 		gamma,
+		g_eval: _,
 	} = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
-		Phase1Output::split(run_phase_1_sumcheck::<F, P, _, _>(
+		run_phase_1_sumcheck::<F, P, _, _>(
 			g.clone(),
 			h.clone(),
 			prepared.batched_eval(),
 			&mut transcript,
 			&GlobalAllocator,
-		))
+		)
 	};
 	let h_eval =
 		ShiftIndSumcheck::<P, _>::new(&GlobalAllocator, &subspace, r_zhat_prime, &r_j, &r_s, &r_v)

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -14,7 +14,7 @@ use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		OperatorClaims, OperatorData, ShiftIndSumcheck, build_key_collection,
+		OperatorClaims, OperatorData, build_key_collection,
 		monster::{build_h, build_monster_segments},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
@@ -326,9 +326,9 @@ fn bench_shift_phases(c: &mut Criterion) {
 			&GlobalAllocator,
 		)
 	};
-	let h_eval =
-		ShiftIndSumcheck::<P, _>::new(&GlobalAllocator, &subspace, r_zhat_prime, &r_j, &r_s, &r_v)
-			.h_eval();
+	// The bit-index phase's rounds are not benchmarked; phase 4 only needs the scalar they reduce
+	// the two bit-index factors to, so a stand-in value serves.
+	let shift_ind_eval = F::random(&mut rng);
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());
@@ -336,7 +336,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 		&GlobalAllocator,
 		&key_collection,
 		&prepared,
-		h_eval,
+		shift_ind_eval,
 		&r_s,
 		&r_v,
 	);
@@ -377,7 +377,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 				&GlobalAllocator,
 				&key_collection,
 				&prepared,
-				h_eval,
+				shift_ind_eval,
 				&r_s,
 				&r_v,
 			)

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -36,4 +36,4 @@ pub use key_collection::{
 	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
 };
 pub use prove::{OperatorData, PreparedOperatorData, prove};
-pub use shift_ind::ShiftIndSumcheck;
+pub use shift_ind::{Phase3Output, ShiftIndSumcheck};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -283,12 +283,12 @@ mod tests {
 
 	use super::{super::ShiftIndSumcheck, *};
 
-	/// Phase 1's h multilinear and the h evaluation the last sumcheck claims must agree.
+	/// Phase 1's h multilinear and the claim phase 3 starts from must agree.
 	///
-	/// The claim sums the shift indicators over the bit index, weighted by the Lagrange
-	/// evaluations; the multilinear holds those sums over the whole shift axis. So evaluating the
-	/// multilinear at `(r_j, r_s, r_v)` must give the claim — which is the single scalar phase 2
-	/// weights its keys by.
+	/// Phase 3 sums the shift indicators over the bit index, weighted by the Lagrange evaluations
+	/// and by the constant it carries; the multilinear holds those sums over the whole shift axis.
+	/// So with the carried constant set to one, evaluating the multilinear at `(r_j, r_s, r_v)`
+	/// must give phase 3's claim.
 	#[test]
 	fn h_op_consistency() {
 		type F = BinaryField128bGhash;
@@ -305,7 +305,7 @@ mod tests {
 			let r_s = random_scalars::<F>(&mut rng, Word::LOG_BITS);
 			let r_v = random_scalars::<F>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
 
-			// Method 1: the sum the last sumcheck claims.
+			// Method 1: the claim phase 3 starts from, with the carried constant set to one.
 			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 			let claimed = ShiftIndSumcheck::<P, _>::new(
 				&GlobalAllocator,
@@ -314,8 +314,9 @@ mod tests {
 				&r_j,
 				&r_s,
 				&r_v,
+				F::ONE,
 			)
-			.h_eval();
+			.beta();
 
 			// Method 2: evaluate the built multilinear at the whole point.
 			let h = build_h(&GlobalAllocator, &subspace, r_zhat_prime);

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -9,7 +9,7 @@ use std::{
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, WideMul};
-use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
+use binius_ip::sumcheck::RoundCoeffs;
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
@@ -50,40 +50,23 @@ pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_V
 /// amount, then the shift variant.
 pub const LOG_SHIFT_ROWS: usize = PHASE_1_LOG_LEN - Word::LOG_BITS;
 
-/// What phase 1 leaves phase 2: its sumcheck's challenge point, split into the axes it binds,
-/// and the evaluation claim it reduced to.
+/// What phase 1 leaves the phases after it: its sumcheck's challenge point, split into the axes
+/// it binds, and the two evaluations it reduced to.
 #[derive(Debug, Clone)]
 pub struct Phase1Output<F> {
 	/// The bit position within a word.
 	pub r_j: Vec<F>,
 	/// The shift amount.
 	pub r_s: Vec<F>,
-	/// The shift variant.
+	/// The shift variant, called the operation in the paper.
 	pub r_v: Vec<F>,
-	/// The evaluation claim phase 2 proves, called gamma in the paper.
+	/// The evaluation claim the next phase proves, called gamma in the paper: the product of the
+	/// two evaluations below.
 	pub gamma: F,
-}
-
-impl<F> Phase1Output<F> {
-	/// Splits the phase-1 sumcheck's output into the axes its challenge point binds: the bit
-	/// position within a word, then the shift amount, then the shift variant, in increasing order
-	/// of significance.
-	pub fn split(output: SumcheckOutput<F>) -> Self {
-		let SumcheckOutput {
-			challenges: mut r_j,
-			eval: gamma,
-		} = output;
-		assert_eq!(r_j.len(), PHASE_1_LOG_LEN);
-
-		let r_v = r_j.split_off(Word::LOG_BITS * 2);
-		let r_s = r_j.split_off(Word::LOG_BITS);
-		Self {
-			r_j,
-			r_s,
-			r_v,
-			gamma,
-		}
-	}
+	/// `g(r_j, r_s, r_v)`, the sum over the word index of the constraint matrix against the
+	/// witness. It is the scalar the bit-index phase carries through its rounds, so the sum never
+	/// has to be formed a second time.
+	pub g_eval: F,
 }
 
 /// Proves the first phase of the shift reduction.
@@ -116,7 +99,7 @@ where
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
 	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 
-	Phase1Output::split(run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc))
+	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
 }
 
 /// The number of packed elements one row of `Word::BITS` scalars occupies.
@@ -429,20 +412,30 @@ pub fn run_phase_1_sumcheck<
 	sum: F,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F> {
+) -> Phase1Output<F> {
 	let ProveSingleOutput {
 		multilinear_evals,
 		mut challenges,
 	} = prove_single(Phase1SumcheckProver::new(g, h, sum, alloc), channel);
+	// Reverse the challenges into the evaluation point, then split it into the axes the rounds
+	// bound: the bit position within a word, then the shift amount, then the shift variant, in
+	// increasing order of significance.
 	challenges.reverse();
+	assert_eq!(challenges.len(), PHASE_1_LOG_LEN);
+	let mut r_j = challenges;
+	let r_v = r_j.split_off(Word::LOG_BITS * 2);
+	let r_s = r_j.split_off(Word::LOG_BITS);
 
 	let [g_eval, h_eval] = multilinear_evals
 		.try_into()
 		.expect("prover has 2 multilinear polynomials");
 
-	SumcheckOutput {
-		challenges,
-		eval: g_eval * h_eval,
+	Phase1Output {
+		r_j,
+		r_s,
+		r_v,
+		gamma: g_eval * h_eval,
+		g_eval,
 	}
 }
 
@@ -806,7 +799,7 @@ mod tests {
 		h: FieldVec<P, GlobalAllocator>,
 		sum: F,
 		channel: &mut ProverTranscript<StdChallenger>,
-	) -> SumcheckOutput<F> {
+	) -> (Vec<F>, F) {
 		let prover =
 			bivariate_product_prover(&GlobalAllocator, [g.scatter(&GlobalAllocator), h], sum);
 
@@ -820,10 +813,7 @@ mod tests {
 			.try_into()
 			.expect("prover has 2 multilinear polynomials");
 
-		SumcheckOutput {
-			challenges,
-			eval: g_eval * h_eval,
-		}
+		(challenges, g_eval * h_eval)
 	}
 
 	/// The phase-1 `g` and `h` of a constraint system, at a pseudo-random univariate challenge.
@@ -876,10 +866,13 @@ mod tests {
 		);
 
 		let mut dense_transcript = ProverTranscript::<StdChallenger>::default();
-		let dense = run_dense_reference(&g, h, sum, &mut dense_transcript);
+		let (dense_challenges, dense_eval) = run_dense_reference(&g, h, sum, &mut dense_transcript);
 
-		assert_eq!(sparse.challenges, dense.challenges);
-		assert_eq!(sparse.eval, dense.eval);
+		// The sparse prover splits its challenge point into the axes the rounds bound; the dense
+		// reference leaves it whole.
+		let sparse_challenges = [sparse.r_j, sparse.r_s, sparse.r_v].concat();
+		assert_eq!(sparse_challenges, dense_challenges);
+		assert_eq!(sparse.gamma, dense_eval);
 		assert_eq!(sparse_transcript.finalize(), dense_transcript.finalize());
 	}
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -29,7 +29,7 @@ use tracing::instrument;
 
 use super::{
 	SegmentWords, claims::PreparedOperatorClaims, key_collection::KeyCollection,
-	monster::build_monster_segments, phase_1::Phase1Output,
+	monster::build_monster_segments, phase_1::Phase1Output, shift_ind::Phase3Output,
 };
 use crate::fold_word::fold_words;
 
@@ -64,7 +64,7 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
 	words: SegmentWords<'_>,
 	prepared: &PreparedOperatorClaims<F>,
 	phase_1_output: Phase1Output<F>,
-	h_eval: F,
+	phase_3_output: Phase3Output<F>,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F>
@@ -77,9 +77,13 @@ where
 		r_j,
 		r_s,
 		r_v,
-		gamma,
+		gamma: _,
 		g_eval: _,
 	} = phase_1_output;
+	let Phase3Output {
+		shift_ind_eval,
+		eval: epsilon,
+	} = phase_3_output;
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
@@ -89,7 +93,7 @@ where
 	let hidden_folded = fold_words::<_, P, _>(alloc, words.hidden, r_j_tensor.as_ref());
 
 	let (public_monster, hidden_monster) =
-		build_monster_segments(alloc, key_collection, prepared, h_eval, &r_s, &r_v);
+		build_monster_segments(alloc, key_collection, prepared, shift_ind_eval, &r_s, &r_v);
 
 	// Both halves of the sumcheck share one word-index address space, spanning the wider of the
 	// two segments. The hidden segment is normally the wider one, but a system with more public
@@ -105,7 +109,7 @@ where
 		hidden_monster,
 		words.public,
 		r_j,
-		gamma,
+		epsilon,
 		channel,
 		alloc,
 	)

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -78,6 +78,7 @@ where
 		r_s,
 		r_v,
 		gamma,
+		g_eval: _,
 	} = phase_1_output;
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -126,10 +126,12 @@ impl<F: Field> PreparedOperatorData<F> {
 ///
 /// The result is a single multilinear evaluation claim on the witness.
 ///
-/// Two sumcheck phases run in sequence:
+/// One sumcheck runs, in four prover phases:
 ///
-/// 1. phase 1 proves the batched claims over the shift variants and operand positions;
-/// 2. phase 2 reduces those to a witness evaluation, against the monster multilinear.
+/// 1. phases 1 and 2 prove the batched claims over the shift variants, the shift amounts and the
+///    bit positions, sparsely and then densely;
+/// 2. phase 3 binds the bit index the shift indicators read;
+/// 3. phase 4 reduces what is left to a witness evaluation, against the monster multilinear.
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
@@ -173,7 +175,8 @@ where
 		claims.prepare(|| channel.sample())
 	};
 
-	// Phase 1 outputs challenges `r_j || r_s || r_v`, and `gamma` as its evaluation (see paper).
+	// Phases 1 and 2 bind the shift variant, the shift amount and the bit position, outputting
+	// challenges `r_j || r_s || r_v` and the claim `gamma` (see paper).
 	let phase_1_output = prove_phase_1::<_, P, _, _>(
 		key_collection,
 		words,
@@ -183,33 +186,30 @@ where
 		alloc,
 	);
 
-	// The h evaluation phase 2 weights every shift key by, with the multilinears the final
-	// sumcheck proves it from. All four operations share `r_zhat_prime`, so it is drawn from the
-	// BitAnd claim, as phase 1's h multilinear is.
-	let shift_ind = ShiftIndSumcheck::<P, _>::new(
+	// Phase 3 binds the bit index the shift indicators read, carrying phase 1's `g` evaluation
+	// through its rounds as a constant. All four operations share `r_zhat_prime`, so it is drawn
+	// from the BitAnd claim, as phase 1's h multilinear is.
+	let phase_3 = ShiftIndSumcheck::<P, _>::new(
 		alloc,
 		domain_subspace,
 		prepared.bitand.r_zhat_prime,
 		&phase_1_output.r_j,
 		&phase_1_output.r_s,
 		&phase_1_output.r_v,
+		phase_1_output.g_eval,
 	);
+	debug_assert_eq!(phase_3.beta(), phase_1_output.gamma);
+	let phase_3_output = phase_3.prove(channel, alloc);
 
-	// Phase 2 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
+	// Phase 4 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
 	// the univariate variable `r_j` and the multilinear variable `r_y`.
-	let output = prove_phase_2::<_, P, _, _>(
+	prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
 		phase_1_output,
-		shift_ind.h_eval(),
+		phase_3_output,
 		channel,
 		alloc,
-	);
-
-	// The h evaluation phase 2 was proved against is itself a sum over the bit index, which this
-	// last sumcheck binds.
-	shift_ind.prove(channel, alloc);
-
-	output
+	)
 }

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -1,48 +1,71 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-//! The sumcheck binding the bit index the h polynomials sum over, and the shift indicator
-//! partial evaluations it runs over.
+//! The sumcheck rounds binding the bit index the shift indicators read, and the shift indicator
+//! partial evaluations they run over.
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, FieldOps, PackedField};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{bivariate_product_prover, prove_single},
+	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
 };
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
-	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+	BinarySubspace, FieldBuffer, FieldVec,
+	inner_product::inner_product,
+	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
+	univariate::lagrange_evals,
 };
 
 /// The number of bit variables a half-word (`*32`) shift variant acts over.
 const HALF_WORD_LOG_BITS: usize = Word::LOG_BITS - 1;
 
-/// The shift reduction's last sumcheck, over the bit index the h polynomials sum over.
+/// Phase 3 of the shift reduction's sumcheck: the [`Word::LOG_BITS`] rounds binding the bit
+/// index the shift indicators read.
 ///
-/// The scalar phase 2 weights every shift key by is that sum, at the phase-1 challenges:
+/// Phases 1 and 2 leave the claim
 ///
 /// $$
+/// \beta = h(r_j, r_s, r_v) \cdot G, \qquad
 /// h(r_j, r_s, r_v) = \sum_i \widetilde{L}(i) \cdot
-///     \sum_{\text{op}} \widetilde{eq}(r_v, \text{op}) \cdot \text{ind}_{\text{op}}(i, r_j, r_s)
+///     \sum_{\text{op}} \widetilde{eq}(r_v, \text{op}) \cdot \text{ind}_{\text{op}}(i, r_j, r_s),
 /// $$
 ///
-/// Proving it as a sumcheck over the two multilinears in `i` leaves the verifier one evaluation
-/// of each at a random point, which it computes directly with
-/// [`evaluate_shift_inds`](binius_verifier::protocols::shift::evaluate_shift_inds) — no
-/// summation over the bit index, and no partial evaluation.
+/// with $G = g(r_j, r_s, r_v)$ the sum over the word index that phase 4 goes on to bind. Unrolling
+/// $h$ exposes these rounds as a sumcheck over two multilinears in the bit index — the Lagrange
+/// weights and the interpolated shift indicators — with $G$ riding along as a constant.
+///
+/// The two are held apart rather than multiplied together, which is what keeps the round
+/// polynomials degree 2. The constant is folded into the weights, so the pair sums to $\beta$ and
+/// the rounds are the ones the verifier's single sumcheck expects. Phase 4 then scales its
+/// monster multilinear by [`Phase3Output::shift_ind_eval`], the evaluation these rounds reduce
+/// the two factors to.
 pub struct ShiftIndSumcheck<P: PackedField, A: Allocator> {
-	/// The Lagrange evaluations at the univariate challenge, over the bit index.
-	l_tilde: FieldVec<P, A>,
+	/// The Lagrange evaluations at the univariate challenge, over the bit index, scaled by `G`.
+	scaled_l_tilde: FieldVec<P, A>,
 	/// The shift indicators interpolated over the shift variant, over the bit index.
 	shift_ind: FieldVec<P, A>,
-	/// The claimed sum of their product: the h evaluation.
-	h_eval: P::Scalar,
+	/// The unscaled Lagrange evaluations, kept to evaluate them at the challenge point.
+	l_tilde: Vec<P::Scalar>,
+	/// The claim these rounds start from: `h(r_j, r_s, r_v) * G`.
+	beta: P::Scalar,
+}
+
+/// What phase 3 leaves phase 4.
+#[derive(Debug, Clone, Copy)]
+pub struct Phase3Output<F> {
+	/// The product of the two factors at the bit-index challenge point:
+	/// `L(r_i) * shift_ind(r_i, r_j, r_s, r_v)`. Phase 4 scales its monster multilinear by it,
+	/// and the verifier recomputes it from `r_i` alone.
+	pub shift_ind_eval: F,
+	/// The claim phase 4 proves: `shift_ind_eval * G`.
+	pub eval: F,
 }
 
 impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<P, A> {
-	/// Builds the two multilinears the sumcheck runs over, and their claimed sum.
+	/// Builds the two multilinears the rounds run over, from phase 1's challenges and its `g`
+	/// evaluation.
 	///
 	/// # Arguments
 	///
@@ -50,6 +73,7 @@ impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<
 	/// - `r_zhat_prime`: the univariate challenge, shared by every operation.
 	/// - `r_j`, `r_s`, `r_v`: phase 1's challenges — the input bit position, the shift amount and
 	///   the shift variant.
+	/// - `g_eval`: `g(r_j, r_s, r_v)`, the constant these rounds carry.
 	pub fn new(
 		alloc: &A,
 		domain_subspace: &BinarySubspace<F>,
@@ -57,34 +81,61 @@ impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<
 		r_j: &[F],
 		r_s: &[F],
 		r_v: &[F],
+		g_eval: F,
 	) -> Self {
 		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-		let l_tilde = l_tilde.as_ref();
-
+		let l_tilde = l_tilde.as_ref().to_vec();
 		let shift_ind = build_shift_ind(r_j, r_s, r_v);
-		let h_eval = inner_product(l_tilde.iter().copied(), shift_ind.iter().copied());
+
+		// Folding the constant into one of the two factors makes the pair sum to the incoming
+		// claim, so the standard bivariate-product prover emits the right rounds.
+		let scaled_l_tilde = l_tilde
+			.iter()
+			.map(|&weight| weight * g_eval)
+			.collect::<Vec<_>>();
+		let beta = inner_product(scaled_l_tilde.iter().copied(), shift_ind.iter().copied());
 
 		Self {
-			l_tilde: FieldBuffer::from_values_in(alloc, l_tilde),
+			scaled_l_tilde: FieldBuffer::from_values_in(alloc, &scaled_l_tilde),
 			shift_ind: FieldBuffer::from_values_in(alloc, &shift_ind),
-			h_eval,
+			l_tilde,
+			beta,
 		}
 	}
 
-	/// The h evaluation, which phase 2 weights every shift key by.
-	pub const fn h_eval(&self) -> F {
-		self.h_eval
+	/// The claim these rounds start from, which phase 2 reduced to.
+	pub const fn beta(&self) -> F {
+		self.beta
 	}
 
-	/// Sends the h evaluation and proves it, in the [`Word::LOG_BITS`] rounds that bind the bit
-	/// index.
-	///
-	/// The reduced evaluations the sumcheck ends at are dropped: the verifier evaluates both
-	/// multilinears at the challenge point itself.
-	pub fn prove(self, channel: &mut impl IPProverChannel<F>, alloc: &A) {
-		channel.send_one(self.h_eval);
-		let prover = bivariate_product_prover(alloc, [self.l_tilde, self.shift_ind], self.h_eval);
-		prove_single(prover, channel);
+	/// Proves the [`Word::LOG_BITS`] rounds binding the bit index.
+	pub fn prove(self, channel: &mut impl IPProverChannel<F>, alloc: &A) -> Phase3Output<F> {
+		let Self {
+			scaled_l_tilde,
+			shift_ind,
+			l_tilde,
+			beta,
+		} = self;
+
+		let prover = bivariate_product_prover(alloc, [scaled_l_tilde, shift_ind], beta);
+		let ProveSingleOutput {
+			multilinear_evals,
+			mut challenges,
+		} = prove_single(prover, channel);
+		challenges.reverse();
+
+		let [scaled_l_tilde_eval, shift_ind_eval] = multilinear_evals
+			.try_into()
+			.expect("prover has 2 multilinear polynomials");
+
+		// The scale rides in the first evaluation, so the unscaled weights are evaluated at the
+		// challenge point separately — the same 64-term inner product the verifier runs.
+		let l_tilde_eval = inner_product(l_tilde, eq_ind_partial_eval_scalars(&challenges));
+
+		Phase3Output {
+			shift_ind_eval: l_tilde_eval * shift_ind_eval,
+			eval: scaled_l_tilde_eval * shift_ind_eval,
+		}
 	}
 }
 
@@ -361,8 +412,8 @@ mod tests {
 		}
 	}
 
-	/// The claimed sum is the h evaluation: the Lagrange weights contracted against the
-	/// indicator multilinear.
+	/// The claim phase 3 starts from is the h evaluation scaled by the constant it carries: the
+	/// Lagrange weights contracted against the indicator multilinear, times `g_eval`.
 	#[test]
 	fn claimed_sum_is_the_weighted_indicator_sum() {
 		use binius_compute::GlobalAllocator;
@@ -376,6 +427,7 @@ mod tests {
 		let r_s = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
 		let r_v = random_scalars::<B128>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
 
+		let g_eval = B128::random(&mut rng);
 		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let sumcheck = ShiftIndSumcheck::<P, _>::new(
 			&GlobalAllocator,
@@ -384,10 +436,11 @@ mod tests {
 			&r_j,
 			&r_s,
 			&r_v,
+			g_eval,
 		);
 
 		let l_tilde = lagrange_evals_scalars(&subspace, &r_zhat_prime);
-		let expected = inner_product(l_tilde, build_shift_ind(&r_j, &r_s, &r_v));
-		assert_eq!(sumcheck.h_eval(), expected);
+		let expected = g_eval * inner_product(l_tilde, build_shift_ind(&r_j, &r_s, &r_v));
+		assert_eq!(sumcheck.beta(), expected);
 	}
 }

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -1,12 +1,22 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_core::word::Word;
+
 /// The base-2 logarithm of [`SHIFT_VARIANT_COUNT`].
 ///
 /// Phase 1 folds the shift variant with this many sumcheck variables, in the high index
 /// positions of its two multilinears.
 pub const LOG_SHIFT_VARIANT_COUNT: usize = 3;
 pub const SHIFT_VARIANT_COUNT: usize = 1 << LOG_SHIFT_VARIANT_COUNT;
+
+/// The number of variables the shift reduction's sumcheck binds outside the word index.
+///
+/// The claim sums over five axes: the shift variant, the shift amount, the bit position within a
+/// word, the bit index the shift indicators read, and the word index. This counts the first four;
+/// the word index is sized by the constraint system.
+pub const SHIFT_LOG_VARS: usize = Word::LOG_BITS * 3 + LOG_SHIFT_VARIANT_COUNT;
+
 pub const ZERO_ARITY: usize = 1;
 pub const BITAND_ARITY: usize = 3;
 pub const INTMUL_ARITY: usize = 4;

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -24,9 +24,8 @@ use binius_math::{
 use getset::Getters;
 
 use super::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, OperationEvalFn,
-	SHIFT_VARIANT_COUNT, ZERO_ARITY, encode_operation_input, error::Error,
-	shift_ind::evaluate_shift_inds,
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperationEvalFn, SHIFT_LOG_VARS, SHIFT_VARIANT_COUNT,
+	ZERO_ARITY, encode_operation_input, error::Error, shift_ind::evaluate_shift_inds,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -116,20 +115,15 @@ pub struct VerifyOutput<F> {
 	pub r_v: Vec<F>,
 	/// Challenge point for the word index variables (length `log_segment_words`).
 	pub r_y: Vec<F>,
+	/// Challenge point for the bit index the shift indicators read (length `Word::LOG_BITS`).
+	pub r_i: Vec<F>,
 	/// Challenge for the witness's segment selector variable.
 	pub r_segment: F,
-	/// Final evaluation claim from the second sumcheck.
+	/// Final evaluation claim from the sumcheck.
 	eval: F,
 	/// The claimed witness evaluation at the challenge point.
 	#[getset(get = "pub")]
 	pub witness_eval: F,
-	/// The claimed h evaluation, which the monster multilinear is scaled by.
-	h_eval: F,
-	/// Challenge point for the bit index variables the h sumcheck binds (length
-	/// `Word::LOG_BITS`).
-	pub r_i: Vec<F>,
-	/// Final evaluation claim from the h sumcheck.
-	h_sumcheck_eval: F,
 }
 
 impl<F> VerifyOutput<F> {
@@ -158,18 +152,19 @@ impl<F> VerifyOutput<F> {
 	}
 }
 
-/// Verifies the shift protocol using a two-phase sumcheck approach.
+/// Verifies the shift protocol with a single sumcheck.
 ///
 /// # Protocol Overview
 /// 1. **Sampling Phase**: Samples random lambda coefficients for batching bitand, intmul and binmul
 ///    evaluation claims across operands.
-/// 2. **First Sumcheck**: Verifies the batched evaluation claim over `Word::LOG_BITS * 2` variables
-/// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j`, `r_s` and `r_v` components
-/// 4. **Second Sumcheck**: Verifies the gamma claim over `log_word_count` variables
-/// 5. **Shift Indicator Sumcheck**: Verifies the h evaluation the monster multilinear is scaled by,
-///    over the `Word::LOG_BITS` bit-index variables it sums over
-/// 6. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
-///    monster multilinear evaluations for AND constraints (bitand), IMUL constraints (intmul) and
+/// 2. **Sumcheck**: Verifies the batched evaluation claim over all `SHIFT_LOG_VARS +
+///    log_word_count` variables of the claim, degree 2 in each. The rounds bind the shift variant,
+///    then the shift amount, then the bit position within a word, then the bit index the shift
+///    indicators read, and last the word index — the order the prover's four phases need.
+/// 3. **Challenge Splitting**: Splits the challenge point into its `r_v`, `r_s`, `r_j`, `r_i` and
+///    `r_y` runs
+/// 4. **Monster Multilinear Verification**: Checks that the claim the sumcheck reduced to matches
+///    the product of its four factors, for AND constraints (bitand), IMUL constraints (intmul) and
 ///    BMUL constraints (binmul)
 ///
 /// # Parameters
@@ -211,18 +206,7 @@ where
 		+ intmul_data.batched_eval(intmul_lambda.clone())
 		+ binmul_data.batched_eval(binmul_lambda.clone());
 
-	let SumcheckOutput {
-		eval: gamma,
-		challenges: mut r_j,
-	} = verify_sumcheck(Word::LOG_BITS * 2 + LOG_SHIFT_VARIANT_COUNT, 2, eval, channel)?;
-
-	r_j.reverse();
-	// Split the challenges as `r_j, r_s, r_v`: the bit position within a word, then the shift
-	// amount, then the shift variant, in increasing order of significance.
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
-
-	// The second sumcheck runs over the witness: the public segment in the low half-cube and
+	// The sumcheck runs over the witness as well: the public segment in the low half-cube and
 	// the hidden segment in the high half-cube, selected by the top word-index variable. Each
 	// half spans the wider of the two segments, which the prover zero-pads the shorter one up
 	// to, so a public segment longer than the hidden one draws the extra word-index challenges.
@@ -230,23 +214,23 @@ where
 
 	let SumcheckOutput {
 		eval,
-		challenges: mut r_y,
-	} = verify_sumcheck(log_word_count, 2, gamma, channel)?;
+		challenges: mut point,
+	} = verify_sumcheck(SHIFT_LOG_VARS + log_word_count, 2, eval, channel)?;
 
-	r_y.reverse();
+	// Reverse the challenges into the evaluation point, whose coordinates then run in increasing
+	// order of significance: the word index, the bit index the shift indicators read, the bit
+	// position within a word, the shift amount, and the shift variant. The rounds bind them in
+	// the opposite order — variant first, word index last — which is what admits the prover's
+	// four phases.
+	point.reverse();
+	let r_v = point.split_off(log_word_count + Word::LOG_BITS * 3);
+	let r_s = point.split_off(log_word_count + Word::LOG_BITS * 2);
+	let r_j = point.split_off(log_word_count + Word::LOG_BITS);
+	let r_i = point.split_off(log_word_count);
+	let mut r_y = point;
 	let r_segment = r_y.pop().expect("log_word_count >= 1");
 
 	let witness_eval = channel.recv_one()?;
-
-	// The monster multilinear is scaled by one h evaluation, which is itself a sum over the bit
-	// index the shift indicators read. A last sumcheck binds that index, leaving `check_eval` an
-	// evaluation to compute rather than a summation to run.
-	let h_eval = channel.recv_one()?;
-	let SumcheckOutput {
-		eval: h_sumcheck_eval,
-		challenges: mut r_i,
-	} = verify_sumcheck(Word::LOG_BITS, 2, h_eval.clone(), channel)?;
-	r_i.reverse();
 
 	Ok(VerifyOutput {
 		zero_lambda,
@@ -258,11 +242,9 @@ where
 		r_segment,
 		r_s,
 		r_v,
+		r_i,
 		eval,
 		witness_eval,
-		h_eval,
-		r_i,
-		h_sumcheck_eval,
 	})
 }
 
@@ -281,8 +263,8 @@ where
 /// ```
 ///
 /// where `monster_eval` is the sum of evaluations for AND, IMUL and BMUL constraint polynomials,
-/// scaled by the h evaluation the shift indicator sumcheck reduced. That sumcheck's own claim is
-/// checked here too, against the two evaluations it reduced to.
+/// scaled by the sumcheck's two bit-index factors — the Lagrange weights and the interpolated
+/// shift indicators, both at `r_i`.
 ///
 /// `trace_eval` is the witness evaluation reconstructed from its two segments:
 /// ```text
@@ -329,20 +311,17 @@ where
 		r_v,
 		r_y,
 		r_segment,
-		witness_eval,
-		h_eval,
 		r_i,
-		h_sumcheck_eval,
+		witness_eval,
 	} = output;
 
-	// The h sumcheck reduced its claim to the product of two evaluations at `r_i`: the Lagrange
-	// weights of the univariate challenge, and the shift indicators interpolated over the variant
-	// axis.
+	// Two of the sumcheck's four factors depend on the bit index the middle rounds bound: the
+	// Lagrange weights of the univariate challenge, and the shift indicators interpolated over the
+	// variant axis. Both are evaluated at `r_i` alone.
 	let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime);
 	let l_tilde_eval = inner_product_scalars(l_tilde, eq_ind_partial_eval_scalars(r_i));
 	let shift_ind_eval =
 		inner_product_scalars(evaluate_shift_inds(r_i, r_j, r_s), eq_ind_partial_eval_scalars(r_v));
-	channel.assert_zero(h_sumcheck_eval.clone() - l_tilde_eval * shift_ind_eval)?;
 
 	// `monster_eval` is a function of purely public-channel-derived elements
 	// (`bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime` vectors, `r_s`, `r_v`,
@@ -350,8 +329,8 @@ where
 	// the MLE evaluation in plaintext, and materialize the result as a single inout wire instead
 	// of building the entire sub-circuit in wrapper channels.
 	//
-	// The h evaluation, which every shift scalar of the monster is scaled by, is a prover message
-	// rather than a public value, so it multiplies the result out here instead.
+	// The two bit-index factors scale every shift scalar of the monster; they multiply the result
+	// out here rather than entering the function, which keeps its input free of `r_i`.
 	let monster_eval = {
 		let zero_r_x_prime_len = zero_data.r_x_prime.len();
 		let bitand_r_x_prime_len = bitand_data.r_x_prime.len();
@@ -386,7 +365,7 @@ where
 			r_v_len,
 			r_y_len,
 		};
-		h_eval.clone() * channel.compute_public_value(&inputs, eval_fn)
+		l_tilde_eval * shift_ind_eval * channel.compute_public_value(&inputs, eval_fn)
 	};
 
 	// Reconstruct the witness evaluation from its two segments.


### PR DESCRIPTION
Closes [BINIUS-467](https://linear.app/jimpo/issue/BINIUS-467/shift-present-the-shift-reduction-as-one-sumcheck-phased-in-the-prover). Implements [binius.xyz#123](https://github.com/binius-zk/binius.xyz/pull/123), following #2113.

The shift reduction becomes one sumcheck over all `SHIFT_LOG_VARS + log_word_count` variables of the claim, degree 2 in each, with the rounds binding the shift variant, then the shift amount, then the bit position within a word, then the bit index the shift indicators read, and last the word index. The verifier runs a single sumcheck verification and splits the challenge point into its five runs; the phase structure lives entirely in the prover.

### Commits

1. **Return the g evaluation from the phase-1 sumcheck** — the phase-1 sumcheck folds both multilinears to a scalar and keeps only their product. The bit-index phase needs `g(r_j, r_s, r_v)` on its own, so return it. `run_phase_1_sumcheck` now splits the challenge point itself and returns `Phase1Output`, which every caller was building from it anyway.
2. **Bind the shift indicator bit index before the word index** — the protocol change.

### What moved

The bit-index rounds were a sumcheck of their own, running after the word-index rounds against a claim the prover sent as advice. They now sit in front of the word-index rounds, and:

- **`h_eval` stops being a prover message.** Phase 3 carries phase 1's `g` evaluation through its rounds as a constant, folded into the Lagrange weights so the pair sums to the claim phase 2 reduced to. A `debug_assert` ties that sum back to `gamma`.
- **Phase 4 scales its monster multilinear** by the evaluation phase 3 reduces the two bit-index factors to — exactly where `h_eval` used to sit, so `build_monster_segments` is unchanged but for the name of its scalar.
- **`check_eval` checks one equation instead of two**: the closing claim against the product of the sumcheck's four factors.

### Departure from the writeup

The writeup has phase 3 recover its carried constant by dividing the incoming claim by `h(r_j, r_s, r_v)`, with a fallback for when that is zero and a corresponding completeness caveat. That division is avoidable here: the phase-1 sumcheck already folds `g` down to a scalar and `prove_single` hands it back, so the constant is read off directly. No inversion, no exceptional case. jimpo confirmed this and is updating the writeup.

### Transcript

One field element shorter (no `h_eval`), same number of sumcheck rounds, same challenges drawn. Three `verify_sumcheck` calls collapse to one.

### Testing

`binius-verifier` and `binius-prover` shift tests, the `shift` prove/verify integration test, `binius-m4-prover`, `binius-recursion`, rustdoc, and clippy over the touched crates. The full workspace run is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)