### PR TITLE
Move the padded-leaf claim reduction to the prover

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -4,7 +4,10 @@ use std::iter;
 
 use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
-use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim, sumcheck::RoundCoeffs};
+use binius_ip::{
+	fracaddcheck::FracAddEvalClaim, mlecheck, prodcheck::MultilinearEvalClaim,
+	sumcheck::RoundCoeffs,
+};
 use binius_math::{
 	FieldBuffer, FieldVec,
 	batch_invert::BatchInversion,
@@ -698,7 +701,7 @@ where
 /// shared reduced `eval_point`.
 ///
 /// Those leaf claims are on the *padded* witnesses.
-/// [`binius_ip::fracaddcheck::unpad_leaf_claim`] reduces one to the claims on the tree's own
+/// [`unpad_leaf_claim`] reduces one to the claims on the tree's own
 /// witness, given how much depth that tree was padded by.
 pub fn batch_prove_unequal_depths<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
@@ -842,6 +845,61 @@ where
 		.collect();
 
 	(next_provers, layer_provers)
+}
+
+/// Reduces a leaf claim on a zero-fraction-padded witness to the claim on the witness itself.
+///
+/// A batched fractional-addition check over trees of unequal depths lifts each shallow tree to the
+/// batch's depth by filling `n_pad_vars` extra leaf positions with the zero fraction $0/1$, which
+/// leaves its fractional sum unchanged. [`binius_ip::fracaddcheck::verify`] is oblivious to that,
+/// so the claims it outputs for such a tree are claims on the padded witness
+///
+/// $$
+/// N'(X_\text{pad}, X_\text{real}) = N(X_\text{real}) \cdot \text{eq}(0^\nu; X_\text{pad}),
+/// \qquad
+/// D'(X_\text{pad}, X_\text{real}) = 1 + \bigl( D(X_\text{real}) - 1 \bigr) \cdot
+/// \text{eq}(0^\nu; X_\text{pad}),
+/// $$
+///
+/// whose padding variables are the lowest ones. This divides out their equality weight and drops
+/// them from the point, leaving the claims on $N$ and $D$.
+///
+/// # Arguments
+///
+/// * `fraction` - The claimed numerator and denominator evaluations of the padded witness.
+/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
+///   stripped.
+/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
+///   own.
+///
+/// # Preconditions
+/// * `point.len() >= n_pad_vars`
+///
+/// # Panics
+///
+/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
+/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
+/// probability at most $\nu / |K|$.
+pub fn unpad_leaf_claim<F: Field>(
+	fraction: (F, F),
+	point: &[F],
+	n_pad_vars: usize,
+) -> FracAddEvalClaim<F> {
+	assert!(point.len() >= n_pad_vars); // precondition
+
+	let pad_eq = point[..n_pad_vars]
+		.iter()
+		.map(|&coord| eq_one_var(F::ZERO, coord))
+		.product::<F>();
+	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
+	let pad_eq_inv = pad_eq.invert_or_zero();
+
+	let (num_eval, den_eval) = fraction;
+	FracAddEvalClaim {
+		num_eval: num_eval * pad_eq_inv,
+		den_eval: F::ONE + (den_eval - F::ONE) * pad_eq_inv,
+		point: point[n_pad_vars..].to_vec(),
+	}
 }
 
 #[cfg(test)]
@@ -1326,8 +1384,7 @@ mod tests {
 		// Each tree's reduced claims are on its *padded* witness; unpadding them yields claims on
 		// the witness itself, at a suffix of the shared node point.
 		for (i, (&depth, (num, den))) in iter::zip(depths, &witnesses).enumerate() {
-			let leaf =
-				fracaddcheck::unpad_leaf_claim(fractions[i], &eval_point[k..], n_layers - depth);
+			let leaf = unpad_leaf_claim(fractions[i], &eval_point[k..], n_layers - depth);
 			assert_eq!(leaf.point.len(), depth);
 			assert_eq!(leaf.num_eval, evaluate(num, &leaf.point), "tree {i} numerator");
 			assert_eq!(leaf.den_eval, evaluate(den, &leaf.point), "tree {i} denominator");

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -8,7 +8,6 @@ use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, PackedField};
 use binius_ip::{
 	MultilinearEvalClaim,
-	fracaddcheck::unpad_leaf_claim,
 	logup_star::{LogupOutput, LogupTableOutput},
 };
 use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univariate};
