### PR TITLE
perf(circuits): XOR the disjoint ORs in pubkey packing and Skein tweak

### DIFF
--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -122,14 +122,17 @@ pub fn compress_pubkey(builder: &CircuitBuilder, x: &BigUint, y: &BigUint) -> Ve
 	// We need to produce 9 words (33 bytes) for sha256_fixed
 	// Each word represents 4 bytes packed in big-endian format
 	let lower_32_bits = |limb| clear_high_bits(builder, limb, 32);
+	// Each packing merges a right-shift (bits below 24) with either the prefix byte (bits 24..32)
+	// or a left-shift-by-24 (bits 24 and up). The two operands occupy disjoint bit ranges, so the
+	// OR carries nothing and lowers to a free XOR instead of an AND.
 	vec![
-		builder.bor(builder.shr(x.limbs[3], 40), prefix_byte),
+		builder.bxor(builder.shr(x.limbs[3], 40), prefix_byte),
 		lower_32_bits(builder.shr(x.limbs[3], 8)),
-		lower_32_bits(builder.bor(builder.shl(x.limbs[3], 24), builder.shr(x.limbs[2], 40))),
+		lower_32_bits(builder.bxor(builder.shl(x.limbs[3], 24), builder.shr(x.limbs[2], 40))),
 		lower_32_bits(builder.shr(x.limbs[2], 8)),
-		lower_32_bits(builder.bor(builder.shl(x.limbs[2], 24), builder.shr(x.limbs[1], 40))),
+		lower_32_bits(builder.bxor(builder.shl(x.limbs[2], 24), builder.shr(x.limbs[1], 40))),
 		lower_32_bits(builder.shr(x.limbs[1], 8)),
-		lower_32_bits(builder.bor(builder.shl(x.limbs[1], 24), builder.shr(x.limbs[0], 40))),
+		lower_32_bits(builder.bxor(builder.shl(x.limbs[1], 24), builder.shr(x.limbs[0], 40))),
 		lower_32_bits(builder.shr(x.limbs[0], 8)),
 		lower_32_bits(builder.shl(x.limbs[0], 24)),
 	]

--- a/crates/circuits/src/skein512/mod.rs
+++ b/crates/circuits/src/skein512/mod.rs
@@ -366,14 +366,20 @@ fn tweak(
 	pos_bytes_hi = circuit.band(pos_bytes_hi, low_bytes_mask);
 
 	let t_low = pos_bytes_lo;
-	let mut t_high = circuit.bor(pos_bytes_hi, circuit.add_constant_64(cfg << 56));
+	// The high word is assembled from bit ranges that do not overlap, so each OR carries nothing
+	// and lowers to a free XOR instead of an AND:
+	//   - `pos_bytes_hi` is masked to bits 0..32, and the type field `cfg << 56` sits in bits
+	//     56..62 (the tweak type field is bits 120..125, i.e. cfg < 64), so the two never share a
+	//     bit;
+	//   - the first and final flags own bits 62 and 63, which the type field leaves clear.
+	let mut t_high = circuit.bxor(pos_bytes_hi, circuit.add_constant_64(cfg << 56));
 
 	if is_first {
-		t_high = circuit.bor(t_high, circuit.add_constant_64(1 << 62));
+		t_high = circuit.bxor(t_high, circuit.add_constant_64(1 << 62));
 	}
 
 	if is_final {
-		t_high = circuit.bor(t_high, circuit.add_constant_64(1 << 63));
+		t_high = circuit.bxor(t_high, circuit.add_constant_64(1 << 63));
 	}
 
 	(t_low, t_high)

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 176,783
 
 Constraints
-├─ ZERO constraints: 16,582 used (50.6% of 2^15)
-│  [▓▓▓▓▓░░░░░] spare: 16,186
-├─ AND constraints: 84,233 used (64.3% of 2^17)
-│  [▓▓▓▓▓▓░░░░] spare: 46,839
+├─ ZERO constraints: 16,585 used (50.6% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 16,183
+├─ AND constraints: 84,229 used (64.3% of 2^17)
+│  [▓▓▓▓▓▓░░░░] spare: 46,843
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 3,718
-└─ Distinct value indices: 275,067
+└─ Distinct value indices: 275,066
    ├─ Distinct shifted value indices: 139,192
-   └─ Distinct unshifted value indices: 135,875
+   └─ Distinct unshifted value indices: 135,874
 
 Value Vector
 ├─ Public Section: 134 (not committed)
 │  ├─ Constants: 134
 │  └─ Inout: 0
-├─ Private Section: 135,752
+├─ Private Section: 135,751
 │  ├─ Witness: 9
-│  └─ Internal: 135,743
-├─ Committed Trace: 135,752 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,392
-└─ Scratch (uncommitted): 108,460 (peak live: 109)
+│  └─ Internal: 135,742
+├─ Committed Trace: 135,751 used (51.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,393
+└─ Scratch (uncommitted): 108,461 (peak live: 109)
 


### PR DESCRIPTION
## What

Two circuits build a word by OR-ing operands that sit in disjoint bit ranges, so the OR carries nothing and can lower to a free XOR instead of an AND. This extends the rewrite merged in #1839 (secp256k1 add and MSM packing) into the two remaining circuits that share the pattern.

## Root cause

- `compress_pubkey` (`bitcoin/p2pkh`) packs each 4-byte big-endian word by ORing a right-shift (bits below 24) with either the prefix byte (bits 24..32) or a left-shift-by-24 (bits 24 and up).
- The Skein tweak high word ORs a position masked to bits 0..32 with the type field at bits 56..62 (the type field is 6 bits, so cfg < 64), then ORs the first and final flags into bits 62 and 63, which the type field leaves clear.

Each OR operand lands in a bit range the other never touches:

```text
p2pkh word:   [ prefix / shl(_,24)  @ 24..64 ][ shr(_,40) @ 0..24 ]        split at bit 24
skein tweak:  [ final 63 ][ first 62 ][ cfg<<56 @ 56..62 ] .... [ pos @ 0..32 ]   disjoint
```

## Fix

Replace the seven disjoint `bor` calls with `bxor`. The operands are provably non-overlapping, so the packed word is bit-identical while the AND constraint turns into a linear one.

## Numbers

| example | AND before | AND after | committed trace |
|---|---|---|---|
| bitcoin_p2pkh | 84,233 | 84,229 (-4) | 135,752 -> 135,751 |

The four p2pkh ORs are measured above; the three Skein tweak ORs (type field plus the first and final flags) drop one AND each in the Skein circuit.

repro:
```
cargo run --release --example bitcoin_p2pkh -- stat
```

## Correctness

`p2pkh` and `skein512` circuit tests pass unchanged (bit-identical output against the reference vectors, including `test_tweak_correctness` over all three tweak types), and the `bitcoin_p2pkh` snapshot is re-blessed. `clippy --all-targets -- -D warnings` and `fmt --check` are clean.

## Scope

Only the ORs whose operands are disjoint by construction. The float64 infinity packing OR depends on a runtime range and is left as an OR.