### PR TITLE
BINIUS-420: Allow verifying multiple linear relations on oracles

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -60,17 +60,11 @@ struct CommittedOracleData<P: PackedField, C, Data: Deref<Target = [P]>> {
 }
 
 /// A committed-oracle relation queued for the single batched opening.
-///
-/// Each entry records the transparent multilinear a committed message is opened against, and which
-/// committed oracle that message belongs to. That index reconciles the arrival-order and
-/// oracle-index views of the batch.
 struct QueuedRelation<P: PackedField, Data: Deref<Target = [P]>> {
-	/// Index of the committed oracle this relation opens.
-	oracle_index: usize,
-	/// The transparent multilinear `t_i` paired with the message, backed by the caller's
+	/// The transparent multilinear `t` the message is opened against, backed by the caller's
 	/// allocator.
 	transparent: FieldBuffer<P, Data>,
-	/// The claimed inner product `s_i = <pi_i, t_i>`.
+	/// The claimed inner product `s = <pi, t>`.
 	claim: P::Scalar,
 }
 
@@ -107,10 +101,10 @@ where
 	/// The combined FRI parameters over all committed oracles.
 	fri_params: FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment, A::Vec<P>>>,
-	/// Oracle relations queued by [`IOPProverChannel::prove_oracle_relation`], opened together in
-	/// [`Self::finish`].
-	queue: Vec<QueuedRelation<P, A::Vec<P>>>,
-	next_oracle_index: usize,
+	/// Oracle relations queued by [`IOPProverChannel::prove_oracle_relation`], indexed by oracle
+	/// index and opened together in [`Self::finish`]. One entry per committed oracle, so its
+	/// length is also the number of oracles committed so far.
+	queue: Vec<Vec<QueuedRelation<P, A::Vec<P>>>>,
 	rng: StdRng,
 }
 
@@ -141,7 +135,6 @@ where
 			fri_params,
 			committed_oracles: Vec::new(),
 			queue: Vec::new(),
-			next_oracle_index: 0,
 			rng: StdRng::from_rng(&mut rng),
 		}
 	}
@@ -163,14 +156,13 @@ where
 			fri_params,
 			committed_oracles,
 			queue,
-			next_oracle_index,
 			rng: _,
 		} = self;
 
-		let n_remaining = oracle_specs.len() - next_oracle_index;
+		let n_remaining = oracle_specs.len() - queue.len();
 		assert!(n_remaining == 0, "finish called but {n_remaining} oracle specs remaining",);
 
-		if queue.is_empty() {
+		if queue.iter().all(Vec::is_empty) {
 			return;
 		}
 
@@ -194,19 +186,16 @@ where
 /// point `r`, then opens all committed oracles together with a single combined FRI. Mirrors
 /// [`binius_iop::basefold::channel::BaseFoldVerifierChannel::finish`].
 ///
-/// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
-/// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
-/// α_i and the FRI openings are emitted in oracle-index order. Each relation carries its oracle's
-/// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
-/// per-oracle data (`oracle_specs`, `fri_params`, `committed_oracles`) is all indexed by oracle
-/// index.
+/// Everything runs in oracle-index order: `relations` arrives indexed by oracle, as do the
+/// per-oracle data (`oracle_specs`, `fri_params`, `committed_oracles`), the masking inner products
+/// σ_i, the sumcheck provers, the reduced evaluations α_i, and the FRI openings.
 fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	channel: &mut Channel,
 	ntt: &NTT,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	mut committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment, A::Vec<P>>>,
-	relations: Vec<QueuedRelation<P, A::Vec<P>>>,
+	relations: Vec<Vec<QueuedRelation<P, A::Vec<P>>>>,
 	alloc: &A,
 ) where
 	A: Allocator,
@@ -217,11 +206,15 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 {
 	let n_committed = committed_oracles.len();
 	assert_eq!(oracle_specs.len(), n_committed);
+	assert_eq!(relations.len(), n_committed);
 
 	// TODO: Remove this limitation, it shouldn't be necessary. It is currently because of how the
 	// sumcheck reduces to the multilinear evaluations (alphas): an oracle with no relation gets no
 	// sumcheck prover, so its α would have to come from a plain multilinear evaluation.
-	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
+	assert!(
+		relations.iter().all(|relations| !relations.is_empty()),
+		"expects at least one relation per committed oracle",
+	);
 
 	// Take ownership of the committed messages π_i, leaving the masks and codewords in place. Every
 	// committed oracle must have been handed back with `finalize_oracle`.
@@ -236,6 +229,10 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		})
 		.collect::<Vec<_>>();
 
+	// Batch each oracle's claims into one, so everything below runs exactly one relation per
+	// committed oracle.
+	let relations = batch_relations_per_oracle::<A, _, _, _>(channel, relations);
+
 	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
 	let max_n = oracle_specs
 		.iter()
@@ -244,23 +241,17 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		.expect("at least one oracle");
 
 	// === Masking step (whitepaper 7.2) ===
