### PR TITLE
BINIUS-471: bind the Merkle openings and the committed vector to their roots

### DIFF
--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -2,26 +2,24 @@
 
 //! The channel that turns a verifier run into a circuit.
 
-use std::rc::Rc;
+use std::{array, rc::Rc};
 
 use binius_circuits::multiplexer::multi_wire_multiplex;
 use binius_core::word::Word;
-use binius_field::{BinaryField, BinaryField128bGhash as B128, Field, FieldOps, util::FieldFn};
-use binius_frontend::{Circuit, Wire};
-use binius_iop::merkle_channel::{self, MerkleIPVerifierChannel};
+use binius_field::{BinaryField128bGhash as B128, Field, FieldOps, util::FieldFn};
+use binius_frontend::{Circuit, CircuitBuilder};
+use binius_hash::StdHashSuite;
+use binius_iop::{
+	merkle_channel::{self, MerkleIPVerifierChannel},
+	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
+};
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
 
 use crate::{
+	merkle::{self, Digest, ELEMENT_WORDS, Element},
 	shared::Shared,
 	symbolic::{SymbolicElem, SymbolicWord},
 };
-
-/// Number of 64-bit words a SHA-256 digest occupies.
-pub(crate) const DIGEST_WORDS: usize = 4;
-
-/// Number of 64-bit words one field element holds, which is the two halves a [`SymbolicElem`]
-/// carries.
-const WORDS_PER_ELEM: usize = B128::N_BITS / Word::BITS;
 
 /// A Merkle commitment received by the builder channel.
 ///
