### PR TITLE
Move ValueTable and WitnessM4 into binius-core

### DIFF
--- a/crates/core/src/constraint_system/m4.rs
+++ b/crates/core/src/constraint_system/m4.rs
@@ -8,6 +8,10 @@ use crate::{
 	error::{ConstraintSystemError, VerificationM4Error},
 };
 
+mod witness;
+
+pub use witness::WitnessM4;
+
 /// The chip instances of an M4 witness, addressed by chip ID and row.
 ///
 /// [`ConstraintSystemM4::verify`] reads one instance at a time and never holds two, so this is all

--- a/crates/core/src/constraint_system/m4/witness.rs
+++ b/crates/core/src/constraint_system/m4/witness.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 The Binius Developers
+
+//! The witness for an M4 constraint system: the main chip's values and one table per chip.
+
+use std::borrow::Cow;
+
+use super::{ChipInstances, ConstraintSystemM4};
+use crate::{ValueTable, ValueVec, error::VerificationM4Error};
+
+/// A full M4 witness: the main chip's values and one [`ValueTable`] per chip of a
+/// [`ConstraintSystemM4`].
+///
+/// The tables are indexed by chip ID, so `tables[i]` holds every instance of chip `i`. One row of a
+/// table is one invocation of that chip: the chip's local constraints must hold on the row, and the
+/// row's inout values must be matched by exactly one chip call elsewhere in the system.
+///
+/// Generating one is the circuit frontend's business, since it takes circuits to evaluate — see
+/// `CircuitM4::generate_witness`. This crate is where one is checked.
+#[derive(Debug)]
+pub struct WitnessM4 {
+	/// The values of the main chip, which runs once.
+	pub main: ValueVec,
+	/// The instances of each chip, indexed by chip ID.
+	pub tables: Vec<ValueTable>,
+}
+
+impl WitnessM4 {
+	/// Checks that this witness satisfies an M4 constraint system.
+	///
+	/// [`ConstraintSystemM4::verify`] checks the local constraints of every instance and matches
+	/// every chip call against the instance serving it. It reads the instances one at a time, so a
+	/// table is never expanded into value vectors whole: the tables are the witness, and they stay
+	/// the only copy of it.
+	pub fn verify(&self, cs: &ConstraintSystemM4) -> Result<(), VerificationM4Error> {
+		cs.verify(
+			&self.main,
+			&TableInstances {
+				tables: &self.tables,
+				cs,
+			},
+		)
+	}
+}
+
+/// A witness's tables read as chip instances, each built when it is asked for.
+///
+/// The constants are the one part of an instance a table does not store, so the system is held
+/// alongside to supply them.
+struct TableInstances<'a> {
+	tables: &'a [ValueTable],
+	cs: &'a ConstraintSystemM4,
+}
+
+impl ChipInstances for TableInstances<'_> {
+	fn n_chips(&self) -> usize {
+		self.tables.len()
+	}
+
+	fn n_instances(&self, chip_id: usize) -> usize {
+		self.tables[chip_id].n_instances()
+	}
+
+	fn instance(&self, chip_id: usize, row: usize) -> Cow<'_, ValueVec> {
+		let constants = &self.cs.chips[chip_id].0.cs.constants;
+		Cow::Owned(self.tables[chip_id].instance_value_vec(row, constants))
+	}
+}

--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -9,6 +9,7 @@ mod proof;
 mod shift;
 mod system;
 mod value_index;
+mod value_table;
 mod value_vec;
 mod values_data;
 
@@ -18,5 +19,6 @@ pub use proof::*;
 pub use shift::*;
 pub use system::*;
 pub use value_index::*;
+pub use value_table::*;
 pub use value_vec::*;
 pub use values_data::*;

