### PR TITLE
Constrain a circuit inverse without the zero case

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -4,7 +4,10 @@ use std::iter;
 
 use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
-use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim, sumcheck::RoundCoeffs};
+use binius_ip::{
+	fracaddcheck::FracAddEvalClaim, mlecheck, prodcheck::MultilinearEvalClaim,
+	sumcheck::RoundCoeffs,
+};
 use binius_math::{
 	FieldBuffer, FieldVec,
 	batch_invert::BatchInversion,
@@ -698,7 +701,7 @@ where
 /// shared reduced `eval_point`.
 ///
 /// Those leaf claims are on the *padded* witnesses.
-/// [`binius_ip::fracaddcheck::unpad_leaf_claim`] reduces one to the claims on the tree's own
+/// [`unpad_leaf_claim`] reduces one to the claims on the tree's own
 /// witness, given how much depth that tree was padded by.
 pub fn batch_prove_unequal_depths<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
@@ -842,6 +845,61 @@ where
 		.collect();
 
 	(next_provers, layer_provers)
+}
+
+/// Reduces a leaf claim on a zero-fraction-padded witness to the claim on the witness itself.
+///
+/// A batched fractional-addition check over trees of unequal depths lifts each shallow tree to the
+/// batch's depth by filling `n_pad_vars` extra leaf positions with the zero fraction $0/1$, which
+/// leaves its fractional sum unchanged. [`binius_ip::fracaddcheck::verify`] is oblivious to that,
+/// so the claims it outputs for such a tree are claims on the padded witness
+///
+/// $$
+/// N'(X_\text{pad}, X_\text{real}) = N(X_\text{real}) \cdot \text{eq}(0^\nu; X_\text{pad}),
+/// \qquad
+/// D'(X_\text{pad}, X_\text{real}) = 1 + \bigl( D(X_\text{real}) - 1 \bigr) \cdot
+/// \text{eq}(0^\nu; X_\text{pad}),
+/// $$
+///
+/// whose padding variables are the lowest ones. This divides out their equality weight and drops
+/// them from the point, leaving the claims on $N$ and $D$.
+///
+/// # Arguments
+///
+/// * `fraction` - The claimed numerator and denominator evaluations of the padded witness.
+/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
+///   stripped.
+/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
+///   own.
+///
+/// # Preconditions
+/// * `point.len() >= n_pad_vars`
+///
+/// # Panics
+///
+/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
+/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
+/// probability at most $\nu / |K|$.
+pub fn unpad_leaf_claim<F: Field>(
+	fraction: (F, F),
+	point: &[F],
+	n_pad_vars: usize,
+) -> FracAddEvalClaim<F> {
+	assert!(point.len() >= n_pad_vars); // precondition
+
+	let pad_eq = point[..n_pad_vars]
+		.iter()
+		.map(|&coord| eq_one_var(F::ZERO, coord))
+		.product::<F>();
+	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
+	let pad_eq_inv = pad_eq.invert_or_zero();
+
+	let (num_eval, den_eval) = fraction;
+	FracAddEvalClaim {
+		num_eval: num_eval * pad_eq_inv,
+		den_eval: F::ONE + (den_eval - F::ONE) * pad_eq_inv,
+		point: point[n_pad_vars..].to_vec(),
+	}
 }
 
 #[cfg(test)]
@@ -1326,8 +1384,7 @@ mod tests {
 		// Each tree's reduced claims are on its *padded* witness; unpadding them yields claims on
 		// the witness itself, at a suffix of the shared node point.
 		for (i, (&depth, (num, den))) in iter::zip(depths, &witnesses).enumerate() {
-			let leaf =
-				fracaddcheck::unpad_leaf_claim(fractions[i], &eval_point[k..], n_layers - depth);
+			let leaf = unpad_leaf_claim(fractions[i], &eval_point[k..], n_layers - depth);
 			assert_eq!(leaf.point.len(), depth);
 			assert_eq!(leaf.num_eval, evaluate(num, &leaf.point), "tree {i} numerator");
 			assert_eq!(leaf.den_eval, evaluate(den, &leaf.point), "tree {i} denominator");

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -8,7 +8,6 @@ use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, PackedField};
 use binius_ip::{
 	MultilinearEvalClaim,
-	fracaddcheck::unpad_leaf_claim,
 	logup_star::{LogupOutput, LogupTableOutput},
 };
 use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univariate};