@@ -30,7 +28,7 @@ const WORDS_PER_ELEM: usize = B128::N_BITS / Word::BITS;
 #[derive(Clone)]
 pub struct Commitment {
 	/// The commitment root.
-	pub root: [Wire; DIGEST_WORDS],
+	pub root: Digest,
 	/// Field elements in each leaf.
 	pub leaf_size: usize,
 	/// Base-2 logarithm of the number of leaves.
@@ -61,6 +59,10 @@ pub struct Binius64BuilderChannel {
 	shared: Rc<Shared>,
 	/// How many assertions have been recorded, so each gets a distinct name.
 	n_assertions: usize,
+	/// Consulted only for the layer depth an opening decommits to, so no tree is ever built.
+	scheme: BinaryMerkleTreeScheme<B128, StdHashSuite>,
+	/// Merkle verifications emitted so far, used to name subcircuits.
+	n_merkle_checks: usize,
 }
 
 impl Binius64BuilderChannel {
@@ -73,6 +75,8 @@ impl Binius64BuilderChannel {
 		Self {
 			shared: Rc::new(Shared::new()),
 			n_assertions: 0,
+			scheme: BinaryMerkleTreeScheme::new(),
+			n_merkle_checks: 0,
 		}
 	}
 
@@ -91,10 +95,32 @@ impl Binius64BuilderChannel {
 	}
 
 	/// Allocates the `(lo, hi)` pair one field element occupies, as circuit inputs.
+	fn input_element(&mut self, kind: &'static str) -> Element {
+		array::from_fn(|_| self.shared.input_wire(kind))
+	}
+
+	/// Allocates the wires one digest occupies, as circuit inputs.
+	fn input_digest(&mut self, kind: &'static str) -> Digest {
+		array::from_fn(|_| self.shared.input_wire(kind))
+	}
+
+	/// Allocates one field element as circuit inputs, in the form the protocol reads.
 	fn input_elem(&mut self, kind: &'static str) -> SymbolicElem {
-		let lo = self.shared.input_wire(kind);
-		let hi = self.shared.input_wire(kind);
+		let element = self.input_element(kind);
+		self.elem(element)
+	}
+
+	/// Lifts a wire pair to the element type the protocol sees.
+	fn elem(&self, [lo, hi]: Element) -> SymbolicElem {
 		SymbolicElem::wires(&self.shared, lo, hi)
+	}
+
+	/// A subcircuit named for the next Merkle verification.
+	fn merkle_subcircuit(&mut self, what: &str) -> CircuitBuilder {
+		// A distinct name per check keeps a failing assertion traceable to the check that broke.
+		let name = format!("{what}[{}]", self.n_merkle_checks);
+		self.n_merkle_checks += 1;
+		self.shared.builder().subcircuit(name)
 	}
 }
 
@@ -240,7 +266,7 @@ impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 		// takes the low half against a zero high half.
 		let builder = self.shared.builder();
 		words
-			.chunks(WORDS_PER_ELEM)
+			.chunks(ELEMENT_WORDS)
 			.map(|chunk| {
 				let lo = chunk[0].to_wire(builder);
 				let hi = chunk
@@ -260,7 +286,7 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 		leaf_size: usize,
 		depth: usize,
 	) -> Result<Commitment, merkle_channel::Error> {
-		let root = std::array::from_fn(|_| self.shared.input_wire("merkle_root"));
+		let root = self.input_digest("merkle_root");
 		Ok(Commitment {
 			root,
 			leaf_size,
@@ -268,25 +294,73 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 		})
 	}
 
+	/// Opens the commitment at every query index, returning the elements the opened leaves hold.
+	///
+	/// The opened values stay circuit inputs, since they are proof data.
+	/// They stop being *free*: each leaf is hashed and climbed to a layer the root fixes.
+	///
+	/// The index is a wire, so no range check is possible while the circuit is built.
+	/// An opening is verified at the index reduced modulo the leaf count.
+	/// Masking the sampled index so that reduction is a no-op is BINIUS-470.
 	fn recv_openings(
 		&mut self,
 		commitment: &Commitment,
 		indices: &[SymbolicWord],
 	) -> Result<Vec<SymbolicElem>, merkle_channel::Error> {
-		// UNCONSTRAINED: nothing binds the opened values to the root. Hashing each leaf and
-		// climbing the path is the gadget this skeleton leaves out.
-		Ok((0..indices.len() * commitment.leaf_size)
-			.map(|_| self.input_elem("opening"))
-			.collect())
+		let tree_depth = commitment.depth;
+		// The same rule the native verifier applies, so both sides stop climbing at the same level.
+		let layer_depth = self.scheme.optimal_verify_layer(indices.len(), tree_depth);
+
+		// One internal layer, folded to the root once and then shared by every climb below.
+		let layer = (0..1 << layer_depth)
+			.map(|_| self.input_digest("merkle_layer"))
+			.collect::<Vec<_>>();
+		let builder = self.merkle_subcircuit("layer");
+		merkle::verify_layer(&builder, commitment.root, &layer);
+
+		// Every query then climbs from its own leaf up to that layer.
+		let mut values = Vec::with_capacity(indices.len() * commitment.leaf_size);
+		for index in indices {
+			let leaf = (0..commitment.leaf_size)
+				.map(|_| self.input_element("opening"))
+				.collect::<Vec<_>>();
+			let branch = (0..tree_depth - layer_depth)
+				.map(|_| self.input_digest("merkle_branch"))
+				.collect::<Vec<_>>();
+
+			// Hashes the leaf, climbs the branch, then matches the layer entry the index addresses.
+			let builder = self.merkle_subcircuit("opening");
+			let index = index.to_wire(&builder);
+			merkle::verify_opening(
+				&builder,
+				index,
+				&leaf,
+				layer_depth,
+				tree_depth,
+				&layer,
+				&branch,
+			);
+			values.extend(leaf.into_iter().map(|element| self.elem(element)));
+		}
+		Ok(values)
 	}
 
+	/// Receives the whole committed vector, checked by rebuilding its tree.
+	///
+	/// The data arrives in the clear, so there is no path to climb: the tree is rebuilt over it.
 	fn recv_committed_vector(
 		&mut self,
 		commitment: &Commitment,
 	) -> Result<Vec<SymbolicElem>, merkle_channel::Error> {
-		// UNCONSTRAINED: nothing rebuilds the tree over the vector.
-		Ok((0..commitment.leaf_size << commitment.depth)
-			.map(|_| self.input_elem("committed_vector"))
-			.collect())
+		// One leaf's worth of elements per leaf, across every leaf of the tree.
+		let len = commitment.leaf_size << commitment.depth;
+		let data = (0..len)
+			.map(|_| self.input_element("committed_vector"))
+			.collect::<Vec<_>>();
+
+		let builder = self.merkle_subcircuit("vector");
+		merkle::verify_vector(&builder, commitment.root, &data, commitment.leaf_size);
+
+		Ok(data.into_iter().map(|element| self.elem(element)).collect())
 	}
 }

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -2,21 +2,25 @@
 
 //! Filling a recursive circuit's witness by replaying the verifier.
 
-use std::borrow::BorrowMut;
+use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash as B128, util::FieldFn};
 use binius_frontend::WitnessFiller;
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop::merkle_channel::{
-	self, MerkleIPVerifierChannel, TranscriptMerkleCommitment, VerifierMerkleTranscriptChannel,
+use binius_iop::{
+	merkle_channel::{self, MerkleIPVerifierChannel, TranscriptMerkleCommitment},
+	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
 
-use crate::{channel::DIGEST_WORDS, shared::Input};
+use crate::{
+	merkle::{DIGEST_WORDS, digest_words},
+	shared::Input,
+};
 
 /// A channel that runs the verifier for real while writing what it sees into a witness.
 ///
@@ -30,13 +34,20 @@ use crate::{channel::DIGEST_WORDS, shared::Input};
 /// diverging in opposite directions still add up, and every later value would land in the wrong
 /// wire silently.
 ///
-/// It exists because the skeleton leaves the Fiat-Shamir state and the Merkle openings
-/// unconstrained. Every one of those wires is a value the circuit ought to derive, so as gadgets
-/// land the recorded list shrinks, and with all of them in place only the proof itself remains.
+/// It exists because the skeleton leaves the Fiat-Shamir state unconstrained.
+/// Those wires carry values the circuit ought to derive.
+/// As gadgets land the recorded list shrinks, until only the proof itself remains.
+///
+/// The transcript is read directly rather than through a `VerifierMerkleTranscriptChannel`.
+/// That channel consumes the layer and branch digests internally, never handing them back.
+/// A circuit needs them on wires, so they are read here instead.
 pub struct WitnessFillerChannel<'a, 'c, T, Challenger_, H: HashSuite> {
-	inner: VerifierMerkleTranscriptChannel<T, Challenger_, B128, H>,
+	transcript: T,
+	/// Reproduces the layer depth and the native checks the builder's scheme also picks.
+	scheme: BinaryMerkleTreeScheme<B128, H>,
 	filler: &'a mut WitnessFiller<'c>,
 	wires: std::vec::IntoIter<Input>,
+	_challenger_marker: PhantomData<Challenger_>,
 }
 
 impl<'a, 'c, T, Challenger_, H> WitnessFillerChannel<'a, 'c, T, Challenger_, H>
@@ -46,9 +57,11 @@ where
 	/// Replays over a transcript, filling `wires` in the order the build recorded them.
 	pub fn new(transcript: T, filler: &'a mut WitnessFiller<'c>, wires: Vec<Input>) -> Self {
 		Self {
-			inner: VerifierMerkleTranscriptChannel::new(transcript),
+			transcript,
+			scheme: BinaryMerkleTreeScheme::new(),
 			filler,
 			wires: wires.into_iter(),
+			_challenger_marker: PhantomData,
 		}
 	}
 
@@ -77,6 +90,16 @@ where
 		self.fill_word(kind, Word::from_u64(value as u64));
 		self.fill_word(kind, Word::from_u64((value >> 64) as u64));
 	}
+
+	/// Writes one digest, in the packed byte order the hashing gadgets read.
+	fn fill_digest(&mut self, kind: &'static str, digest: &Output<H::LeafHash>) {
+		let bytes = digest.as_slice();
+		assert_eq!(bytes.len(), DIGEST_WORDS * Word::BYTES);
+		let bytes = bytes.try_into().expect("the length is checked above");
+		for word in digest_words(bytes) {
+			self.fill_word(kind, Word(word));
+		}
+	}
 }
 
 impl<T, Challenger_, H> IPVerifierChannel<B128> for WitnessFillerChannel<'_, '_, T, Challenger_, H>