@@ -21,7 +20,7 @@ use super::{
 };
 use crate::{
 	channel::IPProverChannel,
-	fracaddcheck::{self, FracAddCheckProver},
+	fracaddcheck::{self, FracAddCheckProver, unpad_leaf_claim},
 };
 
 /// One looker's column and claim: `(I^* T)(eval_point) = eval_claim` against the table it reads.

--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -6,7 +6,9 @@ use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
-	FieldBuffer, FieldVec, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
+	FieldBuffer, FieldVec,
+	line::extrapolate_line_packed,
+	multilinear::eq::{eq_ind_partial_eval, eq_one_var},
 };
 use binius_utils::rayon::{
 	prelude::*,
@@ -485,7 +487,7 @@ pub struct BatchProveUnequalDepthsOutput<F, Prover> {
 /// provers and the selector rounds that follow finishes the check.
 ///
 /// The returned claims and, after the final layer, the per-tree leaf evaluations are claims on the
-/// *padded* witnesses. [`binius_ip::prodcheck::unpad_leaf_claim`] reduces one to the claim on the
+/// *padded* witnesses. [`unpad_leaf_claim`] reduces one to the claim on the
 /// tree's own witness.
 pub fn batch_prove_unequal_depths<'a, A, F, P, Channel>(
 	mut provers: Vec<ProdcheckProver<'a, A, P>>,
@@ -573,6 +575,56 @@ fn layer_provers<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 			one_pad_mle::new(alloc, layer, pad_len.min(node_len), node_point.to_vec(), claim)
 		})
 		.collect()
+}
+
+/// Reduces a leaf claim on a one-padded witness to the claim on the witness itself.
+///
+/// A batched product check over trees of unequal depths lifts each shallow tree to the batch's
+/// depth by filling `n_pad_vars` extra leaf positions with ones, which leaves its product
+/// unchanged. [`binius_ip::prodcheck::verify`] is oblivious to that, so the claim it outputs for
+/// such a tree is a claim on the padded witness
+///
+/// $$
+/// M'(X_\text{pad}, X_\text{real}) = 1 + \bigl( M(X_\text{real}) - 1 \bigr) \cdot
+/// \text{eq}(0^\nu; X_\text{pad}),
+/// $$
+///
+/// whose padding variables are the lowest ones. This divides out their equality weight and drops
+/// them from the point, leaving the claim on $M$.
+///
+/// # Arguments
+///
+/// * `eval` - The claimed evaluation of the padded witness.
+/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
+///   stripped.
+/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
+///   own.
+///
+/// # Preconditions
+/// * `point.len() >= n_pad_vars`
+///
+/// # Panics
+///
+/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
+/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
+/// probability at most $\nu / |K|$.
+pub fn unpad_leaf_claim<F: Field>(
+	eval: F,
+	point: &[F],
+	n_pad_vars: usize,
+) -> MultilinearEvalClaim<F> {
+	assert!(point.len() >= n_pad_vars); // precondition
+
+	let pad_eq = point[..n_pad_vars]
+		.iter()
+		.map(|&coord| eq_one_var(F::ZERO, coord))
+		.product::<F>();
+	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
+
+	MultilinearEvalClaim {
+		eval: F::ONE + (eval - F::ONE) * pad_eq.invert_or_zero(),
+		point: point[n_pad_vars..].to_vec(),
+	}
 }
 
 #[cfg(test)]
