### PR TITLE
Prove a composite M4 system from a WitnessM4

### DIFF
--- a/crates/m4-prover/src/composite.rs
+++ b/crates/m4-prover/src/composite.rs
@@ -1,0 +1,322 @@
+// Copyright 2026 The Binius Developers
+
+//! Proving a whole [`ConstraintSystemM4`](binius_core::constraint_system::m4::ConstraintSystemM4):
+//! the main chip and every numbered chip.
+
+use std::iter;
+
+use binius_compute::{Allocator, BufferPool};
+use binius_core::{
+	Word,
+	constraint_system::{InoutSegment, m4::WitnessM4},
+};
+use binius_field::PackedField;
+use binius_hash::StdHashSuite;
+use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_ip_prover::channel::WordIPProverChannel;
+use binius_m4_verifier::{IOPVerifierM4, VerifierM4};
+use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded};
+use binius_prover::{Error, protocols::shift::build_key_collection};
+use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
+use binius_verifier::config::B128;
+
+use crate::prove::{IOPProver, ProverNtt};
+
+/// IOP prover for a composite M4 system.
+///
+/// It mirrors [`IOPVerifierM4`] sub-system for sub-system: the Binius64 prover for the main chip,
+/// which runs once, and this crate's data-parallel [`IOPProver`] for each numbered chip's batch of
+/// instances. The sub-proofs share one channel, and so one Fiat-Shamir transcript and one combined
+/// FRI opening.
+///
+/// ## What a composite proof does not prove
+///
+/// Chip calls are unconstrained; see [`IOPVerifierM4`] for what that leaves out.
+pub struct IOPProverM4 {
+	/// The prover for the main chip, which runs once.
+	main: binius_prover::IOPProver,
+	/// The prover for each numbered chip's batch of instances, indexed by chip ID.
+	chips: Vec<IOPProver>,
+}
+
+impl IOPProverM4 {
+	/// Builds the sub-provers matching an IOP verifier, deriving each one's shift keys.
+	///
+	/// The main chip's keys are built over the public segment, since its inout values are the
+	/// statement; every chip's are built over the hidden segment, since its inout values are
+	/// committed with the private ones. The two are not interchangeable.
+	pub fn new(iop_verifier: &IOPVerifierM4) -> Self {
+		let main_cs = iop_verifier.main().constraint_system();
+		let main = binius_prover::IOPProver::new(
+			iop_verifier.main().clone(),
+			build_key_collection(main_cs, InoutSegment::Public),
+		);
+
+		let chips = iop_verifier
+			.chips()
+			.iter()
+			.map(|chip| {
+				let key_collection =
+					build_key_collection(chip.constraint_system(), InoutSegment::Hidden);
+				IOPProver::new(chip.clone(), key_collection)
+			})
+			.collect();
+
+		Self { main, chips }
+	}
+
+	/// The prover for the main chip.
+	pub const fn main(&self) -> &binius_prover::IOPProver {
+		&self.main
+	}
+
+	/// The provers for the numbered chips, indexed by chip ID.
+	pub fn chips(&self) -> &[IOPProver] {
+		&self.chips
+	}
+
+	/// Proves that a witness satisfies the composite system, using an IOP channel.
+	///
+	/// The sub-proofs run on one channel in the order
+	/// [`IOPVerifierM4::verify`](binius_m4_verifier::IOPVerifierM4::verify) reads them — the main
+	/// chip, then the chips in ID order. One channel is one Fiat-Shamir transcript, so the two
+	/// orders must agree exactly.
+	///
+	/// The main chip's prover observes its own inout values from the witness, so the statement is
+	/// not a separate argument here as it is on the verifier.
+	///
+	/// ## Preconditions
+	/// * the witness holds one table per chip of the system this prover was built for
+	///
+	/// # Errors
+	///
+	/// Returns an error if the main chip's witness does not fit its committed shape.
+	pub fn prove<P, Channel, A>(
+		&self,
+		witness: &WitnessM4,
+		channel: &mut Channel,
+		alloc: &A,
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = B128>,
+		Channel: IOPProverChannel<P, A> + WordIPProverChannel<B128, Word = Word>,
+		A: Allocator,
+	{
+		// A short witness would leave the trailing chips' oracles unsent while the verifier still
+		// reads them, so hold the two to the same length rather than letting `zip` truncate.
+		assert_eq!(
+			witness.tables.len(),
+			self.chips.len(),
+			"the witness must hold one table per chip of the system this prover was built for"
+		);
+
+		self.main.prove::<_, P, _>(&witness.main, channel, alloc)?;
+		for (prover, table) in iter::zip(&self.chips, &witness.tables) {
+			prover.prove_chip::<P, _, _>(table, channel, alloc);
+		}
+		Ok(())
+	}
+}
+
+/// Proves a composite M4 system.
+///
+/// Built from a [`VerifierM4`], so both sides share one set of FRI parameters.
+///
+/// See [`IOPVerifierM4`] for what a composite proof does and does not establish.
+pub struct ProverM4<P>
+where
+	P: PackedField<Scalar = B128>,
+{
+	iop_prover: IOPProverM4,
+	/// The precomputed BaseFold prover, holding the NTT and the FRI parameters.
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNtt>,
+	/// The pool that recycles this prover's working buffers. It lives for the prover's lifetime,
+	/// so blocks freed by one proof are reused by the next.
+	pool: BufferPool,
+}
+
+impl<P> ProverM4<P>
+where
+	P: PackedField<Scalar = B128>,
+{
+	/// Builds the prover from a verifier, inheriting its sub-systems and FRI parameters.
+	///
+	/// The prover encodes the codeword with the multithreaded NTT, spread across the cores.
+	/// Reusing the verifier's compiler keeps both sides on one set of FRI parameters.
+	pub fn setup(verifier: &VerifierM4) -> Self {
+		// Reuse the verifier's evaluation domain so both sides agree on the code: its compiler
+		// fixed that domain as the Gao-Mateer basis of this dimension.
+		let domain_context =
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_log_domain_size());
+
+		// Spread the NTT across the available cores.
+		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
+		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
+
+		// Inherit the verifier's oracle specs and FRI parameters verbatim.
+		let basefold_compiler =
+			BaseFoldProverCompiler::from_verifier_compiler(verifier.iop_compiler(), ntt);
+
+		Self {
+			iop_prover: IOPProverM4::new(verifier.iop_verifier()),
+			basefold_compiler,
+			pool: BufferPool::new(),
+		}
+	}
+
+	/// Returns a reference to the IOP prover.
+	pub const fn iop_prover(&self) -> &IOPProverM4 {
+		&self.iop_prover
+	}
+
+	/// Proves that a witness satisfies the composite system.
+	///
+	/// Creates the IOP channel from the transcript, delegates to [`IOPProverM4::prove`], then
+	/// finishes the channel with the combined FRI opening.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the main chip's witness does not fit its committed shape.
+	pub fn prove<Challenger_>(
+		&self,
+		witness: &WitnessM4,
+		transcript: &mut ProverTranscript<Challenger_>,
+	) -> Result<(), Error>
+	where
+		Challenger_: Challenger,
+	{
+		// A composite proof is transparent: every oracle is committed without a mask, so the
+		// channel draws no randomness.
+		let mut channel = self
+			.basefold_compiler
+			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _, _>(
+				transcript,
+			);
+
+		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
+		// by earlier proofs.
+		let alloc = &self.pool;
+		self.iop_prover
+			.prove::<P, _, _>(witness, &mut channel, &alloc)?;
+
+		let _scope = tracing::debug_span!("PCS opening").entered();
+		channel.finish(&alloc);
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::{ValueTable, constraint_system::m4::ConstraintSystemM4};
+	use binius_field::PackedBinaryGhash1x128b;
+	use binius_transcript::VerifierTranscript;
+	use binius_verifier::config::StdChallenger;
+
+	use super::*;
+	use crate::test_utils::{crc64_chip_circuit, crc64_iso_reference};
+
+	type P = PackedBinaryGhash1x128b;
+
+	/// The rate every test proves at.
+	const LOG_INV_RATE: usize = 1;
+
+	/// The message the fixture absorbs, one chip call per word.
+	const MESSAGE: [u64; 4] = [0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210, 0, u64::MAX];
+
+	/// Builds the composite fixture and a witness over [`MESSAGE`].
+	fn fixture() -> (ConstraintSystemM4, WitnessM4) {
+		let c = crc64_chip_circuit(MESSAGE.len());
+		let cs = c.circuit.to_constraint_system();
+		let witness = c
+			.circuit
+			.generate_witness(|filler| {
+				for (&wire, &word) in iter::zip(&c.input, &MESSAGE) {
+					filler[wire] = Word(word);
+				}
+			})
+			.unwrap();
+
+		// The witness computes the right thing and satisfies the system, so a proof of it failing
+		// to verify below is the protocol's fault and not the fixture's.
+		let output = c.circuit.main.circuit.witness_index(c.output);
+		assert_eq!(witness.main[output], Word(crc64_iso_reference(&MESSAGE)));
+		witness.verify(&cs).unwrap();
+
+		(cs, witness)
+	}
+
+	/// Proves `witness` against `cs` and returns the proof bytes.
+	fn prove(cs: &ConstraintSystemM4, witness: &WitnessM4) -> Vec<u8> {
+		let verifier = VerifierM4::setup(cs, LOG_INV_RATE).unwrap();
+		let prover = ProverM4::<P>::setup(&verifier);
+
+		let mut transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(witness, &mut transcript).unwrap();
+		transcript.finalize()
+	}
+
+	#[test]
+	fn a_composite_proof_verifies() {
+		let (cs, witness) = fixture();
+		let proof = prove(&cs, &witness);
+
+		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		verifier
+			.verify(witness.main.inout(), &mut transcript)
+			.expect("a faithful composite proof verifies");
+		transcript.finalize().expect("no trailing proof data");
+	}
+
+	#[test]
+	fn the_prover_mirrors_the_verifier_sub_system_for_sub_system() {
+		let (cs, _) = fixture();
+		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let prover = ProverM4::<P>::setup(&verifier);
+
+		assert_eq!(prover.iop_prover().chips().len(), cs.chips.len());
+	}
+
+	#[test]
+	fn a_proof_is_rejected_against_another_statement() {
+		let (cs, witness) = fixture();
+		let proof = prove(&cs, &witness);
+
+		// Mutation: one inout word of the statement differs from the one proved.
+		let mut inout = witness.main.inout().to_vec();
+		inout[0] = Word(inout[0].as_u64() ^ 1);
+
+		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		assert!(
+			verifier.verify(&inout, &mut transcript).is_err(),
+			"a proof of one statement must not verify against another"
+		);
+	}
+
+	#[test]
+	fn a_chip_instance_that_breaks_its_constraints_is_rejected() {
+		let (cs, mut witness) = fixture();
+
+		// Mutation: flip a bit of the chip's committed table, so one instance no longer satisfies
+		// the chip's constraints. Nothing about main changes, so only the chip's sub-proof can
+		// catch this — which is the point of the test.
+		let table = &witness.tables[0];
+		let mut words = table.as_words().to_vec();
+		words[0] = Word(words[0].as_u64() ^ 1);
+		witness.tables[0] =
+			ValueTable::from_hidden_words(table.layout().clone(), table.log_instances(), words);
+
+		let proof = prove(&cs, &witness);
+
+		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		assert!(
+			verifier
+				.verify(witness.main.inout(), &mut transcript)
+				.is_err(),
+			"a chip instance that breaks the chip's constraints must not verify"
+		);
+	}
+}

--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -7,6 +7,7 @@
 //! [`binius_core`] defines and [`binius_frontend`] populates. This crate commits one and reduces
 //! the constraint system over it.
 
+mod composite;
 mod prove;
 mod shift;
 #[cfg(test)]
@@ -14,6 +15,7 @@ mod test_utils;
 mod value_table;
 mod witness;
 
+pub use composite::{IOPProverM4, ProverM4};
 pub use prove::{IOPProver, Prover};
 pub use value_table::{commit_layout, pack_table};
 pub use witness::OperandColumns;

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -49,7 +49,7 @@ use crate::{
 };
 
 /// The multithreaded additive NTT used to encode the committed codeword.
-type ProverNtt = NeighborsLastMultiThread<GaoMateerPreExpanded<B128>>;
+pub(crate) type ProverNtt = NeighborsLastMultiThread<GaoMateerPreExpanded<B128>>;
 
 /// IOP prover for the M4 constraint reduction of a particular constraint system.
 ///

--- a/crates/m4-prover/src/test_utils.rs
+++ b/crates/m4-prover/src/test_utils.rs
@@ -6,7 +6,7 @@
 //! Both need a circuit whose AND-constraint operands carry real shifts.
 
 use binius_core::{ValueTable, word::Word};
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
+use binius_frontend::{Circuit, CircuitBuilder, CircuitM4, Wire, hints::Hint};
 
 /// The CRC-64/GO-ISO generator polynomial, in reflected form.
 ///
@@ -33,18 +33,23 @@ pub const N_INPUT_WORDS: usize = 4;
 ///
 /// The `Circuit` counterpart mirrors this loop gate for gate, so the two agree bit for bit.
 pub fn crc64_iso_reference(words: &[u64; N_INPUT_WORDS]) -> u64 {
-	let mut crc = INIT;
-	for &word in words {
-		for i in 0..64 {
-			let bit = (word >> i) & 1;
-			let mix = (crc ^ bit) & 1;
-			crc >>= 1;
-			if mix != 0 {
-				crc ^= POLY_REFLECTED;
-			}
+	words.iter().fold(INIT, |crc, &word| mix_word(crc, word)) ^ XOR_OUT
+}
+
+/// Mixes one message word into the register, absorbing its bits from bit 0 up.
+///
+/// This is one iteration of [`crc64_iso_reference`]'s fold, which the chip fixture below makes a
+/// chip of its own.
+pub fn mix_word(mut crc: u64, word: u64) -> u64 {
+	for i in 0..64 {
+		let bit = (word >> i) & 1;
+		let mix = (crc ^ bit) & 1;
+		crc >>= 1;
+		if mix != 0 {
+			crc ^= POLY_REFLECTED;
 		}
 	}
-	crc ^ XOR_OUT
+	crc
 }
 
 /// A circuit computing CRC-64/GO-ISO over four message words.
@@ -114,6 +119,91 @@ pub fn populate_crc64_witness(c: &Crc64Circuit, inputs: &[[u64; N_INPUT_WORDS]])
 			}
 		})
 		.unwrap()