@@ -88,19 +111,19 @@ where
 	type Elem = B128;
 
 	fn recv_one(&mut self) -> Result<B128, binius_ip::channel::Error> {
-		let value = self.inner.recv_one()?;
+		let value = self.transcript.borrow_mut().recv_one()?;
 		self.fill_elem("recv_one", value);
 		Ok(value)
 	}
 
 	fn sample(&mut self) -> B128 {
-		let value = self.inner.sample();
+		let value = IPVerifierChannel::<B128>::sample(self.transcript.borrow_mut());
 		self.fill_elem("sample", value);
 		value
 	}
 
 	fn observe_one(&mut self, val: B128) -> B128 {
-		let value = self.inner.observe_one(val);
+		let value = self.transcript.borrow_mut().observe_one(val);
 		self.fill_elem("observe_one", value);
 		value
 	}
@@ -108,12 +131,12 @@ where
 	fn assert_zero(&mut self, val: B128) -> Result<(), binius_ip::channel::Error> {
 		// The real check still runs, so a bad proof is caught here rather than surfacing as an
 		// unsatisfiable circuit.
-		self.inner.assert_zero(val)
+		self.transcript.borrow_mut().assert_zero(val)
 	}
 
 	fn compute_public_value(&mut self, inputs: &[B128], f: impl FieldFn<B128>) -> B128 {
 		// The builder evaluates this symbolically, so it records no wires and none are filled.
-		self.inner.compute_public_value(inputs, f)
+		self.transcript.borrow_mut().compute_public_value(inputs, f)
 	}
 }
 
