### PR TITLE
Add Sync bound to the sparse-dense product sumcheck prover impl

### DIFF
--- a/crates/ip-prover/src/sumcheck/sparse_dense_product.rs
+++ b/crates/ip-prover/src/sumcheck/sparse_dense_product.rs
@@ -115,7 +115,7 @@ impl<P: PackedField, Data: BufferData<P>> SparseDenseProductSumcheckProver<P, Da
 	}
 }
 
-impl<F: Field, P: PackedField<Scalar = F>, Data: BufferData<P>> SumcheckProver<F>
+impl<F: Field, P: PackedField<Scalar = F>, Data: BufferData<P> + Sync> SumcheckProver<F>
 	for SparseDenseProductSumcheckProver<P, Data>
 {
 	fn n_vars(&self) -> usize {


### PR DESCRIPTION
Fixes the `build-docs` failure on main: https://github.com/binius-zk/binius64/actions/runs/31586461259/job/94081330057

`SparseDenseProductSumcheckProver::execute` sums over the sparse entries with a parallel iterator whose closure borrows `self.dense`, so rayon's `ParallelIterator::map` requires the closure to be `Sync`, which requires `FieldBuffer<P, Data>: Sync` and hence `Data: Sync`. The `SumcheckProver` impl didn't carry that bound:

```
error[E0277]: `Data` cannot be shared between threads safely
  --> crates/ip-prover/src/sumcheck/sparse_dense_product.rs:136:9
```

This only shows up with the `rayon` feature on — without it, `par_iter` resolves to the serial shim in `binius-utils`, which has no `Sync` bound. No job in `ci.yml` enables the feature, so the only build that exercises the parallel path is the Documentation workflow's `cargo doc --no-deps --all-features`, which runs on push to main. That gap is worth closing separately; this PR just fixes the compile error.

All three `BufferData` impls (`Vec<T>`, `PoolVec`, `&mut [T]`) are `Sync` for `Sync` payloads, so no existing caller is excluded.

Verified with `cargo check --workspace --all-features --all-targets`.