--- a/crates/core/src/constraint_system/value_table.rs
+++ b/crates/core/src/constraint_system/value_table.rs
@@ -1,0 +1,225 @@
+// Copyright 2026 The Binius Developers
+
+use super::{ValueIndex, ValueVec, ValueVecLayout};
+use crate::word::Word;
+
+/// The witness for a batch of `2^k` independent instances of one circuit, in wire-major order.
+///
+/// Each wire's values across all instances are grouped together, one wire per row (wire-major):
+///
+/// ```text
+///                 instance 0   instance 1   ...   instance K-1
+///   wire 0       [   w        |   w        | ... |   w        ]   <- one row
+///   wire 1       [   w        |   w        | ... |   w        ]
+///        ...
+/// ```
+///
+/// Each row is one wire and each column is one instance.
+/// So a batched interpreter can advance every instance of a wire in a single pass.
+///
+/// This is the batched counterpart of [`ValueVec`]: one instance read back out with
+/// [`Self::instance_value_vec`] is bit-for-bit the value vector populating that instance on its own
+/// would produce.
+///
+/// This table is specialized for the M4 accelerator setting, where the value vector splits with
+/// the inout values on the hidden side ([`InoutSegment::Hidden`](super::InoutSegment::Hidden)):
+///
+/// 1. **Inout wires are committed.** Every instance chooses its own inout words, so they are not
+///    one set of shared values a verifier can evaluate. They are committed with the private values
+///    instead, at the front of the hidden segment.
+/// 2. **Constants are not stored.** The constants live once on the constraint system as a
+///    `Vec<Word>`, not replicated per instance. Only the hidden segment — the inout, witness and
+///    internal words — is stored here. Reading an instance back takes the constants as an argument.
+///
+/// So the stored data holds exactly the hidden segment of every instance: `n_hidden_words` rows by
+/// `2^log_instances` columns.
+///
+/// The committed inout words are not tied to any value the verifier knows, so the statement a
+/// proof over this table makes is that *some* inout values complete every instance.
+///
+/// Populating one is the circuit frontend's business, since it takes a circuit to evaluate — see
+/// `Circuit::populate_batch`.
+#[derive(Clone, Debug)]
+pub struct ValueTable {
+	/// The per-instance value layout, shared by every instance in the batch.
+	layout: ValueVecLayout,
+	/// The base-2 logarithm of the instance count.
+	log_instances: usize,
+	/// The number of hidden-word rows the proving protocol commits per instance.
+	///
+	/// This is the inout values followed by the private ones, which is
+	/// [`ConstraintSystem::n_hidden_words`](super::ConstraintSystem::n_hidden_words) under
+	/// [`InoutSegment::Hidden`](super::InoutSegment::Hidden).
+	n_hidden_words: usize,
+	/// The hidden words of every wire, in wire-major order.
+	///
+	/// Row `r` (for `r` in `0..n_hidden_words`) holds the `2^log_instances` values of hidden wire
+	/// `r` — inout value `r`, then private value `r - n_inout` — one per instance. The rows are
+	/// laid out contiguously, so the length is `n_hidden_words << log_instances`.
+	data: Vec<Word>,
+}
+
+impl ValueTable {
+	/// Builds a table from the hidden words of every instance, in wire-major order.
+	///
+	/// `data` is what [`Self::as_words`] returns: the rows of the hidden segment laid out
+	/// contiguously, each holding one wire's value in every instance. The row count follows from
+	/// the layout, so it is not passed separately.
+	///
+	/// This is the seam the frontend populates through; nothing in this crate can evaluate a
+	/// circuit to produce the words.
+	///
+	/// # Panics
+	///
+	/// Panics if `data` is not `n_hidden_words << log_instances` words long.
+	pub fn from_hidden_words(
+		layout: ValueVecLayout,
+		log_instances: usize,
+		data: Vec<Word>,
+	) -> Self {
+		let n_hidden_words = layout.combined_len() - layout.offset_inout();
+		assert_eq!(
+			data.len(),
+			n_hidden_words << log_instances,
+			"the data must hold one row per hidden word, one column per instance"
+		);
+		Self {
+			layout,
+			log_instances,
+			n_hidden_words,
+			data,
+		}
+	}
+
+	/// The base-2 logarithm of the number of instances.
+	pub const fn log_instances(&self) -> usize {
+		self.log_instances
+	}
+
+	/// The number of instances in the batch.
+	pub const fn n_instances(&self) -> usize {
+		1usize << self.log_instances
+	}
+
+	/// The per-instance value layout shared by every instance.
+	pub const fn layout(&self) -> &ValueVecLayout {
+		&self.layout
+	}
+
+	/// The number of hidden-word rows per instance, including the protocol's zero padding.
+	pub const fn n_hidden_words(&self) -> usize {
+		self.n_hidden_words
+	}
+
+	/// The whole batch as one flat, wire-major word buffer.
+	///
+	/// Row `r` (hidden wire `r`) occupies `data[r << log_instances .. (r + 1) << log_instances]`,
+	/// holding that wire's value in every instance.
+	pub fn as_words(&self) -> &[Word] {
+		&self.data
+	}
+
+	/// Reconstructs one instance as a standalone single-instance value vector.
+	///
+	/// Because the constants are not stored in the table, the caller supplies them (they live on
+	/// the constraint system). The result is bit-for-bit what populating this instance on its own
+	/// would produce, so it can be fed directly to single-instance constraint checking.
+	///
+	/// # Panics
+	///
+	/// Panics if the index is not below the instance count, or if `constants` does not match the
+	/// layout's constant count.
+	pub fn instance_value_vec(&self, instance: usize, constants: &[Word]) -> ValueVec {
+		assert!(instance < self.n_instances(), "instance index out of range");
+		assert_eq!(
+			constants.len(),
+			self.layout.n_const,
+			"constants length must match the layout's constant count"
+		);
+
+		// The constants are the whole public segment; the table stores everything after them.
+		let mut values = ValueVec::new(&self.layout);
+		for (i, &constant) in constants.iter().enumerate() {
+			values[ValueIndex::constant(i as u32)] = constant;
+		}
+
+		// Gather this instance's column of hidden values across every row, which the value vector
+		// holds from the first inout word onwards.
+		for row in 0..self.n_hidden_words {
+			*values.word_mut((self.layout.offset_inout() + row) as u32) =
+				self.data[(row << self.log_instances) + instance];
+		}
+
+		values
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// A layout of one constant, two inout values and one private value.
+	fn layout() -> ValueVecLayout {
+		ValueVecLayout {
+			n_const: 1,
+			n_inout: 2,
+			n_witness: 1,
+			n_internal: 0,
+			n_scratch: 0,
+		}
+	}
+
+	/// A two-instance table whose hidden word `r` holds `0x10 * r + instance`.
+	fn table() -> ValueTable {
+		let n_hidden_words = layout().combined_len() - layout().offset_inout();
+		let data = (0..n_hidden_words)
+			.flat_map(|row| {
+				(0..2).map(move |instance| Word::from_u64(0x10 * row as u64 + instance))
+			})
+			.collect();
+		ValueTable::from_hidden_words(layout(), 1, data)
+	}
+
+	#[test]
+	fn the_row_count_follows_from_the_layout() {
+		let table = table();
+		assert_eq!(table.log_instances(), 1);
+		assert_eq!(table.n_instances(), 2);
+		// Three hidden words: two inout values and one private one.
+		assert_eq!(table.n_hidden_words(), 3);
+		assert_eq!(table.as_words().len(), 6);
+	}
+
+	#[test]
+	#[should_panic(expected = "one row per hidden word")]
+	fn a_buffer_of_the_wrong_length_is_rejected() {
+		ValueTable::from_hidden_words(layout(), 1, vec![Word::ZERO; 5]);
+	}
+
+	// An instance is the column at its index, behind the constants the table does not store.
+	#[test]
+	fn an_instance_reads_back_as_its_own_column() {
+		let table = table();
+		let constants = [Word::from_u64(0xc0)];
+
+		for instance in 0..2 {
+			let values = table.instance_value_vec(instance, &constants);
+			assert_eq!(values[ValueIndex::constant(0)], constants[0]);
+			assert_eq!(values[ValueIndex::inout(0)], Word::from_u64(instance as u64));
+			assert_eq!(values[ValueIndex::inout(1)], Word::from_u64(0x10 + instance as u64));
+			assert_eq!(values[ValueIndex::private(0)], Word::from_u64(0x20 + instance as u64));
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "instance index out of range")]
+	fn reading_past_the_last_instance_panics() {
+		table().instance_value_vec(2, &[Word::from_u64(0xc0)]);
+	}
+
+	#[test]
+	#[should_panic(expected = "constants length must match")]
+	fn the_wrong_number_of_constants_is_rejected() {
+		table().instance_value_vec(0, &[]);
+	}
+}

--- a/crates/frontend/src/batch.rs
+++ b/crates/frontend/src/batch.rs
@@ -1,0 +1,491 @@
+// Copyright 2026 The Binius Developers
+
+//! Populating a [`ValueTable`] by evaluating one circuit over many independent instances.
+//!
+//! The table itself is [`binius_core`]'s, alongside the [`ValueVec`](binius_core::ValueVec) it
+//! batches. Filling one takes a circuit to evaluate, which is what puts these entry points here.
+
+use std::ops::{Index, IndexMut};
+
+use binius_core::{ValueTable, Word};
+use binius_utils::strided_array::StridedArray2DViewMut;
+
+use crate::{BatchPopulateError, Circuit, Wire};
+
+/// Default number of instance columns evaluated by one parallel witness-generation task.
+const DEFAULT_PARALLEL_STRIPE_WIDTH: usize = 1024;
+
+// The single-instance API lives in `compiler::circuit`; this block deliberately keeps the batched
+// population in its own module rather than growing that one.
+#[allow(clippy::multiple_inherent_impl)]
+impl Circuit {
+	/// Builds the batch witness in wire-major order, populating all `2^log_instances` instances.
+	///
+	/// The instances are independent. For each, `fill` sets the input wires; the batched
+	/// interpreter then derives every remaining wire, filling all instances of one wire at a time.
+	///
+	/// # Arguments
+	///
+	/// - `log_instances`: base-2 logarithm of the instance count.
+	/// - `fill`: sets the input wires of instance `i`, for `i` in `0..2^log_instances`. It must
+	///   assign every witness input and every inout wire on each call.
+	///
+	/// # Errors
+	///
+	/// Returns an error naming the lowest-indexed instance whose inputs do not satisfy the circuit.
+	pub fn populate_batch<F>(
+		&self,
+		log_instances: usize,
+		fill: F,
+	) -> Result<ValueTable, BatchPopulateError>
+	where
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
+	{
+		self.populate_batch_with(log_instances, None, fill)
+	}
+
+	/// Builds the batch witness in wire-major order, evaluating instance stripes in parallel.
+	///
+	/// This is the parallel counterpart to [`Self::populate_batch`]. Input filling is still
+	/// performed once up front, then circuit evaluation runs over disjoint vertical instance
+	/// stripes.
+	///
+	/// # Errors
+	///
+	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
+	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
+	pub fn populate_batch_parallel<F>(
+		&self,
+		log_instances: usize,
+		fill: F,
+	) -> Result<ValueTable, BatchPopulateError>
+	where
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
+	{
+		self.populate_batch_parallel_with_stripe_width(
+			log_instances,
+			DEFAULT_PARALLEL_STRIPE_WIDTH,
+			fill,
+		)
+	}
+
+	/// Builds the batch witness in parallel using a caller-provided stripe width.
+	///
+	/// This is exposed for benchmarking stripe widths. Production callers should use
+	/// [`Self::populate_batch_parallel`].
+	///
+	/// # Errors
+	///
+	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
+	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
+	///
+	/// # Panics
+	///
+	/// Panics if `stripe_width == 0`.
+	pub fn populate_batch_parallel_with_stripe_width<F>(
+		&self,
+		log_instances: usize,
+		stripe_width: usize,
+		fill: F,
+	) -> Result<ValueTable, BatchPopulateError>
+	where
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
+	{
+		assert!(stripe_width > 0, "stripe width must be positive");
+		self.populate_batch_with(log_instances, Some(stripe_width), fill)
+	}
+
+	fn populate_batch_with<F>(
+		&self,
+		log_instances: usize,
+		parallel_stripe_width: Option<usize>,
+		fill: F,
+	) -> Result<ValueTable, BatchPopulateError>
+	where
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
+	{
+		let layout = self.value_vec_layout().clone();
+		let n_instances = 1usize << log_instances;
+
+		// The transient working buffer spans the full value vector — constants, inputs, internal
+		// values, and scratch — for every instance, in wire-major order.
+		let full_len = layout.combined_len() + layout.n_scratch;
+		let mut working = vec![Word::ZERO; full_len << log_instances];
+
+		{
+			let mut values =
+				StridedArray2DViewMut::without_stride(&mut working, full_len, n_instances)
+					.expect("full_len * n_instances == working.len() by construction");
+
+			// The caller assigns each instance's witness input wires into that instance's column.
+			for instance in 0..n_instances {
+				let mut filler = BatchWitnessFiller {
+					circuit: self,
+					values: &mut values,
+					instance,
+				};
+				fill(instance, &mut filler);
+			}
+
+			if let Some(stripe_width) = parallel_stripe_width {
+				// Broadcast the constants once, then evaluate disjoint instance stripes in
+				// parallel.
+				self.populate_wire_witness_batched_parallel(values, stripe_width)?;
+			} else {
+				// Broadcast the constants and evaluate every instance's remaining wires.
+				self.populate_wire_witness_batched(&mut values)?;
+			}
+		}
+
+		// Keep the hidden segment: rows `[offset_inout, combined_len)`, the inout values followed
+		// by the private ones. In the wire-major working buffer these rows are contiguous, so
+		// this is a single slice of the words. The constants and scratch are dropped.
+		let start = layout.offset_inout() << log_instances;
+		let end = layout.combined_len() << log_instances;
+		let data = working[start..end].to_vec();
+
+		Ok(ValueTable::from_hidden_words(layout, log_instances, data))
+	}
+}
+
+/// Assigns witness input wires of one instance into a [`ValueTable`] working buffer.
+///
+/// Indexing by [`Wire`] targets that wire's row in the instance's column, mirroring the
+/// single-instance [`WitnessFiller`](crate::WitnessFiller).
+pub struct BatchWitnessFiller<'a, 'v> {
+	circuit: &'a Circuit,
+	values: &'a mut StridedArray2DViewMut<'v, Word>,
+	instance: usize,
+}
+
+impl Index<Wire> for BatchWitnessFiller<'_, '_> {
+	type Output = Word;
+
+	fn index(&self, wire: Wire) -> &Self::Output {
+		&self.values[(self.circuit.witness_row(wire), self.instance)]
+	}
+}
+
+impl IndexMut<Wire> for BatchWitnessFiller<'_, '_> {
+	fn index_mut(&mut self, wire: Wire) -> &mut Self::Output {
+		let row = self.circuit.witness_row(wire);
+		&mut self.values[(row, self.instance)]
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::{ValueVec, constraint_system::InoutSegment};
+	use proptest::prelude::*;
+
+	use super::*;
+	use crate::{AssertionFailure, CircuitBuilder};
+
+	/// The constant the mix circuit XORs its first input against.
+	const MIX_K: u64 = 0x0123_4567_89ab_cdef;
+
+	// A circuit deriving four words from two public inputs and a constant, each promoted to a
+	// public output. The promotions are what keep the derivations alive under dead-code
+	// elimination.
+	struct MixCircuit {
+		circuit: Circuit,
+		a: Wire,
+		b: Wire,
+	}
+
+	impl MixCircuit {
+		// Assigns one instance's inputs; the circuit derives its public outputs.
+		fn fill<F: IndexMut<Wire, Output = Word>>(&self, filler: &mut F, a: u64, b: u64) {
+			filler[self.a] = Word(a);
+			filler[self.b] = Word(b);
+		}
+	}
+
+	fn mix_circuit() -> MixCircuit {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		let k = builder.add_constant_64(MIX_K);
+
+		let and = builder.band(a, b);
+		let xor = builder.bxor(a, k);
+		let (sum, _cout) = builder.iadd(a, b);
+		let rot = builder.rotr(b, 7);
+		let or = builder.bor(and, rot);
+
+		for wire in [and, xor, sum, or] {
+			builder.mark_inout(wire);
+		}
+
+		MixCircuit {
+			circuit: builder.build(),
+			a,
+			b,
+		}
+	}
+
+	// Populate one instance on its own through the ordinary single-instance flow.
+	fn reference_value_vec(c: &MixCircuit, a: u64, b: u64) -> ValueVec {
+		let mut filler = c.circuit.new_witness_filler();
+		c.fill(&mut filler, a, b);
+		c.circuit.populate_wire_witness(&mut filler).unwrap();
+		filler.into_value_vec()
+	}
+
+	#[test]
+	fn shape_matches_layout() {
+		let c = mix_circuit();
+		let log_instances = 3;
+		let table = c
+			.circuit
+			.populate_batch(log_instances, |i, w| {
+				c.fill(w, i as u64, i as u64 + 1);
+			})
+			.unwrap();
+
+		let layout = c.circuit.value_vec_layout();
+		assert_eq!(table.log_instances(), log_instances);
+		assert_eq!(table.n_instances(), 8);
+		let n_hidden_words = c
+			.circuit
+			.constraint_system()
+			.n_hidden_words(InoutSegment::Hidden);
+		assert_eq!(table.n_hidden_words(), n_hidden_words);
+		assert_eq!(table.as_words().len(), n_hidden_words * 8);
+		// The committed rows are the inout values the layout stores, then the private ones.
+		assert_eq!(n_hidden_words, layout.n_inout + layout.n_private());
+	}
+
+	#[test]
+	fn every_instance_satisfies_the_constraint_system() {
+		let c = mix_circuit();
+		let constants = &c.circuit.constraint_system().constants;
+
+		let table = c
+			.circuit
+			.populate_batch(2, |i, w| {
+				c.fill(w, i as u64 * 0x9e37_79b9, i as u64 ^ 0xdead);
+			})
+			.unwrap();
+
+		for i in 0..table.n_instances() {
+			let vv = table.instance_value_vec(i, constants);
+			c.circuit
+				.constraint_system()
+				.verify(&vv)
+				.unwrap_or_else(|e| panic!("instance {i} failed verification: {e}"));
+		}
+	}
+
+	#[test]
+	fn single_instance_batch_matches_reference() {
+		let c = mix_circuit();
+		let constants = &c.circuit.constraint_system().constants;
+
+		let table = c
+			.circuit
+			.populate_batch(0, |_, w| {
+				c.fill(w, 0xABCD, 0x0F0F);
+			})
+			.unwrap();
+
+		assert_eq!(table.n_instances(), 1);
+		let reference = reference_value_vec(&c, 0xABCD, 0x0F0F);
+		// The reconstructed instance equals the reference's committed witness, word for word.
+		let reconstructed = table.instance_value_vec(0, constants);
+		assert_eq!(reconstructed.combined_witness(), reference.combined_witness());
+	}
+
+	proptest! {
+		// Invariant: every batch instance equals the single-instance witness for the same inputs.
+		#[test]
+		fn batch_instances_match_single_instance_reference(
+			inputs in prop::collection::vec((any::<u64>(), any::<u64>()), 4),
+		) {
+			let c = mix_circuit();
+			let constants = c.circuit.constraint_system().constants.clone();
+
+			let table = c.circuit.populate_batch(2, |i, w| {
+				let (a, b) = inputs[i];
+				c.fill(w, a, b);
+			})
+			.unwrap();
+
+			for (i, &(a, b)) in inputs.iter().enumerate() {
+				let reference = reference_value_vec(&c, a, b);
+				let reconstructed = table.instance_value_vec(i, &constants);
+				prop_assert_eq!(reconstructed.combined_witness(), reference.combined_witness());
+			}
+		}
+	}
+
+	#[test]
+	fn parallel_population_matches_serial_for_varied_stripe_widths() {
+		let c = mix_circuit();
+		let log_instances = 3;
+		let fill = |i: usize, w: &mut BatchWitnessFiller<'_, '_>| {
+			c.fill(
+				w,
+				(i as u64).wrapping_mul(0x9e37_79b9),
+				(i as u64).rotate_left(17) ^ 0xdead_beef,
+			);
+		};
+
+		let serial = c.circuit.populate_batch(log_instances, fill).unwrap();
+
+		let default_parallel = c
+			.circuit
+			.populate_batch_parallel(log_instances, fill)
+			.unwrap();
+		assert_eq!(default_parallel.as_words(), serial.as_words());
+
+		for stripe_width in [1, 2, 3, 8, 64] {
+			let parallel = c
+				.circuit
+				.populate_batch_parallel_with_stripe_width(log_instances, stripe_width, fill)
+				.unwrap();
+
+			assert_eq!(
+				parallel.as_words(),
+				serial.as_words(),
+				"stripe width {stripe_width} changed the populated table"
+			);
+		}
+	}
+
+	#[test]
+	fn unsatisfiable_instance_reports_its_index() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Instance 2 violates a == b; the others satisfy it.
+		let result = circuit.populate_batch(2, |i, w| {
+			w[a] = Word(i as u64);
+			w[b] = Word(if i == 2 { 99 } else { i as u64 });
+		});
+
+		let err = result.expect_err("instance 2 violates a == b");
+		assert_eq!(err.instance, 2);
+		assert_eq!(err.source.total, 1);
+		assert_eq!(
+			err.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: "Word(0x0000000000000002) != Word(0x0000000000000063)".to_string(),
+			}]
+		);
+	}
+
+	#[test]
+	fn parallel_unsatisfiable_instance_reports_global_index_across_stripes() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Instance 5 is in the third two-column stripe. Reporting a local stripe index would
+		// incorrectly return 1 instead of the global instance index 5.
+		let result = circuit.populate_batch_parallel_with_stripe_width(3, 2, |i, w| {
+			w[a] = Word(i as u64);
+			w[b] = Word(if i == 5 { 99 } else { i as u64 });
+		});
+
+		let err = result.expect_err("instance 5 violates a == b");
+		assert_eq!(err.instance, 5);
+		assert_eq!(err.source.total, 1);
+		assert_eq!(
+			err.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: "Word(0x0000000000000005) != Word(0x0000000000000063)".to_string(),
+			}]
+		);
+	}
+
+	#[test]
+	fn parallel_failure_diagnostics_report_global_instance_across_stripes() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Instances 5 and 7 fail in different two-column stripes. The parallel path may report
+		// either stripe depending on scheduling, but it must report a global instance index and
+		// diagnostics for that instance rather than aggregating unrelated stripes.
+		let fill = |i: usize, w: &mut BatchWitnessFiller<'_, '_>| {
+			w[a] = Word(i as u64);
+			w[b] = Word(if i == 5 || i == 7 { 99 } else { i as u64 });
+		};
+		let parallel = circuit
+			.populate_batch_parallel_with_stripe_width(3, 2, fill)
+			.expect_err("instances fail");
+
+		assert!(parallel.instance == 5 || parallel.instance == 7);
+		assert_eq!(parallel.source.total, 1);
+		assert_eq!(
+			parallel.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: format!("Word(0x{0:016x}) != Word(0x0000000000000063)", parallel.instance),
+			}]
+		);
+	}
+
+	// Inout wires are committed, so they lead the stored rows: row `i` is inout value `i`, and the
+	// private values follow. Each instance carries its own inout words.
+	#[test]
+	fn inout_wires_lead_the_committed_rows() {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		// A private wire, so the table carries private rows behind the inout ones.
+		let w = builder.add_witness();
+		let and = builder.band(a, b);
+		let mixed = builder.bxor(and, w);
+		builder.mark_inout(and);
+		builder.mark_inout(mixed);
+		let circuit = builder.build();
+
+		let log_instances = 2;
+		let table = circuit
+			.populate_batch(log_instances, |i, f| {
+				f[a] = Word(i as u64);
+				f[b] = Word(i as u64 + 0x100);
+				f[w] = Word(i as u64 ^ 0xbeef);
+			})
+			.unwrap();
+
+		// The inout values lead the private ones, all of them committed.
+		let layout = circuit.value_vec_layout();
+		assert_eq!(layout.n_inout, 4);
+		assert!(layout.n_private() > 0, "the fixture must carry private rows too");
+		assert_eq!(table.n_hidden_words(), layout.n_inout + layout.n_private());
+
+		// The inout rows hold what the filler assigned, one column per instance.
+		let inout_row =
+			|row: usize| &table.as_words()[row << log_instances..(row + 1) << log_instances];
+		assert_eq!(inout_row(0), [Word(0), Word(1), Word(2), Word(3)]);
+		assert_eq!(inout_row(1), [Word(0x100), Word(0x101), Word(0x102), Word(0x103)]);
+
+		// And each instance reconstructs to a witness the constraint system accepts, inout
+		// values included.
+		let constants = &circuit.constraint_system().constants;
+		for i in 0..table.n_instances() {
+			let vv = table.instance_value_vec(i, constants);
+			assert_eq!(vv[circuit.witness_index(a)], Word(i as u64));
+			assert_eq!(vv[circuit.witness_index(b)], Word(i as u64 + 0x100));
+			circuit
+				.constraint_system()
+				.verify(&vv)
+				.unwrap_or_else(|e| panic!("instance {i} failed verification: {e}"));
+		}
+	}
+}