@@ -21,7 +20,7 @@ use super::{
 };
 use crate::{
 	channel::IPProverChannel,
-	fracaddcheck::{self, FracAddCheckProver},
+	fracaddcheck::{self, FracAddCheckProver, unpad_leaf_claim},
 };
 
 /// One looker's column and claim: `(I^* T)(eval_point) = eval_claim` against the table it reads.

--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -6,7 +6,9 @@ use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
-	FieldBuffer, FieldVec, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
+	FieldBuffer, FieldVec,
+	line::extrapolate_line_packed,
+	multilinear::eq::{eq_ind_partial_eval, eq_one_var},
 };
 use binius_utils::rayon::{
 	prelude::*,
@@ -485,7 +487,7 @@ pub struct BatchProveUnequalDepthsOutput<F, Prover> {
 /// provers and the selector rounds that follow finishes the check.
 ///
 /// The returned claims and, after the final layer, the per-tree leaf evaluations are claims on the
-/// *padded* witnesses. [`binius_ip::prodcheck::unpad_leaf_claim`] reduces one to the claim on the
+/// *padded* witnesses. [`unpad_leaf_claim`] reduces one to the claim on the
 /// tree's own witness.
 pub fn batch_prove_unequal_depths<'a, A, F, P, Channel>(
 	mut provers: Vec<ProdcheckProver<'a, A, P>>,
@@ -573,6 +575,56 @@ fn layer_provers<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 			one_pad_mle::new(alloc, layer, pad_len.min(node_len), node_point.to_vec(), claim)
 		})
 		.collect()
+}
+
+/// Reduces a leaf claim on a one-padded witness to the claim on the witness itself.
+///
+/// A batched product check over trees of unequal depths lifts each shallow tree to the batch's
+/// depth by filling `n_pad_vars` extra leaf positions with ones, which leaves its product
+/// unchanged. [`binius_ip::prodcheck::verify`] is oblivious to that, so the claim it outputs for
+/// such a tree is a claim on the padded witness
+///
+/// $$
+/// M'(X_\text{pad}, X_\text{real}) = 1 + \bigl( M(X_\text{real}) - 1 \bigr) \cdot
+/// \text{eq}(0^\nu; X_\text{pad}),
+/// $$
+///
+/// whose padding variables are the lowest ones. This divides out their equality weight and drops
+/// them from the point, leaving the claim on $M$.
+///
+/// # Arguments
+///
+/// * `eval` - The claimed evaluation of the padded witness.
+/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
+///   stripped.
+/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
+///   own.
+///
+/// # Preconditions
+/// * `point.len() >= n_pad_vars`
+///
+/// # Panics
+///
+/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
+/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
+/// probability at most $\nu / |K|$.
+pub fn unpad_leaf_claim<F: Field>(
+	eval: F,
+	point: &[F],
+	n_pad_vars: usize,
+) -> MultilinearEvalClaim<F> {
+	assert!(point.len() >= n_pad_vars); // precondition
+
+	let pad_eq = point[..n_pad_vars]
+		.iter()
+		.map(|&coord| eq_one_var(F::ZERO, coord))
+		.product::<F>();
+	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
+
+	MultilinearEvalClaim {
+		eval: F::ONE + (eval - F::ONE) * pad_eq.invert_or_zero(),
+		point: point[n_pad_vars..].to_vec(),
+	}
 }
 
 #[cfg(test)]