@@ -973,7 +1025,7 @@ mod tests {
 		// Each tree's reduced claim is on its *padded* witness; unpadding it yields a claim on the
 		// witness itself, at a suffix of the shared node point.
 		for (i, (&depth, witness)) in iter::zip(depths, &witnesses).enumerate() {
-			let leaf = prodcheck::unpad_leaf_claim(evals[i], &eval_point[k..], n_layers - depth);
+			let leaf = unpad_leaf_claim(evals[i], &eval_point[k..], n_layers - depth);
 			assert_eq!(leaf.point.len(), depth);
 			assert_eq!(leaf.eval, evaluate(witness, &leaf.point), "tree {i}");
 		}

--- a/crates/ip/src/fracaddcheck.rs
+++ b/crates/ip/src/fracaddcheck.rs
@@ -6,7 +6,7 @@
 //! (a0 / b0) + (a1 / b1) = (a0 * b1 + a1 * b0) / (b0 * b1).
 
 use binius_field::{Field, field::FieldOps};
-use binius_math::{line::extrapolate_line, multilinear::eq::eq_one_var};
+use binius_math::line::extrapolate_line;
 use binius_transcript::Error as TranscriptError;
 
 use crate::{
@@ -83,12 +83,13 @@ where
 	)
 }
 
-/// Pads a leaf fraction — the forward map that [`unpad_leaf_claim`] inverts.
+/// Pads a leaf fraction — the forward map that the prover's `unpad_leaf_claim` inverts.
 ///
 /// Padding a tree scales its numerator by the padding coordinates' equality weight $q$ and sends
 /// its denominator through the one-padding selector $\textsf{sel}(q, v) = 1 + (v - 1) q$. A
 /// verifier that rebuilds a padded batch's leaf claim from transparent parts applies this to each
-/// tree, so the two directions live together.
+/// tree. The inverse direction is the prover's: only it holds claims on padded witnesses to
+/// reduce, so `unpad_leaf_claim` lives in `binius-ip-prover`.
 ///
 /// The weight is a parameter rather than the padding coordinates, so a caller padding several
 /// trees computes each distinct one once.
@@ -103,61 +104,6 @@ where
 pub fn pad_leaf_fraction<E: FieldOps>(fraction: (E, E), pad_eq: E) -> (E, E) {
 	let (num, den) = fraction;
 	(num * pad_eq.clone(), E::one() + (den - E::one()) * pad_eq)
-}
-
-/// Reduces a leaf claim on a zero-fraction-padded witness to the claim on the witness itself.
-///
-/// A batched fractional-addition check over trees of unequal depths lifts each shallow tree to the
-/// batch's depth by filling `n_pad_vars` extra leaf positions with the zero fraction $0/1$, which
-/// leaves its fractional sum unchanged. [`verify`] is oblivious to that, so the claims it outputs
-/// for such a tree are claims on the padded witness
-///
-/// $$
-/// N'(X_\text{pad}, X_\text{real}) = N(X_\text{real}) \cdot \text{eq}(0^\nu; X_\text{pad}),
-/// \qquad
-/// D'(X_\text{pad}, X_\text{real}) = 1 + \bigl( D(X_\text{real}) - 1 \bigr) \cdot
-/// \text{eq}(0^\nu; X_\text{pad}),
-/// $$
-///
-/// whose padding variables are the lowest ones. This divides out their equality weight and drops
-/// them from the point, leaving the claims on $N$ and $D$.
-///
-/// # Arguments
-///
-/// * `fraction` - The claimed numerator and denominator evaluations of the padded witness.
-/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
-///   stripped.
-/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
-///   own.
-///
-/// # Preconditions
-/// * `point.len() >= n_pad_vars`
-///
-/// # Panics
-///
-/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
-/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
-/// probability at most $\nu / |K|$.
-pub fn unpad_leaf_claim<F: Field>(
-	fraction: (F, F),
-	point: &[F],
-	n_pad_vars: usize,
-) -> FracAddEvalClaim<F> {
-	assert!(point.len() >= n_pad_vars); // precondition
-
-	let pad_eq = point[..n_pad_vars]
-		.iter()
-		.map(|&coord| eq_one_var(F::ZERO, coord))
-		.product::<F>();
-	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
-	let pad_eq_inv = pad_eq.invert_or_zero();
-
-	let (num_eval, den_eval) = fraction;
-	FracAddEvalClaim {
-		num_eval: num_eval * pad_eq_inv,
-		den_eval: F::ONE + (den_eval - F::ONE) * pad_eq_inv,
-		point: point[n_pad_vars..].to_vec(),
-	}
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/ip/src/prodcheck.rs
+++ b/crates/ip/src/prodcheck.rs
@@ -17,7 +17,7 @@
 //! ; X) \text{eq}(z ; Z) p_{i+1}(z, 0, x) p_{i+1}(z, 1, x) $$
 
 use binius_field::Field;
-use binius_math::{line::extrapolate_line, multilinear::eq::eq_one_var};
+use binius_math::line::extrapolate_line;
 use binius_transcript::Error as TranscriptError;
 
 // Re-export MultilinearEvalClaim from crate root for backward compatibility
@@ -69,56 +69,6 @@ where
 		},
 		channel,
 	)