--- a/crates/frontend/src/chip_witness.rs
+++ b/crates/frontend/src/chip_witness.rs
@@ -1,33 +1,24 @@
 // Copyright 2026 The Binius Developers
 
-//! The witness for an M4 circuit: the main circuit's values and one table per chip.
+//! Generating the witness of an M4 circuit: the main circuit's values and one table per chip.
+//!
+//! The witness itself is [`binius_core`]'s [`WitnessM4`], which is also where one is checked.
+//! Filling one takes circuits to evaluate, which is what puts generation here.
 
-use std::{borrow::Cow, mem};
+use std::mem;
 
 use binius_core::{
-	ValueVec, VerificationM4Error, Word,
-	m4::{ChipCall, ChipInstances, ConstraintSystemM4},
+	ValueTable, ValueVec, Word,
+	m4::{ChipCall, WitnessM4},
 };
-use binius_frontend::{BatchPopulateError, CircuitM4, PopulateError, WitnessFiller};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
-use crate::value_table::ValueTable;
+use crate::{BatchPopulateError, CircuitM4, PopulateError, WitnessFiller};
 
-/// A full M4 witness: the main circuit's values and one [`ValueTable`] per chip of a
-/// [`CircuitM4`].
-///
-/// The tables are indexed by chip ID, so `tables[i]` holds every instance of chip `i`. One row of a
-/// table is one invocation of that chip: the chip's local constraints must hold on the row, and the
-/// row's inout values must be matched by exactly one chip call elsewhere in the system.
-#[derive(Debug)]
-pub struct WitnessM4 {
-	/// The values of the main circuit, which runs once.
-	pub main: ValueVec,
-	/// The instances of each chip, indexed by chip ID.
-	pub tables: Vec<ValueTable>,
-}
-
-impl WitnessM4 {
+// The system's own API lives in `chip`; this block deliberately keeps witness generation in its own
+// module rather than growing that one.
+#[allow(clippy::multiple_inherent_impl)]
+impl CircuitM4 {
 	/// Generates the witness for a whole system from the main circuit's inputs.
 	///
 	/// `fill_main` assigns the witness inputs of the main circuit; every other value in the system
@@ -38,16 +29,15 @@ impl WitnessM4 {
 	///
 	/// # Panics
 	///
-	/// Panics if the system does not pass [`CircuitM4::validate`], which covers both the ordering
-	/// this walks the chips in and the well-formedness of the operands it evaluates.
-	pub fn generate<F>(circuit: &CircuitM4, fill_main: F) -> Result<Self, PopulateM4Error>
+	/// Panics if the system does not pass [`Self::validate`], which covers both the ordering this
+	/// walks the chips in and the well-formedness of the operands it evaluates.
+	pub fn generate_witness<F>(&self, fill_main: F) -> Result<WitnessM4, PopulateM4Error>
 	where
 		F: FnOnce(&mut WitnessFiller<'_>),
 	{
-		let mut main_witness_filler = circuit.main.circuit.new_witness_filler();
+		let mut main_witness_filler = self.main.circuit.new_witness_filler();
 		fill_main(&mut main_witness_filler);
-		circuit
-			.main
+		self.main
 			.circuit
 			.populate_wire_witness(&mut main_witness_filler)?;
 
@@ -56,13 +46,13 @@ impl WitnessM4 {
 		// The invocations awaiting each chip, in the order the calls run: main's first, then the
 		// calls of each chip in ID order, instance-major and call-minor. Calls only run to higher
 		// IDs, so a chip's list is complete by the time the pass below reaches it.
-		let mut pending = vec![Vec::new(); circuit.chips.len()];
-		for call in &circuit.main.chip_calls {
+		let mut pending = vec![Vec::new(); self.chips.len()];
+		for call in &self.main.chip_calls {
 			pending[call.chip_id].push(eval_call(&main_values, call));
 		}
 
-		let mut tables = Vec::<ValueTable>::with_capacity(circuit.chips.len());
-		for (chip_id, (chip, n_active)) in circuit.chips.iter().enumerate() {
+		let mut tables = Vec::<ValueTable>::with_capacity(self.chips.len());
+		for (chip_id, (chip, n_active)) in self.chips.iter().enumerate() {
 			let call_data = mem::take(&mut pending[chip_id]);
 
 			// Invariants checked in `CircuitM4::validate()`
@@ -70,8 +60,9 @@ impl WitnessM4 {
 			assert!(*n_active > 0, "chip {chip_id} is never called");
 
 			let log_instances = log2_ceil_usize(call_data.len());
-			let table =
-				ValueTable::populate_parallel(&chip.circuit, log_instances, |instance, filler| {
+			let table = chip
+				.circuit
+				.populate_batch_parallel(log_instances, |instance, filler| {
 					// Instances past the last invocation repeat it.
 					let inout = &call_data[instance.min(call_data.len() - 1)];
 					for (i, &wire) in chip.circuit.inout().iter().enumerate() {
@@ -97,50 +88,10 @@ impl WitnessM4 {
 			tables.push(table);
 		}
 
-		Ok(Self {
+		Ok(WitnessM4 {
 			main: main_values,
 			tables,
 		})
-	}
-
-	/// Checks that this witness satisfies an M4 constraint system.
-	///
-	/// [`ConstraintSystemM4::verify`] checks the local constraints of every instance and matches
-	/// every chip call against the instance serving it. It reads the instances one at a time, so a
-	/// table is never expanded into value vectors whole: the tables are the witness, and they stay
-	/// the only copy of it.
-	pub fn verify(&self, cs: &ConstraintSystemM4) -> Result<(), VerificationM4Error> {
-		cs.verify(
-			&self.main,
-			&TableInstances {
-				tables: &self.tables,
-				cs,
-			},
-		)
-	}
-}
-
-/// A witness's tables read as chip instances, each built when it is asked for.
-///
-/// The constants are the one part of an instance a table does not store, so the system is held
-/// alongside to supply them.
-struct TableInstances<'a> {
-	tables: &'a [ValueTable],
-	cs: &'a ConstraintSystemM4,
-}
-
-impl ChipInstances for TableInstances<'_> {
-	fn n_chips(&self) -> usize {
-		self.tables.len()
-	}
-
-	fn n_instances(&self, chip_id: usize) -> usize {
-		self.tables[chip_id].n_instances()
-	}
-
-	fn instance(&self, chip_id: usize, row: usize) -> Cow<'_, ValueVec> {
-		let constants = &self.cs.chips[chip_id].0.cs.constants;
-		Cow::Owned(self.tables[chip_id].instance_value_vec(row, constants))
 	}
 }
 
@@ -170,10 +121,10 @@ pub enum PopulateM4Error {
 mod tests {
 	use std::iter;
 
-	use binius_core::{ShiftedValueIndex, ValueIndex, error::OperandFault};
-	use binius_frontend::{Circuit, CircuitBuilder, CircuitM4Error, EmbeddedCircuit, Wire};
+	use binius_core::{ShiftedValueIndex, ValueIndex, VerificationM4Error, error::OperandFault};
 
 	use super::*;
+	use crate::{Circuit, CircuitBuilder, CircuitM4Error, EmbeddedCircuit, Wire};
 
 	/// A chip whose inout words are `(a, b, c)`, constrained by `c == a & b`.
 	///
@@ -325,13 +276,14 @@ mod tests {
 		circuit.validate().unwrap();
 
 		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0)];
-		let witness = WitnessM4::generate(&circuit, |filler| {
-			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
-				filler[a] = Word(a_word);
-				filler[b] = Word(b_word);
-			}
-		})
-		.unwrap();
+		let witness = circuit
+			.generate_witness(|filler| {
+				for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+					filler[a] = Word(a_word);
+					filler[b] = Word(b_word);
+				}
+			})
+			.unwrap();
 
 		assert_eq!(witness.tables[0].n_instances(), 2);
 		for (instance, &(a, b)) in words.iter().enumerate() {
@@ -348,13 +300,14 @@ mod tests {
 		circuit.validate().unwrap();
 
 		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0)];
-		let witness = WitnessM4::generate(&circuit, |filler| {
-			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
-				filler[a] = Word(a_word);
-				filler[b] = Word(b_word);
-			}
-		})
-		.unwrap();
+		let witness = circuit
+			.generate_witness(|filler| {
+				for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+					filler[a] = Word(a_word);
+					filler[b] = Word(b_word);
+				}
+			})
+			.unwrap();
 
 		// Chip 0 serves main's two calls, in call order.
 		let (chip_0, chip_1) = (&circuit.chips[0].0, &circuit.chips[1].0);
@@ -394,7 +347,7 @@ mod tests {
 			instance_inout(&circuit.chips[0].0, &witness.tables[0], 0)
 		};
 
-		let witness = WitnessM4::generate(&circuit, fill).unwrap();
+		let witness = circuit.generate_witness(fill).unwrap();
 		assert_eq!(row(&circuit, &witness), vec![0b1100, 0b1010, 0b1000]);
 		witness.verify(&circuit.to_constraint_system()).unwrap();
 
@@ -402,7 +355,7 @@ mod tests {
 		// succeeds, and the row still holds the conjunction rather than what the call passed — so
 		// the call no longer matches its instance, which is exactly what verification rejects.
 		circuit.main.chip_calls[0].inout[2] = operand(&circuit.main.circuit, a);
-		let witness = WitnessM4::generate(&circuit, fill).unwrap();
+		let witness = circuit.generate_witness(fill).unwrap();
 		assert_eq!(row(&circuit, &witness), vec![0b1100, 0b1010, 0b1000]);
 		let err = witness.verify(&circuit.to_constraint_system()).unwrap_err();
 		assert!(
@@ -438,13 +391,14 @@ mod tests {
 		assert_eq!(circuit.chips[1].1, 4);
 
 		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0)];
-		let witness = WitnessM4::generate(&circuit, |filler| {
-			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
-				filler[a] = Word(a_word);
-				filler[b] = Word(b_word);
-			}
-		})
-		.unwrap();
+		let witness = circuit
+			.generate_witness(|filler| {
+				for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+					filler[a] = Word(a_word);
+					filler[b] = Word(b_word);
+				}
+			})
+			.unwrap();
 
 		// Instance 0's two calls come before instance 1's, each forwarding `(a, a)` then `(b, b)`.
 		let expected = [words[0].0, words[0].1, words[1].0, words[1].1];
@@ -465,13 +419,14 @@ mod tests {
 		circuit.validate().unwrap();
 
 		let words = [(0b1100u64, 0b1010u64), (0xff00, 0x0ff0), (0xabcd, 0xdcba)];
-		let witness = WitnessM4::generate(&circuit, |filler| {
-			for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
-				filler[a] = Word(a_word);
-				filler[b] = Word(b_word);
-			}
-		})
-		.unwrap();
+		let witness = circuit
+			.generate_witness(|filler| {
+				for (&(a, b), &(a_word, b_word)) in iter::zip(&inputs, &words) {
+					filler[a] = Word(a_word);
+					filler[b] = Word(b_word);
+				}
+			})
+			.unwrap();
 
 		// Three calls round up to four instances, the fourth repeating the third.
 		let chip_0 = &circuit.chips[0].0;
@@ -492,11 +447,12 @@ mod tests {
 		let (a, b) = inputs[0];
 		circuit.main.chip_calls[0].inout[2] = operand(&circuit.main.circuit, a);
 
-		let err = WitnessM4::generate(&circuit, |filler| {
-			filler[a] = Word(0b1100);
-			filler[b] = Word(0b1010);
-		})
-		.unwrap_err();
+		let err = circuit
+			.generate_witness(|filler| {
+				filler[a] = Word(0b1100);
+				filler[b] = Word(0b1010);
+			})
+			.unwrap_err();
 		assert!(matches!(err, PopulateM4Error::Chip { chip_id: 0, .. }), "{err}");
 	}
 

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -26,12 +26,16 @@
 
 #![warn(rustdoc::missing_crate_level_docs)]
 
+mod batch;
 pub mod chip;
+mod chip_witness;
 mod compiler;
 pub mod ops;
 pub mod stat;
 
+pub use batch::BatchWitnessFiller;
 pub use chip::{ChipRef, CircuitM4, CircuitM4Error, EmbeddedCircuit};
+pub use chip_witness::PopulateM4Error;
 pub use compiler::{
 	CircuitBuilder, Options, Wire,
 	circuit::{AssertionFailure, Circuit, PopulateError, WitnessFiller},

--- a/crates/frontend/tests/crc64_chip.rs
+++ b/crates/frontend/tests/crc64_chip.rs
@@ -6,13 +6,12 @@
 //! Main learns each register state from a hint rather than computing it, so its own constraints
 //! say nothing about the CRC at all — the chip calls are what tie the states together.
 //!
-//! The plain circuit this mirrors is the CRC-64 fixture in this crate's `test_utils`.
+//! The plain circuit this mirrors is the CRC-64 fixture in `binius-m4-prover`'s `test_utils`.
 
 use std::iter;
 
 use binius_core::Word;
 use binius_frontend::{CircuitBuilder, CircuitM4, Wire, hints::Hint};
-use binius_m4_prover::WitnessM4;
 
 /// The CRC-64/GO-ISO generator polynomial, in reflected form.
 const POLY_REFLECTED: u64 = 0xd800_0000_0000_0000;
@@ -130,12 +129,14 @@ fn chip_accelerated_crc64_matches_the_reference() {
 	let cs = c.circuit.to_constraint_system();
 	cs.validate().unwrap();
 
-	let witness = WitnessM4::generate(&c.circuit, |filler| {
-		for (&wire, &word) in iter::zip(&c.input, &words) {
-			filler[wire] = Word(word);
-		}
-	})
-	.unwrap();
+	let witness = c
+		.circuit
+		.generate_witness(|filler| {
+			for (&wire, &word) in iter::zip(&c.input, &words) {
+				filler[wire] = Word(word);
+			}
+		})
+		.unwrap();
 
 	// The hints carried the whole computation, and they carried it correctly.
 	let main = &c.circuit.main.circuit;

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -15,7 +15,7 @@ use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_compute::BufferPool;
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::{OperandColumns, ValueTable};
+use binius_m4_prover::OperandColumns;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 /// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
@@ -54,12 +54,13 @@ fn bench_assemble_operation_witness(c: &mut Criterion) {
 	let (circuit, input) = build_keccak_circuit();
 
 	// Setup (not timed): populate the wire-major batch table for every instance.
-	let table = ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
-		for lane in 0..STATE_LANES {
-			w[input[lane]] = input_word(instance, lane);
-		}
-	})
-	.unwrap();
+	let table = circuit
+		.populate_batch(LOG_INSTANCES, |instance, w| {
+			for lane in 0..STATE_LANES {
+				w[input[lane]] = input_word(instance, lane);
+			}
+		})
+		.unwrap();
 
 	// The circuit's constants, shared by every instance.
 	let constants = circuit.constraint_system().constants.clone();

--- a/crates/m4-prover/benches/blake3_compressions.rs
+++ b/crates/m4-prover/benches/blake3_compressions.rs
@@ -18,8 +18,7 @@ use std::{array, env};
 
 use binius_circuits::blake3::blake3_compress_2x;
 use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::BatchWitnessFiller;
+use binius_frontend::{BatchWitnessFiller, Circuit, CircuitBuilder, Wire};
 use criterion::{Criterion, criterion_group, criterion_main};
 use m4_bench::bench_m4_proving;
 use rand::prelude::*;

--- a/crates/m4-prover/benches/keccak_protocol.rs
+++ b/crates/m4-prover/benches/keccak_protocol.rs
@@ -15,8 +15,7 @@ use std::{array, env};
 
 use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::BatchWitnessFiller;
+use binius_frontend::{BatchWitnessFiller, Circuit, CircuitBuilder, Wire};
 use criterion::{Criterion, criterion_group, criterion_main};
 use m4_bench::bench_m4_proving;
 

--- a/crates/m4-prover/benches/keccak_witness_gen.rs
+++ b/crates/m4-prover/benches/keccak_witness_gen.rs
@@ -10,7 +10,6 @@ use std::array;
 use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::ValueTable;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 /// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
@@ -57,29 +56,30 @@ fn bench_keccak_witness_gen(c: &mut Criterion) {
 
 	group.bench_function("value_table", |b| {
 		b.iter(|| {
-			ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
-				for lane in 0..STATE_LANES {
-					w[input[lane]] = input_word(instance, lane);
-				}
-			})
-			.unwrap()
+			circuit
+				.populate_batch(LOG_INSTANCES, |instance, w| {
+					for lane in 0..STATE_LANES {
+						w[input[lane]] = input_word(instance, lane);
+					}
+				})
+				.unwrap()
 		});
 	});
 
 	for stripe_width in STRIPE_WIDTHS {
 		group.bench_function(format!("value_table_parallel_{stripe_width}"), |b| {
 			b.iter(|| {
-				ValueTable::populate_parallel_with_stripe_width(
-					&circuit,
-					LOG_INSTANCES,
-					stripe_width,
-					|instance, w| {
-						for lane in 0..STATE_LANES {
-							w[input[lane]] = input_word(instance, lane);
-						}
-					},
-				)
-				.unwrap()
+				circuit
+					.populate_batch_parallel_with_stripe_width(
+						LOG_INSTANCES,
+						stripe_width,
+						|instance, w| {
+							for lane in 0..STATE_LANES {
+								w[input[lane]] = input_word(instance, lane);
+							}
+						},
+					)
+					.unwrap()
 			});
 		});
 	}

--- a/crates/m4-prover/benches/sha256_compressions.rs
+++ b/crates/m4-prover/benches/sha256_compressions.rs
@@ -17,8 +17,7 @@ use std::{array, env};
 
 use binius_circuits::sha256::{State, sha256_compress_2x};
 use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::BatchWitnessFiller;
+use binius_frontend::{BatchWitnessFiller, Circuit, CircuitBuilder, Wire};
 use criterion::{Criterion, criterion_group, criterion_main};
 use m4_bench::bench_m4_proving;
 use rand::prelude::*;

--- a/crates/m4-prover/benches/utils/m4_bench.rs
+++ b/crates/m4-prover/benches/utils/m4_bench.rs
@@ -8,8 +8,8 @@
 //! Witness generation is inside the timed unit.
 //! Published Flock figures include it in the proof path, so the measured unit matches.
 
-use binius_frontend::Circuit;
-use binius_m4_prover::{BatchWitnessFiller, Prover, ValueTable};
+use binius_frontend::{BatchWitnessFiller, Circuit};
+use binius_m4_prover::Prover;
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
 use binius_transcript::ProverTranscript;
@@ -62,7 +62,8 @@ pub fn bench_m4_proving<F>(
 	// Correctness gate: prove and verify one batch before timing.
 	// A bench that measures a proof of nothing is worse than no bench.
 	{
-		let table = ValueTable::populate_parallel(circuit, log_instances, &fill)
+		let table = circuit
+			.populate_batch_parallel(log_instances, &fill)
 			.expect("witness inputs satisfy the circuit");
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove(&table, &mut prover_transcript);
@@ -88,7 +89,9 @@ pub fn bench_m4_proving<F>(
 	group.bench_function(BenchmarkId::from_parameter(log_instances), |b| {
 		b.iter(|| {
 			// Regenerate the batch witness, then prove it: the per-batch work of a real prover.
-			let table = ValueTable::populate_parallel(circuit, log_instances, &fill).unwrap();
+			let table = circuit
+				.populate_batch_parallel(log_instances, &fill)
+				.unwrap();
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 			prover.prove(&table, &mut prover_transcript);
 			prover_transcript

--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -1,9 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-//! Witness table and prover for the data-parallel Binius64 M4 proof system.
+//! Prover for the data-parallel Binius64 M4 proof system.
+//!
+//! The witness it proves over is a [`ValueTable`](binius_core::ValueTable), which
+//! [`binius_core`] defines and [`binius_frontend`] populates. This crate commits one and reduces
+//! the constraint system over it.
 
-mod m4_witness;
 mod prove;
 mod shift;
 #[cfg(test)]
@@ -11,7 +14,6 @@ mod test_utils;
 mod value_table;
 mod witness;
 
-pub use m4_witness::{PopulateM4Error, WitnessM4};
 pub use prove::{IOPProver, Prover};
-pub use value_table::{BatchWitnessFiller, ValueTable};
+pub use value_table::{commit_layout, pack_table};
 pub use witness::OperandColumns;

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -3,7 +3,7 @@
 
 use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{
-	constraint_system::{ConstraintSystem, InoutSegment},
+	constraint_system::{ConstraintSystem, InoutSegment, ValueTable},
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
@@ -43,8 +43,8 @@ use binius_verifier::{
 };
 
 use crate::{
-	ValueTable,
 	shift::prove as prove_shift,
+	value_table::pack_table,
 	witness::{FoldedWitness, OperandColumns},
 };
 
@@ -118,7 +118,7 @@ impl IOPProver {
 		// Pack the 2-D table into one multilinear and commit it as the trace oracle.
 		let trace_packed = {
 			let _scope = tracing::debug_span!("Prepare trace").entered();
-			table.pack::<P, _>(alloc)
+			pack_table::<P, _>(table, alloc)
 		};
 		let trace_oracle = {
 			let _scope = tracing::debug_span!("Commit trace").entered();
@@ -745,13 +745,14 @@ mod tests {
 		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit BMUL constraints");
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
-			}
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.next_u64());
+				}
+			})
+			.unwrap();
 
 		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);
@@ -818,13 +819,14 @@ mod tests {
 		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit BMUL constraints");
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
-			}
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.next_u64());
+				}
+			})
+			.unwrap();
 
 		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);
@@ -874,13 +876,14 @@ mod tests {
 		cs.validate().unwrap();
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
-			}
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.next_u64());
+				}
+			})
+			.unwrap();
 
 		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);
@@ -954,12 +957,13 @@ mod tests {
 		// Fill each instance's two multiplicands from a per-instance seed; the circuit derives the
 		// two product words.
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			w[x] = Word(rng.next_u64());
-			w[y] = Word(rng.next_u64());
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				w[x] = Word(rng.next_u64());
+				w[y] = Word(rng.next_u64());
+			})
+			.unwrap();
 
 		// Setup once: the verifier fixes the shape and FRI parameters, the prover inherits them.
 		let verifier = Verifier::setup(&cs, log_instances, 1);
@@ -1009,15 +1013,16 @@ mod tests {
 		// Every instance chooses its own inout words — the reason they cannot be shared public
 		// data.
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			let input_word = rng.next_u64();
-			let secret_word = rng.next_u64();
-			w[input] = Word(input_word);
-			w[secret] = Word(secret_word);
-			w[output] = Word((input_word & secret_word) ^ 0x0123_4567_89ab_cdef);
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				let input_word = rng.next_u64();
+				let secret_word = rng.next_u64();
+				w[input] = Word(input_word);
+				w[secret] = Word(secret_word);
+				w[output] = Word((input_word & secret_word) ^ 0x0123_4567_89ab_cdef);
+			})
+			.unwrap();
 
 		// The committed segment covers the inout words as well as the private ones.
 		assert_eq!(
@@ -1072,24 +1077,25 @@ mod tests {
 
 		// Fill each instance's inputs from a per-instance seed; the compression derives the rest.
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			// A 32-bit value per chaining-value word.
-			for wire in cv {
-				w[wire] = Word(rng.next_u32() as u64);
-			}
-			// A 32-bit value per message word.
-			for wire in block {
-				w[wire] = Word(rng.next_u32() as u64);
-			}
-			// A full 64-bit block counter.
-			w[counter] = Word(rng.next_u64());
-			// A byte length in 0..=64.
-			w[block_len] = Word((rng.next_u32() % 65) as u64);
-			// Arbitrary domain-separation flags.
-			w[flags] = Word(rng.next_u32() as u64);
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				// A 32-bit value per chaining-value word.
+				for wire in cv {
+					w[wire] = Word(rng.next_u32() as u64);
+				}
+				// A 32-bit value per message word.
+				for wire in block {
+					w[wire] = Word(rng.next_u32() as u64);
+				}
+				// A full 64-bit block counter.
+				w[counter] = Word(rng.next_u64());
+				// A byte length in 0..=64.
+				w[block_len] = Word((rng.next_u32() % 65) as u64);
+				// Arbitrary domain-separation flags.
+				w[flags] = Word(rng.next_u32() as u64);
+			})
+			.unwrap();
 
 		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);