@@ -132,26 +155,26 @@ where
 		for &word in words {
 			self.fill_word("observe_words", word);
 		}
-		self.inner.observe_words(words)
+		WordIPVerifierChannel::<B128>::observe_words(self.transcript.borrow_mut(), words)
 	}
 
 	fn subset_sum(&mut self, elems: &[B128], word: &Word) -> B128 {
-		self.inner.subset_sum(elems, word)
+		self.transcript.borrow_mut().subset_sum(elems, word)
 	}
 
 	fn select(&mut self, elems: &[B128], word: &Word) -> B128 {
-		self.inner.select(elems, word)
+		self.transcript.borrow_mut().select(elems, word)
 	}
 
 	fn sample_bits(&mut self, bits: usize) -> Word {
-		let value = self.inner.sample_bits(bits);
+		let value = WordIPVerifierChannel::<B128>::sample_bits(self.transcript.borrow_mut(), bits);
 		self.fill_word("sample_bits", value);
 		value
 	}
 
 	// The build pairs up wires it already has, allocating none, so there is nothing to fill.
 	fn pack_words(&mut self, words: &[Word]) -> Vec<B128> {
-		self.inner.pack_words(words)
+		self.transcript.borrow_mut().pack_words(words)
 	}
 }
 
@@ -171,27 +194,64 @@ where
 		leaf_size: usize,
 		depth: usize,
 	) -> Result<Self::Commitment, merkle_channel::Error> {
-		let commitment = self.inner.recv_merkle_commitment(leaf_size, depth)?;
-
-		// The root goes in as words so the wires hold the digest the prover sent, rather than a
-		// placeholder that would look right until the Merkle gadget started reading it.
-		let bytes = commitment.commitment.root.as_slice();
-		assert_eq!(bytes.len(), DIGEST_WORDS * Word::BYTES);
-		for chunk in bytes.chunks(Word::BYTES) {
-			let word = u64::from_le_bytes(chunk.try_into().expect("chunks of eight bytes"));
-			self.fill_word("merkle_root", Word::from_u64(word));
-		}
-		Ok(commitment)
+		let root: Output<H::LeafHash> = self.transcript.borrow_mut().message().read()?;
+		self.fill_digest("merkle_root", &root);
+		Ok(TranscriptMerkleCommitment {
+			commitment: binius_iop::merkle_tree::Commitment { root, depth },
+			leaf_size,
+		})
 	}
 
+	/// Reads the same advice the native channel reads, and fills the wires the gadget checks.
+	///
+	/// The climb is not repeated natively: the circuit hashes each leaf and matches the layer.
+	/// A forged opening therefore surfaces as an unsatisfied constraint, not an error at this call.
 	fn recv_openings(
 		&mut self,
 		commitment: &Self::Commitment,
 		indices: &[Word],
 	) -> Result<Vec<B128>, merkle_channel::Error> {
-		let values = self.inner.recv_openings(commitment, indices)?;
-		for &value in &values {
-			self.fill_elem("opening", value);
+		let tree_depth = commitment.commitment.depth;
+		let indices = indices
+			.iter()
+			.map(|index| index.as_u64() as usize)
+			.collect::<Vec<_>>();
+		assert!(indices.iter().all(|&index| index < 1 << tree_depth)); // precondition
+
+		let layer_depth = self.scheme.optimal_verify_layer(indices.len(), tree_depth);
+
+		// The reader borrows the transcript for as long as it lives, so the whole batch is read
+		// before any of it is written into wires.
+		let (layer, openings) = {
+			let mut advice = self.transcript.borrow_mut().decommitment();
+			let layer = advice.read_vec::<Output<H::LeafHash>>(1 << layer_depth)?;
+			let mut openings = Vec::with_capacity(indices.len());
+			for _ in &indices {
+				let leaf = advice.read_scalar_slice::<B128>(commitment.leaf_size)?;
+				let branch = advice.read_vec::<Output<H::LeafHash>>(tree_depth - layer_depth)?;
+				openings.push((leaf, branch));
+			}
+			(layer, openings)
+		};
+
+		// The layer folds to the root over concrete digests, so that half stays a native check.
+		self.scheme
+			.verify_layer(&commitment.commitment.root, layer_depth, &layer)?;
+
+		// Filled in the order the build allocated: the shared layer, then a leaf and a branch per
+		// query.
+		for digest in &layer {
+			self.fill_digest("merkle_layer", digest);
+		}
+		let mut values = Vec::with_capacity(indices.len() * commitment.leaf_size);
+		for (leaf, branch) in openings {
+			for &value in &leaf {
+				self.fill_elem("opening", value);
+			}
+			for digest in &branch {
+				self.fill_digest("merkle_branch", digest);
+			}
+			values.extend_from_slice(&leaf);
 		}
 		Ok(values)
 	}
@@ -200,10 +260,19 @@ where
 		&mut self,
 		commitment: &Self::Commitment,
 	) -> Result<Vec<B128>, merkle_channel::Error> {
-		let values = self.inner.recv_committed_vector(commitment)?;
-		for &value in &values {
+		let len = commitment.leaf_size << commitment.commitment.depth;
+		let data = self
+			.transcript
+			.borrow_mut()
+			.decommitment()
+			.read_scalar_slice::<B128>(len)?;
+		// The rebuild runs over concrete values too, so this stays a native check.
+		self.scheme
+			.verify_vector(&commitment.commitment.root, &data, commitment.leaf_size)?;
+
+		for &value in &data {
 			self.fill_elem("committed_vector", value);
 		}
-		Ok(values)
+		Ok(data)
 	}
 }

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -20,28 +20,22 @@
 //!
 //! # Status: a skeleton, and not sound
 //!
