### PR TITLE
Read the setup channel's statement without observing it

### DIFF
--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -114,10 +114,9 @@ impl IOPVerifier {
 	/// `verify`, rather than duplicating it here.
 	pub fn oracle_specs(&self, is_zk: bool) -> Vec<OracleSpec> {
 		let mut channel = OracleSetupChannel::new(is_zk);
-		let inout = WordIPVerifierChannel::<B128>::observe_words(
-			&mut channel,
-			&vec![Word::ZERO; self.constraint_system.n_inout],
-		);
+		// The setup channel carries concrete words, so the statement it verifies against is just
+		// words — handing them through `observe_words` to get them back buys nothing.
+		let inout = vec![Word::ZERO; self.constraint_system.n_inout];
 		// The result is discarded: the setup channel performs no real verification (all `recv_*`
 		// return zero, `assert_zero` is a no-op), so we only read back the recorded oracle specs.
 		let _ = self.verify(&inout, &mut channel);


### PR DESCRIPTION
The follow-up promised on [#2116](https://github.com/binius-zk/binius64/pull/2116#discussion_r3766158259), which was already in the merge queue when @jimpo left the nit.

`oracle_specs` runs the verifier against `OracleSetupChannel`, whose `Word` is `Word`, so the statement it verifies against is just words. Handing them through `observe_words` to get the same words back bought nothing — and needed a turbofish to name the field, since the channel's element type otherwise leaves it open:

```diff
-		let inout = WordIPVerifierChannel::<B128>::observe_words(
-			&mut channel,
-			&vec![Word::ZERO; self.constraint_system.n_inout],
-		);
+		let inout = vec![Word::ZERO; self.constraint_system.n_inout];
```

The dry run records oracle shapes only, so there was nothing to observe into in the first place.

## Verification

`cargo test -p binius-verifier -p binius-prover` (6 suites) and `cargo clippy -p binius-verifier --all-targets -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)