@@ -973,7 +1025,7 @@ mod tests {
 		// Each tree's reduced claim is on its *padded* witness; unpadding it yields a claim on the
 		// witness itself, at a suffix of the shared node point.
 		for (i, (&depth, witness)) in iter::zip(depths, &witnesses).enumerate() {
-			let leaf = prodcheck::unpad_leaf_claim(evals[i], &eval_point[k..], n_layers - depth);
+			let leaf = unpad_leaf_claim(evals[i], &eval_point[k..], n_layers - depth);
 			assert_eq!(leaf.point.len(), depth);
 			assert_eq!(leaf.eval, evaluate(witness, &leaf.point), "tree {i}");
 		}

--- a/crates/ip/src/fracaddcheck.rs
+++ b/crates/ip/src/fracaddcheck.rs
@@ -6,7 +6,7 @@
 //! (a0 / b0) + (a1 / b1) = (a0 * b1 + a1 * b0) / (b0 * b1).
 
 use binius_field::{Field, field::FieldOps};
-use binius_math::{line::extrapolate_line, multilinear::eq::eq_one_var};
+use binius_math::line::extrapolate_line;
 use binius_transcript::Error as TranscriptError;
 
 use crate::{
@@ -83,12 +83,13 @@ where
 	)
 }
 
-/// Pads a leaf fraction — the forward map that [`unpad_leaf_claim`] inverts.
+/// Pads a leaf fraction — the forward map that the prover's `unpad_leaf_claim` inverts.
 ///
 /// Padding a tree scales its numerator by the padding coordinates' equality weight $q$ and sends
 /// its denominator through the one-padding selector $\textsf{sel}(q, v) = 1 + (v - 1) q$. A
 /// verifier that rebuilds a padded batch's leaf claim from transparent parts applies this to each
-/// tree, so the two directions live together.
+/// tree. The inverse direction is the prover's: only it holds claims on padded witnesses to
+/// reduce, so `unpad_leaf_claim` lives in `binius-ip-prover`.
 ///
 /// The weight is a parameter rather than the padding coordinates, so a caller padding several
 /// trees computes each distinct one once.
@@ -103,61 +104,6 @@ where
 pub fn pad_leaf_fraction<E: FieldOps>(fraction: (E, E), pad_eq: E) -> (E, E) {
 	let (num, den) = fraction;
 	(num * pad_eq.clone(), E::one() + (den - E::one()) * pad_eq)
-}
-
-/// Reduces a leaf claim on a zero-fraction-padded witness to the claim on the witness itself.
-///
-/// A batched fractional-addition check over trees of unequal depths lifts each shallow tree to the
-/// batch's depth by filling `n_pad_vars` extra leaf positions with the zero fraction $0/1$, which
-/// leaves its fractional sum unchanged. [`verify`] is oblivious to that, so the claims it outputs
-/// for such a tree are claims on the padded witness
-///
-/// $$
-/// N'(X_\text{pad}, X_\text{real}) = N(X_\text{real}) \cdot \text{eq}(0^\nu; X_\text{pad}),
-/// \qquad
-/// D'(X_\text{pad}, X_\text{real}) = 1 + \bigl( D(X_\text{real}) - 1 \bigr) \cdot
-/// \text{eq}(0^\nu; X_\text{pad}),
-/// $$
-///
-/// whose padding variables are the lowest ones. This divides out their equality weight and drops
-/// them from the point, leaving the claims on $N$ and $D$.
-///
-/// # Arguments
-///
-/// * `fraction` - The claimed numerator and denominator evaluations of the padded witness.
-/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
-///   stripped.
-/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
-///   own.
-///
-/// # Preconditions
-/// * `point.len() >= n_pad_vars`
-///
-/// # Panics
-///
-/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
-/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
-/// probability at most $\nu / |K|$.
-pub fn unpad_leaf_claim<F: Field>(
-	fraction: (F, F),
-	point: &[F],
-	n_pad_vars: usize,
-) -> FracAddEvalClaim<F> {
-	assert!(point.len() >= n_pad_vars); // precondition
-
-	let pad_eq = point[..n_pad_vars]
-		.iter()
-		.map(|&coord| eq_one_var(F::ZERO, coord))
-		.product::<F>();
-	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
-	let pad_eq_inv = pad_eq.invert_or_zero();
-
-	let (num_eval, den_eval) = fraction;
-	FracAddEvalClaim {
-		num_eval: num_eval * pad_eq_inv,
-		den_eval: F::ONE + (den_eval - F::ONE) * pad_eq_inv,
-		point: point[n_pad_vars..].to_vec(),
-	}
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/ip/src/prodcheck.rs
+++ b/crates/ip/src/prodcheck.rs
@@ -17,7 +17,7 @@
 //! ; X) \text{eq}(z ; Z) p_{i+1}(z, 0, x) p_{i+1}(z, 1, x) $$
 
 use binius_field::Field;
-use binius_math::{line::extrapolate_line, multilinear::eq::eq_one_var};
+use binius_math::line::extrapolate_line;
 use binius_transcript::Error as TranscriptError;
 
 // Re-export MultilinearEvalClaim from crate root for backward compatibility
@@ -69,56 +69,6 @@ where
 		},
 		channel,
 	)