-//! The gadgets a real recursive verifier needs are not written. In their place, values that ought
-//! to be derived are left as circuit inputs for the replay to supply:
+//! One gadget is still missing, so a value that ought to be derived is left as a circuit input:
 //!
 //! - **The Fiat-Shamir state.** `sample` and `sample_bits` return free wires rather than the
 //!   challenger's output, so nothing ties a challenge to the transcript that produced it.
-//! - **The Merkle openings.** `recv_openings` and `recv_committed_vector` return free wires rather
-//!   than values checked against a commitment root.
 //!
 //! What *is* constrained is the verifier's arithmetic: the sumcheck folding, the eq-indicator and
 //! Lagrange evaluations, the monster multilinear, every `assert_zero` along the way, and both field
 //! gadgets that used to be bare hints.
 //!
-//! So a circuit built here accepts proofs it should reject. It is useful for measuring that
-//! arithmetic and for keeping the pipeline honest while the gadgets are written, not for proving
-//! anything. Each gadget that lands removes entries from the recorded input list; with all of them
-//! in place the only input left is the proof itself.
+//! The Merkle commitments are constrained too, by [`merkle`].
+//! An opened leaf is hashed and climbed to a decommitted layer the root fixes.
+//! A committed vector has its tree rebuilt over it.
+//! Both keep their values as circuit inputs, since those values are proof data.
 //!
-//! The gadget for the first bullet now exists in [`challenger`], reproducing the native
-//! challenger's byte stream over wires.
-//! The gadgets for the second exist in [`merkle`], matching the native binary Merkle scheme.
-//! Driving them from `sample`, `sample_bits`, `recv_openings` and `recv_committed_vector` is what
-//! removes the two remaining bullets.
+//! A circuit built here still accepts proofs it should reject: a prover picks its own challenges.
+//! Driving [`challenger`] from `sample` and `sample_bits` is what removes the bullet above.
 
 pub mod challenger;
 mod channel;

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -10,19 +10,22 @@
 //!   recursive circuit  <----------  its witness  ->  validated
 //! ```
 //!
-//! What this does *not* show is that the recursive circuit rejects anything. The skeleton leaves
-//! the Fiat-Shamir state and the Merkle openings unconstrained, so the values that would pin them
-//! are supplied by the replay rather than derived. What it does show is that the shapes line up:
-//! one verifier runs over both channels, reaching the same operations in the same order, and the
-//! circuit the first produced is satisfied by the witness the second filled.
+//! One verifier runs over both channels and reaches the same operations in the same order.
+//! The circuit the first produced is satisfied by the witness the second filled.
+//!
+//! The Merkle commitments are checked in-circuit, so tampering with their advice is rejected here.
+//! The Fiat-Shamir state is not, so a challenge is still whatever the replay supplies.
 
 use binius_core::{constraint_system::ValueVec, word::Word};
 use binius_field::arch::OptimalPackedB128;
-use binius_frontend::{Circuit, CircuitBuilder, CircuitStat, Wire};
+use binius_frontend::{
+	Circuit, CircuitBuilder, CircuitStat, MAX_ASSERTION_FAILURES, PopulateError, Wire,
+	WitnessFiller,
+};
 use binius_hash::StdHashSuite;
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_prover::Prover;
-use binius_recursion::{Binius64BuilderChannel, WitnessFillerChannel};
+use binius_recursion::{Binius64BuilderChannel, Recorded, WitnessFillerChannel};
 use binius_transcript::{ProverTranscript, VerifierTranscript};
 use binius_verifier::{Verifier, config::StdChallenger};
 
