### PR TITLE
BINIUS-475: Give each chip call the callee instance it invokes

### DIFF
--- a/crates/core/src/constraint_system/m4.rs
+++ b/crates/core/src/constraint_system/m4.rs
@@ -91,6 +91,16 @@ impl EmbeddedConstraintSystem {
 pub struct ChipCall {
 	/// The ID of the chip being called: its index in [`ConstraintSystemM4::chips`].
 	pub chip_id: usize,
+	/// The instance of the callee that the caller's first instance invokes.
+	///
+	/// A call site runs once per instance of its caller, so it claims the callee's instances
+	/// `first_instance..first_instance + n_active`, where `n_active` is the *caller's* own
+	/// active-instance count: the caller's instance `i` invokes instance `first_instance + i`.
+	/// Main runs once, so each of its calls claims a single instance.
+	///
+	/// Like the active-instance counts, this is denormalized — the call graph already says it, and
+	/// [`ConstraintSystemM4::validate`] holds the two to each other.
+	pub first_instance: usize,
 	/// The words passed as the callee's inout values, positionally, as operands over the caller's
 	/// value vector.
 	///
@@ -107,12 +117,13 @@ pub struct ChipCall {
 ///
 /// Validity invariants:
 /// - all embedded constraint systems in `chips` must have a chip_id value that indexes into `chips`
+/// - the chip calls must claim each chip's active instances exactly once between them
 ///
 /// The chips are in topological order: a chip calls only chips with a higher ID, and main, which
-/// is not one of them, calls any. Call positions are defined by enumerating the chips in ID order
-/// and witness generation walks them the same way, so every caller of a chip is reached before the
-/// chip itself. [`Self::validate`] requires it, which makes the call graph acyclic as a
-/// consequence.
+/// is not one of them, calls any. Enumerating the chips in ID order therefore reaches every caller
+/// of a chip before the chip itself, which is what lets one pass assign the instances and one pass
+/// generate the witness. [`Self::validate`] requires the ordering, which makes the call graph
+/// acyclic as a consequence.
 pub struct ConstraintSystemM4 {
 	/// The entry point of the system. It calls chips, but no chip ID names it, so nothing calls
 	/// it.
@@ -126,7 +137,8 @@ pub struct ConstraintSystemM4 {
 }
 
 impl ConstraintSystemM4 {
-	/// Checks every chip and every chip call, and requires the chips to be in topological order.
+	/// Checks every chip and every chip call, requires the chips to be in topological order, and
+	/// holds the instances the calls name against the ones the call graph gives them.
 	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
 		self.main.validate()?;
 		self.validate_calls(None, &self.main.chip_calls)?;
@@ -136,7 +148,7 @@ impl ConstraintSystemM4 {
 			self.validate_calls(Some(chip_index), &chip.chip_calls)?;
 		}
 
-		Ok(())
+		self.validate_instances()
 	}
 
 	/// Checks that one caller's calls name existing chips, run only to later chips, and pass no
@@ -181,6 +193,60 @@ impl ConstraintSystemM4 {
 		Ok(())
 	}
 
+	/// Checks that the calls claim each chip's active instances exactly once between them.
+	///
+	/// A call site claims one instance of its callee per instance of its caller, and the claims are
+	/// handed out in the order the chips are populated: main's calls first, then the calls of each
+	/// chip in ID order. Only main and lower-numbered chips call a chip, so one pass in ID order
+	/// settles a chip's own claims before reading them.
+	///
+	/// This runs after [`Self::validate_calls`] has range-checked every `chip_id` and rejected the
+	/// calls that run backwards, both of which it relies on.
+	fn validate_instances(&self) -> Result<(), ConstraintSystemError> {
+		let mut n_claimed = vec![0usize; self.chips.len()];
+		let callers = iter::once((None, &self.main, 1)).chain(
+			self.chips
+				.iter()
+				.enumerate()
+				.map(|(chip_index, (chip, n_active))| (Some(chip_index), chip, *n_active)),
+		);
+		for (chip_index, caller, n_active) in callers {
+			for (call_index, call) in caller.chip_calls.iter().enumerate() {
+				let claimed = &mut n_claimed[call.chip_id];
+				if call.first_instance != *claimed {
+					return Err(ConstraintSystemError::WrongCallInstance {
+						chip_index,
+						call_index,
+						first_instance: call.first_instance,
+						expected: *claimed,
+					});
+				}
+
+				// The claims multiply down the call graph — a chain whose every chip calls the
+				// next twice reaches `2^depth` — so a system of a few dozen chips can outgrow a
+				// `usize`. Counting it out unchecked would wrap to a total that a declared count
+				// could then agree with.
+				*claimed = claimed.checked_add(n_active).ok_or(
+					ConstraintSystemError::TooManyInstances {
+						chip_id: call.chip_id,
+					},
+				)?;
+			}
+		}
+
+		for (chip_id, ((_, n_active), &claimed)) in iter::zip(&self.chips, &n_claimed).enumerate() {
+			if claimed != *n_active {
+				return Err(ConstraintSystemError::WrongActiveInstanceCount {
+					chip_id,
+					declared: *n_active,
+					actual: claimed,
+				});
+			}
+		}
+
+		Ok(())
+	}
+
 	/// Checks that a witness satisfies this system.
 	///
 	/// The witness is the main chip's value vector and, per chip, one value vector per instance.
@@ -189,10 +255,10 @@ impl ConstraintSystemM4 {
 	/// - the main chip's constraints, on `main`;
 	/// - each chip's constraints, on every one of its instances — the instances past the active
 	///   ones included, since every instance is committed;
-	/// - every chip call, by the instance at the call's position: counting main's calls first and
-	///   then the calls of each chip's active instances in ID, instance and call order, invocation
-	///   `i` of a chip passes exactly the inout words its instance `i` holds. An inout value the
-	///   call has no operand for must hold zero.
+	/// - every chip call, by the instance it names: the caller's instance `i` invokes the callee's
+	///   instance [`first_instance`](ChipCall::first_instance) plus `i`, and passes exactly the
+	///   inout words that instance holds. An inout value the call has no operand for must hold
+	///   zero.
 	///
 	/// This is the reference the proving protocol's argument is checked against, in the manner of
 	/// [`ConstraintSystem::verify`].
@@ -241,10 +307,7 @@ impl ConstraintSystemM4 {
 			}
 		}
 
-		// The next instance each chip's calls are served by, advanced call by call so that
-		// invocation `i` lands on instance `i`.
-		let mut cursor = vec![0usize; self.chips.len()];
-		self.check_caller(None, &self.main.chip_calls, main, &mut cursor, chip_instances)?;
+		self.check_caller(None, &self.main.chip_calls, main, chip_instances)?;
 		for (caller_chip, (chip, n_active)) in self.chips.iter().enumerate() {
 			for caller_instance in 0..*n_active {
 				let values = chip_instances.instance(caller_chip, caller_instance);
@@ -252,49 +315,34 @@ impl ConstraintSystemM4 {
 					Some((caller_chip, caller_instance)),
 					&chip.chip_calls,
 					&values,
-					&mut cursor,
 					chip_instances,
 				)?;
-			}
-		}
-
-		for (chip_id, ((_, n_active), &n_invocations)) in
-			iter::zip(&self.chips, &cursor).enumerate()
-		{
-			if n_invocations != *n_active {
-				return Err(VerificationM4Error::WrongInvocationCount {
-					chip_id,
-					n_invocations,
-					n_active: *n_active,
-				});
 			}
 		}
 
 		Ok(())
 	}
 
-	/// Checks one caller's calls against the instances at their positions, advancing the cursors.
+	/// Checks one caller's calls against the instances they name.
 	///
 	/// `caller` names the caller for diagnostics: a chip instance, or `None` for the main chip.
-	/// `values` is that caller's value vector, which the call operands are evaluated on. A call
-	/// past its chip's active instances is counted but compared to nothing; the caller reports the
-	/// overshoot when the cursors are read back.
+	/// `values` is that caller's value vector, which the call operands are evaluated on.
+	///
+	/// The instance a call reaches is its own, offset by which instance of the caller is making it.
+	/// That every one of them exists is [`Self::validate`]'s to establish.
 	fn check_caller<I: ChipInstances + ?Sized>(
 		&self,
 		caller: Option<(usize, usize)>,
 		calls: &[ChipCall],
 		values: &ValueVec,
-		cursor: &mut [usize],
 		chip_instances: &I,
 	) -> Result<(), VerificationM4Error> {
+		// Main runs once, so its calls are the ones its single instance makes.
+		let caller_instance = caller.map_or(0, |(_, instance)| instance);
 		for (call_index, call) in calls.iter().enumerate() {
 			let chip_id = call.chip_id;
-			let (chip, n_active) = &self.chips[chip_id];
-			let row = cursor[chip_id];
-			cursor[chip_id] += 1;
-			if row >= *n_active {
-				continue;
-			}
+			let chip = &self.chips[chip_id].0;
+			let row = call.first_instance + caller_instance;
 
 			// Only the callee's own inout values are compared. An operand past them is one
 			// `validate` rejects, and nothing here would have a word to compare it to.
@@ -343,12 +391,15 @@ mod tests {
 
 	/// A chip that calls each of `callees` once, over a value vector of 8 inout and 8 private
 	/// words.
+	///
+	/// The calls name instance 0 until [`system`] gives them the ones the call graph does.
 	fn chip(callees: &[usize]) -> EmbeddedConstraintSystem {
 		let cs = LAYOUT.constraint_system_shape(vec![]);
 		let chip_calls = callees
 			.iter()
 			.map(|&chip_id| ChipCall {
 				chip_id,
+				first_instance: 0,
 				inout: vec![],
 			})
 			.collect();
@@ -360,14 +411,33 @@ mod tests {
 		ValueVec::new(&LAYOUT)
 	}
 
-	/// A system whose main chip calls each of `main_callees` once, over the given chips.
+	/// A system whose main chip calls each of `main_callees` once, over the given chips, with the
+	/// instances and active-instance counts the call graph gives them.
 	///
-	/// The active-instance counts are not what `validate` checks, so every chip declares one.
+	/// This is the assignment `CircuitM4::recompute_instances` writes in the frontend, redone here
+	/// because these systems are built by hand rather than lowered from a circuit. Like it, this
+	/// panics on a call to a chip the system does not have, so a test wanting one corrupts a
+	/// system built without it.
 	fn system(main_callees: &[usize], chips: Vec<EmbeddedConstraintSystem>) -> ConstraintSystemM4 {
-		ConstraintSystemM4 {
+		let mut cs = ConstraintSystemM4 {
 			main: chip(main_callees),
-			chips: chips.into_iter().map(|chip| (chip, 1)).collect(),
+			chips: chips.into_iter().map(|chip| (chip, 0)).collect(),
+		};
+
+		let mut n_calls = vec![0usize; cs.chips.len()];
+		for call in &mut cs.main.chip_calls {
+			call.first_instance = n_calls[call.chip_id];
+			n_calls[call.chip_id] += 1;
 		}
+		for chip_index in 0..cs.chips.len() {
+			let n_active = n_calls[chip_index];
+			cs.chips[chip_index].1 = n_active;
+			for call in &mut cs.chips[chip_index].0.chip_calls {
+				call.first_instance = n_calls[call.chip_id];
+				n_calls[call.chip_id] = n_calls[call.chip_id].saturating_add(n_active);
+			}
+		}
+		cs
 	}
 
 	#[test]
@@ -447,7 +517,12 @@ mod tests {
 	fn validate_rejects_a_call_to_a_chip_that_does_not_exist() {
 		// Chip 0's first call is to a later chip, so the out-of-range second one is the only
 		// fault and the range check is what has to catch it.
-		let cs = system(&[0], vec![chip(&[1, 7]), chip(&[])]);
+		let mut cs = system(&[0], vec![chip(&[1]), chip(&[])]);
+		cs.chips[0].0.chip_calls.push(ChipCall {
+			chip_id: 7,
+			first_instance: 0,
+			inout: vec![],
+		});
 		assert!(matches!(
 			cs.validate(),
 			Err(ConstraintSystemError::OutOfRangeChipId {
@@ -460,7 +535,8 @@ mod tests {
 
 	#[test]
 	fn validate_rejects_a_main_call_to_a_chip_that_does_not_exist() {
-		let cs = system(&[7], vec![chip(&[])]);
+		let mut cs = system(&[0], vec![chip(&[])]);
+		cs.main.chip_calls[0].chip_id = 7;
 		assert!(matches!(
 			cs.validate(),
 			Err(ConstraintSystemError::OutOfRangeChipId {
@@ -468,6 +544,66 @@ mod tests {
 				chip_id: 7,
 				n_chips: 1,
 			})
+		));
+	}
+
+	// A call site claims one instance of its callee per instance of its caller, so the instance a
+	// call names is the one the calls before it leave free.
+	#[test]
+	fn validate_rejects_a_call_naming_the_wrong_instance() {
+		let mut cs = system(&[0, 0], vec![chip(&[])]);
+		cs.main.chip_calls[1].first_instance = 0;
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::WrongCallInstance {
+				chip_index: None,
+				call_index: 1,
+				first_instance: 0,
+				expected: 1,
+			})
+		));
+	}
+
+	// The call-to-instance map is a bijection, not just an injection: a chip claimed by more
+	// invocations than it has active instances has calls that no row answers for.
+	#[test]
+	fn validate_rejects_more_invocations_than_a_chip_has_active_instances() {
+		// Main calls chip 0 twice; declaring one active instance leaves the second call unanswered.
+		let mut cs = system(&[0, 0], vec![chip(&[])]);
+		cs.chips[0].1 = 1;
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::WrongActiveInstanceCount {
+				chip_id: 0,
+				declared: 1,
+				actual: 2,
+			})
+		));
+	}
+
+	// Instance counts multiply down the call graph, so a chain of a few dozen chips outgrows a
+	// `usize`. Counting it out unchecked would wrap to a plausible-looking total.
+	#[test]
+	fn validate_rejects_an_instance_count_that_outgrows_a_usize() {
+		// A chain of 70 chips, each calling the next twice, so chip `i` is reached 2^i times.
+		const DEPTH: usize = 70;
+		let chips = (0..DEPTH)
+			.map(|i| {
+				let callees = if i + 1 < DEPTH {
+					vec![i + 1, i + 1]
+				} else {
+					vec![]
+				};
+				chip(&callees)
+			})
+			.collect();
+
+		// Chip 63 is reached 2^63 times and calls chip 64 twice, which is where the count leaves
+		// the range.
+		let cs = system(&[0], chips);
+		assert!(matches!(
+			cs.validate(),
+			Err(ConstraintSystemError::TooManyInstances { chip_id: 64 })
 		));
 	}
 
@@ -527,26 +663,6 @@ mod tests {
 				VerificationM4Error::MissingInstances {
 					chip_id: 0,
 					n_instances: 0,
-					n_active: 1,
-				}
-			),
-			"{err}"
-		);
-	}
-
-	// The call-to-instance map is a bijection, not just an injection: a chip reached by more
-	// invocations than it has active instances has calls that no row answers for.
-	#[test]
-	fn verify_rejects_more_invocations_than_a_chip_has_active_instances() {
-		// Main calls chip 0 twice, but the chip declares one active instance.
-		let cs = system(&[0, 0], vec![chip(&[])]);
-		let err = cs.verify(&instance(), &[vec![instance()]][..]).unwrap_err();
-		assert!(
-			matches!(
-				err,
-				VerificationM4Error::WrongInvocationCount {
-					chip_id: 0,
-					n_invocations: 2,
 					n_active: 1,
 				}
 			),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -44,6 +44,24 @@ pub enum ConstraintSystemError {
 	},
 	#[error("chip #{chip_index} calls chip {callee}, which is not a later chip")]
 	CallOutOfOrder { chip_index: usize, callee: usize },
+	#[error(
+		"{}'s call #{call_index} names instance {first_instance}, but the call graph gives it {expected}",
+		ChipName(*chip_index)
+	)]
+	WrongCallInstance {
+		chip_index: Option<usize>,
+		call_index: usize,
+		first_instance: usize,
+		expected: usize,
+	},
+	#[error("chip #{chip_id} declares {declared} active instances, but {actual} calls claim it")]
+	WrongActiveInstanceCount {
+		chip_id: usize,
+		declared: usize,
+		actual: usize,
+	},
+	#[error("more invocations reach chip #{chip_id} than a usize can count")]
+	TooManyInstances { chip_id: usize },
 }
 
 /// Names the chip of an M4 system that a diagnostic is about: `chip #3`, or `the main chip`.
@@ -206,7 +224,7 @@ impl fmt::Display for CallerName {
 ///
 /// A witness is the main chip's value vector and one list of instance value vectors per chip.
 /// It must satisfy every chip's local constraints on every instance, and serve every chip call
-/// with the instance at the call's position.
+/// with the instance that call names.
 #[allow(missing_docs)] // errors are self-documenting
 #[derive(Debug, thiserror::Error)]
 pub enum VerificationM4Error {
@@ -228,14 +246,6 @@ pub enum VerificationM4Error {
 	MissingInstances {
 		chip_id: usize,
 		n_instances: usize,
-		n_active: usize,
-	},
-	#[error(
-		"{n_invocations} invocations reach chip #{chip_id}, which has {n_active} active instances"
-	)]
-	WrongInvocationCount {
-		chip_id: usize,
-		n_invocations: usize,
 		n_active: usize,
 	},
 	#[error(

--- a/crates/frontend/src/chip.rs
+++ b/crates/frontend/src/chip.rs
@@ -45,7 +45,8 @@ pub struct CircuitM4 {
 	/// power of two.
 	///
 	/// The count is denormalized — it says what the call graph already says, and
-	/// [`Self::recompute_n_active`] derives it. [`Self::validate`] holds the two to each other.
+	/// [`Self::recompute_instances`] derives it, along with the instance each call claims.
+	/// [`Self::validate`] holds the two to each other.
 	pub chips: Vec<(EmbeddedCircuit, usize)>,
 }
 
@@ -72,7 +73,8 @@ impl CircuitM4 {
 	/// - the chips are in topological order, each calling only chips with a higher ID, so every
 	///   caller of a chip is populated before the chip itself;
 	/// - each chip's declared active-instance count is the number of invocations that reach it, no
-	///   chip is left uncalled, and no count outgrows a `usize`.
+	///   chip is left uncalled, and no count outgrows a `usize`;
+	/// - each call names the callee instance the call graph gives it.
 	///
 	/// A system that passes here lowers to one that passes
 	/// [`ConstraintSystemM4::validate`](binius_core::m4::ConstraintSystemM4::validate), which
@@ -95,11 +97,12 @@ impl CircuitM4 {
 			}
 		}
 
-		// The invocations reaching each chip, counted the way witness generation gathers them. Only
-		// main and lower-numbered chips call a chip, so a single pass in ID order sees every caller
-		// of chip `i` before it reads chip `i`'s own total.
+		// The invocations reaching each chip, counted the way [`Self::recompute_instances`] hands
+		// them out. Only main and lower-numbered chips call a chip, so a single pass in ID order
+		// sees every caller of chip `i` before it reads chip `i`'s own total.
 		let mut n_calls = vec![0usize; n_chips];
-		for call in &self.main.chip_calls {
+		for (call_index, call) in self.main.chip_calls.iter().enumerate() {
+			Self::check_call_instance(None, call_index, call, &n_calls)?;
 			n_calls[call.chip_id] += 1;
 		}
 		for (chip_index, (chip, n_active)) in self.chips.iter().enumerate() {
@@ -120,9 +123,10 @@ impl CircuitM4 {
 			// The counts multiply down the call graph — a chain whose every chip calls the next
 			// twice reaches `2^depth` — so a system of a few dozen chips can outgrow a `usize`.
 			// Counting it out unchecked would wrap to a small total that then agrees with a
-			// `recompute_n_active` that wrapped the same way, and the system would go on to be
+			// `recompute_instances` that wrapped the same way, and the system would go on to be
 			// populated against a count that is not the number of calls.
-			for call in &chip.chip_calls {
+			for (call_index, call) in chip.chip_calls.iter().enumerate() {
+				Self::check_call_instance(Some(chip_index), call_index, call, &n_calls)?;
 				n_calls[call.chip_id] = n_calls[call.chip_id].checked_add(*n_active).ok_or(
 					CircuitM4Error::TooManyInstances {
 						chip_index: call.chip_id,
@@ -131,6 +135,25 @@ impl CircuitM4 {
 			}
 		}
 
+		Ok(())
+	}
+
+	/// Checks that one call names the callee instance the invocations counted so far leave it.
+	fn check_call_instance(
+		chip_index: Option<usize>,
+		call_index: usize,
+		call: &ChipCall,
+		n_calls: &[usize],
+	) -> Result<(), CircuitM4Error> {
+		let expected = n_calls[call.chip_id];
+		if call.first_instance != expected {
+			return Err(CircuitM4Error::WrongCallInstance {
+				chip_index,
+				call_index,
+				first_instance: call.first_instance,
+				expected,
+			});
+		}
 		Ok(())
 	}
 
@@ -183,13 +206,17 @@ impl CircuitM4 {
 		Ok(())
 	}
 
-	/// Sets each chip's active-instance count to the number of invocations that reach it.
+	/// Gives each call the callee instances it invokes, and each chip the count of the ones it is
+	/// left with.
 	///
-	/// A chip is invoked once per call site naming it, per active instance of the caller. Main runs
-	/// once, so each of its call sites counts for one.
+	/// A chip is invoked once per call site naming it, per active instance of the caller, and a
+	/// call site's invocations are consecutive instances of the callee: the caller's instance `i`
+	/// invokes the call's [`first_instance`](ChipCall::first_instance) plus `i`. Main runs once, so
+	/// each of its call sites claims a single instance.
 	///
-	/// This is what [`Self::validate`] checks the declared counts against, so a system whose call
-	/// sites have just been written or rewritten passes it here rather than counting by hand.
+	/// This is what [`Self::validate`] checks the declared counts and instances against, so a
+	/// system whose call sites have just been written or rewritten passes it here rather than
+	/// counting by hand.
 	///
 	/// A count that outgrows a `usize` saturates rather than wrapping, so it stays too large for
 	/// the invocations that reach the chip and [`Self::validate`] reports it.
@@ -199,9 +226,10 @@ impl CircuitM4 {
 	/// Panics if a chip call names a chip this system does not have. Chips out of topological
 	/// order are not detected here: a call to a lower ID counts against a total already written
 	/// back, and [`Self::validate`] is what rejects the result.
-	pub fn recompute_n_active(&mut self) {
+	pub fn recompute_instances(&mut self) {
 		let mut n_calls = vec![0usize; self.chips.len()];
-		for call in &self.main.chip_calls {
+		for call in &mut self.main.chip_calls {
+			call.first_instance = n_calls[call.chip_id];
 			n_calls[call.chip_id] += 1;
 		}
 		// Only main and lower-numbered chips call a chip, so one pass in ID order settles chip
@@ -212,7 +240,8 @@ impl CircuitM4 {
 
 			// Only the active instances of this chip have their calls enforced, so only they
 			// demand an instance of the callee.
-			for call in &self.chips[chip_index].0.chip_calls {
+			for call in &mut self.chips[chip_index].0.chip_calls {
+				call.first_instance = n_calls[call.chip_id];
 				n_calls[call.chip_id] = n_calls[call.chip_id].saturating_add(n_active);
 			}
 		}
@@ -295,6 +324,16 @@ pub enum CircuitM4Error {
 	},
 	#[error("chip #{chip_index} calls chip {callee}, which is not a later chip")]
 	CallOutOfOrder { chip_index: usize, callee: usize },
+	#[error(
+		"{}'s call #{call_index} names instance {first_instance}, but the call graph gives it {expected}",
+		ChipName(*chip_index)
+	)]
+	WrongCallInstance {
+		chip_index: Option<usize>,
+		call_index: usize,
+		first_instance: usize,
+		expected: usize,
+	},
 	#[error("chip #{chip_index} declares {declared} active instances, but {actual} calls reach it")]
 	WrongActiveInstanceCount {
 		chip_index: usize,

--- a/crates/frontend/src/chip_witness.rs
+++ b/crates/frontend/src/chip_witness.rs
@@ -23,9 +23,9 @@ impl CircuitM4 {
 	///
 	/// `fill_main` assigns the witness inputs of the main circuit; every other value in the system
 	/// is derived from them. Each chip's table holds one instance per invocation that reaches it,
-	/// ordered by caller: main's calls first, then the calls of each chip in ID order, and within a
-	/// chip by instance. The instance count is rounded up to a power of two by repeating the last
-	/// invocation, which satisfies the chip because the invocation it copies does.
+	/// each at the row the invoking call names. The instance count is rounded up to a power of two
+	/// by repeating the last invocation, which satisfies the chip because the invocation it copies
+	/// does.
 	///
 	/// # Panics
 	///
@@ -43,20 +43,22 @@ impl CircuitM4 {
 
 		let main_values = main_witness_filler.into_value_vec();
 
-		// The invocations awaiting each chip, in the order the calls run: main's first, then the
-		// calls of each chip in ID order, instance-major and call-minor. Calls only run to higher
-		// IDs, so a chip's list is complete by the time the pass below reaches it.
-		let mut pending = vec![Vec::new(); self.chips.len()];
+		// The instances of each chip, each written by the call that invokes it. Calls only run to
+		// higher IDs, so a chip's instances are all written by the time the pass below reaches it.
+		let mut pending = self
+			.chips
+			.iter()
+			.map(|(_, n_active)| vec![Vec::new(); *n_active])
+			.collect::<Vec<_>>();
 		for call in &self.main.chip_calls {
-			pending[call.chip_id].push(eval_call(&main_values, call));
+			pending[call.chip_id][call.first_instance] = eval_call(&main_values, call);
 		}
 
 		let mut tables = Vec::<ValueTable>::with_capacity(self.chips.len());
 		for (chip_id, (chip, n_active)) in self.chips.iter().enumerate() {
 			let call_data = mem::take(&mut pending[chip_id]);
 
-			// Invariants checked in `CircuitM4::validate()`
-			assert_eq!(call_data.len(), *n_active);
+			// Invariant checked in `CircuitM4::validate()`
 			assert!(*n_active > 0, "chip {chip_id} is never called");
 
 			let log_instances = log2_ceil_usize(call_data.len());
@@ -73,14 +75,15 @@ impl CircuitM4 {
 
 			// Read this chip's own calls off each active instance, for the chips after it to
 			// serve. Building the instance is what costs here — a value vector allocated and
-			// gathered word by word — so each is built once and every call it makes is read off
-			// it, rather than once per callee.
+			// gathered word by word — so the instances are walked on the outside and every call
+			// one makes is read off it, rather than the chip being walked once per callee.
 			if !chip.chip_calls.is_empty() {
 				let constants = &chip.circuit.constraint_system().constants;
 				for instance in 0..*n_active {
 					let values = table.instance_value_vec(instance, constants);
 					for call in &chip.chip_calls {
-						pending[call.chip_id].push(eval_call(&values, call));
+						pending[call.chip_id][call.first_instance + instance] =
+							eval_call(&values, call);
 					}
 				}
 			}
@@ -139,6 +142,7 @@ mod tests {
 		EmbeddedCircuit {
 			chip_calls: vec![ChipCall {
 				chip_id: callee,
+				first_instance: 0,
 				inout: vec![forward_c.clone(), forward_c],
 			}],
 			circuit,
@@ -156,6 +160,7 @@ mod tests {
 
 		let call = |wire| ChipCall {
 			chip_id: callee,
+			first_instance: 0,
 			inout: vec![operand(&circuit, wire), operand(&circuit, wire)],
 		};
 		let chip_calls = vec![call(a), call(b)];
@@ -214,6 +219,7 @@ mod tests {
 		let chip_calls = iter::zip(&inputs, &conjunctions)
 			.map(|(&(a, b), &and)| ChipCall {
 				chip_id: 0,
+				first_instance: 0,
 				inout: vec![
 					operand(&circuit, a),
 					operand(&circuit, b),
@@ -237,7 +243,7 @@ mod tests {
 			main,
 			chips: vec![(and_chip(1), 0), (eq_chip(), 0)],
 		};
-		circuit.recompute_n_active();
+		circuit.recompute_instances();
 		(circuit, inputs)
 	}
 
@@ -373,17 +379,18 @@ mod tests {
 		);
 	}
 
-	// A caller with several instances making several calls to one callee is what pins the order
-	// generation and verification both walk the calls in: instance-major, call-minor. With one
-	// call per callee the two orders coincide and neither side would notice the other drifting.
+	// A caller with several instances making several calls to one callee is what tells the two
+	// apart: each call site claims a contiguous block of the callee's instances, one per instance
+	// of the caller, rather than the caller's instances taking consecutive rows. With one call per
+	// callee the two coincide and nothing would notice generation and verification disagreeing.
 	#[test]
-	fn generate_interleaves_a_callers_instances_before_its_calls() {
+	fn generate_gives_each_call_site_a_contiguous_block_of_instances() {
 		let (main, inputs) = main_circuit(2);
 		let mut circuit = CircuitM4 {
 			main,
 			chips: vec![(twice_calling_and_chip(1), 0), (eq_chip(), 0)],
 		};
-		circuit.recompute_n_active();
+		circuit.recompute_instances();
 		circuit.validate().unwrap();
 
 		// Chip 0 serves main's two calls, and each of its instances calls chip 1 twice.
@@ -400,8 +407,9 @@ mod tests {
 			})
 			.unwrap();
 
-		// Instance 0's two calls come before instance 1's, each forwarding `(a, a)` then `(b, b)`.
-		let expected = [words[0].0, words[0].1, words[1].0, words[1].1];
+		// The first call site forwards `(a, a)` from each of chip 0's two instances, and the second
+		// forwards `(b, b)` from each, so the two blocks are `a`s then `b`s.
+		let expected = [words[0].0, words[1].0, words[0].1, words[1].1];
 		assert_eq!(witness.tables[1].n_instances(), 4);
 		for (instance, &word) in expected.iter().enumerate() {
 			assert_eq!(
@@ -476,6 +484,7 @@ mod tests {
 		// Chip 1 is a leaf; make it call chip 0, which is populated before it.
 		circuit.chips[1].0.chip_calls.push(ChipCall {
 			chip_id: 0,
+			first_instance: 0,
 			inout: vec![],
 		});
 		assert!(matches!(
@@ -501,11 +510,29 @@ mod tests {
 		));
 	}
 
+	// A call site claims one instance of its callee per instance of its caller, so the instance it
+	// names is the one the calls before it leave free. A graph edited without recomputing the
+	// instances leaves a call naming a row another one already claims.
+	#[test]
+	fn validate_rejects_a_call_naming_the_wrong_instance() {
+		let (mut circuit, _) = system(2);
+		circuit.main.chip_calls[1].first_instance = 0;
+		assert!(matches!(
+			circuit.validate(),
+			Err(CircuitM4Error::WrongCallInstance {
+				chip_index: None,
+				call_index: 1,
+				first_instance: 0,
+				expected: 1,
+			})
+		));
+	}
+
 	#[test]
 	fn validate_rejects_a_chip_nothing_calls() {
 		let (mut circuit, _) = system(1);
 		circuit.main.chip_calls.clear();
-		circuit.recompute_n_active();
+		circuit.recompute_instances();
 		assert!(matches!(circuit.validate(), Err(CircuitM4Error::NeverCalled { chip_index: 0 })));
 	}
 
@@ -561,6 +588,7 @@ mod tests {
 					.flat_map(|chip_id| {
 						iter::repeat_with(move || ChipCall {
 							chip_id,
+							first_instance: 0,
 							inout: vec![],
 						})
 						.take(2)
@@ -575,6 +603,7 @@ mod tests {
 				circuit: CircuitBuilder::new().build(),
 				chip_calls: vec![ChipCall {
 					chip_id: 0,
+					first_instance: 0,
 					inout: vec![],
 				}],
 			},
@@ -582,7 +611,7 @@ mod tests {
 				.map(|i| (chip((i + 1 < DEPTH).then_some(i + 1)), 0))
 				.collect(),
 		};
-		circuit.recompute_n_active();
+		circuit.recompute_instances();
 
 		// Chip 63 is reached 2^63 times and calls chip 64 twice, which is where the count leaves
 		// the range.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -241,9 +241,9 @@ impl CircuitBuilder {
 	/// into its own run, so the chips stay in the topological order [`CircuitM4::validate`]
 	/// requires.
 	///
-	/// The registered system's active-instance counts are dropped. They say how often its own main
-	/// reached each chip, which says nothing about how often this circuit will;
-	/// [`Self::build_m4`] recounts the whole graph.
+	/// The registered system's active-instance counts are dropped, and the instances its calls name
+	/// are left stale. They say how often its own main reached each chip, which says nothing about
+	/// how often this circuit will; [`Self::build_m4`] recounts the whole graph.
 	///
 	/// Only [`Self::build_m4`] returns the registered chips; [`Self::build`] rejects a builder
 	/// carrying any.
@@ -345,10 +345,13 @@ impl CircuitBuilder {
 		let pending = mem::take(&mut shared.chip_calls);
 		let circuit = Self::compile(shared, &pending);
 
+		// The instances and the active-instance counts are the whole call graph's to settle, so
+		// both are left to `recompute_instances` below.
 		let chip_calls = pending
 			.into_iter()
 			.map(|call| ChipCall {
 				chip_id: call.chip.chip_id(),
+				first_instance: 0,
 				inout: call
 					.inout
 					.iter()
@@ -364,7 +367,7 @@ impl CircuitBuilder {
 			},
 			chips: chips.into_iter().map(|chip| (chip, 0)).collect(),
 		};
-		circuit.recompute_n_active();
+		circuit.recompute_instances();
 		circuit
 	}
 


### PR DESCRIPTION
Closes [BINIUS-475](https://linear.app/jimpo/issue/BINIUS-475).

A chip call names an instance of its callee, but that association was implicit in the order the
calls were walked: witness generation appended to a per-chip queue and verification advanced a
matching cursor, and the two agreed only because they walked the same order. `ChipCall` now carries
the instance, and both sides read it.

```diff
 pub struct ChipCall {
     pub chip_id: usize,
+    /// The instance of the callee that the caller's first instance invokes.
+    pub first_instance: usize,
     pub inout: Vec<Operand>,
 }
```

### A call site claims a block, not a row

A call site runs once per instance of its caller, so it claims a *range* of the callee's instances
rather than a single one: the caller's instance `i` invokes `first_instance + i`. Main runs once, so
each of its calls claims one.

Making that range contiguous is what lets the index be handed out in the same accumulation that
counts the active instances, exactly as the issue guessed — `n_calls[callee]` before the call is the
call's `first_instance`, and adding the caller's `n_active` moves it on. So the frontend's
`recompute_n_active` becomes `recompute_instances` and writes both.

**This reorders the instances a chip holds.** Before, invocations arrived instance-major over the
caller and call-minor within it; now each call site's block is consecutive. Only a caller with more
than one instance *and* more than one call to the same chip can tell the difference — with one call
per callee the two orders coincide. Nothing pins the witness layout, and both sides now take the
mapping from the same stored index instead of each recomputing an order, which is what the old
`generate_interleaves_a_callers_instances_before_its_calls` test existed to pin down.

### Where the invariant is checked

The stored indices are held to the call graph where the active-instance counts already are.
`ConstraintSystemM4::validate` gained `validate_instances`, which checks every call's index against
the one the graph gives it and every declared count against the claims it receives. That is what
`verify` used to establish at witness-checking time by reading its cursors back, so
`VerificationM4Error::WrongInvocationCount` is gone, `verify` carries no cursors, and `check_caller`
is down to `row = call.first_instance + caller_instance`.

`CircuitM4::validate` gains the same check on the frontend side, keeping its existing property that
a system passing there lowers to one passing the core check.

New errors: `ConstraintSystemError::{WrongCallInstance, WrongActiveInstanceCount, TooManyInstances}`
and `CircuitM4Error::WrongCallInstance`. The two `TooManyInstances` guard the same overflow the
frontend already guarded — instance counts multiply down the call graph, so a chain of a few dozen
chips outgrows a `usize`.

### Notes

- `first_instance` is denormalized: the call graph already says it. That is the same bargain
  `n_active` already strikes in this struct — derived by one method, held against the graph by
  `validate` — and it is what lets the prover and verifier stop deriving the mapping in lockstep.
- Chip calls remain otherwise unconstrained, per the issue.
- `verify` on a system that never passed `validate` can now panic on an out-of-range instance where
  it used to skip the call. Its contract already said malformed systems are `validate`'s to reject
  and that verifying one may panic.
- The core tests reimplement the instance assignment in ~16 lines, because core builds its systems
  by hand rather than lowering them from a circuit. The alternative was public API on
  `ConstraintSystemM4` with no production caller.

### Verification

On the rebased branch (this landed on top of #2120, which moved witness generation into
`binius-frontend::chip_witness`):

- 405 tests across `binius-core`, `binius-frontend`, `binius-m4-prover`, `binius-m4-verifier` — all
  pass
- `cargo clippy --all --tests --benches --examples -- -D warnings` — clean
- nightly `fmt --all --check` — clean
- the full `--workspace` run is left to CI

New tests: `validate_rejects_a_call_naming_the_wrong_instance` on both sides, core versions of the
active-instance-count and `usize`-overflow rejections (previously only the frontend had them, and
the count one was a `verify`-time check), and
`generate_gives_each_call_site_a_contiguous_block_of_instances` replacing the interleaving test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)