-}
-
-/// Reduces a leaf claim on a one-padded witness to the claim on the witness itself.
-///
-/// A batched product check over trees of unequal depths lifts each shallow tree to the batch's
-/// depth by filling `n_pad_vars` extra leaf positions with ones, which leaves its product
-/// unchanged. [`verify`] is oblivious to that, so the claim it outputs for such a tree is a claim
-/// on the padded witness
-///
-/// $$
-/// M'(X_\text{pad}, X_\text{real}) = 1 + \bigl( M(X_\text{real}) - 1 \bigr) \cdot
-/// \text{eq}(0^\nu; X_\text{pad}),
-/// $$
-///
-/// whose padding variables are the lowest ones. This divides out their equality weight and drops
-/// them from the point, leaving the claim on $M$.
-///
-/// # Arguments
-///
-/// * `eval` - The claimed evaluation of the padded witness.
-/// * `point` - The reduced evaluation point, with the batch's selector coordinates already
-///   stripped.
-/// * `n_pad_vars` - How much depth this tree was padded by: the batch's layer count less the tree's
-///   own.
-///
-/// # Preconditions
-/// * `point.len() >= n_pad_vars`
-///
-/// # Panics
-///
-/// Panics if the padding coordinates' equality weight is zero, which requires one of them to equal
-/// one. They are the verifier's own challenges, so no prover can induce this; it happens with
-/// probability at most $\nu / |K|$.
-pub fn unpad_leaf_claim<F: Field>(
-	eval: F,
-	point: &[F],
-	n_pad_vars: usize,
-) -> MultilinearEvalClaim<F> {
-	assert!(point.len() >= n_pad_vars); // precondition
-
-	let pad_eq = point[..n_pad_vars]
-		.iter()
-		.map(|&coord| eq_one_var(F::ZERO, coord))
-		.product::<F>();
-	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
-
-	MultilinearEvalClaim {
-		eval: F::ONE + (eval - F::ONE) * pad_eq.invert_or_zero(),
-		point: point[n_pad_vars..].to_vec(),
-	}
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -52,6 +52,26 @@ pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> Fie
 	FieldBuffer::new(subspace.dim(), result)
 }
 
+/// The barycentric weight shared by every point of a binary subspace.
+///
+/// A subspace is an additive subgroup, so the usual per-point weight $\prod_{j \neq i} (d_i -
+/// d_j)^{-1}$ is the same at every point: subtracting $d_i$ permutes the subspace, leaving the
+/// product over its non-zero elements. That product is what this inverts.
+fn subspace_barycentric_weight<F: BinaryField, E: FieldOps + From<F>>(
+	subspace: &BinarySubspace<F>,
+) -> E {
+	let product = subspace
+		.iter()
+		.skip(1)
+		.map(E::from)
+		.fold(E::one(), |acc, d| acc * d);
+	// SAFETY: the product runs over the subspace's non-zero elements — index 0 is the zero
+	// element, which `skip(1)` drops — so it is non-zero by construction, whatever the caller
+	// passes. Inverting without the zero case spares the wrapper channels a constraint that
+	// could never fire.
+	unsafe { product.invert() }
+}
+
 /// Scalar variant of [`lagrange_evals`] that returns a `Vec<E>` instead of a `FieldBuffer`.
 ///
 /// Computes Lagrange polynomial evaluations for a binary subspace domain, converting domain