@@ -96,9 +99,17 @@ fn crc64_witness(crc64: &Crc64, message: &[u64; N_INPUT_WORDS]) -> ValueVec {
 	filler.into_value_vec()
 }
 
-#[test]
-fn recursive_circuit_is_satisfied_by_a_real_proof() {
-	// --- the inner circuit and its proof -------------------------------------------------------
+/// One CRC-64 statement, proved once, for the recursion pipeline to consume.
+struct Proved {
+	verifier: Verifier<StdHashSuite>,
+	witness: ValueVec,
+	proof: Vec<u8>,
+}
+
+/// Proves one CRC-64 statement, and checks it verifies natively.
+///
+/// A proof that fails here would make every recursion failure below ambiguous.
+fn prove_crc64() -> Proved {
 	let crc64 = crc64_circuit();
 	let message = [0x0123456789abcdef, 0xfedcba9876543210, 1, u64::MAX];
 	let witness = crc64_witness(&crc64, &message);
@@ -112,30 +123,65 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 	prover.prove(&witness, &mut prover_transcript).unwrap();
 	let proof = prover_transcript.finalize();
 
-	// The proof verifies natively, so anything the recursion trips over is the recursion's fault.
-	{
-		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof.clone());
-		verifier.verify(witness.inout(), &mut transcript).unwrap();
-		transcript.finalize().unwrap();
-	}
+	let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof.clone());
+	verifier.verify(witness.inout(), &mut transcript).unwrap();
+	transcript.finalize().unwrap();
 