@@ -1146,13 +1152,14 @@ mod tests {
 		);
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
-			}
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.next_u64());
+				}
+			})
+			.unwrap();
 
 		// Prove with the wide packing; the verifier is packing-agnostic.
 		let verifier = Verifier::setup(&cs, log_instances, 1);
@@ -1200,12 +1207,13 @@ mod tests {
 		// Fill each instance's multiplicand from a per-instance seed; the circuit derives the two
 		// product words.
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			w[x_lo] = Word(rng.next_u64());
-			w[x_hi] = Word(rng.next_u64());
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				w[x_lo] = Word(rng.next_u64());
+				w[x_hi] = Word(rng.next_u64());
+			})
+			.unwrap();
 
 		// Setup once: the verifier fixes the shape and FRI parameters, the prover inherits them.
 		let verifier = Verifier::setup(&cs, log_instances, 1);
@@ -1273,13 +1281,14 @@ mod tests {
 		);
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
-			}
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.next_u64());
+				}
+			})
+			.unwrap();
 
 		// Prove with the wide packing; the verifier is packing-agnostic.
 		let verifier = Verifier::setup(&cs, log_instances, 1);
@@ -1340,13 +1349,14 @@ mod tests {
 		}
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
-			}
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.next_u64());
+				}
+			})
+			.unwrap();
 
 		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);