+}
+
+/// Mixes one message word into the register in gates, mirroring [`mix_word`] round for round.
+fn mix_word_gates(builder: &CircuitBuilder, mut crc: Wire, word: Wire) -> Wire {
+	let poly = builder.add_constant_64(POLY_REFLECTED);
+	for i in 0..64 {
+		// Isolate message bit `i` into the low bit; the higher bits are junk we discard.
+		let bit = if i == 0 { word } else { builder.shr(word, i) };
+
+		// The low bit that decides whether the polynomial is mixed in this round.
+		let mixed = builder.bxor(crc, bit);
+
+		// Broadcast that low bit across the whole word: all ones iff it is set, else zero.
+		let to_msb = builder.shl(mixed, 63);
+		let mask = builder.sar(to_msb, 63);
+		let poly_term = builder.band(mask, poly);
+
+		// Advance the register: shift right by one, then conditionally mix the polynomial.
+		crc = builder.bxor(builder.shr(crc, 1), poly_term);
+	}
+	crc
+}
+
+/// The register state one call produces, which main takes on trust and the call constrains.
+struct MixWord;
+
+impl Hint for MixWord {
+	const NAME: &'static str = "crc64_iso_mix_word";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(2, 1)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		outputs[0] = Word(mix_word(inputs[0].as_u64(), inputs[1].as_u64()));
+	}
+}
+
+/// A chip-accelerated CRC-64/GO-ISO circuit over message words.
+pub struct Crc64ChipCircuit {
+	pub circuit: CircuitM4,
+	pub input: Vec<Wire>,
+	pub output: Wire,
+}
+
+/// Builds a composite CRC-64/GO-ISO circuit over `n_words` message words: one chip, called once
+/// per word.
+///
+/// Mixing one word into the register is the chip. Main learns each register state from a hint
+/// rather than computing it, so its own constraints say nothing about the CRC — the chip calls are
+/// what tie the states together. That makes main much smaller than the chip it calls, which is
+/// what a composite fixture wants: the two sub-systems commit oracles of different sizes.
+pub fn crc64_chip_circuit(n_words: usize) -> Crc64ChipCircuit {
+	let chip = {
+		let builder = CircuitBuilder::new();
+		let crc_in = builder.add_inout();
+		let word = builder.add_inout();
+		// `crc_out` is promoted rather than declared, so the chip states the relation in the word
+		// it already computes rather than paying for a third inout and an assertion.
+		builder.mark_inout(mix_word_gates(&builder, crc_in, word));
+		builder.build_m4()
+	};
+
+	let builder = CircuitBuilder::new();
+	let chip = builder.add_chip(chip);
+
+	let input = (0..n_words)
+		.map(|_| builder.add_inout())
+		.collect::<Vec<_>>();
+
+	let mut crc = builder.add_constant_64(INIT);
+	for &word in &input {
+		let next = builder.call_hint(MixWord, &[], &[crc, word])[0];
+		builder.call_chip(chip, &[crc, word, next]);
+		crc = next;
+	}
+
+	let output = builder.bxor(crc, builder.add_constant_64(XOR_OUT));
+	builder.mark_inout(output);
+
+	Crc64ChipCircuit {
+		circuit: builder.build_m4(),
+		input,
+		output,
+	}
 }
 
 #[cfg(test)]