-	// --- the recursive circuit -----------------------------------------------------------------
-	// The verifier runs over the builder channel, wrapped in the same BaseFold layer the transcript
-	// channel gets, and what it records becomes the circuit.
-	let recorded = {
-		let builder_channel = Binius64BuilderChannel::new();
-		let mut channel = verifier.iop_compiler().create_channel(builder_channel);
-		// The statement is observed by the caller, and what comes back is what the verifier reads.
-		// On this channel those are wires, so the recorded circuit takes the statement as input
-		// rather than baking it in.
-		let inout = channel.observe_words(witness.inout());
-		verifier
-			.iop_verifier()
-			.verify(&inout, &mut channel)
-			.expect("the symbolic run records rather than checks, so it cannot fail");
-		let builder_channel = channel.finish().unwrap();
-		builder_channel.build()
-	};
+	Proved {
+		verifier,
+		witness,
+		proof,
+	}
+}
+
+/// Records the verifier run as a circuit.
+///
+/// The builder channel is wrapped in the same BaseFold layer the transcript channel gets.
+/// What the verifier does over it becomes the circuit.
+fn record(proved: &Proved) -> Recorded {
+	let builder_channel = Binius64BuilderChannel::new();
+	let mut channel = proved
+		.verifier
+		.iop_compiler()
+		.create_channel(builder_channel);
+	// The statement is observed by the caller, and what comes back is what the verifier reads.
+	// On this channel those are wires, so the recorded circuit takes the statement as input
+	// rather than baking it in.
+	let inout = channel.observe_words(proved.witness.inout());
+	proved
+		.verifier
+		.iop_verifier()
+		.verify(&inout, &mut channel)
+		.expect("the symbolic run records rather than checks, so it cannot fail");
+	channel.finish().unwrap().build()
+}
+
+/// Replays the verifier over the real transcript, filling every wire the build recorded.
+fn replay(proved: &Proved, recorded: &Recorded, filler: &mut WitnessFiller) {
+	let mut transcript = VerifierTranscript::new(StdChallenger::default(), proved.proof.clone());
+	let filler_channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
+		&mut transcript,
+		filler,
+		recorded.inputs.clone(),
+	);
+	let mut channel = proved
+		.verifier
+		.iop_compiler()
+		.create_channel(filler_channel);
+	let inout = channel.observe_words(proved.witness.inout());
+	proved
+		.verifier
+		.iop_verifier()
+		.verify(&inout, &mut channel)
+		.unwrap();
+	channel.finish().unwrap().finish();
+}
+
+#[test]
+fn recursive_circuit_is_satisfied_by_a_real_proof() {
+	let proved = prove_crc64();
+	let recorded = record(&proved);
+	let witness = &proved.witness;
 
 	let stat = CircuitStat::collect(&recorded.circuit);
 	println!(
@@ -158,28 +204,89 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 		.count();
 	assert_eq!(statement_wires, witness.inout().len());
 
+	// The decommitted layer is on wires now, which is what the opened leaves are matched against.
+	assert!(
+		recorded
+			.inputs
+			.iter()
+			.any(|input| input.kind == "merkle_layer"),
+		"the query phase must record the layer it decommits to"
+	);
+
 	// --- its witness ---------------------------------------------------------------------------
 	// The same verifier runs again over the real transcript, and every value the circuit cannot
 	// derive is written into the wire the build recorded for it.
 	let mut filler = recorded.circuit.new_witness_filler();
-	{
-		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
-		let filler_channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
-			&mut transcript,
-			&mut filler,
-			recorded.inputs.clone(),
-		);
-		let mut channel = verifier.iop_compiler().create_channel(filler_channel);
-		let inout = channel.observe_words(witness.inout());
-		verifier
-			.iop_verifier()
-			.verify(&inout, &mut channel)
-			.unwrap();
-		channel.finish().unwrap().finish();
-	}
+	replay(&proved, &recorded, &mut filler);
 
 	recorded
 		.circuit
 		.populate_wire_witness(&mut filler)
 		.expect("the recorded circuit is satisfied by the replayed witness");
+}
+
+/// Flips one bit of the first recorded wire of `kind`, and returns why the circuit then fails.
+///
+/// The wire is tampered after an honest replay, so only that bit differs from a good witness.
+fn reject_tampered(kind: &'static str) -> Vec<String> {
+	let proved = prove_crc64();
+	let recorded = record(&proved);
+	let mut filler = recorded.circuit.new_witness_filler();
+	replay(&proved, &recorded, &mut filler);
+
+	let input = recorded
+		.inputs
+		.iter()
+		.find(|input| input.kind == kind)
+		.unwrap_or_else(|| panic!("the verifier must record at least one {kind} wire"));
+	filler[input.wire] = Word(filler[input.wire].0 ^ 1);
+
+	let error = recorded
+		.circuit
+		.populate_wire_witness(&mut filler)
+		.expect_err("a tampered witness must leave the circuit unsatisfied");
+
+	// `..` is forced: `PopulateError` is non-exhaustive. Both of its fields are checked here.
+	let PopulateError {
+		failures, total, ..
+	} = error;
+	assert!(total > 0, "an unsatisfied circuit must report a failing assertion");
+	assert_eq!(failures.len(), total.min(MAX_ASSERTION_FAILURES));
+	for failure in &failures {
+		assert!(!failure.detail.is_empty(), "a failure must carry a diagnostic");
+	}
+	failures.into_iter().map(|failure| failure.path).collect()
+}
+
+#[test]
+fn a_tampered_layer_digest_leaves_the_circuit_unsatisfied() {
+	// Invariant: the decommitted layer is folded to the root, so its digests are not free.
+	//
+	// Fixture state: one honest proof, replayed in full, with one layer digest then flipped.
+	//
+	//     before:  layer  -> fold -> the root the commitment carries
+	//     after:   layer' -> fold -> a digest that root does not match
+	//
+	// A layer digest reaches no arithmetic anywhere in the verifier, so the fold is the only thing
+	// that reads it. That is what makes this isolate the binding under test.
+	let paths = reject_tampered("merkle_layer");
+	assert!(
+		paths.iter().any(|path| path.contains("verify_layer")),
+		"a corrupted layer digest must fail the fold to the root: {paths:?}"
+	);
+}
+
+#[test]
+fn a_tampered_committed_vector_leaves_the_circuit_unsatisfied() {
+	// Invariant: a vector sent in the clear is bound by the tree rebuilt over it.
+	//
+	// Fixture state: one honest proof, replayed in full, with one committed value then flipped.
+	//
+	//     before:  data  -> rebuild -> the root the commitment carries
+	//     after:   data' -> rebuild -> a different root
+	let paths = reject_tampered("committed_vector");
+	assert!(
+		paths.iter().any(|path| path.contains("verify_vector")),
+		"a corrupted committed value must fail the rebuilt tree: {paths:?}"
+	);
 }


