### PR TITLE
BINIUS-465: hand the statement to the Binius64 IOP as the channel's own words

### DIFF
--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -2,6 +2,7 @@
 
 //! BaseFold ZK implementation of the IOP verifier channel.
 
+use binius_core::word::Word;
 use binius_field::{BinaryField, util::FieldFn};
 use binius_ip::{
 	channel::{IPVerifierChannel, WordIPVerifierChannel},
@@ -291,8 +292,8 @@ where
 {
 	type Word = Channel::Word;
 
-	fn observe_words(&mut self, words: &[Self::Word]) {
-		self.channel.observe_words(words);
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Self::Word> {
+		self.channel.observe_words(words)
 	}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
@@ -305,6 +306,10 @@ where
 
 	fn sample_bits(&mut self, bits: usize) -> Self::Word {
 		self.channel.sample_bits(bits)
+	}
+
+	fn pack_words(&mut self, words: &[Self::Word]) -> Vec<Self::Elem> {
+		self.channel.pack_words(words)
 	}
 }
 

--- a/crates/iop/src/channel/oracle_setup.rs
+++ b/crates/iop/src/channel/oracle_setup.rs
@@ -10,7 +10,7 @@ use std::{
 
 use binius_core::word::Word;
 use binius_field::{
-	ExtensionField, Field, FieldOps,
+	BinaryField, ExtensionField, Field, FieldOps,
 	arithmetic_traits::{InvertOrZero, Square},
 	util::FieldFn,
 };
@@ -203,11 +203,13 @@ impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
 	}
 }
 
-impl<F: Field> WordIPVerifierChannel<F> for OracleSetupChannel {
+impl<F: BinaryField> WordIPVerifierChannel<F> for OracleSetupChannel {
 	type Word = Word;
 
 	// The dry run records oracle shapes only, so nothing reaches a Fiat-Shamir state.
-	fn observe_words(&mut self, _words: &[Word]) {}
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
+		words.to_vec()
+	}
 
 	fn subset_sum(&mut self, _elems: &[DummyElem<F>], _word: &Word) -> DummyElem<F> {
 		DummyElem(PhantomData)
@@ -220,6 +222,12 @@ impl<F: Field> WordIPVerifierChannel<F> for OracleSetupChannel {
 	// The recorded oracle shapes do not depend on which leaves a protocol would query.
 	fn sample_bits(&mut self, _bits: usize) -> Word {
 		Word::ZERO
+	}
+
+	// Only the element count matters here, and it follows from the word count alone.
+	fn pack_words(&mut self, words: &[Word]) -> Vec<DummyElem<F>> {
+		let words_per_elem = F::N_BITS / Word::BITS;
+		vec![DummyElem(PhantomData); words.len().div_ceil(words_per_elem)]
 	}
 }
 

--- a/crates/iop/src/channel/size_tracking.rs
+++ b/crates/iop/src/channel/size_tracking.rs
@@ -5,8 +5,10 @@
 use std::{marker::PhantomData, mem::size_of};
 
 use binius_core::word::Word;
-use binius_field::{Field, util::FieldFn};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_field::{BinaryField, util::FieldFn};
+use binius_ip::channel::{
+	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
+};
 use binius_utils::serialization::FixedSizeSerializeBytes;
 
 use crate::{
@@ -60,7 +62,7 @@ impl<'a, F, MerkleScheme_> SizeTrackingChannel<'a, F, MerkleScheme_> {
 
 impl<F, MerkleScheme_> IPVerifierChannel<F> for SizeTrackingChannel<'_, F, MerkleScheme_>
 where
-	F: Field + FixedSizeSerializeBytes,
+	F: BinaryField + FixedSizeSerializeBytes,
 	MerkleScheme_: MerkleTreeScheme<F>,
 {
 	// Nothing here reads a value, so a zero-sized stand-in would seem to fit.
@@ -106,13 +108,15 @@ where
 
 impl<F, MerkleScheme_> WordIPVerifierChannel<F> for SizeTrackingChannel<'_, F, MerkleScheme_>
 where
-	F: Field + FixedSizeSerializeBytes,
+	F: BinaryField + FixedSizeSerializeBytes,
 	MerkleScheme_: MerkleTreeScheme<F>,
 {
 	type Word = Word;
 
 	// Observing feeds the Fiat-Shamir state rather than the proof tape, so it costs no bytes.
-	fn observe_words(&mut self, _words: &[Word]) {}
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
+		words.to_vec()
+	}
 
 	fn subset_sum(&mut self, elems: &[F], word: &Word) -> F {
 		subset_sum_word(elems, *word)
@@ -126,11 +130,15 @@ where
 	fn sample_bits(&mut self, _bits: usize) -> Word {
 		Word::ZERO
 	}
+
+	fn pack_words(&mut self, words: &[Word]) -> Vec<F> {
+		pack_words_concrete::<F, F>(words)
+	}
 }
 
 impl<F, MerkleScheme_> MerkleIPVerifierChannel<F> for SizeTrackingChannel<'_, F, MerkleScheme_>
 where
-	F: Field + FixedSizeSerializeBytes,
+	F: BinaryField + FixedSizeSerializeBytes,
 	MerkleScheme_: MerkleTreeScheme<F>,
 {
 	type Commitment = CommittedShape;

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -15,7 +15,7 @@
 use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_core::word::Word;
-use binius_field::{Field, util::FieldFn};
+use binius_field::{BinaryField, Field, util::FieldFn};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
@@ -151,15 +151,15 @@ where
 impl<F, T, Challenger_, H> WordIPVerifierChannel<F>
 	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
 where
-	F: Field,
+	F: BinaryField,
 	T: BorrowMut<VerifierTranscript<Challenger_>>,
 	Challenger_: Challenger,
 	H: HashSuite,
 {
 	type Word = Word;
 
-	fn observe_words(&mut self, words: &[Word]) {
-		WordIPVerifierChannel::<F>::observe_words(self.transcript.borrow_mut(), words);
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
+		WordIPVerifierChannel::<F>::observe_words(self.transcript.borrow_mut(), words)
 	}
 
 	fn subset_sum(&mut self, elems: &[F], word: &Word) -> F {
@@ -173,12 +173,16 @@ where
 	fn sample_bits(&mut self, bits: usize) -> Word {
 		WordIPVerifierChannel::<F>::sample_bits(self.transcript.borrow_mut(), bits)
 	}
+
+	fn pack_words(&mut self, words: &[Word]) -> Vec<F> {
+		WordIPVerifierChannel::<F>::pack_words(self.transcript.borrow_mut(), words)
+	}
 }
 
 impl<F, T, Challenger_, H> MerkleIPVerifierChannel<F>
 	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
 where
-	F: Field + FixedSizeSerializeBytes,
+	F: BinaryField + FixedSizeSerializeBytes,
 	T: BorrowMut<VerifierTranscript<Challenger_>>,
 	Challenger_: Challenger,
 	H: HashSuite,

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -22,7 +22,9 @@
 use std::{iter::repeat_with, ops::Shr};
 
 use binius_core::word::Word;
-use binius_field::{Field, field::FieldOps, util::FieldFn};
+use binius_field::{
+	BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps, util::FieldFn,
+};
 use binius_transcript::{
 	VerifierTranscript,
 	fiat_shamir::{CanSample, CanSampleBits, Challenger},
@@ -136,8 +138,15 @@ pub trait WordIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 	/// `u32` to match [`Word`]'s own [`Shl`](std::ops::Shl) and [`Shr`] impls.
 	type Word: Clone + From<Word> + Shr<u32, Output = Self::Word>;
 
-	/// Feeds words into the Fiat-Shamir state, each as eight little-endian bytes.
-	fn observe_words(&mut self, words: &[Self::Word]);
+	/// Feeds words into the Fiat-Shamir state, each as eight little-endian bytes, and returns them
+	/// as this channel's word type.
+	///
+	/// The words go in concrete, because the statement is fixed data the verifier is handed rather
+	/// than something the protocol derives. They come back as [`Self::Word`], which is where a
+	/// channel that carries words as wires introduces them: it allocates the wires here, and the
+	/// protocol sees the statement symbolically from this point on. A channel over concrete values
+	/// hands the same words straight back.
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Self::Word>;
 
 	/// Returns the sum of the `elems` selected by the low bits of `word`, low bit first.
 	///
@@ -163,6 +172,47 @@ pub trait WordIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 	/// The result is masked to `bits` bits. Protocols rely on that bound, so an implementation
 	/// must enforce it rather than assume the sampled value already fits.
 	fn sample_bits(&mut self, bits: usize) -> Self::Word;
+
+	/// Packs words into field elements, as many words to an element as one holds.
+	///
+	/// Word `i` occupies bits `[Word::BITS * i, Word::BITS * (i + 1))` of element
+	/// `i / words_per_elem`, so the packed form reads the same way the committed trace does: the
+	/// low bit-index coordinates address the bit within a word, the next the word within its
+	/// element. A word count that does not fill the last element leaves its high words zero.
+	///
+	/// This is a channel method rather than a free function because the words may be wires: a
+	/// channel over concrete values computes the elements, and a circuit-building one emits the
+	/// gates that assemble them.
+	fn pack_words(&mut self, words: &[Self::Word]) -> Vec<Self::Elem>;
+}
+
+/// [`WordIPVerifierChannel::pack_words`] over concrete words, for channels carrying [`Word`].
+///
+/// A set bit contributes the basis element at its position in the packed layout, which is what
+/// makes this agree with reading the element's bits back out.
+pub fn pack_words_concrete<F, E>(words: &[Word]) -> Vec<E>
+where
+	F: BinaryField,
+	E: FieldOps<Scalar = F> + From<F>,
+{
+	let words_per_elem = F::N_BITS / Word::BITS;
+	words
+		.chunks(words_per_elem)
+		.map(|chunk| {
+			let packed = chunk
+				.iter()
+				.enumerate()
+				.flat_map(|(i, word)| {
+					(0..Word::BITS)
+						.filter(|&bit| word.extract_bit(bit))
+						.map(move |bit| {
+							<F as ExtensionField<BinaryField1b>>::basis(i * Word::BITS + bit)
+						})
+				})
+				.sum::<F>();
+			E::from(packed)
+		})
+		.collect()
 }
 
 /// [`WordIPVerifierChannel::subset_sum`] over a concrete word, for channels carrying [`Word`].
@@ -242,13 +292,14 @@ where
 
 impl<F, Challenger_> WordIPVerifierChannel<F> for VerifierTranscript<Challenger_>
 where
-	F: Field,
+	F: BinaryField,
 	Challenger_: Challenger,
 {
 	type Word = Word;
 
-	fn observe_words(&mut self, words: &[Word]) {
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
 		self.observe().write_slice(words);
+		words.to_vec()
 	}
 
 	fn subset_sum(&mut self, elems: &[F], word: &Word) -> F {
@@ -261,6 +312,10 @@ where
 
 	fn sample_bits(&mut self, bits: usize) -> Word {
 		Word::from_u64(CanSampleBits::<u32>::sample_bits(self, bits) as u64)
+	}
+
+	fn pack_words(&mut self, words: &[Word]) -> Vec<F> {
+		pack_words_concrete::<F, F>(words)
 	}
 }
 

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -12,6 +12,7 @@ use binius_iop::{
 	fri::{ConstantArityStrategy, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
+use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_verifier::{
 	Error,
@@ -113,7 +114,7 @@ impl IOPVerifier {
 	/// Returns an error if the reduction, the ring-switch, or the trace opening fails.
 	pub fn verify<Channel>(&self, channel: &mut Channel) -> Result<(), Error>
 	where
-		Channel: IOPVerifierChannel<B128>,
+		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 	{
 		// Receive the trace commitment.
@@ -121,14 +122,21 @@ impl IOPVerifier {
 		let trace_oracle = channel.recv_oracle(self.layout.log_witness_elems, true)?;
 
 		// Reduce every instance's constraints to one claim on the committed trace.
-		// A batch hides its inout words, so the public data is the shared constants alone.
+		// A batch hides its inout words, so the public data is the shared constants alone. They are
+		// fixed by the constraint system, so they lift into the channel's word type as themselves.
+		let constants = self
+			.cs
+			.constants
+			.iter()
+			.map(|&word| Channel::Word::from(word))
+			.collect::<Vec<_>>();
 		let reduction = reduce_constraints(
 			&self.cs,
 			Instances::Batch {
 				log_instances: self.layout.log_instances,
 			},
 			InoutSegment::Hidden,
-			&self.cs.constants,
+			&constants,
 			channel,
 		)?;
 

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -13,6 +13,7 @@ use binius_core::constraint_system::{ConstraintSystem, InoutSegment, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
+use binius_ip::channel::WordIPVerifierChannel;
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded};
 use binius_spartan_frontend::constraint_system::WitnessLayout;
 use binius_spartan_prover::wrapper::{ReplayChannel, ZKWrappedProverChannel};
@@ -156,8 +157,11 @@ where
 			{
 				let inner_iop_verifier = &self.inner_iop_verifier;
 				move |replay_channel: &mut ReplayChannel<B128>| {
+					// A faithful replay of the verifier's call sequence, which observes the
+					// statement before delegating.
+					let inout = replay_channel.observe_words(inout_words);
 					inner_iop_verifier
-						.verify(inout_words, replay_channel)
+						.verify(&inout, replay_channel)
 						.expect("replay verification should not fail");
 				}
 			},

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use binius_circuits::multiplexer::multi_wire_multiplex;
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash as B128, Field, FieldOps, util::FieldFn};
+use binius_field::{BinaryField, BinaryField128bGhash as B128, Field, FieldOps, util::FieldFn};
 use binius_frontend::{Circuit, Wire};
 use binius_iop::merkle_channel::{self, MerkleIPVerifierChannel};
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
@@ -18,6 +18,10 @@ use crate::{
 
 /// Number of 64-bit words a SHA-256 digest occupies.
 pub(crate) const DIGEST_WORDS: usize = 4;
+
+/// Number of 64-bit words one field element holds, which is the two halves a [`SymbolicElem`]
+/// carries.
+const WORDS_PER_ELEM: usize = B128::N_BITS / Word::BITS;
 
 /// A Merkle commitment received by the builder channel.
 ///
@@ -159,9 +163,17 @@ impl IPVerifierChannel<B128> for Binius64BuilderChannel {
 impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 	type Word = SymbolicWord;
 
-	fn observe_words(&mut self, _words: &[SymbolicWord]) {
-		// UNCONSTRAINED: the statement must reach the Fiat-Shamir state for the circuit to be
-		// bound to what it claims to verify.
+	fn observe_words(&mut self, words: &[Word]) -> Vec<SymbolicWord> {
+		// The statement enters the circuit here, one input wire per word, so everything downstream
+		// reads it symbolically instead of baking it in as constants. That is what makes the
+		// recorded circuit verify a *statement* rather than one fixed instance of it.
+		//
+		// UNCONSTRAINED: nothing feeds these into a Fiat-Shamir state yet, so the circuit is not
+		// yet bound to the statement it claims to verify.
+		words
+			.iter()
+			.map(|_| SymbolicWord::wire(&self.shared, self.shared.input_wire("observe_words")))
+			.collect()
 	}
 
 	fn subset_sum(&mut self, elems: &[SymbolicElem], word: &SymbolicWord) -> SymbolicElem {
@@ -220,6 +232,23 @@ impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 		// UNCONSTRAINED, twice over: the index should come from the Fiat-Shamir state, and it
 		// should be masked to `bits` bits, which the FRI code relies on rather than asserting.
 		SymbolicWord::wire(&self.shared, self.shared.input_wire("sample_bits"))
+	}
+
+	fn pack_words(&mut self, words: &[SymbolicWord]) -> Vec<SymbolicElem> {
+		// A `SymbolicElem` *is* the low and high wire of a 128-bit element, and a word fills half
+		// of it, so packing is pairing the wires up. It costs no gates, and a trailing odd word
+		// takes the low half against a zero high half.
+		let builder = self.shared.builder();
+		words
+			.chunks(WORDS_PER_ELEM)
+			.map(|chunk| {
+				let lo = chunk[0].to_wire(builder);
+				let hi = chunk
+					.get(1)
+					.map_or_else(|| builder.add_constant_64(0), |word| word.to_wire(builder));
+				SymbolicElem::wires(&self.shared, lo, hi)
+			})
+			.collect()
 	}
 }
 

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -126,8 +126,13 @@ where
 {
 	type Word = Word;
 
-	fn observe_words(&mut self, words: &[Word]) {
-		self.inner.observe_words(words);
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
+		// The build allocated one input wire per statement word here, so the replay fills them in
+		// the same order before forwarding to the real Fiat-Shamir state.
+		for &word in words {
+			self.fill_word("observe_words", word);
+		}
+		self.inner.observe_words(words)
 	}
 
 	fn subset_sum(&mut self, elems: &[B128], word: &Word) -> B128 {
@@ -142,6 +147,11 @@ where
 		let value = self.inner.sample_bits(bits);
 		self.fill_word("sample_bits", value);
 		value
+	}
+
+	// The build pairs up wires it already has, allocating none, so there is nothing to fill.
+	fn pack_words(&mut self, words: &[Word]) -> Vec<B128> {
+		self.inner.pack_words(words)
 	}
 }
 

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -20,6 +20,7 @@ use binius_core::{constraint_system::ValueVec, word::Word};
 use binius_field::arch::OptimalPackedB128;
 use binius_frontend::{Circuit, CircuitBuilder, CircuitStat, Wire};
 use binius_hash::StdHashSuite;
+use binius_ip::channel::WordIPVerifierChannel;
 use binius_prover::Prover;
 use binius_recursion::{Binius64BuilderChannel, WitnessFillerChannel};
 use binius_transcript::{ProverTranscript, VerifierTranscript};
@@ -124,9 +125,13 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 	let recorded = {
 		let builder_channel = Binius64BuilderChannel::new();
 		let mut channel = verifier.iop_compiler().create_channel(builder_channel);
+		// The statement is observed by the caller, and what comes back is what the verifier reads.
+		// On this channel those are wires, so the recorded circuit takes the statement as input
+		// rather than baking it in.
+		let inout = channel.observe_words(witness.inout());
 		verifier
 			.iop_verifier()
-			.verify(witness.inout(), &mut channel)
+			.verify(&inout, &mut channel)
 			.expect("the symbolic run records rather than checks, so it cannot fail");
 		let builder_channel = channel.finish().unwrap();
 		builder_channel.build()
@@ -143,6 +148,16 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 	);
 	assert!(stat.n_bmul_constraints > 0, "the verifier's field arithmetic should be recorded");
 
+	// The statement reaches the circuit as wires, one per inout word, rather than as constants
+	// baked in while building. That is what makes the recorded circuit verify a statement rather
+	// than one fixed instance of it.
+	let statement_wires = recorded
+		.inputs
+		.iter()
+		.filter(|input| input.kind == "observe_words")
+		.count();
+	assert_eq!(statement_wires, witness.inout().len());
+
 	// --- its witness ---------------------------------------------------------------------------
 	// The same verifier runs again over the real transcript, and every value the circuit cannot
 	// derive is written into the wire the build recorded for it.
@@ -155,9 +170,10 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 			recorded.inputs.clone(),
 		);
 		let mut channel = verifier.iop_compiler().create_channel(filler_channel);
+		let inout = channel.observe_words(witness.inout());
 		verifier
 			.iop_verifier()
-			.verify(witness.inout(), &mut channel)
+			.verify(&inout, &mut channel)
 			.unwrap();
 		channel.finish().unwrap().finish();
 	}

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -11,9 +11,11 @@ use std::{
 };
 
 use binius_core::word::Word;
-use binius_field::{Field, util::FieldFn};
+use binius_field::{BinaryField, Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_ip::channel::{
+	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
+};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, WireAllocator, WitnessError, WitnessGenerator},
 	constraint_system::{WireKind, Witness, WitnessLayout},
@@ -143,12 +145,14 @@ impl<F: Field> IPVerifierChannel<F> for ReplayChannel<F> {
 	}
 }
 
-impl<F: Field> WordIPVerifierChannel<F> for ReplayChannel<F> {
+impl<F: BinaryField> WordIPVerifierChannel<F> for ReplayChannel<F> {
 	type Word = Word;
 
 	// The recorded interaction already holds whatever the Fiat-Shamir state produced, so replaying
 	// observes nothing. This mirrors `IronSpartanBuilderChannel::observe_words`.
-	fn observe_words(&mut self, _words: &[Word]) {}
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
+		words.to_vec()
+	}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
 		subset_sum_word(elems, *word)
@@ -160,6 +164,10 @@ impl<F: Field> WordIPVerifierChannel<F> for ReplayChannel<F> {
 
 	fn sample_bits(&mut self, _bits: usize) -> Word {
 		Word::ZERO
+	}
+
+	fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
+		pack_words_concrete::<F, Self::Elem>(words)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -9,9 +9,11 @@ use std::{
 };
 
 use binius_core::word::Word;
-use binius_field::{Field, util::FieldFn};
+use binius_field::{BinaryField, Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_ip::channel::{
+	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
+};
 use binius_spartan_frontend::circuit_builder::{CircuitBuilder, ConstraintBuilder};
 
 use super::circuit_elem::CircuitElem;
@@ -125,11 +127,13 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	}
 }
 
-impl<F: Field> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
+impl<F: BinaryField> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	type Word = Word;
 
 	// The outer verifier rebinds the public inputs, so the wrapper records no Fiat-Shamir state.
-	fn observe_words(&mut self, _words: &[Word]) {}
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
+		words.to_vec()
+	}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
 		// The word is concrete, so which elements the sum runs over is settled while building.
@@ -142,6 +146,11 @@ impl<F: Field> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 
 	fn sample_bits(&mut self, _bits: usize) -> Word {
 		Word::ZERO
+	}
+
+	fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
+		// The words are concrete, so the packed elements are settled while building.
+		pack_words_concrete::<F, Self::Elem>(words)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -20,7 +20,9 @@ use binius_iop::{
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	merkle_channel::MerkleIPVerifierChannel,
 };
-use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_ip::channel::{
+	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
+};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
@@ -235,10 +237,10 @@ where
 {
 	type Word = Word;
 
-	fn observe_words(&mut self, words: &[Word]) {
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Word> {
 		// The inner channel holds the Fiat-Shamir state the inner prover mirrors, so the words go
 		// there. The outer verifier recomputes what depends on them from the public segment.
-		self.inner_channel.observe_words(words);
+		self.inner_channel.observe_words(words)
 	}
 
 	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
@@ -251,6 +253,11 @@ where
 
 	fn sample_bits(&mut self, bits: usize) -> Word {
 		self.inner_channel.sample_bits(bits)
+	}
+
+	fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
+		// The words are concrete, so the packed elements are constants of the wrapper circuit.
+		pack_words_concrete::<F, Self::Elem>(words)
 	}
 }
 

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -26,7 +26,7 @@ use binius_core::{
 use binius_field::{AESTowerField8b as B8, ExtensionField, FieldOps};
 use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::{
-	channel::IPVerifierChannel,
+	channel::{IPVerifierChannel, WordIPVerifierChannel},
 	sumcheck::{BatchSumcheckOutput, SumcheckOutput, batch_verify, verify as verify_sumcheck},
 };
 use binius_math::{
@@ -136,7 +136,8 @@ impl<F: Clone> ReductionOutput<F> {
 /// - `cs`: the single-instance constraint system every instance satisfies.
 /// - `instances`: whether this is the monolithic reduction or a batch, and how wide.
 /// - `inout`: which value segment the inout words sit in.
-/// - `public`: the declared public values, unpadded — the constants, then the inout values.
+/// - `public`: the declared public values as the channel carries them, unpadded — the constants,
+///   then the inout values.
 /// - `channel`: the verifier channel that reads messages and redraws Fiat-Shamir challenges.
 ///
 /// # Errors
@@ -154,11 +155,11 @@ pub fn reduce_constraints<Channel>(
 	cs: &ConstraintSystem,
 	instances: Instances,
 	inout: InoutSegment,
-	public: &[Word],
+	public: &[Channel::Word],
 	channel: &mut Channel,
 ) -> Result<ReductionOutput<Channel::Elem>, Error>
 where
-	Channel: IOPVerifierChannel<B128>,
+	Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 	Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 {
 	let log_instances = instances.log_count();
@@ -340,12 +341,12 @@ where
 fn verify_public_eval<Channel>(
 	cs: &ConstraintSystem,
 	inout: InoutSegment,
-	public: &[Word],
+	public: &[Channel::Word],
 	shift: &shift::VerifyOutput<Channel::Elem>,
 	channel: &mut Channel,
 ) -> Result<Channel::Elem, Error>
 where
-	Channel: IPVerifierChannel<B128>,
+	Channel: WordIPVerifierChannel<B128>,
 	Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 {
 	// The claim is over the packed segment, so it spans whole field elements: a segment shorter
@@ -375,9 +376,9 @@ where
 	// Close it out against the two factors, both of which the verifier computes: the packed
 	// segment's multilinear, over the words it already holds, and the ring-switching indicator.
 	let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
-	let packed_public = pack_words(public)
+	let packed_public = channel
+		.pack_words(public)
 		.into_iter()
-		.map(Channel::Elem::from)
 		// The words past the segment's end read as zero, so the elements past its packed length do
 		// too, up to the power-of-two span the sumcheck ran over.
 		.chain(iter::repeat_with(Channel::Elem::zero))
@@ -390,23 +391,6 @@ where
 	// Extend the claim from the segment's own span to the shift's whole word-index space. Every
 	// word above the segment is zero, so each extra coordinate contributes its eq-zero factor.
 	Ok(eq_ind_zero(&r_y[log_packed_words..]) * public_eval)
-}
-
-/// Packs words into field elements, two words to an element.
-///
-/// Word `2i` takes the low half of element `i` and word `2i + 1` the high half. That is the layout
-/// the committed trace is packed in, so a bit of the packed segment sits where the shift's
-/// bit-index challenges address it: `r_j` over the bit within a word, then the word's parity.
-///
-/// An odd word count leaves a final element whose high half is zero, which is the missing word read
-/// as zero — the same reading the shift gives the words past the segment's end.
-fn pack_words(words: &[Word]) -> Vec<B128> {
-	let (pairs, remainder) = words.as_chunks::<2>();
-	pairs
-		.iter()
-		.map(|[w0, w1]| B128::new(((w1.as_u64() as u128) << 64) | w0.as_u64() as u128))
-		.chain(remainder.iter().map(|w0| B128::new(w0.as_u64() as u128)))
-		.collect()
 }
 
 /// An operation's operand data, or a zero claim at an empty point when it is absent.

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -114,7 +114,10 @@ impl IOPVerifier {
 	/// `verify`, rather than duplicating it here.
 	pub fn oracle_specs(&self, is_zk: bool) -> Vec<OracleSpec> {
 		let mut channel = OracleSetupChannel::new(is_zk);
-		let inout = vec![Word::ZERO; self.constraint_system.n_inout];
+		let inout = WordIPVerifierChannel::<B128>::observe_words(
+			&mut channel,
+			&vec![Word::ZERO; self.constraint_system.n_inout],
+		);
 		// The result is discarded: the setup channel performs no real verification (all `recv_*`
 		// return zero, `assert_zero` is a no-op), so we only read back the recorded oracle specs.
 		let _ = self.verify(&inout, &mut channel);
@@ -125,7 +128,16 @@ impl IOPVerifier {
 	///
 	/// This is the core verification logic, independent of the specific IOP compilation strategy.
 	/// For most users, [`Verifier::verify`] is the simpler interface.
-	pub fn verify<Channel>(&self, inout: &[Word], channel: &mut Channel) -> Result<(), Error>
+	///
+	/// `inout` is the statement as the channel carries it, which is what
+	/// [`WordIPVerifierChannel::observe_words`] returns: the caller observes the concrete words and
+	/// passes on what comes back. A channel that carries words as wires introduces them there, so
+	/// the verification below reads the statement symbolically rather than as fixed data.
+	pub fn verify<Channel>(
+		&self,
+		inout: &[Channel::Word],
+		channel: &mut Channel,
+	) -> Result<(), Error>
 	where
 		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
@@ -140,21 +152,16 @@ impl IOPVerifier {
 			});
 		}
 
-		// Only the inout values go into Fiat-Shamir: they are what varies per instance, and the
-		// constants are fixed by the constraint system the transcript is already bound to.
-		//
-		// The words are lifted into the channel's own word type, so a channel that carries words
-		// as wires still receives them. They arrive here concrete, so such a channel sees the
-		// statement as fixed; taking it symbolically is BINIUS-433.
-		let observed = inout
+		// The shift reduction reads the whole public segment, which is the constants followed by
+		// the inout values — the order the value vector places them in. The constants are fixed by
+		// the constraint system, so they lift into the channel's word type as themselves.
+		let public = self
+			.constraint_system
+			.constants
 			.iter()
 			.map(|&word| Channel::Word::from(word))
+			.chain(inout.iter().cloned())
 			.collect::<Vec<_>>();
-		channel.observe_words(&observed);
-
-		// The shift reduction reads the whole public segment, which is the constants followed by
-		// the inout values — the order the value vector places them in.
-		let public = [self.constraint_system.constants.as_slice(), inout].concat();
 
 		let _verify_guard =
 			tracing::info_span!("Verify", operation = "verify", perfetto_category = "operation")
@@ -320,11 +327,14 @@ where
 		)
 		.entered();
 
-		// Create channel, delegate to IOPVerifier::verify, then finish it.
+		// Create channel, observe the statement, delegate to IOPVerifier::verify, then finish it.
+		// The observation is the caller's step because it is the one place the protocol handles
+		// concrete words; what it returns is what the IOP verifies against.
 		let mut channel = self
 			.iop_compiler
 			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
-		self.iop_verifier.verify(inout, &mut channel)?;
+		let inout = channel.observe_words(inout);
+		self.iop_verifier.verify(&inout, &mut channel)?;
 		channel.finish()?;
 		Ok(())
 	}

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -27,6 +27,7 @@ use binius_iop::{
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
+use binius_ip::channel::WordIPVerifierChannel;
 use binius_spartan_frontend::{
 	compiler::compile,
 	constraint_system::{BlindingInfo, WitnessLayout},
@@ -206,8 +207,11 @@ where
 			)
 			.entered();
 
+			// The statement is observed here, and what comes back is what the IOP verifies
+			// against — the same split the transparent verifier makes.
+			let inout = wrapped_channel.observe_words(inout);
 			self.inner_iop_verifier
-				.verify(inout, &mut wrapped_channel)?;
+				.verify(&inout, &mut wrapped_channel)?;
 		};
 
 		// Finish runs the outer spartan verification.


### PR DESCRIPTION
Closes [BINIUS-465](https://linear.app/jimpo/issue/BINIUS-465/remove-wordipchannel-requirement-for-binius64-iopverifier), following [#2114](https://github.com/binius-zk/binius64/pull/2114) (BINIUS-466).

> **Revised.** The first version hoisted the observation to the callers so the `WordIPVerifierChannel` bound could come off `IOPVerifier::verify`. @jimpo asked for something better: the observation should *return* the channel's own words, and the IOP should verify against those. The description below is what landed.

```rust
fn observe_words(&mut self, words: &[Word]) -> Vec<Self::Word>;
```

The observation is the one place the protocol handles a 64-bit word as fixed data it is handed, so it is also the natural place for a channel to introduce its own representation. A channel over concrete values hands the same words back; one that builds a circuit allocates the wires there. `IOPVerifier::verify` takes what comes back, so everything downstream reads the statement **symbolically**.

That is what the recursive verifier needs. Until now `verify` lifted the statement through `From<Word>`, so `Binius64BuilderChannel` saw it already concrete and baked it in as constants — the recorded circuit verified one fixed instance rather than a statement.

The transcript is unchanged: the same words go into Fiat-Shamir at the same point.

## What changed

- **`WordIPVerifierChannel::observe_words`** takes concrete `&[Word]` and returns `Vec<Self::Word>`. The prover's is untouched — it has no symbolic words, so it returns nothing.
- **`WordIPVerifierChannel::pack_words`** is new. The public segment now reaches the reduction as `Self::Word`, so the packing #2114 added as a free function over concrete words cannot stay one. `pack_words_concrete` serves the channels carrying `Word`; the builder channel pairs wires up, which costs **no gates**, since a `SymbolicElem` is exactly the two halves of a 128-bit element. This is the method BINIUS-466's description anticipated.
- **`IOPVerifier::verify` and `reduce_constraints`** take `&[Channel::Word]`. The constraint system's constants lift into the channel's word type as themselves.
- **Callers observe before delegating**: the transparent verifier, the ZK verifier, the ZK prover's replay closure, and `recursion_end_to_end`.
- **`WordIPVerifierChannel<F>` now requires `F: BinaryField`** rather than `Field`, since packing words into an element needs its bit basis. Every instantiation was already `B128`.

## What this actually buys, and how it is checked

The round trip is green whether the statement is wires or constants — the filler run supplies the same values either way — so no existing test would have shown whether this did anything. `recursion_end_to_end` now asserts the property directly:

```rust
let statement_wires = recorded.inputs.iter()
    .filter(|input| input.kind == "observe_words")
    .count();
assert_eq!(statement_wires, witness.inout().len());
```

## Verification

Tests for the nine affected crates (27 suites: `binius-ip`, `binius-iop`, `binius-verifier`, `binius-prover`, `binius-recursion`, `binius-m4-prover`, `binius-m4-verifier`, `binius-spartan-prover`, `binius-spartan-verifier`), `cargo clippy --all --tests --benches --examples -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` are clean.

Every caller must observe, and missing one fails quietly — Fiat-Shamir diverges and surfaces much later as a bad assert. That is not hypothetical: an intermediate revision left the ZK verifier out and six `prove_verify` cases failed with `OuterVerification(InvalidAssert)`. The ZK and recursion paths both have end-to-end coverage, which is what caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)