@@ -1410,12 +1420,13 @@ mod tests {
 		cs.validate().unwrap();
 
 		let log_instances = 6;
-		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64 + 1);
-			w[x] = Word(rng.next_u64());
-			w[y] = Word(rng.next_u64());
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(log_instances, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64 + 1);
+				w[x] = Word(rng.next_u64());
+				w[y] = Word(rng.next_u64());
+			})
+			.unwrap();
 
 		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -211,6 +211,7 @@ mod tests {
 
 	use binius_compute::GlobalAllocator;
 	use binius_core::{
+		ValueTable,
 		constraint_system::{AndConstraint, InoutSegment},
 		word::Word,
 	};
@@ -234,7 +235,6 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		ValueTable,
 		test_utils::{N_INPUT_WORDS, crc64_circuit, populate_crc64_witness},
 		witness::OperandColumns,
 	};

--- a/crates/m4-prover/src/test_utils.rs
+++ b/crates/m4-prover/src/test_utils.rs
@@ -5,10 +5,8 @@
 //! It is shared by the shift-reduction and constraint-reduction tests.
 //! Both need a circuit whose AND-constraint operands carry real shifts.
 
-use binius_core::word::Word;
+use binius_core::{ValueTable, word::Word};
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
-
-use crate::ValueTable;
 
 /// The CRC-64/GO-ISO generator polynomial, in reflected form.
 ///