### PR DESCRIPTION
Closes [BINIUS-471](https://linear.app/jimpo/issue/BINIUS-471).

Drives the Merkle gadgets from the two channel sites that were handing out free wires, so the opened leaves and the committed vector are now bound to their commitment roots.

### The problem

The gadgets landed in BINIUS-430 (#2104), but nothing called them.

`Binius64BuilderChannel` returned free wires at both sites:

```
recv_openings          -> free wires, bound to nothing
recv_committed_vector  -> free wires, bound to nothing
```

A prover could put any values there and the circuit would still be satisfied.

### The idea

An opening is bound in two steps, and the split is what makes it affordable:

```
layer   ->  folded to the root once, and shared by every query
leaf    ->  hashed, climbed to that layer, matched at the index
```

A vector arrives in the clear instead, so there is no path to climb — the tree is rebuilt over it.

### The change

Both sites now allocate the advice a check needs and call the gadget:

```
recv_openings:
- (0..indices.len() * leaf_size).map(|_| self.input_elem("opening"))     // free wires
+ merkle::verify_layer(&builder, commitment.root, &layer)                // fold to the root
+ merkle::verify_opening(&builder, index, &leaf, .., &layer, &branch)    // one climb per query

recv_committed_vector:
- (0..leaf_size << depth).map(|_| self.input_elem("committed_vector"))   // free wires
+ merkle::verify_vector(&builder, commitment.root, &data, leaf_size)     // rebuild the tree
```

The opened values stay circuit inputs, because they are proof data. What changes is that they stop being *free*.

### The filler had to stop wrapping the native channel

A circuit needs the decommitted layer and each authentication branch **on wires**.

`VerifierMerkleTranscriptChannel` reads them straight into `verify_opening` and never hands them back, so there was no way to reach them from outside.

`WitnessFillerChannel` now holds the transcript directly and reads that advice itself, in exactly the order the native channel reads it:

```
layer digests                                  1 << layer_depth
then per query:  leaf scalars, branch digests  leaf_size, tree_depth - layer_depth
```

The layer fold and the vector rebuild still run natively, since both take slices. The per-query climb does not — the circuit is the check now, so a forged opening surfaces as an unsatisfied constraint rather than an error at that call.

### One latent bug this surfaced

The commitment root was filled little-endian:

```
- u64::from_le_bytes(chunk)      // the root wires, as the proof serializes them
+ digest_words(bytes)            // big-endian halves, packed two to a wire
```

The hashing gadgets read digests in the packed big-endian form. Nothing had noticed, because until now nothing read those wires — `filler.rs` even carried a comment about the root being "a placeholder that would look right until the Merkle gadget started reading it". It started reading it.

### Soundness

- The layer depth comes from the same `optimal_verify_layer` the native verifier uses, so both sides stop climbing at the same level.
- The index is a wire, so no range check is possible at build time, and an opening is verified at the index reduced modulo the leaf count. Masking the sampled index so that reduction is a no-op is [BINIUS-470](https://linear.app/jimpo/issue/BINIUS-470).
- The Fiat-Shamir state is still unconstrained ([BINIUS-469](https://linear.app/jimpo/issue/BINIUS-469)), so a circuit built here still accepts proofs it should reject. This closes one of the two holes, not both.

### The duplicated constant

Folded, as the issue asked:

```
- pub(crate) const DIGEST_WORDS: usize = 4;          // channel.rs
+ use crate::merkle::DIGEST_WORDS;
```

`WORDS_PER_ELEM` went the same way, onto `merkle::ELEMENT_WORDS` — same constant, and it would have drifted for the same reason.

### Scope

- **changed:** the two call sites in `channel.rs`, the Merkle half of `filler.rs`, the crate docs
- **left untouched:** `sample`, `sample_bits` and `observe_words`, which are BINIUS-469 and BINIUS-470
- **left untouched:** the gadgets themselves — this only calls them

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-recursion --no-deps` — clean
- `cargo test -p binius-recursion` — 28 unit + 5 integration passed

Two new negative tests, one per site. Each flips a single bit *after* an honest replay, so nothing but that bit differs from a witness that satisfies the circuit:

| tampered | must fail |
|---|---|
| a layer digest | the fold to the root |
| a committed value | the rebuilt tree |

A layer digest reaches no arithmetic anywhere in the verifier, so that test isolates the new binding and nothing else.

### Cost, measured on the CRC-64 end-to-end fixture

| | before | after |
|---|---|---|
| AND | 16,698 | 316,285 |
| gates | 273,264 | 1,459,176 |
| recorded inputs | 3,663 | 4,687 |

Two readings worth keeping, both of which qualify the issue's estimates.

**The recorded input list grows rather than shrinks.** The issue frames these two sites as 2,368 of 3,661 wires, or 65%, which reads as though they leave the list. They do not: opened values and committed vectors are proof data, so they stay and become bound. The +1,024 is the decommitted layer, which the circuit now needs and previously never read. Only BINIUS-469 and BINIUS-470 actually remove entries, 413 wires between them.

**This fixture is not representative.** CRC-64 is small enough that `optimal_verify_layer` puts the layer *at the leaves* — 1,024 layer wires and zero branch wires. Every climb is zero levels, so the circuit rebuilds whole trees instead of walking short branches, and the AND count is inflated accordingly. It also means no authentication branch is exercised end to end; that path is covered by `merkle.rs`'s own unit tests, and a deeper inner circuit would be needed to reach it from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