--- a/crates/m4-verifier/src/composite.rs
+++ b/crates/m4-verifier/src/composite.rs
@@ -11,7 +11,7 @@ use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,
 	channel::{IOPVerifierChannel, OracleSpec},
-	fri::{ConstantArityStrategy, calculate_n_test_queries},
+	fri::{MinProofSizeStrategy, calculate_n_test_queries},
 };
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
@@ -146,10 +146,8 @@ impl IOPVerifierM4 {
 ///
 /// See [`IOPVerifierM4`] for what a composite proof does and does not establish.
 ///
-/// The hash suite is fixed to [`StdHashSuite`], as it is for a
-/// single-chip [`Verifier`](crate::Verifier). The Binius64 verifier takes it as a parameter, but a
-/// composite proof commits every sub-system on one channel, so there is only ever one suite to
-/// pick.
+/// The hash suite is fixed to [`StdHashSuite`], as it is for a single-chip
+/// [`Verifier`](crate::Verifier). The Binius64 verifier takes it as a parameter instead.
 pub struct VerifierM4 {
 	/// The IOP verifier, holding the sub-verifier for every sub-system.
 	iop_verifier: IOPVerifierM4,
@@ -173,10 +171,9 @@ impl VerifierM4 {
 
 		let iop_verifier = IOPVerifierM4::new(cs);
 
-		// One channel commits every sub-system's oracles into one codeword. Sizing that codeword is
-		// the compiler's job: it batches the specs and chooses the fold arities that minimize proof
-		// size, so the arity strategy passed below is not consulted and nothing here needs to know
-		// which sub-system commits the longest oracle.
+		// One channel commits every sub-system's oracles into one codeword, and sizing that
+		// codeword is the compiler's job: it batches the specs over all of them. So nothing here
+		// needs to know which sub-system commits the longest oracle.
 		let oracle_specs = iop_verifier.oracle_specs();
 
 		// The query count is fixed by the rate and the soundness target.
@@ -187,7 +184,7 @@ impl VerifierM4 {
 			oracle_specs,
 			log_inv_rate,
 			n_test_queries,
-			&ConstantArityStrategy::new(1),
+			&MinProofSizeStrategy,
 		);
 
 		Ok(Self {


### PR DESCRIPTION
[BINIUS-479](https://linear.app/jimpo/issue/BINIUS-479/m4-prove-a-composite-m4-system-from-a-witnessm4) — last of three stacked PRs for [BINIUS-474](https://linear.app/jimpo/issue/BINIUS-474/m4-modify-protocol-to-prove-composite-circuits). #2127 and #2129 have both merged, so this is now a single commit on `main`.

Adds `IOPProverM4` and `ProverM4`, mirroring #2129's verifier sub-system for sub-system: the Binius64 prover for the main chip's `ValueVec`, then this crate's data-parallel prover for each chip's `ValueTable`, in the order the verifier reads them. One channel is one Fiat-Shamir transcript, so the two orders have to agree; it is the order `ConstraintSystemM4::verify` and witness generation already walk.

`setup` builds one `KeyCollection` per sub-system — `InoutSegment::Public` for main, `Hidden` for each chip. `prove` asserts the witness holds one table per chip rather than letting `zip` truncate, since a short witness would leave the trailing chips' oracles unsent while the verifier still reads them.

**Carries your `MinProofSizeStrategy` fix from [#2129](https://github.com/binius-zk/binius64/pull/2129#discussion_r3773747592)** — the 17-line change to `m4-verifier/src/composite.rs`. #2129 was already in the merge queue when I got to that comment, so pushing there would have ejected it.

### Testing

An end-to-end round trip over a composite fixture: a small main chip that takes each CRC register state from a hint and calls a CRC-64 mix chip once per message word to constrain it. The fixture lands in `test_utils` beside the existing single-chip CRC-64 one, and shares its reference implementation — `crc64_iso_reference` is now a fold over the extracted `mix_word`, which is also what the chip's gates mirror and what the hint computes.

Four tests: the round trip verifies and leaves no trailing data; the prover mirrors the verifier sub-system for sub-system; a proof is rejected against a different statement; and **a chip instance that breaks the chip's constraints is rejected** — that one flips a bit in the committed chip table and leaves main untouched, so only the chip's sub-proof can catch it.

Verified green on the current base: `cargo test -p binius-m4-prover -p binius-m4-verifier` (49 passed), `cargo clippy --all --tests --benches --examples -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps`, `cargo fmt --check`.

With this the composite protocol is complete, subject to the documented gap: chip calls stay unconstrained, so a proof establishes strictly less than `ConstraintSystemM4::verify` checks. The `H: HashSuite` follow-up is [BINIUS-480](https://linear.app/jimpo/issue/BINIUS-480/m4-parameterize-verifierm4-and-verifier-by-h-hashsuite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)