-	// Only ZK oracles are masked. Send their σ_i = ⟨ω_i, t_i⟩ (one per ZK oracle, in relation
-	// order), then sample the single shared masking challenge γ — skipped entirely when no ZK
-	// oracle is present.
-	let any_zk_openings = relations
-		.iter()
-		.any(|rel| oracle_specs[rel.oracle_index].is_zk);
+	// Only ZK oracles are masked. Send their σ_i = ⟨ω_i, T_i⟩ against the batched transparent (one
+	// per ZK oracle), then sample the single shared masking challenge γ — skipped entirely when no
+	// ZK oracle is present.
+	let any_zk_openings = oracle_specs.iter().any(|spec| spec.is_zk);
 	let (sigmas, gamma) = if any_zk_openings {
 		let _scope = tracing::debug_span!("Compute ZK mask opening values").entered();
-		let sigmas = relations
-			.iter()
-			.filter(|rel| oracle_specs[rel.oracle_index].is_zk)
-			.map(|rel| {
-				let mask = committed_oracles[rel.oracle_index]
-					.mask
-					.as_ref()
-					.expect("ZK oracle carries a mask");
-				inner_product_par(mask, &rel.transparent)
+		let sigmas = izip!(&relations, oracle_specs, &committed_oracles)
+			.filter(|(_, spec, _)| spec.is_zk)
+			.map(|(relation, _, committed)| {
+				let mask = committed.mask.as_ref().expect("ZK oracle carries a mask");
+				inner_product_par(mask, &relation.transparent)
 			})
 			.collect::<Vec<_>>();
 		channel.send_many(&sigmas);
@@ -274,15 +265,12 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 
 	// Blind each ZK oracle's message in place: π_i' = (1-γ)π_i + γω_i. A non-ZK oracle's message
 	// passes through unmasked.
-	for (index, (message, spec)) in izip!(&mut messages, oracle_specs).enumerate() {
+	for (message, spec, committed) in izip!(&mut messages, oracle_specs, &committed_oracles) {
 		let n_i = spec.log_msg_len;
 		assert_eq!(message.log_len(), n_i); // pre-condition
 
 		if spec.is_zk {
-			let mask = committed_oracles[index]
-				.mask
-				.as_ref()
-				.expect("ZK oracle carries a mask");
+			let mask = committed.mask.as_ref().expect("ZK oracle carries a mask");
 			let gamma_broadcast = P::broadcast(gamma.expect("γ sampled when ZK oracles present"));
 
 			let _scope = tracing::debug_span!("Fold message and ZK mask", log_len = n_i).entered();
@@ -295,46 +283,33 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		}
 	}
 
-	// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
-	// Register one prover per relation, in arrival order, and pad each to `max_n`.
-	// `prover_oracle_indices` records the oracle index behind each (arrival-order) prover so the
-	// reduced evals can be scattered back into oracle-index order.
-	let mut prover_oracle_indices = Vec::with_capacity(relations.len());
+	// === Phase A: batched sumcheck on the masked claims ⟨π_i', T_i⟩ = s_i' ===
+	// One prover per committed oracle, in oracle-index order, each padded to `max_n`.
 	let mut sigma_iter = sigmas.into_iter();
-	let provers = relations
-		.into_iter()
-		.map(
-			|QueuedRelation {
-			     oracle_index: index,
-			     transparent,
-			     claim,
-			 }| {
-				prover_oracle_indices.push(index);
-				let message = messages[index].to_ref();
+	let provers = izip!(relations, &messages, oracle_specs)
+		.map(|(QueuedRelation { transparent, claim }, message, spec)| {
+			let n_i = spec.log_msg_len;
+			assert_eq!(transparent.log_len(), n_i); // pre-condition
 
-				let n_i = oracle_specs[index].log_msg_len;
-				assert_eq!(transparent.log_len(), n_i); // pre-condition
+			// ZK oracle: mask the claim with σ_i.
+			// Non-ZK oracle: the claim passes through unmasked.
+			let sum_prime = if spec.is_zk {
+				let sigma = sigma_iter.next().expect("one σ per ZK oracle");
+				let gamma = gamma.expect("γ sampled when ZK oracles present");
+				extrapolate_line(claim, sigma, gamma)
+			} else {
+				claim
+			};
 
-				// ZK oracle: mask the claim with σ_i.
-				// Non-ZK oracle: the claim passes through unmasked.
-				let sum_prime = if oracle_specs[index].is_zk {
-					let sigma = sigma_iter.next().expect("one σ per ZK oracle");
-					let gamma = gamma.expect("γ sampled when ZK oracles present");
-					extrapolate_line(claim, sigma, gamma)
-				} else {
-					claim
-				};
-
-				let mut store = MleStore::new(n_i, alloc);
-				let message_col = store.push(message);
-				let transparent_col = store.push_owned(transparent);
-				let inner = SharedSumcheckProver::new(
-					store,
-					[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
-				);
-				PaddedSumcheckDecorator::new(inner, max_n - n_i, vec![sum_prime])
-			},
-		)
+			let mut store = MleStore::new(n_i, alloc);
+			let message_col = store.push(message.to_ref());
+			let transparent_col = store.push_owned(transparent);
+			let inner = SharedSumcheckProver::new(
+				store,
+				[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
+			);
+			PaddedSumcheckDecorator::new(inner, max_n - n_i, vec![sum_prime])
+		})
 		.collect::<Vec<_>>();
 
 	let BatchSumcheckOutput {
@@ -346,15 +321,11 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		sumcheck::batch_prove(provers, channel)
 	};
 
-	// Reduced oracle evaluations α_i = π_i'(ρ_i) come out in arrival order; scatter them into
-	// oracle-index order to match how the verifier indexes them.
-	//
-	// TODO: This will fail if one oracle isn't opened. For robustness, we should do a regular
-	// multilinear evaluation in that case.
-	let mut alphas = vec![F::ZERO; n_committed];
-	for (eval_pos, &index) in prover_oracle_indices.iter().enumerate() {
-		alphas[index] = multilinear_evals[eval_pos][0];
-	}
+	// Reduced oracle evaluations α_i = π_i'(ρ_i), one per committed oracle in oracle-index order.
+	let alphas = multilinear_evals
+		.iter()
+		.map(|evals| evals[0])
+		.collect::<Vec<_>>();
 	channel.send_many(&alphas);
 
 	// === Phase B: single combined-FRI MLE-check over the piecewise-concatenated oracle ===
@@ -428,6 +399,63 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		channel,
 		alloc,
 	);
+}
+
+/// Batches each oracle's queued relations down to one, in oracle-index order.
+///
+/// An oracle carrying `k > 1` claims has them folded into a single claim against a single
+/// transparent, using a batching challenge λ shared by every oracle:
+///
+/// ```text
+/// T_i = Σ_j λ^j · t_ij     the combined transparent
+/// S_i = Σ_j λ^j · s_ij     the combined claim
+/// ```
+///
+/// The inner product is linear in the transparent, so `⟨π_i, T_i⟩ = S_i` holds exactly when every
+/// `⟨π_i, t_ij⟩ = s_ij` does, except with probability at most `Σ_i (k_i - 1) / |F|` over λ. λ is
+/// drawn after every claim it combines is already bound to the transcript, so no claim can be
+/// chosen as a function of it. The batched per-oracle claims are then combined again by the
+/// sumcheck's own outer batching coefficient.
+///
+/// Mirrors [`binius_iop::basefold::channel`]'s verifier-side batching.
+fn batch_relations_per_oracle<A, F, P, Channel>(
+	channel: &mut Channel,
+	relations: Vec<Vec<QueuedRelation<P, A::Vec<P>>>>,
+) -> Vec<QueuedRelation<P, A::Vec<P>>>
+where
+	A: Allocator,
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: MerkleIPProverChannel<F>,
+{
+	let lambda = channel.sample();
+
+	relations
+		.into_iter()
+		.map(|relations| {
+			let mut relations = relations.into_iter();
+			let mut batched = relations
+				.next()
+				.expect("pre-condition: every committed oracle carries at least one relation");
+
+			// Powers λ, λ², … scale the oracle's remaining relations into the first. An oracle
+			// carrying a single relation folds nothing.
+			let mut coeff = lambda;
+			for relation in relations {
+				// pre-condition: all of an oracle's transparents match its message length
+				assert_eq!(relation.transparent.log_len(), batched.transparent.log_len());
+
+				accumulate_scaled_buffer(
+					batched.transparent.to_mut(),
+					relation.transparent.to_ref(),
+					P::broadcast(coeff),
+				);
+				batched.claim += coeff * relation.claim;
+				coeff *= lambda;
+			}
+			batched
+		})
+		.collect()
 }
 
 fn accumulate_scaled_buffer<P: PackedField>(
@@ -514,14 +542,14 @@ where
 	type Oracle = BaseFoldOracle;
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
-		&self.oracle_specs[self.next_oracle_index..]
+		&self.oracle_specs[self.queue.len()..]
 	}
 
 	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
 		let remaining = self.remaining_oracle_specs();
 		assert!(!remaining.is_empty(), "send_oracle called but no remaining oracle specs");
 
-		let index = self.next_oracle_index;
+		let index = self.queue.len();
 		let spec = &remaining[0];
 
 		// ZK channel expects raw witness buffer (NOT doubled).
@@ -562,8 +590,7 @@ where
 			commitment,
 			message: None,
 		});
-
-		self.next_oracle_index += 1;
+		self.queue.push(Vec::new());
 
 		BaseFoldOracle { index }
 	}
@@ -574,19 +601,15 @@ where
 		transparent: FieldVec<P, A>,
 		claim: P::Scalar,
 	) {
-		// Queue the relation; the actual opening (masking + sumcheck + combined FRI) happens once,
-		// over all committed oracles, in [`Self::finish`].
-		assert!(
-			oracle.index < self.committed_oracles.len(),
-			"oracle index {} out of bounds, expected < {}",
-			oracle.index,
-			self.committed_oracles.len()
-		);
-		self.queue.push(QueuedRelation {
-			oracle_index: oracle.index,
-			transparent,
-			claim,
-		});
+		// Queue the relation under its oracle; the actual opening (masking + sumcheck + combined
+		// FRI) happens once, over all committed oracles, in [`Self::finish`].
+		let n_committed = self.queue.len();
+		self.queue
+			.get_mut(oracle.index)
+			.unwrap_or_else(|| {
+				panic!("oracle index {} out of bounds, expected < {n_committed}", oracle.index)
+			})
+			.push(QueuedRelation { transparent, claim });
 	}
 
 	fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>) {
@@ -604,6 +627,8 @@ where
 
 #[cfg(test)]
 mod tests {
+	use std::iter;
+
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField, BinaryField128bGhash, Field, PackedBinaryGhash1x128b, PackedField,
@@ -854,7 +879,7 @@ mod tests {
 			.iter()
 			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
 			.collect();
-		for (oracle, (buffer, transparent, claim)) in oracles.into_iter().zip(&data) {
+		for (oracle, (buffer, transparent, claim)) in iter::zip(oracles, &data) {
 			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
 			prover_channel.finalize_oracle(oracle, buffer.clone());
 		}
@@ -871,7 +896,7 @@ mod tests {
 			.iter()
 			.map(|&n| verifier_channel.recv_oracle(n, true).unwrap())
 			.collect();
-		for (i, (oracle, (_, transparent, claim))) in v_oracles.into_iter().zip(&data).enumerate() {
+		for (i, (oracle, (_, transparent, claim))) in iter::zip(v_oracles, &data).enumerate() {
 			let transparent = transparent.clone();
 			let claim = if tamper && i == 0 {
 				*claim + F::ONE
@@ -940,7 +965,7 @@ mod tests {
 			.iter()
 			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
 			.collect();
-		for (oracle, (buffer, transparent, claim)) in oracles.into_iter().zip(&data) {
+		for (oracle, (buffer, transparent, claim)) in iter::zip(oracles, &data) {
 			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
 			prover_channel.finalize_oracle(oracle, buffer.clone());
 		}
@@ -956,7 +981,7 @@ mod tests {
 			.iter()
 			.map(|&(n, _)| verifier_channel.recv_oracle(n, true).unwrap())
 			.collect();
-		for (i, (oracle, (_, transparent, claim))) in v_oracles.into_iter().zip(&data).enumerate() {
+		for (i, (oracle, (_, transparent, claim))) in iter::zip(v_oracles, &data).enumerate() {
 			let transparent = transparent.clone();
 			let claim = if tamper && i == 0 {
 				*claim + F::ONE
@@ -1010,5 +1035,166 @@ mod tests {
 	#[test]
 	fn test_basefold_channel_invalid_proof() {
 		assert!(!run_zk_channel(&[6, 8], true));
+	}
+
+	/// Generates a committed buffer of `n_vars` variables together with `n_relations` independent
+	/// `(transparent, claim)` pairs, each opening the buffer at a different point.
+	fn generate_oracle_relations<F, P, R: Rng>(
+		rng: &mut R,
+		n_vars: usize,
+		n_relations: usize,
+	) -> (FieldBuffer<P>, Vec<(FieldBuffer<P>, F)>)
+	where
+		F: BinaryField,
+		P: PackedField<Scalar = F>,
+	{
+		let buffer = random_field_buffer::<P>(&mut *rng, n_vars);
+		let relations = (0..n_relations)
+			.map(|_| {
+				let point = random_scalars::<F>(&mut *rng, n_vars);
+				let transparent = eq_ind_partial_eval::<P>(&point);
+				let claim = inner_product_buffers(&buffer, &transparent);
+				(transparent, claim)
+			})
+			.collect();
+		(buffer, relations)
+	}
+
+	/// Runs a full prove/verify cycle over oracles described as `(n_vars, is_zk, n_relations)`.
+	///
+	/// The relations are queued round-robin over the oracles, so they arrive interleaved and the
+	/// channel's grouping by oracle is exercised. If `tamper` is set, the verifier's claim at that
+	/// arrival position is corrupted; verification must then fail. Returns whether verification
+	/// accepted.
+	fn run_multi_relation_channel(specs: &[(usize, bool, usize)], tamper: Option<usize>) -> bool {
+		type F = BinaryField128bGhash;
+		type P = PackedBinaryGhash1x128b;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let data = specs
+			.iter()
+			.map(|&(n_vars, _, n_relations)| {
+				generate_oracle_relations::<F, P, _>(&mut rng, n_vars, n_relations)
+			})
+			.collect::<Vec<_>>();
+
+		// Arrival order of the relations, as `(oracle position, relation position)`.
+		let max_relations = specs
+			.iter()
+			.map(|&(_, _, k)| k)
+			.max()
+			.expect("at least one oracle");
+		let arrivals = (0..max_relations)
+			.flat_map(|round| {
+				specs
+					.iter()
+					.enumerate()
+					.filter(move |&(_, &(_, _, k))| round < k)
+					.map(move |(index, _)| (index, round))
+			})
+			.collect::<Vec<_>>();
+
+		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, LOG_INV_RATE);
+		let oracle_specs = specs
+			.iter()
+			.map(|&(n_vars, is_zk, _)| {
+				if is_zk {
+					OracleSpec::new_zk(n_vars)
+				} else {
+					OracleSpec::new(n_vars)
+				}
+			})
+			.collect::<Vec<_>>();
+
+		let verifier_compiler = BaseFoldVerifierCompiler::new(
+			&make_merkle_scheme(),
+			oracle_specs,
+			LOG_INV_RATE,
+			n_test_queries,
+			&MinProofSizeStrategy,
+		);
+
+		// === PROVER SIDE ===
+		let ntt = make_ntt(verifier_compiler.max_log_domain_size());
+		let prover_compiler =
+			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let prover_rng = StdRng::seed_from_u64(1);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
+				&mut prover_transcript,
+				prover_rng,
+			);
+
+		let oracles = data
+			.iter()
+			.map(|(buffer, _)| prover_channel.send_oracle(buffer.to_ref()))
+			.collect::<Vec<_>>();
+		for &(index, round) in &arrivals {
+			let (transparent, claim) = &data[index].1[round];
+			prover_channel.prove_oracle_relation(oracles[index], transparent.clone(), *claim);
+		}
+		for (oracle, (buffer, _)) in iter::zip(&oracles, &data) {
+			prover_channel.finalize_oracle(*oracle, buffer.clone());
+		}
+		prover_channel.finish(&GlobalAllocator);
+
+		// === VERIFIER SIDE ===
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut verifier_transcript,
+			);
+
+		let v_oracles = specs
+			.iter()
+			.map(|&(n_vars, _, _)| verifier_channel.recv_oracle(n_vars, true).unwrap())
+			.collect::<Vec<_>>();
+		for (position, &(index, round)) in arrivals.iter().enumerate() {
+			let (transparent, claim) = &data[index].1[round];
+			let transparent = transparent.clone();
+			let claim = if tamper == Some(position) {
+				*claim + F::ONE
+			} else {
+				*claim
+			};
+			verifier_channel
+				.verify_oracle_relation(
+					v_oracles[index],
+					Box::new(move |point: &[F]| {
+						let eq = eq_ind_partial_eval::<P>(point);
+						inner_product_buffers(&transparent, &eq)
+					}),
+					claim,
+				)
+				.expect("verify_oracle_relation only queues");
+		}
+		verifier_channel.finish().is_ok()
+	}
+
+	#[test]
+	fn test_basefold_channel_two_relations_one_oracle() {
+		// Two claims on the same committed oracle: the channel batches them behind one λ.
+		assert!(run_multi_relation_channel(&[(6, true, 2)], None));
+	}
+
+	#[test]
+	fn test_basefold_channel_two_relations_one_oracle_invalid() {
+		// Tampering the second of the two claims must be rejected.
+		assert!(!run_multi_relation_channel(&[(6, true, 2)], Some(1)));
+	}
+
+	#[test]
+	fn test_basefold_channel_mixed_relation_counts() {
+		// A non-ZK oracle with one claim and a ZK oracle with three, arriving interleaved: only the
+		// multi-claim oracle draws a λ, and the σ accounting must follow the batched relations.
+		assert!(run_multi_relation_channel(&[(8, false, 1), (6, true, 3)], None));
+	}
+
+	#[test]
+	fn test_basefold_channel_mixed_relation_counts_invalid() {
+		// Tampering a claim on the non-ZK oracle in a mixed batch must be rejected.
+		assert!(!run_multi_relation_channel(&[(8, false, 2), (6, true, 2)], Some(2)));
 	}
 }

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -46,7 +46,7 @@ pub struct BaseFoldOracle {
 }
 
 /// Committed oracle data stored internally.
-struct CommittedOracleData<P: PackedField, C> {
+struct CommittedOracleData<P: PackedField, C, Data: Deref<Target = [P]>> {
 	/// The mask buffer generated during [`fri::encode_masked`] for a ZK oracle, held by the
 	/// channel because it is the only party that knows it. `None` for a non-ZK (unmasked) oracle.
 	mask: Option<FieldBuffer<P>>,
@@ -54,18 +54,19 @@ struct CommittedOracleData<P: PackedField, C> {
 	codeword: FieldBuffer<P>,
 	/// The Merkle commitment handle for query proofs, owning the committed tree.
 	commitment: C,
+	/// The committed multilinear message `pi_i`, backed by the caller's allocator. Handed over by
+	/// [`IOPProverChannel::finalize_oracle`], and `None` until then.
+	message: Option<FieldBuffer<P, Data>>,
 }
 
 /// A committed-oracle relation queued for the single batched opening.
 ///
-/// Each entry pairs a committed message with the transparent multilinear it is opened against.
-/// It also records which committed oracle it refers to.
-/// That index reconciles the arrival-order and oracle-index views of the batch.
+/// Each entry records the transparent multilinear a committed message is opened against, and which
+/// committed oracle that message belongs to. That index reconciles the arrival-order and
+/// oracle-index views of the batch.
 struct QueuedRelation<P: PackedField, Data: Deref<Target = [P]>> {
 	/// Index of the committed oracle this relation opens.
 	oracle_index: usize,
-	/// The committed multilinear message `pi_i`, backed by the caller's allocator.
-	message: FieldBuffer<P, Data>,
 	/// The transparent multilinear `t_i` paired with the message, backed by the caller's
 	/// allocator.
 	transparent: FieldBuffer<P, Data>,
@@ -80,7 +81,7 @@ struct QueuedRelation<P: PackedField, Data: Deref<Target = [P]>> {
 /// buffer (not doubled). The channel handles:
 /// - Generating a random mask of equal length
 /// - Interleaving witness and mask for FRI commitment
-/// - Running ZK BaseFold proofs in `prove_oracle_relations`
+/// - Running ZK BaseFold proofs in [`Self::finish`]
 ///
 /// # Type Parameters
 ///
@@ -105,8 +106,8 @@ where
 	oracle_specs: Vec<OracleSpec>,
 	/// The combined FRI parameters over all committed oracles.
 	fri_params: FRIParams<F>,
-	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
-	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
+	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment, A::Vec<P>>>,
+	/// Oracle relations queued by [`IOPProverChannel::prove_oracle_relation`], opened together in
 	/// [`Self::finish`].
 	queue: Vec<QueuedRelation<P, A::Vec<P>>>,
 	next_oracle_index: usize,
@@ -148,7 +149,7 @@ where
 	/// Consumes the channel and proves the single combined opening over **all** committed oracles.
 	///
 	/// All oracle relations queued by
-	/// [`prove_oracle_relations`](IOPProverChannel::prove_oracle_relations) across every call are
+	/// [`prove_oracle_relation`](IOPProverChannel::prove_oracle_relation) across every call are
 	/// processed here in one batch: masking, one batched sumcheck reducing the masked claims to a
 	/// shared point `r`, then one combined FRI opening over every committed oracle
 	/// (in oracle-index order). Mirrors [`BaseFoldVerifierChannel::finish`].
@@ -204,7 +205,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	ntt: &NTT,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
-	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
+	mut committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment, A::Vec<P>>>,
 	relations: Vec<QueuedRelation<P, A::Vec<P>>>,
 	alloc: &A,
 ) where
@@ -218,8 +219,22 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	assert_eq!(oracle_specs.len(), n_committed);
 
 	// TODO: Remove this limitation, it shouldn't be necessary. It is currently because of how the
-	// sumcheck reduces to the multilinear evaluations (alphas).
+	// sumcheck reduces to the multilinear evaluations (alphas): an oracle with no relation gets no
+	// sumcheck prover, so its α would have to come from a plain multilinear evaluation.
 	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
+
+	// Take ownership of the committed messages π_i, leaving the masks and codewords in place. Every
+	// committed oracle must have been handed back with `finalize_oracle`.
+	let mut messages = committed_oracles
+		.iter_mut()
+		.enumerate()
+		.map(|(index, oracle)| {
+			oracle
+				.message
+				.take()
+				.unwrap_or_else(|| panic!("oracle {index} was committed but never finalized"))
+		})
+		.collect::<Vec<_>>();
 
 	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
 	let max_n = oracle_specs
@@ -257,96 +272,69 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		(Vec::new(), None)
 	};
 
+	// Blind each ZK oracle's message in place: π_i' = (1-γ)π_i + γω_i. A non-ZK oracle's message
+	// passes through unmasked.
+	for (index, (message, spec)) in izip!(&mut messages, oracle_specs).enumerate() {
+		let n_i = spec.log_msg_len;
+		assert_eq!(message.log_len(), n_i); // pre-condition
+
+		if spec.is_zk {
+			let mask = committed_oracles[index]
+				.mask
+				.as_ref()
+				.expect("ZK oracle carries a mask");
+			let gamma_broadcast = P::broadcast(gamma.expect("γ sampled when ZK oracles present"));
+
+			let _scope = tracing::debug_span!("Fold message and ZK mask", log_len = n_i).entered();
+			(message.as_mut(), mask.as_ref())
+				.into_par_iter()
+				.with_min_task(WorkPerItem::FieldMuls)
+				.for_each(|(message_i, &mask_i)| {
+					*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
+				});
+		}
+	}
+
 	// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
-	// Register provers in arrival order; form π_i' = (1-γ)π_i + γω_i, storing each clone for Phase
-	// B keyed by oracle index, and pad each prover to `max_n`. `prover_oracle_indices` records the
-	// oracle index behind each (arrival-order) prover so the reduced evals can be scattered back
-	// into oracle-index order.
-	// Built element by element rather than with `vec![None; n]`, which needs `Clone`:
-	// `Allocator::Vec<T>` declares no `Clone` bound. Adding one would be the wrong fix — `PoolVec`
-	// does implement `Clone`, but by drawing a fresh block from the pool, so a `Clone` bound would
-	// make `vec![buffer; n]` quietly allocate `n` blocks.
-	let mut witness_primes = (0..n_committed).map(|_| None).collect::<Vec<_>>();
-	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
-	let relations = relations
+	// Register one prover per relation, in arrival order, and pad each to `max_n`.
+	// `prover_oracle_indices` records the oracle index behind each (arrival-order) prover so the
+	// reduced evals can be scattered back into oracle-index order.
+	let mut prover_oracle_indices = Vec::with_capacity(relations.len());
+	let mut sigma_iter = sigmas.into_iter();
+	let provers = relations
 		.into_iter()
 		.map(
 			|QueuedRelation {
 			     oracle_index: index,
-			     mut message,
 			     transparent,
 			     claim,
 			 }| {
+				prover_oracle_indices.push(index);
+				let message = messages[index].to_ref();
+
 				let n_i = oracle_specs[index].log_msg_len;
-				assert_eq!(message.log_len(), n_i); // pre-condition
 				assert_eq!(transparent.log_len(), n_i); // pre-condition
 
-				// ZK oracle: blind the message π_i' = (1-γ)π_i + γω_i
-				// Non-ZK oracle: the message passes through unmasked.
-				if oracle_specs[index].is_zk {
-					let mask = committed_oracles[index]
-						.mask
-						.as_ref()
-						.expect("ZK oracle carries a mask");
+				// ZK oracle: mask the claim with σ_i.
+				// Non-ZK oracle: the claim passes through unmasked.
+				let sum_prime = if oracle_specs[index].is_zk {
+					let sigma = sigma_iter.next().expect("one σ per ZK oracle");
 					let gamma = gamma.expect("γ sampled when ZK oracles present");
+					extrapolate_line(claim, sigma, gamma)
+				} else {
+					claim
+				};
 
-					let gamma_broadcast = P::broadcast(gamma);
-
-					{
-						let _scope =
-							tracing::debug_span!("Fold message and ZK mask", log_len = n_i)
-								.entered();
-						(message.as_mut(), mask.as_ref())
-							.into_par_iter()
-							.with_min_task(WorkPerItem::FieldMuls)
-							.for_each(|(message_i, &mask_i)| {
-								*message_i =
-									extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
-							});
-					}
-				}
-
-				witness_primes[index] = Some(message);
-				prover_oracle_indices.push(index);
-
-				(index, transparent, claim)
+				let mut store = MleStore::new(n_i, alloc);
+				let message_col = store.push(message);
+				let transparent_col = store.push_owned(transparent);
+				let inner = SharedSumcheckProver::new(
+					store,
+					[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
+				);
+				PaddedSumcheckDecorator::new(inner, max_n - n_i, vec![sum_prime])
 			},
 		)
-		.collect::<Vec<_>>();
-
-	// Create the sumcheck provers
-	let mut sigma_iter = sigmas.into_iter();
-	let provers = relations
-		.into_iter()
-		.map(|(index, transparent, claim)| {
-			let message = witness_primes[index]
-				.as_ref()
-				.expect("entry was set to Some in the prior loop")
-				.to_ref();
-
-			let n_i = oracle_specs[index].log_msg_len;
-			assert_eq!(message.log_len(), n_i); // pre-condition
-			assert_eq!(transparent.log_len(), n_i); // pre-condition
-
-			// ZK oracle: mask the claim with σ_i.
-			// Non-ZK oracle: the claim passes through unmasked.
-			let sum_prime = if oracle_specs[index].is_zk {
-				let sigma = sigma_iter.next().expect("one σ per ZK oracle");
-				let gamma = gamma.expect("γ sampled when ZK oracles present");
-				extrapolate_line(claim, sigma, gamma)
-			} else {
-				claim
-			};
-
-			let mut store = MleStore::new(n_i, alloc);
-			let message_col = store.push(message);
-			let transparent_col = store.push_owned(transparent);
-			let inner = SharedSumcheckProver::new(
-				store,
-				[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
-			);
-			PaddedSumcheckDecorator::new(inner, max_n - n_i, vec![sum_prime])
-		})
 		.collect::<Vec<_>>();
 
 	let BatchSumcheckOutput {
@@ -389,10 +377,8 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 		let mut combined = FieldBuffer::zeros_in(alloc, max_n);
 		let mut s_prime = F::ZERO;
 		for (fri_oracle, witness_prime, eq_i, alpha_i) in
-			izip!(fri_params.input_oracles(), witness_primes, eq_tensor, alphas)
+			izip!(fri_params.input_oracles(), messages, eq_tensor, alphas)
 		{
-			let witness_prime =
-				witness_prime.expect("every committed oracle carries exactly one queued relation");
 			let n_i = witness_prime.log_len();
 			// Each oracle occupies the low 2^{n_i} of every 2^{log_lift}·2^{n_i}-sized lift block,
 			// and that block is *repeated* across the 2^{log_repeat} high dims so the small
@@ -574,6 +560,7 @@ where
 			mask,
 			codeword,
 			commitment,
+			message: None,
 		});
 
 		self.next_oracle_index += 1;
@@ -581,28 +568,37 @@ where
 		BaseFoldOracle { index }
 	}
 
-	fn prove_oracle_relations(
+	fn prove_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
-		>,
+		oracle: Self::Oracle,
+		transparent: FieldVec<P, A>,
+		claim: P::Scalar,
 	) {
-		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
+		// Queue the relation; the actual opening (masking + sumcheck + combined FRI) happens once,
 		// over all committed oracles, in [`Self::finish`].
-		for (oracle, message, transparent, claim) in oracle_relations {
-			assert!(
-				oracle.index < self.committed_oracles.len(),
-				"oracle index {} out of bounds, expected < {}",
-				oracle.index,
-				self.committed_oracles.len()
-			);
-			self.queue.push(QueuedRelation {
-				oracle_index: oracle.index,
-				message,
-				transparent,
-				claim,
-			});
-		}
+		assert!(
+			oracle.index < self.committed_oracles.len(),
+			"oracle index {} out of bounds, expected < {}",
+			oracle.index,
+			self.committed_oracles.len()
+		);
+		self.queue.push(QueuedRelation {
+			oracle_index: oracle.index,
+			transparent,
+			claim,
+		});
+	}
+
+	fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>) {
+		let committed = self
+			.committed_oracles
+			.get_mut(oracle.index)
+			.unwrap_or_else(|| panic!("oracle index {} out of bounds", oracle.index));
+		assert!(
+			committed.message.replace(buffer).is_none(),
+			"oracle {} finalized twice",
+			oracle.index
+		);
 	}
 }
 
@@ -615,7 +611,7 @@ mod tests {
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
 		basefold::compiler::BaseFoldVerifierCompiler,
-		channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+		channel::{IOPVerifierChannel, OracleSpec},
 		fri::MinProofSizeStrategy,
 		merkle_tree::BinaryMerkleTreeScheme,
 	};
@@ -706,12 +702,8 @@ mod tests {
 		let oracle = prover_channel.send_oracle(buffer.to_ref());
 		assert_eq!(oracle.index, 0);
 
-		prover_channel.prove_oracle_relations([(
-			oracle,
-			buffer,
-			transparent_poly.clone(),
-			eval_claim,
-		)]);
+		prover_channel.prove_oracle_relation(oracle, transparent_poly.clone(), eval_claim);
+		prover_channel.finalize_oracle(oracle, buffer);
 		prover_channel.finish(&GlobalAllocator);
 
 		// === VERIFIER SIDE ===
@@ -724,14 +716,14 @@ mod tests {
 		let v_oracle = verifier_channel.recv_oracle(n_vars, true).unwrap();
 
 		verifier_channel
-			.verify_oracle_relations([OracleLinearRelation {
-				oracle: v_oracle,
-				transparent: Box::new(move |point: &[F]| {
+			.verify_oracle_relation(
+				v_oracle,
+				Box::new(move |point: &[F]| {
 					let eq = eq_ind_partial_eval::<P>(point);
 					inner_product_buffers(&transparent_poly, &eq)
 				}),
-				claim: eval_claim,
-			}])
+				eval_claim,
+			)
 			.unwrap();
 		verifier_channel.finish().unwrap();
 	}
@@ -778,10 +770,10 @@ mod tests {
 		let oracle_1 = prover_channel.send_oracle(buffer_1.to_ref());
 		let oracle_2 = prover_channel.send_oracle(buffer_2.to_ref());
 
-		prover_channel.prove_oracle_relations([
-			(oracle_1, buffer_1, transparent_poly_1.clone(), eval_claim_1),
-			(oracle_2, buffer_2, transparent_poly_2.clone(), eval_claim_2),
-		]);
+		prover_channel.prove_oracle_relation(oracle_1, transparent_poly_1.clone(), eval_claim_1);
+		prover_channel.prove_oracle_relation(oracle_2, transparent_poly_2.clone(), eval_claim_2);
+		prover_channel.finalize_oracle(oracle_1, buffer_1);
+		prover_channel.finalize_oracle(oracle_2, buffer_2);
 		prover_channel.finish(&GlobalAllocator);
 
 		// === VERIFIER SIDE ===
@@ -798,24 +790,24 @@ mod tests {
 		let tp2 = transparent_poly_2;
 
 		verifier_channel
-			.verify_oracle_relations([
-				OracleLinearRelation {
-					oracle: v_oracle_1,
-					transparent: Box::new(move |point: &[F]| {
-						let eq = eq_ind_partial_eval::<P>(point);
-						inner_product_buffers(&tp1, &eq)
-					}),
-					claim: eval_claim_1,
-				},
-				OracleLinearRelation {
-					oracle: v_oracle_2,
-					transparent: Box::new(move |point: &[F]| {
-						let eq = eq_ind_partial_eval::<P>(point);
-						inner_product_buffers(&tp2, &eq)
-					}),
-					claim: eval_claim_2,
-				},
-			])
+			.verify_oracle_relation(
+				v_oracle_1,
+				Box::new(move |point: &[F]| {
+					let eq = eq_ind_partial_eval::<P>(point);
+					inner_product_buffers(&tp1, &eq)
+				}),
+				eval_claim_1,
+			)
+			.unwrap();
+		verifier_channel
+			.verify_oracle_relation(
+				v_oracle_2,
+				Box::new(move |point: &[F]| {
+					let eq = eq_ind_partial_eval::<P>(point);
+					inner_product_buffers(&tp2, &eq)
+				}),
+				eval_claim_2,
+			)
 			.unwrap();
 		verifier_channel.finish().unwrap();
 	}
@@ -862,14 +854,10 @@ mod tests {
 			.iter()
 			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
 			.collect();
-		let prover_relations: Vec<_> = oracles
-			.into_iter()
-			.zip(&data)
-			.map(|(oracle, (buffer, transparent, claim))| {
-				(oracle, buffer.clone(), transparent.clone(), *claim)
-			})
-			.collect();
-		prover_channel.prove_oracle_relations(prover_relations);
+		for (oracle, (buffer, transparent, claim)) in oracles.into_iter().zip(&data) {
+			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
+			prover_channel.finalize_oracle(oracle, buffer.clone());
+		}
 		prover_channel.finish(&GlobalAllocator);
 
 		// === VERIFIER SIDE ===
@@ -883,30 +871,24 @@ mod tests {
 			.iter()
 			.map(|&n| verifier_channel.recv_oracle(n, true).unwrap())
 			.collect();
-		let relations: Vec<_> = v_oracles
-			.into_iter()
-			.zip(&data)
-			.enumerate()
-			.map(|(i, (oracle, (_, transparent, claim)))| {
-				let transparent = transparent.clone();
-				let claim = if tamper && i == 0 {
-					*claim + F::ONE
-				} else {
-					*claim
-				};
-				OracleLinearRelation {
+		for (i, (oracle, (_, transparent, claim))) in v_oracles.into_iter().zip(&data).enumerate() {
+			let transparent = transparent.clone();
+			let claim = if tamper && i == 0 {
+				*claim + F::ONE
+			} else {
+				*claim
+			};
+			verifier_channel
+				.verify_oracle_relation(
 					oracle,
-					transparent: Box::new(move |point: &[F]| {
+					Box::new(move |point: &[F]| {
 						let eq = eq_ind_partial_eval::<P>(point);
 						inner_product_buffers(&transparent, &eq)
 					}),
 					claim,
-				}
-			})
-			.collect();
-		verifier_channel
-			.verify_oracle_relations(relations)
-			.expect("verify_oracle_relations only queues");
+				)
+				.expect("verify_oracle_relation only queues");
+		}
 		verifier_channel.finish().is_ok()
 	}
 
@@ -958,14 +940,10 @@ mod tests {
 			.iter()
 			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
 			.collect();
-		let prover_relations: Vec<_> = oracles
-			.into_iter()
-			.zip(&data)
-			.map(|(oracle, (buffer, transparent, claim))| {
-				(oracle, buffer.clone(), transparent.clone(), *claim)
-			})
-			.collect();
-		prover_channel.prove_oracle_relations(prover_relations);
+		for (oracle, (buffer, transparent, claim)) in oracles.into_iter().zip(&data) {
+			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
+			prover_channel.finalize_oracle(oracle, buffer.clone());
+		}
 		prover_channel.finish(&GlobalAllocator);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -978,30 +956,24 @@ mod tests {
 			.iter()
 			.map(|&(n, _)| verifier_channel.recv_oracle(n, true).unwrap())
 			.collect();
-		let relations: Vec<_> = v_oracles
-			.into_iter()
-			.zip(&data)
-			.enumerate()
-			.map(|(i, (oracle, (_, transparent, claim)))| {
-				let transparent = transparent.clone();
-				let claim = if tamper && i == 0 {
-					*claim + F::ONE
-				} else {
-					*claim
-				};
-				OracleLinearRelation {
+		for (i, (oracle, (_, transparent, claim))) in v_oracles.into_iter().zip(&data).enumerate() {
+			let transparent = transparent.clone();
+			let claim = if tamper && i == 0 {
+				*claim + F::ONE
+			} else {
+				*claim
+			};
+			verifier_channel
+				.verify_oracle_relation(
 					oracle,
-					transparent: Box::new(move |point: &[F]| {
+					Box::new(move |point: &[F]| {
 						let eq = eq_ind_partial_eval::<P>(point);
 						inner_product_buffers(&transparent, &eq)
 					}),
 					claim,
-				}
-			})
-			.collect();
-		verifier_channel
-			.verify_oracle_relations(relations)
-			.expect("verify_oracle_relations only queues");
+				)
+				.expect("verify_oracle_relation only queues");
+		}
 		verifier_channel.finish().is_ok()
 	}
 

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -21,8 +21,9 @@ use binius_math::{FieldSlice, FieldVec};
 /// # Contract
 ///
 /// The caller must call `send_oracle()` exactly `remaining_oracle_specs().len()` times before
-/// calling `prove_oracle_relations()`. Each oracle buffer must match the corresponding
-/// specification.
+/// calling `prove_oracle_relation()`. Each oracle buffer must match the corresponding
+/// specification. Every committed oracle must be handed back to the channel exactly once with
+/// `finalize_oracle()`.
 pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Scalar> {
 	type Oracle: Clone;
 
@@ -39,26 +40,35 @@ pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Sca
 	/// * `buffer.log_len()` must match the expected length from the next oracle spec.
 	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle;
 
-	/// Generates opening proofs for all oracle linear relations.
+	/// Generates an opening proof for one oracle linear relation.
 	///
-	/// Each item is `(oracle, message, transparent_poly, eval_claim)` where `message` is
-	/// the same buffer that was passed to `send_oracle()` for this oracle. Callers provide
-	/// the message here so the channel does not need to store it internally.
+	/// The relation asserts that `<oracle_poly, transparent> = claim`. An oracle may carry any
+	/// number of relations.
 	///
-	/// The channel owns each message and transparent multilinear until the opening runs, so both
-	/// are drawn from the caller's allocator `A` — a pooled buffer stays pooled all the way
-	/// through the opening.
+	/// The channel owns the transparent multilinear until the opening runs, so it is drawn from
+	/// the caller's allocator `A` — a pooled buffer stays pooled all the way through the opening.
 	///
 	/// # Preconditions
 	///
 	/// * `remaining_oracle_specs()` must be empty (all oracles committed).
-	/// * All oracle handles in `oracle_relations` must be valid handles returned by
-	///   `send_oracle()`.
-	/// * Each `message` must match the buffer previously committed via `send_oracle()`.
-	fn prove_oracle_relations(
+	/// * `oracle` must be a valid handle returned by `send_oracle()`.
+	/// * `transparent.log_len()` must match the oracle's message length.
+	fn prove_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
-		>,
+		oracle: Self::Oracle,
+		transparent: FieldVec<P, A>,
+		claim: P::Scalar,
 	);
+
+	/// Gives ownership of the oracle buffer to the channel.
+	///
+	/// The [`Self::send_oracle`] method takes a borrowed reference to an oracle buffer and returns
+	/// a handle to it. In order to prove the oracle relations without unnecessarily cloning the
+	/// buffer, some channel implementations require ownership of the buffer.
+	///
+	/// # Preconditions
+	///
+	/// * `oracle` must be a valid handle returned by `send_oracle()`, not already finalized.
+	/// * `buffer` must equal the buffer previously committed via `send_oracle()`.
+	fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>);
 }

--- a/crates/iop-prover/src/channel/naive.rs
+++ b/crates/iop-prover/src/channel/naive.rs
@@ -6,7 +6,7 @@ use binius_compute::GlobalAllocator;
 use binius_field::{Field, PackedField};
 use binius_iop::channel::OracleSpec;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice, inner_product::inner_product_buffers};
+use binius_math::{FieldBuffer, FieldSlice};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
@@ -152,40 +152,37 @@ where
 		NaiveOracle { index }
 	}
 
-	fn prove_oracle_relations(
+	fn prove_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
-		>,
+		oracle: Self::Oracle,
+		transparent: FieldBuffer<P>,
+		_claim: P::Scalar,
 	) {
-		// For the naive channel, we write the transparent polynomial to the transcript
-		// so the verifier can read it and verify the inner product directly.
-		for (oracle, message, transparent_poly, eval_claim) in oracle_relations {
-			let index = oracle.index;
-			assert!(index < self.n_committed, "oracle index {index} out of bounds");
+		// For the naive channel, we write the transparent polynomial to the transcript so the
+		// verifier can read it and check the inner product against the message it already read.
+		let index = oracle.index;
+		assert!(index < self.n_committed, "oracle index {index} out of bounds");
 
-			let log_msg_len = self.oracle_specs[index].log_msg_len;
-			assert_eq!(
-				message.log_len(),
-				log_msg_len,
-				"oracle message log_len mismatch: expected {log_msg_len}, got {}",
-				message.log_len()
-			);
+		let log_msg_len = self.oracle_specs[index].log_msg_len;
+		assert_eq!(
+			transparent.log_len(),
+			log_msg_len,
+			"transparent log_len mismatch: expected {log_msg_len}, got {}",
+			transparent.log_len()
+		);
 
-			// Write the transparent polynomial to the transcript
-			self.transcript
-				.message()
-				.write_scalar_iter(transparent_poly.iter_scalars());
+		// Write the transparent polynomial to the transcript
+		self.transcript
+			.message()
+			.write_scalar_iter(transparent.iter_scalars());
 
-			// Sample evaluation point challenges (verifier will sample the same)
-			let _point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
-
-			// Debug assertion: prover should provide consistent eval claims
-			let actual_eval: F = inner_product_buffers(&message, &transparent_poly);
-			debug_assert_eq!(
-				actual_eval, eval_claim,
-				"NaiveProverChannel: eval_claim mismatch for oracle {index}"
-			);
-		}
+		// Sample evaluation point challenges (verifier will sample the same)
+		let _point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
 	}
+
+	/// Drops the buffer.
+	///
+	/// `send_oracle` already wrote the message to the transcript, so this channel needs no copy of
+	/// it to open the oracle.
+	fn finalize_oracle(&mut self, _oracle: Self::Oracle, _buffer: FieldBuffer<P>) {}
 }

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -112,14 +112,14 @@ where
 	//
 	// A table's own point is the first m coordinates of the shared reduced point.
 	let _open_guard = tracing::debug_span!("Open pushforward relations").entered();
-	let relations = izip!(oracles, pushforwards, &tables, &output.tables)
-		.map(|(oracle, pushforward, table, table_output)| {
-			let m = table.table.log_len();
-			let transparent = eq_ind_partial_eval_in::<A, P>(alloc, &output.table_eval_point[..m]);
-			(oracle, pushforward, transparent, table_output.pushforward_claim)
-		})
-		.collect::<Vec<_>>();
-	channel.prove_oracle_relations(relations);
+	for (oracle, pushforward, table, table_output) in
+		izip!(oracles, pushforwards, &tables, &output.tables)
+	{
+		let m = table.table.log_len();
+		let transparent = eq_ind_partial_eval_in::<A, P>(alloc, &output.table_eval_point[..m]);
+		channel.prove_oracle_relation(oracle.clone(), transparent, table_output.pushforward_claim);
+		channel.finalize_oracle(oracle, pushforward);
+	}
 
 	LogupProof {
 		table_eval_point: output.table_eval_point,

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -31,11 +31,9 @@ pub struct BaseFoldOracle {
 
 /// A committed-oracle relation queued for the single batched opening.
 struct QueuedRelation<Elem> {
-	/// Index of the committed oracle this relation opens.
-	oracle_index: usize,
-	/// Evaluates the transparent multilinear `t_i` at the point the opening reduces to.
+	/// Evaluates the transparent multilinear `t` at the point the opening reduces to.
 	transparent: TransparentEvalFn<Elem>,
-	/// The claimed inner product `s_i = <pi_i, t_i>`.
+	/// The claimed inner product `s = <pi, t>`.
 	claim: Elem,
 }
 
@@ -60,10 +58,10 @@ where
 	oracle_specs: &'a [OracleSpec],
 	fri_params: &'a FRIParams<F>,
 	oracle_commitments: Vec<Channel::Commitment>,
-	/// Oracle relations queued by [`IOPVerifierChannel::verify_oracle_relation`], opened together
-	/// in [`Self::finish`].
-	queue: Vec<QueuedRelation<Channel::Elem>>,
-	next_oracle_index: usize,
+	/// Oracle relations queued by [`IOPVerifierChannel::verify_oracle_relation`], indexed by
+	/// oracle index and opened together in [`Self::finish`]. One entry per received oracle, so its
+	/// length is also the number of oracles received so far.
+	queue: Vec<Vec<QueuedRelation<Channel::Elem>>>,
 }
 
 impl<'a, F, Channel> BaseFoldVerifierChannel<'a, F, Channel>
@@ -87,7 +85,6 @@ where
 			fri_params,
 			oracle_commitments: Vec::new(),
 			queue: Vec::new(),
-			next_oracle_index: 0,
 		}
 	}
 
@@ -110,13 +107,12 @@ where
 			fri_params,
 			oracle_commitments,
 			queue,
-			next_oracle_index,
 		} = self;
 
-		let n_remaining = oracle_specs.len() - next_oracle_index;
+		let n_remaining = oracle_specs.len() - queue.len();
 		assert!(n_remaining == 0, "finish called but {n_remaining} oracle specs remaining",);
 
-		if !queue.is_empty() {
+		if !queue.iter().all(Vec::is_empty) {
 			verify_batch_zk_basefold(
 				&mut channel,
 				oracle_specs,
@@ -138,11 +134,9 @@ where
 /// point `r`, then opens all committed oracles together with a single combined FRI over the
 /// piecewise-concatenated oracle.
 ///
-/// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
-/// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
-/// α_i are indexed by oracle index. Each relation carries its oracle's index, so the two orders are
-/// reconciled by indexing rather than by sorting the relations; `oracle_specs` and
-/// `oracle_commitments` are indexed by oracle index.
+/// Everything runs in oracle-index order: `relations` arrives indexed by oracle, as do
+/// `oracle_specs`, `oracle_commitments`, the masking inner products σ_i and the reduced
+/// evaluations α_i.
 ///
 /// Phase B collapses the oracle-index variables up front at sampled batching challenges `r'`: the
 /// combined target is `s' = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j)` with `e = eq_ind_partial_eval(r')`,
@@ -152,13 +146,20 @@ fn verify_batch_zk_basefold<F, Channel>(
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	oracle_commitments: &[Channel::Commitment],
-	relations: Vec<QueuedRelation<Channel::Elem>>,
+	relations: Vec<Vec<QueuedRelation<Channel::Elem>>>,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
 	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
 	let n_committed = oracle_commitments.len();
+	assert_eq!(relations.len(), n_committed);
+
+	// The prover's opening assumes every committed oracle is opened; see the matching assert there.
+	assert!(
+		relations.iter().all(|relations| !relations.is_empty()),
+		"expects at least one relation per committed oracle",
+	);
 
 	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
 	let max_n = oracle_specs
@@ -167,20 +168,23 @@ where
 		.max()
 		.expect("at least one oracle");
 
+	// Batch each oracle's claims into one, so everything below runs exactly one relation per
+	// committed oracle.
+	let relations = batch_relations_per_oracle(channel, relations);
+
 	// === Masking step ===
-	// Only ZK oracles are masked: read their σ_i (one per ZK oracle, in relation order) and sample
-	// the single shared γ. With no ZK oracle, γ is never sampled.
-	let n_zk = oracle_specs.iter().filter(|s| s.is_zk).count();
+	// Only ZK oracles are masked: read their σ_i (one per ZK oracle) and sample the single shared
+	// γ. With no ZK oracle, γ is never sampled.
+	let n_zk = oracle_specs.iter().filter(|spec| spec.is_zk).count();
 	let sigmas = channel.recv_many(n_zk)?;
 	let gamma = (!sigmas.is_empty()).then(|| channel.sample());
 
 	// Masked claim per relation: ZK → s_i' = extrapolate_line(claim, σ_i, γ); non-ZK → s_i' =
 	// claim.
 	let mut sigma_iter = sigmas.into_iter();
-	let sum_primes = relations
-		.iter()
-		.map(|relation| {
-			if oracle_specs[relation.oracle_index].is_zk {
+	let sum_primes = izip!(&relations, oracle_specs)
+		.map(|(relation, spec)| {
+			if spec.is_zk {
 				let sigma = sigma_iter.next().expect("one σ per ZK oracle");
 				extrapolate_line(
 					relation.claim.clone(),
@@ -207,16 +211,13 @@ where
 	let mut point = sumcheck_challenges;
 	point.reverse();
 
-	// Reduce the batched claim: each oracle contributes α_i · t_i(ρ_i) · eq(0^extra, padding).
-	let contributions = relations
-		.into_iter()
-		.map(|relation| {
-			let alpha_i = alphas[relation.oracle_index].clone();
-			let n_i = oracle_specs[relation.oracle_index].log_msg_len;
-			let (eval_coords, padding_coords) = point.split_at(n_i);
+	// Reduce the batched claim: each oracle contributes α_i · T_i(ρ_i) · eq(0^extra, padding).
+	let contributions = izip!(relations, oracle_specs, &alphas)
+		.map(|(relation, spec, alpha_i)| {
+			let (eval_coords, padding_coords) = point.split_at(spec.log_msg_len);
 			let pad_eq = eq_ind_zero(padding_coords);
 			let transparent_eval = (relation.transparent)(eval_coords);
-			alpha_i * transparent_eval * pad_eq
+			alpha_i.clone() * transparent_eval * pad_eq
 		})
 		.collect::<Vec<_>>();
 	let expected = evaluate_univariate(&contributions, &sumcheck_batch_coeff);
@@ -253,6 +254,64 @@ where
 	)?;
 
 	Ok(())
+}
+
+/// Batches each oracle's queued relations down to one, in oracle-index order.
+///
+/// An oracle carrying `k > 1` claims has them folded into a single claim against a single
+/// transparent, using a batching challenge λ shared by every oracle:
+///
+/// ```text
+/// T_i = Σ_j λ^j · t_ij     the combined transparent
+/// S_i = Σ_j λ^j · s_ij     the combined claim
+/// ```
+///
+/// The inner product is linear in the transparent, so `⟨π_i, T_i⟩ = S_i` holds exactly when every
+/// `⟨π_i, t_ij⟩ = s_ij` does, except with probability at most `Σ_i (k_i - 1) / |F|` over λ. λ is
+/// drawn after every claim it combines is already bound to the transcript, so no claim can be
+/// chosen as a function of it. The batched per-oracle claims are then combined again by the
+/// sumcheck's own outer batching coefficient.
+///
+/// Mirrors the prover-side batching in `binius_iop_prover::basefold::channel`.
+fn batch_relations_per_oracle<F, Channel>(
+	channel: &mut Channel,
+	relations: Vec<Vec<QueuedRelation<Channel::Elem>>>,
+) -> Vec<QueuedRelation<Channel::Elem>>
+where
+	F: BinaryField,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
+{
+	let lambda = channel.sample();
+
+	relations
+		.into_iter()
+		.map(|mut relations| {
+			// An oracle carrying a single relation folds nothing.
+			if relations.len() <= 1 {
+				return relations
+					.pop()
+					.expect("pre-condition: every committed oracle carries at least one relation");
+			}
+
+			let (transparents, claims): (Vec<_>, Vec<_>) = relations
+				.into_iter()
+				.map(|relation| (relation.transparent, relation.claim))
+				.unzip();
+			let claim = evaluate_univariate(&claims, &lambda);
+			let lambda = lambda.clone();
+
+			QueuedRelation {
+				transparent: Box::new(move |point: &[Channel::Elem]| {
+					let evals = transparents
+						.iter()
+						.map(|transparent| transparent(point))
+						.collect::<Vec<_>>();
+					evaluate_univariate(&evals, &lambda)
+				}),
+				claim,
+			}
+		})
+		.collect()
 }
 
 impl<F, Channel> IPVerifierChannel<F> for BaseFoldVerifierChannel<'_, F, Channel>
@@ -331,7 +390,7 @@ where
 	type Oracle = BaseFoldOracle;
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
-		&self.oracle_specs[self.next_oracle_index..]
+		&self.oracle_specs[self.queue.len()..]
 	}
 
 	fn recv_oracle(
@@ -346,7 +405,7 @@ where
 			"recv_oracle called but no remaining oracle specs"
 		);
 
-		let index = self.next_oracle_index;
+		let index = self.queue.len();
 
 		// Receive the commitment with its Merkle tree shape, matching the prover-side commit: the
 		// oracle's codeword has dimension `log_dim - log_lift` and one interleaved coset of
@@ -371,7 +430,7 @@ where
 			.recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)?;
 
 		self.oracle_commitments.push(commitment);
-		self.next_oracle_index += 1;
+		self.queue.push(Vec::new());
 
 		Ok(BaseFoldOracle { index })
 	}
@@ -382,19 +441,15 @@ where
 		transparent: TransparentEvalFn<Self::Elem>,
 		claim: Self::Elem,
 	) -> Result<(), Error> {
-		// Queue the relation; the actual opening (masking + sumcheck + combined FRI) happens once,
-		// over all committed oracles, in [`Self::finish`].
-		assert!(
-			oracle.index < self.oracle_commitments.len(),
-			"oracle index {} out of bounds, expected < {}",
-			oracle.index,
-			self.oracle_commitments.len()
-		);
-		self.queue.push(QueuedRelation {
-			oracle_index: oracle.index,
-			transparent,
-			claim,
-		});
+		// Queue the relation under its oracle; the actual opening (masking + sumcheck + combined
+		// FRI) happens once, over all committed oracles, in [`Self::finish`].
+		let n_committed = self.queue.len();
+		self.queue
+			.get_mut(oracle.index)
+			.unwrap_or_else(|| {
+				panic!("oracle index {} out of bounds, expected < {n_committed}", oracle.index)
+			})
+			.push(QueuedRelation { transparent, claim });
 		Ok(())
 	}
 }

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -18,7 +18,7 @@ use itertools::izip;
 
 use crate::{
 	basefold,
-	channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn},
 	fri::FRIParams,
 	merkle_channel::MerkleIPVerifierChannel,
 };
@@ -27,6 +27,16 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub struct BaseFoldOracle {
 	index: usize,
+}
+
+/// A committed-oracle relation queued for the single batched opening.
+struct QueuedRelation<Elem> {
+	/// Index of the committed oracle this relation opens.
+	oracle_index: usize,
+	/// Evaluates the transparent multilinear `t_i` at the point the opening reduces to.
+	transparent: TransparentEvalFn<Elem>,
+	/// The claimed inner product `s_i = <pi_i, t_i>`.
+	claim: Elem,
 }
 
 /// A verifier channel that uses ZK BaseFold for all oracle commitments and openings.
@@ -50,9 +60,9 @@ where
 	oracle_specs: &'a [OracleSpec],
 	fri_params: &'a FRIParams<F>,
 	oracle_commitments: Vec<Channel::Commitment>,
-	/// Oracle relations queued by [`Self::verify_oracle_relations`], opened together in
-	/// [`Self::finish`].
-	queue: Vec<OracleLinearRelation<BaseFoldOracle, Channel::Elem>>,
+	/// Oracle relations queued by [`IOPVerifierChannel::verify_oracle_relation`], opened together
+	/// in [`Self::finish`].
+	queue: Vec<QueuedRelation<Channel::Elem>>,
 	next_oracle_index: usize,
 }
 
@@ -85,7 +95,7 @@ where
 	/// oracles.
 	///
 	/// All oracle relations queued by
-	/// [`verify_oracle_relations`](IOPVerifierChannel::verify_oracle_relations) across every call
+	/// [`verify_oracle_relation`](IOPVerifierChannel::verify_oracle_relation) across every call
 	/// are processed here in one batch: masking, one batched sumcheck reducing the masked claims
 	/// to a shared point `r`, then one combined FRI opening over every committed oracle
 	/// (in oracle-index order). Because the whole opening is deferred to this point, every oracle
@@ -142,7 +152,7 @@ fn verify_batch_zk_basefold<F, Channel>(
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	oracle_commitments: &[Channel::Commitment],
-	relations: Vec<OracleLinearRelation<BaseFoldOracle, Channel::Elem>>,
+	relations: Vec<QueuedRelation<Channel::Elem>>,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
@@ -170,7 +180,7 @@ where
 	let sum_primes = relations
 		.iter()
 		.map(|relation| {
-			if oracle_specs[relation.oracle.index].is_zk {
+			if oracle_specs[relation.oracle_index].is_zk {
 				let sigma = sigma_iter.next().expect("one σ per ZK oracle");
 				extrapolate_line(
 					relation.claim.clone(),
@@ -201,8 +211,8 @@ where
 	let contributions = relations
 		.into_iter()
 		.map(|relation| {
-			let alpha_i = alphas[relation.oracle.index].clone();
-			let n_i = oracle_specs[relation.oracle.index].log_msg_len;
+			let alpha_i = alphas[relation.oracle_index].clone();
+			let n_i = oracle_specs[relation.oracle_index].log_msg_len;
 			let (eval_coords, padding_coords) = point.split_at(n_i);
 			let pad_eq = eq_ind_zero(padding_coords);
 			let transparent_eval = (relation.transparent)(eval_coords);
@@ -366,21 +376,25 @@ where
 		Ok(BaseFoldOracle { index })
 	}
 
-	fn verify_oracle_relations(
+	fn verify_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, Self::Elem>>,
+		oracle: Self::Oracle,
+		transparent: TransparentEvalFn<Self::Elem>,
+		claim: Self::Elem,
 	) -> Result<(), Error> {
-		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
+		// Queue the relation; the actual opening (masking + sumcheck + combined FRI) happens once,
 		// over all committed oracles, in [`Self::finish`].
-		for relation in oracle_relations {
-			assert!(
-				relation.oracle.index < self.oracle_commitments.len(),
-				"oracle index {} out of bounds, expected < {}",
-				relation.oracle.index,
-				self.oracle_commitments.len()
-			);
-			self.queue.push(relation);
-		}
+		assert!(
+			oracle.index < self.oracle_commitments.len(),
+			"oracle index {} out of bounds, expected < {}",
+			oracle.index,
+			self.oracle_commitments.len()
+		);
+		self.queue.push(QueuedRelation {
+			oracle_index: oracle.index,
+			transparent,
+			claim,
+		});
 		Ok(())
 	}
 }

--- a/crates/iop/src/channel/mod.rs
+++ b/crates/iop/src/channel/mod.rs
@@ -58,27 +58,11 @@ impl OracleSpec {
 
 /// A boxed closure that evaluates a transparent MLE at a given point.
 ///
-/// The closure is `'static` and owns every value it reads, sharing large data via `Rc`/`Arc`.
-/// A channel that defers the opening can therefore store it and evaluate it later.
+/// The closure receives the challenge point sampled during the opening and returns the evaluation
+/// of the transparent polynomial's MLE there. It is `'static` and owns every value it reads,
+/// sharing large data via `Rc`/`Arc`, so a channel that defers the opening can store it and
+/// evaluate it later.
 pub type TransparentEvalFn<Elem> = Box<dyn Fn(&[Elem]) -> Elem + 'static>;
-
-/// An oracle linear relation specifying an inner product claim between a committed oracle
-/// polynomial and a transparent polynomial.
-///
-/// The claim asserts that `<oracle_poly, transparent_poly> = claim`, where `transparent_poly` is
-/// the multilinear extension defined by the `transparent` closure evaluated at the challenge point
-/// sampled during the protocol.
-pub struct OracleLinearRelation<Oracle, Elem> {
-	/// The oracle handle for the committed polynomial.
-	pub oracle: Oracle,
-	/// A closure that evaluates the transparent MLE at a given point.
-	///
-	/// The closure receives the challenge point (sampled during `verify_oracle_relations`) and
-	/// returns the evaluation of the transparent polynomial's MLE at that point.
-	pub transparent: TransparentEvalFn<Elem>,
-	/// The claimed inner product of the oracle polynomial and the transparent polynomial.
-	pub claim: Elem,
-}
 
 /// Channel for IOP verifiers that extends the IP verifier channel with oracle operations.
 ///
@@ -91,7 +75,7 @@ pub struct OracleLinearRelation<Oracle, Elem> {
 /// # Contract
 ///
 /// The caller must call `recv_oracle()` exactly `remaining_oracle_specs().len()` times before
-/// calling `verify_oracle_relations()`. The oracles must be received in order and match their
+/// calling `verify_oracle_relation()`. The oracles must be received in order and match their
 /// specifications.
 pub trait IOPVerifierChannel<F: Field>: IPVerifierChannel<F, Elem: 'static> {
 	type Oracle: Clone;
@@ -116,21 +100,19 @@ pub trait IOPVerifierChannel<F: Field>: IPVerifierChannel<F, Elem: 'static> {
 		is_witness_dependent: bool,
 	) -> Result<Self::Oracle, Error>;
 
-	/// Queues oracle linear relations to be opened.
+	/// Queues one oracle linear relation to be opened.
 	///
-	/// Implementations may either verify the relations immediately, or queue them and defer the
-	/// actual opening (masking + sumcheck + FRI) to `finish()`. Either way, each
-	/// relation asserts that `<oracle_poly, transparent_poly> = claim`.
-	///
-	/// The transparent closures are `'static` and own their captures.
-	/// An implementation that defers the opening can store the relations and evaluate them later.
+	/// Implementations may either verify the relation immediately, or queue it and defer the
+	/// actual opening (masking + sumcheck + FRI) to `finish()`. Either way, the relation asserts
+	/// that `<oracle_poly, transparent> = claim`. An oracle may carry any number of relations.
 	///
 	/// # Preconditions
 	///
-	/// * All oracle handles in `oracle_relations` must be valid handles returned by
-	///   `recv_oracle()`.
-	fn verify_oracle_relations(
+	/// * `oracle` must be a valid handle returned by `recv_oracle()`.
+	fn verify_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, Self::Elem>>,
+		oracle: Self::Oracle,
+		transparent: TransparentEvalFn<Self::Elem>,
+		claim: Self::Elem,
 	) -> Result<(), Error>;
 }

--- a/crates/iop/src/channel/naive.rs
+++ b/crates/iop/src/channel/naive.rs
@@ -10,7 +10,7 @@ use binius_transcript::{
 	fiat_shamir::{CanSample, Challenger},
 };
 
-use crate::channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+use crate::channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 
 /// Oracle handle returned by [`NaiveVerifierChannel::recv_oracle`].
 #[derive(Debug, Clone, Copy)]
@@ -175,52 +175,49 @@ where
 		Ok(NaiveOracle { index })
 	}
 
-	fn verify_oracle_relations(
+	fn verify_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, F>>,
+		oracle: Self::Oracle,
+		transparent: TransparentEvalFn<F>,
+		claim: F,
 	) -> Result<(), Error> {
-		for relation in oracle_relations {
-			let index = relation.oracle.index;
-			assert!(index < self.stored_polynomials.len(), "oracle index {index} out of bounds");
+		let index = oracle.index;
+		assert!(index < self.stored_polynomials.len(), "oracle index {index} out of bounds");
 
-			// Extract spec data before mutable borrow of transcript
-			let log_msg_len = self.oracle_specs[index].log_msg_len;
+		// Extract spec data before mutable borrow of transcript
+		let log_msg_len = self.oracle_specs[index].log_msg_len;
 
-			// Read the transparent polynomial from the transcript (prover wrote it in
-			// prove_oracle_relations)
-			let transparent_len = 1 << log_msg_len;
-			let transparent_values = self
-				.transcript
-				.message()
-				.read_scalar_slice(transparent_len)
-				.map_err(|_| Error::ProofEmpty)?;
-			let transparent_poly = FieldBuffer::from_values(&transparent_values);
+		// Read the transparent polynomial from the transcript (prover wrote it in
+		// prove_oracle_relation)
+		let transparent_len = 1 << log_msg_len;
+		let transparent_values = self
+			.transcript
+			.message()
+			.read_scalar_slice(transparent_len)
+			.map_err(|_| Error::ProofEmpty)?;
+		let transparent_poly = FieldBuffer::from_values(&transparent_values);
 
-			// Verify the inner product claim directly
-			let stored_poly = &self.stored_polynomials[index];
-			let witness_poly = stored_poly.to_ref();
-			let actual_inner_product: F = inner_product_buffers(&witness_poly, &transparent_poly);
+		// Verify the inner product claim directly
+		let stored_poly = &self.stored_polynomials[index];
+		let witness_poly = stored_poly.to_ref();
+		let actual_inner_product: F = inner_product_buffers(&witness_poly, &transparent_poly);
 
-			assert_eq!(
-				actual_inner_product, relation.claim,
-				"NaiveVerifierChannel: inner product verification failed"
-			);
+		assert_eq!(
+			actual_inner_product, claim,
+			"NaiveVerifierChannel: inner product verification failed"
+		);
 
-			// Sample evaluation point challenges (same as prover sampled)
-			let point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
+		// Sample evaluation point challenges (same as prover sampled)
+		let point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
 
-			// Evaluate the transparent closure at the challenge point
-			let transparent_eval = (relation.transparent)(&point);
+		// Evaluate the transparent closure at the challenge point
+		let transparent_eval = transparent(&point);
 
-			// Verify the transparent evaluation matches using assert_zero
-			self.assert_zero(
-				transparent_eval
-					- binius_math::multilinear::evaluate::evaluate_inplace(
-						transparent_poly,
-						&point,
-					),
-			)?;
-		}
+		// Verify the transparent evaluation matches using assert_zero
+		self.assert_zero(
+			transparent_eval
+				- binius_math::multilinear::evaluate::evaluate_inplace(transparent_poly, &point),
+		)?;
 
 		Ok(())
 	}

--- a/crates/iop/src/channel/oracle_setup.rs
+++ b/crates/iop/src/channel/oracle_setup.rs
@@ -16,7 +16,7 @@ use binius_field::{
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 
-use crate::channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+use crate::channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 
 /// A dummy field element for [`OracleSetupChannel`], generic over the field `F` it stands in for.
 ///
@@ -251,9 +251,11 @@ impl<F: Field> IOPVerifierChannel<F> for OracleSetupChannel {
 		Ok(())
 	}
 
-	fn verify_oracle_relations(
+	fn verify_oracle_relation(
 		&mut self,
-		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, Self::Elem>>,
+		_oracle: Self::Oracle,
+		_transparent: TransparentEvalFn<Self::Elem>,
+		_claim: Self::Elem,
 	) -> Result<(), Error> {
 		Ok(())
 	}

--- a/crates/iop/src/logup_star.rs
+++ b/crates/iop/src/logup_star.rs
@@ -19,7 +19,7 @@ use binius_ip::logup_star as reduction;
 use binius_math::multilinear::eq::eq_ind;
 use itertools::izip;
 
-use crate::channel::{Error as ChannelError, IOPVerifierChannel, OracleLinearRelation};
+use crate::channel::{Error as ChannelError, IOPVerifierChannel};
 
 /// An error raised while verifying a committed logUp* reduction.
 #[derive(Debug, thiserror::Error)]
@@ -108,17 +108,14 @@ where
 	//
 	// BaseFold reduces each inner product to a challenge point, where the transparent is eq(r, .).
 	// A table's own point is the first m coordinates of the shared reduced point.
-	let relations = izip!(oracles, &table_n_vars, &output.tables)
-		.map(|(oracle, &n_vars, table_output)| {
-			let point = output.table_eval_point[..n_vars].to_vec();
-			OracleLinearRelation {
-				oracle,
-				transparent: Box::new(move |challenge: &[C::Elem]| eq_ind(&point, challenge)),
-				claim: table_output.pushforward_claim.clone(),
-			}
-		})
-		.collect::<Vec<_>>();
-	channel.verify_oracle_relations(relations)?;
+	for (oracle, &n_vars, table_output) in izip!(oracles, &table_n_vars, &output.tables) {
+		let point = output.table_eval_point[..n_vars].to_vec();
+		channel.verify_oracle_relation(
+			oracle,
+			Box::new(move |challenge: &[C::Elem]| eq_ind(&point, challenge)),
+			table_output.pushforward_claim.clone(),
+		)?;
+	}
 
 	Ok(LogupProof {
 		table_eval_point: output.table_eval_point,

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -342,7 +342,8 @@ impl IOPProver {
 
 		// Queue the trace opening against the ring-switch's transparent multilinear.
 		// The final call runs the single combined FRI opening and writes it to the transcript.
-		channel.prove_oracle_relations([(trace_oracle, trace_packed, rs_eq_ind, sumcheck_claim)]);
+		channel.prove_oracle_relation(trace_oracle.clone(), rs_eq_ind, sumcheck_claim);
+		channel.finalize_oracle(trace_oracle, trace_packed);
 	}
 }
 

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -6,9 +6,7 @@ use binius_field::{ExtensionField, FieldOps};
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,
-	channel::{
-		IOPVerifierChannel, OracleLinearRelation, OracleSpec, oracle_setup::OracleSetupChannel,
-	},
+	channel::{IOPVerifierChannel, OracleSpec, oracle_setup::OracleSetupChannel},
 	fri::{ConstantArityStrategy, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
@@ -151,13 +149,13 @@ impl IOPVerifier {
 		// BaseFold reduces to a challenge point where the transparent evaluates as below.
 		let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
 		let eval_point_high = trace_point[log_packing..].to_vec();
-		channel.verify_oracle_relations([OracleLinearRelation {
-			oracle: trace_oracle,
-			transparent: Box::new(move |pt: &[Channel::Elem]| {
+		channel.verify_oracle_relation(
+			trace_oracle,
+			Box::new(move |pt: &[Channel::Elem]| {
 				ring_switch::eval_rs_eq(&eval_point_high, pt, &eq_r_double_prime)
 			}),
-			claim: sumcheck_claim,
-		}])?;
+			sumcheck_claim,
+		)?;
 
 		Ok(())
 	}

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -330,7 +330,8 @@ impl IOPProver {
 
 		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
 		// relation, when the IntMul reduction ran, was already queued inside phase 5.
-		channel.prove_oracle_relations([(trace_oracle, witness_packed, rs_eq_ind, sumcheck_claim)]);
+		channel.prove_oracle_relation(trace_oracle.clone(), rs_eq_ind, sumcheck_claim);
+		channel.finalize_oracle(trace_oracle, witness_packed);
 
 		drop(pcs_guard);
 

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -317,12 +317,18 @@ impl<F: Field> IOPProver<F> {
 		let libra_eval_tensor =
 			zk_mlecheck::expand_libra_eval::<A, P>(alloc, &r_x, n_vars, mask_degree, m_n, m_d);
 
-		// Prove all oracle relations.
-		channel.prove_oracle_relations([
-			(precommit_oracle, precommit_packed, precommit_wiring_poly, precommit_claim),
-			(private_oracle, private_packed, private_wiring_poly, private_claim),
-			(mask_oracle, masks_buffer, libra_eval_tensor, mask_eval),
-		]);
+		// Prove all oracle relations, handing the channel each committed buffer for the combined
+		// opening.
+		channel.prove_oracle_relation(
+			precommit_oracle.clone(),
+			precommit_wiring_poly,
+			precommit_claim,
+		);
+		channel.finalize_oracle(precommit_oracle, precommit_packed);
+		channel.prove_oracle_relation(private_oracle.clone(), private_wiring_poly, private_claim);
+		channel.finalize_oracle(private_oracle, private_packed);
+		channel.prove_oracle_relation(mask_oracle.clone(), libra_eval_tensor, mask_eval);
+		channel.finalize_oracle(mask_oracle, masks_buffer);
 
 		Ok(())
 	}

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -417,9 +417,7 @@ mod tests {
 	#[test]
 	fn test_wiring_prove_verify() {
 		use binius_hash::StdDigest;
-		use binius_iop::channel::{
-			IOPVerifierChannel, OracleLinearRelation, OracleSpec, naive::NaiveVerifierChannel,
-		};
+		use binius_iop::channel::{IOPVerifierChannel, OracleSpec, naive::NaiveVerifierChannel};
 		use binius_iop_prover::channel::{IOPProverChannel, naive::NaiveProverChannel};
 		use binius_ip::channel::IPVerifierChannel;
 		use binius_ip_prover::channel::IPProverChannel;
@@ -504,12 +502,8 @@ mod tests {
 		);
 
 		// Finish the IOP with the oracle relation
-		prover_channel.prove_oracle_relations([(
-			witness_oracle,
-			private_buf,
-			wiring_poly.clone(),
-			trace_claim,
-		)]);
+		prover_channel.prove_oracle_relation(witness_oracle, wiring_poly.clone(), trace_claim);
+		prover_channel.finalize_oracle(witness_oracle, private_buf);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -543,11 +537,7 @@ mod tests {
 
 		// Finish verification.
 		verifier_channel
-			.verify_oracle_relations([OracleLinearRelation {
-				oracle: witness_oracle,
-				transparent,
-				claim: verifier_trace_claim,
-			}])
-			.expect("verify_oracle_relations should succeed (inner product verified)");
+			.verify_oracle_relation(witness_oracle, transparent, verifier_trace_claim)
+			.expect("verify_oracle_relation should succeed (inner product verified)");
 	}
 }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -12,7 +12,7 @@ use std::{
 
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, util::FieldFn};
-use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+use binius_iop::channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 use binius_ip::channel::{
 	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
 };
@@ -186,17 +186,17 @@ impl<F: Field> IOPVerifierChannel<F> for ReplayChannel<F> {
 		Ok(())
 	}
 
-	fn verify_oracle_relations(
+	fn verify_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, Self::Elem>>,
+		_oracle: Self::Oracle,
+		_transparent: TransparentEvalFn<Self::Elem>,
+		claim: Self::Elem,
 	) -> Result<(), binius_iop::channel::Error> {
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
-		for relation in oracle_relations {
-			let decrypted_claim = self.next_inout_elem();
-			self.assert_zero(relation.claim - decrypted_claim)?;
-		}
+		let decrypted_claim = self.next_inout_elem();
+		self.assert_zero(claim - decrypted_claim)?;
 		Ok(())
 	}
 }

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -310,22 +310,23 @@ where
 		self.inner_channel.send_oracle(buffer)
 	}
 
-	fn prove_oracle_relations(
+	fn prove_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
-		>,
+		oracle: Self::Oracle,
+		transparent: FieldVec<P, A>,
+		claim: P::Scalar,
 	) {
-		let oracle_relations = oracle_relations.into_iter().collect::<Vec<_>>();
-
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
-		for (_, _, _, claim) in &oracle_relations {
-			self.inner_channel.send_one(*claim);
-			self.interaction.push(*claim);
-		}
+		self.inner_channel.send_one(claim);
+		self.interaction.push(claim);
 
-		self.inner_channel.prove_oracle_relations(oracle_relations)
+		self.inner_channel
+			.prove_oracle_relation(oracle, transparent, claim)
+	}
+
+	fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>) {
+		self.inner_channel.finalize_oracle(oracle, buffer)
 	}
 }

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -41,7 +41,7 @@ use binius_iop::{
 	basefold,
 	basefold::compiler::BaseFoldVerifierCompiler,
 	channel::{
-		IOPVerifierChannel, OracleLinearRelation, OracleSpec,
+		IOPVerifierChannel, OracleSpec,
 		oracle_setup::{DummyElem, OracleSetupChannel},
 	},
 	fri::{self, MinProofSizeStrategy},
@@ -236,23 +236,9 @@ impl<F: Field> IOPVerifier<F> {
 		let mask_transparent = mask_transparent(cs, &r_x);
 
 		// Verify all oracle relations
-		channel.verify_oracle_relations([
-			OracleLinearRelation {
-				oracle: precommit_oracle,
-				transparent: precommit_transparent,
-				claim: precommit_claim,
-			},
-			OracleLinearRelation {
-				oracle: private_oracle,
-				transparent: private_transparent,
-				claim: private_claim,
-			},
-			OracleLinearRelation {
-				oracle: mask_oracle,
-				transparent: mask_transparent,
-				claim: mask_eval,
-			},
-		])?;
+		channel.verify_oracle_relation(precommit_oracle, precommit_transparent, precommit_claim)?;
+		channel.verify_oracle_relation(private_oracle, private_transparent, private_claim)?;
+		channel.verify_oracle_relation(mask_oracle, mask_transparent, mask_eval)?;
 
 		Ok(())
 	}

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -10,7 +10,7 @@ use std::{
 
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, util::FieldFn};
-use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+use binius_iop::channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 use binius_ip::channel::{
 	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
 };
@@ -169,17 +169,17 @@ impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		Ok(())
 	}
 
-	fn verify_oracle_relations(
+	fn verify_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, Self::Elem>>,
+		_oracle: Self::Oracle,
+		_transparent: TransparentEvalFn<Self::Elem>,
+		claim: Self::Elem,
 	) -> Result<(), binius_iop::channel::Error> {
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
-		for relation in oracle_relations {
-			let decrypted_claim = self.alloc_inout_elem();
-			self.assert_zero(relation.claim - decrypted_claim)?;
-		}
+		let decrypted_claim = self.alloc_inout_elem();
+		self.assert_zero(claim - decrypted_claim)?;
 		Ok(())
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -17,7 +17,7 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, util::FieldFn};
 use binius_iop::{
 	basefold::channel::{BaseFoldOracle, BaseFoldVerifierChannel},
-	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn},
 	merkle_channel::MerkleIPVerifierChannel,
 };
 use binius_ip::channel::{
@@ -39,9 +39,9 @@ use crate::{Error, IOPVerifier, wrapper::circuit_elem::CircuitElem};
 /// them); arithmetic over public values produces derived public values, and mixing with a precommit
 /// key (as `recv_one` arranges via `inout - key`) yields a value-less private result.
 ///
-/// `transparent` closures supplied via [`OracleLinearRelation`] must depend only on public inputs
-/// (constants and sampled challenges), never on private ones — `verify_oracle_relations` panics
-/// otherwise.
+/// `transparent` closures supplied to [`IOPVerifierChannel::verify_oracle_relation`] must depend
+/// only on public inputs (constants and sampled challenges), never on private ones — that method
+/// panics otherwise.
 pub struct ZKWrappedVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
@@ -287,57 +287,47 @@ where
 			.recv_oracle(log_msg_len, is_witness_dependent)
 	}
 
-	fn verify_oracle_relations(
+	fn verify_oracle_relation(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<Self::Oracle, Self::Elem>>,
+		oracle: Self::Oracle,
+		transparent: TransparentEvalFn<Self::Elem>,
+		claim: Self::Elem,
 	) -> Result<(), binius_iop::channel::Error> {
-		let mut inner_relations = Vec::new();
-		for OracleLinearRelation {
-			oracle,
-			transparent,
-			claim,
-		} in oracle_relations
-		{
-			// For each oracle opening, the prover sends the decrypted evaluation. Allocate it as an
-			// inout wire (written into the public segment) and attest `claim == decrypted_claim`,
-			// exactly as the symbolic `IronSpartanBuilderChannel` does. The assertion is a no-op on
-			// values here, but evaluating `claim - decrypted_claim` keeps the instance generator's
-			// wire allocation aligned with the symbolic constraint system. Rebuild the relation
-			// with the decrypted value for the inner channel.
-			let decrypted_value = self.inner_channel.recv_one()?;
-			let decrypted_claim = self.alloc_inout_elem(decrypted_value);
-			self.assert_zero(claim - decrypted_claim)?;
+		// For each oracle opening, the prover sends the decrypted evaluation. Allocate it as an
+		// inout wire (written into the public segment) and attest `claim == decrypted_claim`,
+		// exactly as the symbolic `IronSpartanBuilderChannel` does. The assertion is a no-op on
+		// values here, but evaluating `claim - decrypted_claim` keeps the instance generator's
+		// wire allocation aligned with the symbolic constraint system. The relation is passed on
+		// to the inner channel with the decrypted value.
+		let decrypted_value = self.inner_channel.recv_one()?;
+		let decrypted_claim = self.alloc_inout_elem(decrypted_value);
+		self.assert_zero(claim - decrypted_claim)?;
 
-			// Wrap the sumcheck challenge coordinates for the transparent closure (which expects
-			// `CircuitElem`s). The closure can do further arithmetic; results are required to be
-			// value-known (public), never private.
-			//
-			// HACK: the coordinates are sampled challenges, so they are wrapped as `Constant`s
-			// rather than builder-backed wires. This frees the closure from holding a reference to
-			// the instance generator, and is sound only because the symbolic outer circuit
-			// (`IronSpartanBuilderChannel`) never invokes the transparent closure — it attests only
-			// `claim == decrypted_claim`, with the transparent evaluation performed out of circuit.
-			// This F->CircuitElem->F bridge should eventually be replaced by an F-level transparent
-			// evaluator.
-			let eval_fn = move |vals: &[F]| {
-				let wrapped_vals = vals
-					.iter()
-					.map(|val| CircuitElem::Constant(*val))
-					.collect::<Vec<_>>();
+		// Wrap the sumcheck challenge coordinates for the transparent closure (which expects
+		// `CircuitElem`s). The closure can do further arithmetic; results are required to be
+		// value-known (public), never private.
+		//
+		// HACK: the coordinates are sampled challenges, so they are wrapped as `Constant`s
+		// rather than builder-backed wires. This frees the closure from holding a reference to
+		// the instance generator, and is sound only because the symbolic outer circuit
+		// (`IronSpartanBuilderChannel`) never invokes the transparent closure — it attests only
+		// `claim == decrypted_claim`, with the transparent evaluation performed out of circuit.
+		// This F->CircuitElem->F bridge should eventually be replaced by an F-level transparent
+		// evaluator.
+		let eval_fn = move |vals: &[F]| {
+			let wrapped_vals = vals
+				.iter()
+				.map(|val| CircuitElem::Constant(*val))
+				.collect::<Vec<_>>();
 
-				match transparent(&wrapped_vals) {
-					CircuitElem::Constant(val) => val,
-					CircuitElem::Wire { wire, .. } => wire.value().expect(
-						"precondition: the transparent polynomial evaluation must depend only on known values (constants or sampled challenges)",
-					),
-				}
-			};
-			inner_relations.push(OracleLinearRelation {
-				oracle,
-				claim: decrypted_value,
-				transparent: Box::new(eval_fn),
-			});
-		}
-		self.inner_channel.verify_oracle_relations(inner_relations)
+			match transparent(&wrapped_vals) {
+				CircuitElem::Constant(val) => val,
+				CircuitElem::Wire { wire, .. } => wire.value().expect(
+					"precondition: the transparent polynomial evaluation must depend only on known values (constants or sampled challenges)",
+				),
+			}
+		};
+		self.inner_channel
+			.verify_oracle_relation(oracle, Box::new(eval_fn), decrypted_value)
 	}
 }

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -11,9 +11,7 @@ use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps}
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,
-	channel::{
-		IOPVerifierChannel, OracleLinearRelation, OracleSpec, oracle_setup::OracleSetupChannel,
-	},
+	channel::{IOPVerifierChannel, OracleSpec, oracle_setup::OracleSetupChannel},
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_math::BinarySubspace;
@@ -204,11 +202,7 @@ impl IOPVerifier {
 		// Verify oracle relations (runs BaseFold internally and verifies the product check). The
 		// intmul pushforward relation, when the IntMul reduction ran, was already queued inside
 		// phase 5.
-		channel.verify_oracle_relations([OracleLinearRelation {
-			oracle: trace_oracle,
-			transparent,
-			claim: sumcheck_claim,
-		}])?;
+		channel.verify_oracle_relation(trace_oracle, transparent, sumcheck_claim)?;
 
 		drop(pcs_guard);
 


### PR DESCRIPTION
Closes [BINIUS-420](https://linear.app/jimpo/issue/BINIUS-420).

Lets one committed oracle be opened against several transparent multilinears in the same batched
BaseFold opening, and reshapes the channel interface as proposed in
https://github.com/binius-zk/binius64/pull/2061#issuecomment-5253986872.

Two commits, each independently green.

### 1. Take one oracle relation at a time

`prove_oracle_relations` bundled two responsibilities: stating claims about committed oracles, and
handing the channel ownership of each oracle's message buffer. Passing several relations at once is
a carryover from an earlier interface where the call consumed the channel.

```diff
-fn prove_oracle_relations(
-    &mut self,
-    oracle_relations: impl IntoIterator<Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar)>,
-);
+fn prove_oracle_relation(&mut self, oracle: Self::Oracle, transparent: FieldVec<P, A>, claim: P::Scalar);
+
+/// Gives ownership of the oracle buffer to the channel.
+fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>);
```

The verifier side follows the same shape — `verify_oracle_relation(oracle, transparent, claim)`.
With the method singular, its parameters name what the `OracleLinearRelation` struct existed to
name, so that struct is gone; the BaseFold channels keep a private queue struct of their own.

The BaseFold prover channel now stores each message in its `CommittedOracleData`, which also makes
the ZK blinding `π_i' = (1-γ)π_i + γω_i` a per-oracle step rather than a per-relation one.

No protocol change in this commit: the transcript is byte-identical.

### 2. Allow several relations on one oracle

The opening asserted exactly one relation per committed oracle, with a `TODO` to lift it. That
blocks opening one commitment at several points, which the chip architecture needs directly: one
trace commitment holds the main circuit's words and every chip's block, and the main reduction and
each chip reduction each end with their own evaluation claim on it.

Both channels queue relations in a structure indexed by oracle, and batch each oracle's claims into
one before the opening runs, with a single batching challenge `λ` shared across oracles:

```
T_i = Σ_j λ^j · t_ij     the combined transparent
S_i = Σ_j λ^j · s_ij     the combined claim
```

The inner product is linear in the transparent, so `⟨π_i, T_i⟩ = S_i` holds exactly when every
`⟨π_i, t_ij⟩ = s_ij` does. The batched per-oracle claims are then combined again by the sumcheck's
own outer batching coefficient. Everything downstream — masking, sumcheck, FRI — sees one relation
per oracle, exactly as it did before.

**Soundness.** For oracle `i`, `P_i(X) = Σ_j (⟨π_i, t_ij⟩ - s_ij) X^j` is a nonzero polynomial of
degree `< k_i` whenever one of that oracle's claims is wrong, so a shared `λ` fails with probability
at most `Σ_i (k_i - 1) / |F|`. `λ` is drawn after every claim it combines is already bound to the
transcript, so no claim can be chosen as a function of it. It is sampled only when some oracle
carries more than one claim, matching how `γ` is drawn only when a ZK oracle is present.

**What the oracle-indexed queue buys.** The reconciliation between arrival order and oracle-index
order disappears: the masking values `σ`, the sumcheck provers and the reduced evaluations `α` all
run in oracle-index order, so the scatter of the `α`s is gone. It also settles an accounting
mismatch the assert was hiding — the prover sent one `σ` per ZK *relation* while the verifier read
one per ZK *oracle*, which agreed only while the assert held.

**Proofs move.** Relations are now ordered by oracle index rather than by arrival, and today's
callers do differ between the two: `prove.rs` commits the trace oracle first but opens it last,
after the logUp pushforwards. Nothing pins proof bytes — the committed example snapshots are circuit
statistics — and both sides derive the order the same way, but this is no longer a byte-identical
transcript.

### Not covered

The other half of the old `TODO` remains: an oracle with *no* relation still fails, because its `α`
would have to come from a plain multilinear evaluation rather than from a sumcheck prover. Both
channels now assert that requirement directly ("at least one relation per committed oracle").

### Verification

Locally, on the rebased stack:

- `cargo clippy --all --tests --benches --examples -- -D warnings` — clean
- nightly `fmt --all` — clean
- 206 tests across `binius-iop`, `binius-iop-prover`, `binius-prover`, `binius-verifier`,
  `binius-m4-prover`, `binius-m4-verifier`, `binius-spartan-prover`, `binius-spartan-verifier` —
  all pass, and commit 1 was checked out on its own for the same set before the rework
- the full `--workspace` run is left to CI

Four new channel tests cover the new capability: two claims on one ZK oracle; a mixed batch of a
non-ZK oracle with one claim and a ZK oracle with three, queued round-robin so relations arrive
interleaved across oracles; and tampered claims in a later position and on the non-ZK oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)