@@ -68,12 +88,7 @@ pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 	z: &E,
 ) -> Vec<E> {
 	// The shared barycentric weight of an additive subgroup: w = 1 / prod_{j >= 1} d_j.
-	let w = subspace
-		.iter()
-		.skip(1)
-		.map(E::from)
-		.fold(E::one(), |acc, d| acc * d)
-		.invert_or_zero();
+	let w = subspace_barycentric_weight::<F, E>(subspace);
 
 	// Seed the output with the linear terms t_i = z - d_i.
 	let mut result: Vec<E> = subspace.iter().map(|d| z.clone() - E::from(d)).collect();
@@ -127,12 +142,7 @@ pub fn extrapolate_over_subspace<F: BinaryField, E: FieldOps + From<F>>(
 	assert_eq!(values.len(), n);
 
 	// Compute single barycentric weight for the additive subgroup.
-	let w = subspace
-		.iter()
-		.skip(1)
-		.map(E::from)
-		.fold(E::one(), |acc, d| acc * d)
-		.invert_or_zero();
+	let w = subspace_barycentric_weight::<F, E>(subspace);
 
 	// Accumulate Σ_i values[i] * ∏_{j≠i} (z - domain[j]) using a prefix-product fold.
 	let (acc, _) = izip!(values, subspace.iter()).fold(

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -418,10 +418,32 @@ impl<F: Field, B: CircuitBuilder<Field = F>> Square for CircuitElem<F, B> {
 }
 
 impl<F: Field, B: CircuitBuilder<Field = F>> InvertOrZero for CircuitElem<F, B> {
+	/// Not implemented: nothing the wrapper runs inverts a value that may be zero.
+	///
+	/// The verifier's own inversions are all of random challenges, which it argues are non-zero,
+	/// so they go through [`InvertOrZero::invert`] below. Constraining the zero case as well would
+	/// cost extra constraints on every one of them, to admit an input no caller has.
+	///
+	/// This panics while the circuit is being built rather than at proving time, so a caller that
+	/// does need it fails loudly and can implement it then.
 	fn invert_or_zero(self) -> Self {
+		unimplemented!(
+			"the wrapper inverts only values argued non-zero; use `invert` (see its safety \
+			 contract), or implement this if a zero-admitting inverse is ever needed"
+		)
+	}
+
+	/// Constrains the hinted inverse with the single product the contract allows.
+	///
+	/// # Safety
+	///
+	/// The caller guarantees the value is non-zero. At zero the emitted constraint `x * inv == 1`
+	/// is unsatisfiable, so the circuit becomes unprovable rather than yielding a wrong proof.
+	unsafe fn invert(self) -> Self {
 		let [ret] = Self::combine(
 			[&self],
-			|[x]| [x.invert_or_zero()],
+			// SAFETY: the caller's guarantee carries to the concrete path.
+			|[x]| [unsafe { x.invert() }],
 			|builder, [x]| {
 				let [inv] = builder.hint([x], |[v]| [v.invert_or_zero()]);
 				let one = builder.constant(F::ONE);

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -106,15 +106,26 @@ mod tests {
 	}
 
 	#[test]
-	fn test_invert_or_zero_creates_constraints() {
+	fn test_invert_creates_constraints() {
 		let rc = Rc::new(std::cell::RefCell::new(ConstraintBuilder::<B128>::new()));
 		let elem = alloc_private_wire(&rc);
 
-		let _inv = elem.invert_or_zero();
+		// SAFETY: nothing constrains the wire, so the contract is vacuous here; the test only
+		// counts the constraints the inverse emits.
+		let _inv = unsafe { elem.invert() };
 		let (cs, _layout) = Rc::try_unwrap(rc).unwrap().into_inner().build().finalize();
-		// InvertOrZero creates: a mul constraint (wire * inv) and a zero constraint
+		// The inverse creates: a mul constraint (wire * inv) and a zero constraint
 		// (product ^ one), both of which become mul constraints after finalization.
 		assert!(cs.mul_constraints().len() >= 2);
+	}
+
+	#[test]
+	#[should_panic(expected = "the wrapper inverts only values argued non-zero")]
+	fn test_invert_or_zero_is_unimplemented() {
+		let rc = Rc::new(std::cell::RefCell::new(ConstraintBuilder::<B128>::new()));
+		let elem = alloc_private_wire(&rc);
+
+		let _ = elem.invert_or_zero();
 	}
 
 	#[test]


### PR DESCRIPTION
Second of two for [BINIUS-468](https://linear.app/jimpo/issue/BINIUS-468/all-field-inversions-in-the-verifier-should-use-invertorzeroinvert). **Stacked on #2123** — review that one first; this PR's diff is the two commits above it.

### Commits

1. **Invert the subspace barycentric weight without the zero case.** This is the issue's actual ask, and I had missed the call site: `lagrange_evals_scalars` and `extrapolate_over_subspace` in `binius-math` both invert the barycentric weight of a binary subspace, and the verifier reaches both — `lagrange_evals_scalars` from `reduce_constraints`, `extrapolate_over_subspace` from the BitAnd reduction. Under the ZK wrapper those run with `E = CircuitElem`, so each was emitting the zero-admitting constraint.

   The two computed the same weight, so it is now one `subspace_barycentric_weight` helper that inverts with `InvertOrZero::invert`. The safety argument is stronger than "non-zero with high probability": the product runs over the subspace's *non-zero* elements (index 0 is the zero element, dropped by `skip(1)`), so it is non-zero **by construction**, for any caller.

2. **Constrain a circuit inverse without the zero case.** `CircuitElem::invert_or_zero` emitted `assert_eq(x * inv, 1)`, which is unsatisfiable at `x = 0` — so it already implemented `invert`, and disagreed with its own concrete path, which returns zero there. That body moves to `unsafe fn invert`, whose contract is exactly what the constraint enforces, and `invert_or_zero` becomes `unimplemented!`.

The order matters: with the second commit alone, the ZK wrapper panics building its circuit. Each commit is green on its own.

### How the missed call site turned up

My first version of this PR was commit 2 only, and CI failed on three legs. `binius-prover`'s `prove_verify` suite drives `ZKVerifier::setup`, which symbolically executes the whole verifier through `IronSpartanBuilderChannel` — so it is the test that actually exercises every `Elem` inversion the verifier performs. Its backtrace named the sites one at a time:

```
binius_math::univariate::extrapolate_over_subspace::<..., CircuitElem<...>>
binius_verifier::protocols::bitand::verify_with_channel::<..., IronSpartanBuilderChannel<...>>
```

then, after fixing that one, `lagrange_evals_scalars` from `reduce_constraints`. Making `invert_or_zero` unimplemented is what turned "which inversions does the verifier actually do?" from a grep into something the compiler and test suite answer for you — I had grepped only the verifier-side crates' own sources and concluded there were none, which was wrong because these live in `binius-math`.

### After this

`InvertOrZero::invert_or_zero` is unreachable from the verifier: every inversion it performs is now `invert`, and the wrapper panics loudly at circuit-build time if that ever stops being true.

### Testing

`binius-math` (144), `binius-spartan-verifier` (11), `binius-spartan-prover`, `binius-recursion` (28), and `binius-prover`'s `prove_verify` (15, the ZK wrapper path that caught this). `cargo clippy --workspace --all-targets -- -D warnings` clean, rustdoc clean.

### Not changed here

`SymbolicElem::invert_or_zero` in `binius-recursion` has the same opportunity — under the `invert` contract its `constrain_inverse` collapses from 3 BMUL + 4 ZERO to a single product — but it is reached through a different wrapper. Happy to fold it in if you want the sweep to be complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)