@@ -109,12 +107,13 @@ pub fn crc64_circuit() -> Crc64Circuit {
 /// Circuit evaluation derives the rest, including the public CRC.
 pub fn populate_crc64_witness(c: &Crc64Circuit, inputs: &[[u64; N_INPUT_WORDS]]) -> ValueTable {
 	let log_instances = inputs.len().ilog2() as usize;
-	ValueTable::populate(&c.circuit, log_instances, |i, filler| {
-		for (wire, &w) in c.input.iter().zip(&inputs[i]) {
-			filler[*wire] = Word(w);
-		}
-	})
-	.unwrap()
+	c.circuit
+		.populate_batch(log_instances, |i, filler| {
+			for (wire, &w) in c.input.iter().zip(&inputs[i]) {
+				filler[*wire] = Word(w);
+			}
+		})
+		.unwrap()
 }
 
 #[cfg(test)]

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -1,650 +1,56 @@
 // Copyright 2026 The Binius Developers
 
-use std::ops::{Index, IndexMut};
+//! Committing a [`ValueTable`] as the trace oracle.
+//!
+//! The table is [`binius_core`]'s and populating one is the frontend's, but neither knows about
+//! commitments. These are the two operations that do, so they live with the prover.
 
 use binius_compute::Allocator;
-use binius_core::{
-	constraint_system::{ValueIndex, ValueVec, ValueVecLayout},
-	word::Word,
-};
+use binius_core::ValueTable;
 use binius_field::PackedField;
-use binius_frontend::{BatchPopulateError, Circuit, Wire};
 use binius_m4_verifier::BatchCommitLayout;
 use binius_math::FieldVec;
-use binius_utils::strided_array::StridedArray2DViewMut;
 use binius_verifier::config::B128;
 
-/// Default number of instance columns evaluated by one parallel witness-generation task.
-const DEFAULT_PARALLEL_STRIPE_WIDTH: usize = 1024;
-
-/// The witness for a batch of `2^k` independent instances of one circuit, in wire-major order.
+/// The committed-multilinear layout for a batch.
 ///
-/// Each wire's values across all instances are grouped together, one wire per row (wire-major):
-///
-/// ```text
-///                 instance 0   instance 1   ...   instance K-1
-///   wire 0       [   w        |   w        | ... |   w        ]   <- one row
-///   wire 1       [   w        |   w        | ... |   w        ]
-///        ...
-/// ```
-///
-/// Each row is one wire and each column is one instance.
-/// So a batched interpreter can advance every instance of a wire in a single pass.
-///
-/// This table is specialized for the M4 accelerator setting, where the value vector splits with
-/// the inout values on the hidden side
-/// ([`InoutSegment::Hidden`](binius_core::constraint_system::InoutSegment::Hidden)):
-///
-/// 1. **Inout wires are committed.** Every instance chooses its own inout words, so they are not
-///    one set of shared values a verifier can evaluate. They are committed with the private values
-///    instead, at the front of the hidden segment. A circuit is free to declare them, and
-///    [`Self::populate`] takes their values from the same filler as the witness inputs.
-/// 2. **Constants are not stored.** The constants live once on the constraint system as a
-///    `Vec<Word>`, not replicated per instance. Only the hidden segment — the inout, witness and
-///    internal words — is stored here. Witness generation reads the constants from that separate
-///    bank.
-///
-/// So the stored data holds exactly the hidden segment of every instance: `n_hidden_words` rows by
-/// `2^log_instances` columns.
-///
-/// The committed inout words are not tied to any value the verifier knows, so the statement a
-/// proof over this table makes is that *some* inout values complete every instance.
-#[derive(Clone, Debug)]
-pub struct ValueTable {
-	/// The per-instance value layout, shared by every instance in the batch.
-	layout: ValueVecLayout,
-	/// The base-2 logarithm of the instance count.
-	log_instances: usize,
-	/// The number of hidden-word rows the proving protocol commits per instance.
-	///
-	/// This is the inout values followed by the private ones, which is
-	/// [`ConstraintSystem::n_hidden_words`](binius_core::ConstraintSystem::n_hidden_words) under
-	/// [`InoutSegment::Hidden`](binius_core::constraint_system::InoutSegment::Hidden).
-	n_hidden_words: usize,
-	/// The hidden words of every wire, in wire-major order.
-	///
-	/// Row `r` (for `r` in `0..n_hidden_words`) holds the `2^log_instances` values of hidden wire
-	/// `r` — inout value `r`, then private value `r - n_inout` — one per instance. The rows are
-	/// laid out contiguously, so the length is `n_hidden_words << log_instances`.
-	data: Vec<Word>,
+/// The verifier derives the same layout from the constraint system.
+/// So both sides agree on the committed size.
+pub fn commit_layout(table: &ValueTable) -> BatchCommitLayout {
+	BatchCommitLayout::new(table.n_hidden_words(), table.log_instances())
 }
 
-impl ValueTable {
-	/// Builds the batch witness in wire-major order, populating all `2^log_instances` instances.
-	///
-	/// The instances are independent. For each, `fill` sets the input wires; the batched
-	/// interpreter then derives every remaining wire, filling all instances of one wire at a time.
-	///
-	/// # Arguments
-	///
-	/// - `circuit`: the single-instance circuit.
-	/// - `log_instances`: base-2 logarithm of the instance count.
-	/// - `fill`: sets the input wires of instance `i`, for `i` in `0..2^log_instances`. It must
-	///   assign every witness input and every inout wire on each call.
-	///
-	/// # Errors
-	///
-	/// Returns an error naming the lowest-indexed instance whose inputs do not satisfy the circuit.
-	pub fn populate<F>(
-		circuit: &Circuit,
-		log_instances: usize,
-		fill: F,
-	) -> Result<Self, BatchPopulateError>
-	where
-		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
-	{
-		Self::populate_with(circuit, log_instances, None, fill)
-	}
-
-	/// Builds the batch witness in wire-major order, evaluating instance stripes in parallel.
-	///
-	/// This is the parallel counterpart to [`Self::populate`]. Input filling is still performed
-	/// once up front, then circuit evaluation runs over disjoint vertical instance stripes.
-	///
-	/// # Errors
-	///
-	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
-	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
-	pub fn populate_parallel<F>(
-		circuit: &Circuit,
-		log_instances: usize,
-		fill: F,
-	) -> Result<Self, BatchPopulateError>
-	where
-		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
-	{
-		Self::populate_parallel_with_stripe_width(
-			circuit,
-			log_instances,
-			DEFAULT_PARALLEL_STRIPE_WIDTH,
-			fill,
-		)
-	}
-
-	/// Builds the batch witness in parallel using a caller-provided stripe width.
-	///
-	/// This is exposed for benchmarking stripe widths. Production callers should use
-	/// [`Self::populate_parallel`].
-	///
-	/// # Errors
-	///
-	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
-	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
-	///
-	/// # Panics
-	///
-	/// Panics if `stripe_width == 0`.
-	pub fn populate_parallel_with_stripe_width<F>(
-		circuit: &Circuit,
-		log_instances: usize,
-		stripe_width: usize,
-		fill: F,
-	) -> Result<Self, BatchPopulateError>
-	where
-		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
-	{
-		assert!(stripe_width > 0, "stripe width must be positive");
-		Self::populate_with(circuit, log_instances, Some(stripe_width), fill)
-	}
-
-	fn populate_with<F>(
-		circuit: &Circuit,
-		log_instances: usize,
-		parallel_stripe_width: Option<usize>,
-		fill: F,
-	) -> Result<Self, BatchPopulateError>
-	where
-		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
-	{
-		let layout = circuit.value_vec_layout().clone();
-		let n_instances = 1usize << log_instances;
-
-		// The transient working buffer spans the full value vector — constants, inputs, internal
-		// values, and scratch — for every instance, in wire-major order.
-		let full_len = layout.combined_len() + layout.n_scratch;
-		let mut working = vec![Word::ZERO; full_len << log_instances];
-
-		{
-			let mut values =
-				StridedArray2DViewMut::without_stride(&mut working, full_len, n_instances)
-					.expect("full_len * n_instances == working.len() by construction");
-
-			// The caller assigns each instance's witness input wires into that instance's column.
-			for instance in 0..n_instances {
-				let mut filler = BatchWitnessFiller {
-					circuit,
-					values: &mut values,
-					instance,
-				};
-				fill(instance, &mut filler);
-			}
-
-			if let Some(stripe_width) = parallel_stripe_width {
-				// Broadcast the constants once, then evaluate disjoint instance stripes in
-				// parallel.
-				circuit.populate_wire_witness_batched_parallel(values, stripe_width)?;
-			} else {
-				// Broadcast the constants and evaluate every instance's remaining wires.
-				circuit.populate_wire_witness_batched(&mut values)?;
-			}
-		}
-
-		// Keep the hidden segment: rows `[offset_inout, combined_len)`, the inout values followed
-		// by the private ones. In the wire-major working buffer these rows are contiguous, so
-		// this is a single slice of the words. The constants and scratch are dropped.
-		let start = layout.offset_inout() << log_instances;
-		let end = layout.combined_len() << log_instances;
-		let data = working[start..end].to_vec();
-
-		Ok(Self {
-			n_hidden_words: layout.combined_len() - layout.offset_inout(),
-			layout,
-			log_instances,
-			data,
-		})
-	}
-
-	/// The base-2 logarithm of the number of instances.
-	pub const fn log_instances(&self) -> usize {
-		self.log_instances
-	}
-
-	/// The number of instances in the batch.
-	pub const fn n_instances(&self) -> usize {
-		1usize << self.log_instances
-	}
-
-	/// The per-instance value layout shared by every instance.
-	pub const fn layout(&self) -> &ValueVecLayout {
-		&self.layout
-	}
-
-	/// The number of hidden-word rows per instance, including the protocol's zero padding.
-	pub const fn n_hidden_words(&self) -> usize {
-		self.n_hidden_words
-	}
-
-	/// The whole batch as one flat, wire-major word buffer.
-	///
-	/// Row `r` (hidden wire `r`) occupies `data[r << log_instances .. (r + 1) << log_instances]`,
-	/// holding that wire's value in every instance.
-	pub fn as_words(&self) -> &[Word] {
-		&self.data
-	}
-
-	/// Reconstructs one instance as a standalone single-instance value vector.
-	///
-	/// Because the constants are not stored in the table, the caller supplies them (they live on
-	/// the constraint system). The result is bit-for-bit what populating this instance on its own
-	/// would produce, so it can be fed directly to single-instance constraint checking.
-	///
-	/// # Panics
-	///
-	/// Panics if the index is not below the instance count, or if `constants` does not match the
-	/// layout's constant count.
-	pub fn instance_value_vec(&self, instance: usize, constants: &[Word]) -> ValueVec {
-		assert!(instance < self.n_instances(), "instance index out of range");
-		assert_eq!(
-			constants.len(),
-			self.layout.n_const,
-			"constants length must match the layout's constant count"
-		);
-
-		// The constants are the whole public segment; the table stores everything after them.
-		let mut values = ValueVec::new(&self.layout);
-		for (i, &constant) in constants.iter().enumerate() {
-			values[ValueIndex::constant(i as u32)] = constant;
-		}
-
-		// Gather this instance's column of hidden values across every row, which the value vector
-		// holds from the first inout word onwards.
-		for row in 0..self.n_hidden_words {
-			*values.word_mut((self.layout.offset_inout() + row) as u32) =
-				self.data[(row << self.log_instances) + instance];
-		}
-
-		values
-	}
-
-	/// The committed-multilinear layout for this batch.
-	///
-	/// The verifier derives the same layout from the constraint system.
-	/// So both sides agree on the committed size.
-	pub fn commit_layout(&self) -> BatchCommitLayout {
-		BatchCommitLayout::new(self.n_hidden_words(), self.log_instances())
-	}
-
-	/// Packs the wire-major hidden buffer into the multilinear committed as the trace oracle.
-	///
-	/// Two little-endian words pack into one field element.
-	/// The element sequence is zero-padded up to the committed element count.
-	/// The instance index occupies the low coordinates, the hidden-word index the high coordinates.
-	/// Only the hidden segment is committed; the shared constants are not part of the oracle.
-	/// The packed buffer is drawn from `alloc`.
-	pub fn pack<P, A>(&self, alloc: &A) -> FieldVec<P, A>
-	where
-		P: PackedField<Scalar = B128>,
-		A: Allocator,
-	{
-		// The stored buffer is already the committed word sequence, wire-major.
-		// The base packer zero-pads it up to `2^log_witness_elems` elements.
-		let layout = self.commit_layout();
-		binius_prover::pack_witness::<P, A>(alloc, layout.log_witness_elems, self.as_words())
-			.expect("the hidden buffer fits in 2^log_witness_elems field elements by construction")
-	}
-}
-
-/// Assigns witness input wires of one instance into a [`ValueTable`] working buffer.
+/// Packs the wire-major hidden buffer into the multilinear committed as the trace oracle.
 ///
-/// Indexing by [`Wire`] targets that wire's row in the instance's column, mirroring the
-/// single-instance [`WitnessFiller`](binius_frontend::WitnessFiller).
-pub struct BatchWitnessFiller<'a, 'v> {
-	circuit: &'a Circuit,
-	values: &'a mut StridedArray2DViewMut<'v, Word>,
-	instance: usize,
-}
-
-impl Index<Wire> for BatchWitnessFiller<'_, '_> {
-	type Output = Word;
-
-	fn index(&self, wire: Wire) -> &Self::Output {
-		&self.values[(self.circuit.witness_row(wire), self.instance)]
-	}
-}
-
-impl IndexMut<Wire> for BatchWitnessFiller<'_, '_> {
-	fn index_mut(&mut self, wire: Wire) -> &mut Self::Output {
-		let row = self.circuit.witness_row(wire);
-		&mut self.values[(row, self.instance)]
-	}
+/// Two little-endian words pack into one field element.
+/// The element sequence is zero-padded up to the committed element count.
+/// The instance index occupies the low coordinates, the hidden-word index the high coordinates.
+/// Only the hidden segment is committed; the shared constants are not part of the oracle.
+/// The packed buffer is drawn from `alloc`.
+pub fn pack_table<P, A>(table: &ValueTable, alloc: &A) -> FieldVec<P, A>
+where
+	P: PackedField<Scalar = B128>,
+	A: Allocator,
+{
+	// The stored buffer is already the committed word sequence, wire-major.
+	// The base packer zero-pads it up to `2^log_witness_elems` elements.
+	let layout = commit_layout(table);
+	binius_prover::pack_witness::<P, A>(alloc, layout.log_witness_elems, table.as_words())
+		.expect("the hidden buffer fits in 2^log_witness_elems field elements by construction")
 }
 
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_core::constraint_system::InoutSegment;
+	use binius_core::{Word, constraint_system::InoutSegment};
 	use binius_field::PackedBinaryGhash1x128b;
-	use binius_frontend::{AssertionFailure, CircuitBuilder, Wire};
-	use proptest::prelude::*;
+	use binius_frontend::CircuitBuilder;
 	use rand::prelude::*;
 
 	use super::*;
 	use crate::test_utils::{
 		N_INPUT_WORDS, crc64_circuit, crc64_iso_reference, populate_crc64_witness,
 	};
-
-	/// The constant the mix circuit XORs its first input against.
-	const MIX_K: u64 = 0x0123_4567_89ab_cdef;
-
-	// A circuit deriving four words from two public inputs and a constant, each promoted to a
-	// public output. The promotions are what keep the derivations alive under dead-code
-	// elimination.
-	struct MixCircuit {
-		circuit: Circuit,
-		a: Wire,
-		b: Wire,
-	}
-
-	impl MixCircuit {
-		// Assigns one instance's inputs; the circuit derives its public outputs.
-		fn fill<F: IndexMut<Wire, Output = Word>>(&self, filler: &mut F, a: u64, b: u64) {
-			filler[self.a] = Word(a);
-			filler[self.b] = Word(b);
-		}
-	}
-
-	fn mix_circuit() -> MixCircuit {
-		let builder = CircuitBuilder::new();
-		let a = builder.add_inout();
-		let b = builder.add_inout();
-		let k = builder.add_constant_64(MIX_K);
-
-		let and = builder.band(a, b);
-		let xor = builder.bxor(a, k);
-		let (sum, _cout) = builder.iadd(a, b);
-		let rot = builder.rotr(b, 7);
-		let or = builder.bor(and, rot);
-
-		for wire in [and, xor, sum, or] {
-			builder.mark_inout(wire);
-		}
-
-		MixCircuit {
-			circuit: builder.build(),
-			a,
-			b,
-		}
-	}
-
-	// Populate one instance on its own through the ordinary single-instance flow.
-	fn reference_value_vec(c: &MixCircuit, a: u64, b: u64) -> ValueVec {
-		let mut filler = c.circuit.new_witness_filler();
-		c.fill(&mut filler, a, b);
-		c.circuit.populate_wire_witness(&mut filler).unwrap();
-		filler.into_value_vec()
-	}
-
-	#[test]
-	fn shape_matches_layout() {
-		let c = mix_circuit();
-		let log_instances = 3;
-		let table = ValueTable::populate(&c.circuit, log_instances, |i, w| {
-			c.fill(w, i as u64, i as u64 + 1);
-		})
-		.unwrap();
-
-		let layout = c.circuit.value_vec_layout();
-		assert_eq!(table.log_instances(), log_instances);
-		assert_eq!(table.n_instances(), 8);
-		let n_hidden_words = c
-			.circuit
-			.constraint_system()
-			.n_hidden_words(InoutSegment::Hidden);
-		assert_eq!(table.n_hidden_words(), n_hidden_words);
-		assert_eq!(table.as_words().len(), n_hidden_words * 8);
-		// The committed rows are the inout values the layout stores, then the private ones.
-		assert_eq!(n_hidden_words, layout.n_inout + layout.n_private());
-	}
-
-	#[test]
-	fn every_instance_satisfies_the_constraint_system() {
-		let c = mix_circuit();
-		let constants = &c.circuit.constraint_system().constants;
-
-		let table = ValueTable::populate(&c.circuit, 2, |i, w| {
-			c.fill(w, i as u64 * 0x9e37_79b9, i as u64 ^ 0xdead);
-		})
-		.unwrap();
-
-		for i in 0..table.n_instances() {
-			let vv = table.instance_value_vec(i, constants);
-			c.circuit
-				.constraint_system()
-				.verify(&vv)
-				.unwrap_or_else(|e| panic!("instance {i} failed verification: {e}"));
-		}
-	}
-
-	#[test]
-	fn single_instance_batch_matches_reference() {
-		let c = mix_circuit();
-		let constants = &c.circuit.constraint_system().constants;
-
-		let table = ValueTable::populate(&c.circuit, 0, |_, w| {
-			c.fill(w, 0xABCD, 0x0F0F);
-		})
-		.unwrap();
-
-		assert_eq!(table.n_instances(), 1);
-		let reference = reference_value_vec(&c, 0xABCD, 0x0F0F);
-		// The reconstructed instance equals the reference's committed witness, word for word.
-		let reconstructed = table.instance_value_vec(0, constants);
-		assert_eq!(reconstructed.combined_witness(), reference.combined_witness());
-	}
-
-	proptest! {
-		// Invariant: every batch instance equals the single-instance witness for the same inputs.
-		#[test]
-		fn batch_instances_match_single_instance_reference(
-			inputs in prop::collection::vec((any::<u64>(), any::<u64>()), 4),
-		) {
-			let c = mix_circuit();
-			let constants = c.circuit.constraint_system().constants.clone();
-
-			let table = ValueTable::populate(&c.circuit, 2, |i, w| {
-				let (a, b) = inputs[i];
-				c.fill(w, a, b);
-			})
-			.unwrap();
-
-			for (i, &(a, b)) in inputs.iter().enumerate() {
-				let reference = reference_value_vec(&c, a, b);
-				let reconstructed = table.instance_value_vec(i, &constants);
-				prop_assert_eq!(reconstructed.combined_witness(), reference.combined_witness());
-			}
-		}
-	}
-
-	#[test]
-	fn parallel_population_matches_serial_for_varied_stripe_widths() {
-		let c = mix_circuit();
-		let log_instances = 3;
-
-		let serial = ValueTable::populate(&c.circuit, log_instances, |i, w| {
-			c.fill(
-				w,
-				(i as u64).wrapping_mul(0x9e37_79b9),
-				(i as u64).rotate_left(17) ^ 0xdead_beef,
-			);
-		})
-		.unwrap();
-
-		let default_parallel = ValueTable::populate_parallel(&c.circuit, log_instances, |i, w| {
-			c.fill(
-				w,
-				(i as u64).wrapping_mul(0x9e37_79b9),
-				(i as u64).rotate_left(17) ^ 0xdead_beef,
-			);
-		})
-		.unwrap();
-		assert_eq!(default_parallel.as_words(), serial.as_words());
-
-		for stripe_width in [1, 2, 3, 8, 64] {
-			let parallel = ValueTable::populate_parallel_with_stripe_width(
-				&c.circuit,
-				log_instances,
-				stripe_width,
-				|i, w| {
-					c.fill(
-						w,
-						(i as u64).wrapping_mul(0x9e37_79b9),
-						(i as u64).rotate_left(17) ^ 0xdead_beef,
-					);
-				},
-			)
-			.unwrap();
-
-			assert_eq!(
-				parallel.as_words(),
-				serial.as_words(),
-				"stripe width {stripe_width} changed the populated table"
-			);
-		}
-	}
-
-	#[test]
-	fn unsatisfiable_instance_reports_its_index() {
-		// A circuit that asserts a == b; instances where they differ fail.
-		let builder = CircuitBuilder::new();
-		let a = builder.add_inout();
-		let b = builder.add_inout();
-		builder.assert_eq("a_eq_b", a, b);
-		let circuit = builder.build();
-
-		// Instance 2 violates a == b; the others satisfy it.
-		let result = ValueTable::populate(&circuit, 2, |i, w| {
-			w[a] = Word(i as u64);
-			w[b] = Word(if i == 2 { 99 } else { i as u64 });
-		});
-
-		let err = result.expect_err("instance 2 violates a == b");
-		assert_eq!(err.instance, 2);
-		assert_eq!(err.source.total, 1);
-		assert_eq!(
-			err.source.failures,
-			vec![AssertionFailure {
-				path: ".a_eq_b".to_string(),
-				detail: "Word(0x0000000000000002) != Word(0x0000000000000063)".to_string(),
-			}]
-		);
-	}
-
-	#[test]
-	fn parallel_unsatisfiable_instance_reports_global_index_across_stripes() {
-		// A circuit that asserts a == b; instances where they differ fail.
-		let builder = CircuitBuilder::new();
-		let a = builder.add_inout();
-		let b = builder.add_inout();
-		builder.assert_eq("a_eq_b", a, b);
-		let circuit = builder.build();
-
-		// Instance 5 is in the third two-column stripe. Reporting a local stripe index would
-		// incorrectly return 1 instead of the global instance index 5.
-		let result = ValueTable::populate_parallel_with_stripe_width(&circuit, 3, 2, |i, w| {
-			w[a] = Word(i as u64);
-			w[b] = Word(if i == 5 { 99 } else { i as u64 });
-		});
-
-		let err = result.expect_err("instance 5 violates a == b");
-		assert_eq!(err.instance, 5);
-		assert_eq!(err.source.total, 1);
-		assert_eq!(
-			err.source.failures,
-			vec![AssertionFailure {
-				path: ".a_eq_b".to_string(),
-				detail: "Word(0x0000000000000005) != Word(0x0000000000000063)".to_string(),
-			}]
-		);
-	}
-
-	#[test]
-	fn parallel_failure_diagnostics_report_global_instance_across_stripes() {
-		// A circuit that asserts a == b; instances where they differ fail.
-		let builder = CircuitBuilder::new();
-		let a = builder.add_inout();
-		let b = builder.add_inout();
-		builder.assert_eq("a_eq_b", a, b);
-		let circuit = builder.build();
-
-		// Instances 5 and 7 fail in different two-column stripes. The parallel path may report
-		// either stripe depending on scheduling, but it must report a global instance index and
-		// diagnostics for that instance rather than aggregating unrelated stripes.
-		let fill = |i: usize, w: &mut BatchWitnessFiller<'_, '_>| {
-			w[a] = Word(i as u64);
-			w[b] = Word(if i == 5 || i == 7 { 99 } else { i as u64 });
-		};
-		let parallel = ValueTable::populate_parallel_with_stripe_width(&circuit, 3, 2, fill)
-			.expect_err("instances fail");
-
-		assert!(parallel.instance == 5 || parallel.instance == 7);
-		assert_eq!(parallel.source.total, 1);
-		assert_eq!(
-			parallel.source.failures,
-			vec![AssertionFailure {
-				path: ".a_eq_b".to_string(),
-				detail: format!("Word(0x{0:016x}) != Word(0x0000000000000063)", parallel.instance),
-			}]
-		);
-	}
-
-	// Inout wires are committed, so they lead the stored rows: row `i` is inout value `i`, and the
-	// private values follow. Each instance carries its own inout words.
-	#[test]
-	fn inout_wires_lead_the_committed_rows() {
-		let builder = CircuitBuilder::new();
-		let a = builder.add_inout();
-		let b = builder.add_inout();
-		// A private wire, so the table carries private rows behind the inout ones.
-		let w = builder.add_witness();
-		let and = builder.band(a, b);
-		let mixed = builder.bxor(and, w);
-		builder.mark_inout(and);
-		builder.mark_inout(mixed);
-		let circuit = builder.build();
-
-		let log_instances = 2;
-		let table = ValueTable::populate(&circuit, log_instances, |i, f| {
-			f[a] = Word(i as u64);
-			f[b] = Word(i as u64 + 0x100);
-			f[w] = Word(i as u64 ^ 0xbeef);
-		})
-		.unwrap();
-
-		// The inout values lead the private ones, all of them committed.
-		let layout = circuit.value_vec_layout();
-		assert_eq!(layout.n_inout, 4);
-		assert!(layout.n_private() > 0, "the fixture must carry private rows too");
-		assert_eq!(table.n_hidden_words(), layout.n_inout + layout.n_private());
-
-		// The inout rows hold what the filler assigned, one column per instance.
-		let inout_row =
-			|row: usize| &table.as_words()[row << log_instances..(row + 1) << log_instances];
-		assert_eq!(inout_row(0), [Word(0), Word(1), Word(2), Word(3)]);
-		assert_eq!(inout_row(1), [Word(0x100), Word(0x101), Word(0x102), Word(0x103)]);
-
-		// And each instance reconstructs to a witness the constraint system accepts, inout
-		// values included.
-		let constants = &circuit.constraint_system().constants;
-		for i in 0..table.n_instances() {
-			let vv = table.instance_value_vec(i, constants);
-			assert_eq!(vv[circuit.witness_index(a)], Word(i as u64));
-			assert_eq!(vv[circuit.witness_index(b)], Word(i as u64 + 0x100));
-			circuit
-				.constraint_system()
-				.verify(&vv)
-				.unwrap_or_else(|e| panic!("instance {i} failed verification: {e}"));
-		}
-	}
 
 	// A large batch of independent random instances populates to the documented shape.
 	// Each instance reconstructs to a witness that satisfies the circuit.
@@ -693,17 +99,27 @@ mod tests {
 	#[test]
 	fn pack_lays_out_hidden_words_wire_major() {
 		type P = PackedBinaryGhash1x128b;
-		let c = mix_circuit();
+
+		// A circuit deriving a few words from two inout inputs, so the table carries several rows.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		let and = builder.band(a, b);
+		let (sum, _cout) = builder.iadd(a, b);
+		builder.mark_inout(and);
+		builder.mark_inout(sum);
+		let circuit = builder.build();
 
 		// Fixture state: 4 instances with distinct witness inputs.
-		let table = ValueTable::populate(&c.circuit, 2, |i, w| {
-			c.fill(w, (i as u64).wrapping_mul(0x9e37_79b9), i as u64 ^ 0xdead);
-		})
-		.unwrap();
+		let table = circuit
+			.populate_batch(2, |i, w| {
+				w[a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
+				w[b] = Word(i as u64 ^ 0xdead);
+			})
+			.unwrap();
 
-		let layout = table.commit_layout();
-		let packed: Vec<B128> = table
-			.pack::<P, _>(&GlobalAllocator)
+		let layout = commit_layout(&table);
+		let packed: Vec<B128> = pack_table::<P, _>(&table, &GlobalAllocator)
 			.iter_scalars()
 			.collect();
 

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -3,13 +3,11 @@
 //! The committed witness with its instance axis collapsed at a challenge point.
 
 use binius_compute::{Allocator, VecLike};
-use binius_core::word::Word;
+use binius_core::{ValueTable, word::Word};
 use binius_field::{BinaryField, PackedField};
 use binius_math::{FieldVec, inner_product::inner_product};
 use binius_prover::fold_word::WordFolder;
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-
-use crate::ValueTable;
 
 /// One 64-bit word with its bit axis expanded into full field elements.
 ///
@@ -238,13 +236,14 @@ mod tests {
 		let circuit = builder.build();
 
 		// Every instance gets its own seed, so no two instances share an input.
-		ValueTable::populate(&circuit, 3, |i, w| {
-			let mut rng = StdRng::seed_from_u64(i as u64);
-			for &wire in &inputs {
-				w[wire] = Word(rng.random());
-			}
-		})
-		.unwrap()
+		circuit
+			.populate_batch(3, |i, w| {
+				let mut rng = StdRng::seed_from_u64(i as u64);
+				for &wire in &inputs {
+					w[wire] = Word(rng.random());
+				}
+			})
+			.unwrap()
 	}
 
 	#[test]

--- a/crates/m4-prover/src/witness/mod.rs
+++ b/crates/m4-prover/src/witness/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 The Binius Developers
 
-//! The projections of a populated [`ValueTable`](crate::ValueTable) that the reductions consume.
+//! The projections of a populated [`ValueTable`](binius_core::ValueTable) that the reductions
+//! consume.
 //!
 //! The table stores raw words, wire-major; no reduction reads it in that form.
 //!

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -7,7 +7,7 @@ use std::{iter, mem::MaybeUninit, ptr};
 
 use binius_compute::{Allocator, VecLike};
 use binius_core::{
-	ValueSegment,
+	ValueSegment, ValueTable,
 	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex},
 	word::Word,
 };
@@ -16,8 +16,6 @@ use binius_math::{FieldBuffer, FieldVec};
 use binius_prover::fold_word::fold_words;
 use binius_utils::rayon::{prelude::*, task_size::IndexedParallelIteratorExt};
 use binius_verifier::config::B128;
-
-use crate::ValueTable;
 
 /// The operand columns of one batched fixed-arity operation.
 ///
@@ -719,14 +717,15 @@ mod tests {
 	// So a tuple like `(1, 3, 7)` means `x=1, y=3, w=7`, not `1 & 3 = 7`.
 	fn populate_table(c: &AndCircuit, inputs: &[(u64, u64, u64)]) -> ValueTable {
 		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable::populate(&c.circuit, log_instances, |i, filler| {
-			let (x, y, w) = inputs[i];
-			filler[c.x] = Word(x);
-			filler[c.y] = Word(y);
-			filler[c.w] = Word(w);
-			filler[c.z] = Word((x & y) ^ w);
-		})
-		.unwrap()
+		c.circuit
+			.populate_batch(log_instances, |i, filler| {
+				let (x, y, w) = inputs[i];
+				filler[c.x] = Word(x);
+				filler[c.y] = Word(y);
+				filler[c.w] = Word(w);
+				filler[c.z] = Word((x & y) ^ w);
+			})
+			.unwrap()
 	}
 
 	// The reference for one instance: the core operand evaluator on its reconstructed value vec.
@@ -825,12 +824,13 @@ mod tests {
 	// Populate one instance per input pair; the circuit derives the two product words.
 	fn populate_mul_table(c: &MulCircuit, inputs: &[(u64, u64)]) -> ValueTable {
 		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable::populate(&c.circuit, log_instances, |i, filler| {
-			let (x, y) = inputs[i];
-			filler[c.x] = Word(x);
-			filler[c.y] = Word(y);
-		})
-		.unwrap()
+		c.circuit
+			.populate_batch(log_instances, |i, filler| {
+				let (x, y) = inputs[i];
+				filler[c.x] = Word(x);
+				filler[c.y] = Word(y);
+			})
+			.unwrap()
 	}
 
 	// The four IntMul columns are laid out constraint-major, in the order [A, B, LO, HI].
@@ -915,14 +915,15 @@ mod tests {
 	// Populate one instance per input tuple; the circuit derives the two product words.
 	fn populate_binmul_table(c: &BinMulCircuit, inputs: &[(u64, u64, u64, u64)]) -> ValueTable {
 		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable::populate(&c.circuit, log_instances, |i, filler| {
-			let (a_lo, a_hi, b_lo, b_hi) = inputs[i];
-			filler[c.a_lo] = Word(a_lo);
-			filler[c.a_hi] = Word(a_hi);
-			filler[c.b_lo] = Word(b_lo);
-			filler[c.b_hi] = Word(b_hi);
-		})
-		.unwrap()
+		c.circuit
+			.populate_batch(log_instances, |i, filler| {
+				let (a_lo, a_hi, b_lo, b_hi) = inputs[i];
+				filler[c.a_lo] = Word(a_lo);
+				filler[c.a_hi] = Word(a_hi);
+				filler[c.b_lo] = Word(b_lo);
+				filler[c.b_hi] = Word(b_hi);
+			})
+			.unwrap()
 	}
 
 	// The six BinMul columns are laid out constraint-major, in operand order.

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -26,8 +26,8 @@ use std::array;
 
 use binius_circuits::{blake3::blake3_compress_2x, keccak::permutation::keccak_f1600};
 use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, CircuitStat, Wire};
-use binius_m4_prover::{BatchWitnessFiller, Prover, ValueTable};
+use binius_frontend::{BatchWitnessFiller, Circuit, CircuitBuilder, CircuitStat, Wire};
+use binius_m4_prover::Prover;
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
 use binius_transcript::ProverTranscript;
@@ -102,7 +102,7 @@ where
 
 	// Generate the single-instance witness in its own span.
 	let table = info_span!("witness_generation", primitive = name)
-		.in_scope(|| ValueTable::populate(circuit, log_instances, fill).unwrap());
+		.in_scope(|| circuit.populate_batch(log_instances, fill).unwrap());
 
 	// Clone and validate the shared single-instance constraint system.
 	let cs = circuit.constraint_system().clone();


### PR DESCRIPTION
Follow-up to #2109.

`ValueTable` and `WitnessM4` are witness data over a `ValueVec`, which is core's, but both lived in `binius-m4-prover`. This moves them down to sit beside the thing they are made of.

## The constraint that shapes it

`binius-core` depends on `binius-field` and `binius-utils` and nothing else. `ValueTable::populate` and `WitnessM4::generate` are defined over `binius_frontend::Circuit` and `CircuitM4`, and the frontend depends on core — so the entry points cannot come along. They invert instead: the types move down, and the constructors become methods on the frontend's own types, which is where a reader looks for them anyway.

```rust
- let table = ValueTable::populate(&circuit, log_instances, fill)?;
+ let table = circuit.populate_batch(log_instances, fill)?;

- let witness = WitnessM4::generate(&circuit, fill_main)?;
+ let witness = circuit.generate_witness(fill_main)?;
```

## Where each piece lands

**binius-core**
- `constraint_system::ValueTable` — storage, accessors and `instance_value_vec`, plus a new `from_hidden_words` constructor. That is the seam the frontend fills: it takes the wire-major hidden buffer, and derives the row count from the layout rather than taking it on trust.
- `m4::WitnessM4` — the fields and `verify`, next to the `ConstraintSystemM4` that checks a witness and the `ChipInstances` accessor it is served through. The private `TableInstances` adapter comes with it.

**binius-frontend**
- `Circuit::populate_batch`, `populate_batch_parallel` and `populate_batch_parallel_with_stripe_width`, with `BatchWitnessFiller` alongside them.
- `CircuitM4::generate_witness`, carrying `PopulateM4Error` with it — that error wraps the frontend's own `PopulateError` and `BatchPopulateError`, so it cannot live below them either.

**binius-m4-prover**
- `commit_layout(&ValueTable)` and `pack_table(&ValueTable, alloc)` stay, as free functions over a borrowed table. They reach `binius-prover`, `binius-m4-verifier` and `binius-compute`, none of which core can depend on, and neither has anything to do with building a table.

## Tests

They follow their subjects: the batch-population tests move to the frontend, as does the chip-accelerated CRC-64 integration test. The CRC-64 *population* test stays with the prover, because its fixture is that crate's `test_utils`, which `prove`, `shift` and `instance_fold` all still use — moving it would drag `test_utils` across for one test. Say the word if you would rather it moved.

Core's own `ValueTable` tests are new and hand-built, since core cannot construct a circuit to populate one: they cover the layout-derived row count, the length assertion on `from_hidden_words`, and reading an instance back as its own column.

## Note

The two new inherent-impl blocks carry `#[allow(clippy::multiple_inherent_impl)]`. That lint is `warn` in the workspace and CI runs clippy with `-D warnings`; `ops.rs` already takes the same exemption, for the same reason — keeping a coherent group of methods in its own module rather than growing the defining one.

## Verification

`cargo test --workspace` and `cargo clippy --all --tests --benches --examples -- -D warnings` are clean.

Three tests in `binius-examples`' `cli_artifacts` fail, but they fail identically on `main` at `fcdeb527` with the same panic (`iop-prover/src/basefold/channel.rs:404: repeat placement requires whole-packed lift blocks`). Pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)