-}
-
-/// Reduces a leaf claim on a one-padded witness to the claim on the witness itself.
-///
-/// A batched product check over trees of unequal depths lifts each shallow tree to the batch's
-/// depth by filling `n_pad_vars` extra leaf positions with ones, which leaves its product
-/// unchanged. [`verify`] is oblivious to that, so the claim it outputs for such a tree is a claim
-/// on the padded witness
-///
-/// $$
-/// M'(X_\text{pad}, X_\text{real}) = 1 + \bigl( M(X_\text{real}) - 1 \bigr) \cdot
-/// \text{eq}(0^\nu; X_\text{pad}),
-/// $$
-///
-/// whose padding variables are the lowest ones. This divides out their equality weight and drops
-/// them from the point, leaving the claim on $M$.
-///
-/// # Arguments
-///
-/// * `eval` - The claimed evaluation of the padded witness.
-/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
-///   stripped.
-/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
-///   own.
-///
-/// # Preconditions
-/// * `point.len() >= n_pad_vars`
-///
-/// # Panics
-///
-/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
-/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
-/// probability at most $\nu / |K|$.
-pub fn unpad_leaf_claim<F: Field>(
-	eval: F,
-	point: &[F],
-	n_pad_vars: usize,
-) -> MultilinearEvalClaim<F> {
-	assert!(point.len() >= n_pad_vars); // precondition
-
-	let pad_eq = point[..n_pad_vars]
-		.iter()
-		.map(|&coord| eq_one_var(F::ZERO, coord))
-		.product::<F>();
-	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
-
-	MultilinearEvalClaim {
-		eval: F::ONE + (eval - F::ONE) * pad_eq.invert_or_zero(),
-		point: point[n_pad_vars..].to_vec(),
-	}
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
First of two for [BINIUS-468](https://linear.app/jimpo/issue/BINIUS-468/all-field-inversions-in-the-verifier-should-use-invertorzeroinvert), per your direction on the issue.

`unpad_leaf_claim` turns a claim on a padded witness back into a claim on the witness itself. Only the prover ever holds such a claim: both copies — the product check's and the fractional-addition check's — are called exclusively from `binius-ip-prover`, and neither is reachable from any verifier.

```
crates/ip-prover/src/prodcheck/mod.rs:976        prodcheck::unpad_leaf_claim(...)
crates/ip-prover/src/fracaddcheck/mod.rs:1330    fracaddcheck::unpad_leaf_claim(...)
crates/ip-prover/src/logup_star/prove.rs:297,318 unpad_leaf_claim(...)
```

So they move to the crate that uses them, next to their callers.

`pad_leaf_fraction` stays in `binius-ip`: a verifier rebuilding a padded batch's leaf claim from transparent parts does apply the forward map, and `logup_star/verify.rs` calls it. Its doc used to say the two directions live together; it now says where the inverse went and why.

### Why this is the first half of that issue

The issue asked for the verifier's `invert_or_zero` calls to become `InvertOrZero::invert`. Scope-checking turned up only two such calls, and both were inside these functions — so rather than relax a contract in the verifier, the functions leave it. After this, `binius-ip`, `binius-iop`, `binius-verifier`, `binius-m4-verifier` and `binius-spartan-verifier` contain no field inversion at all.

Each call divides by a padding weight that the line above asserts is non-zero, so the move carries no behavioural change; the assertions come along unchanged.

The second PR will make `CircuitElem::invert_or_zero` unreachable and implement `invert` on it.

### Testing

`binius-ip` and `binius-ip-prover` test suites (13 and 95), plus builds of the dependent verifier, prover, recursion and spartan-verifier crates. Clippy and rustdoc clean over the two crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)