### PR TITLE
perf(circuits): read each msm window in one shift, not a band per bit

### DIFF
--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -208,7 +208,6 @@ fn strauss_accumulate(
 		.map(|table| table.iter().map(Vec::as_slice).collect())
 		.collect();
 
-	let one = b.add_constant_64(1);
 	let n_windows = exponent_bits.div_ceil(window);
 	let mut acc = Secp256k1Affine::point_at_infinity(b);
 
@@ -223,23 +222,28 @@ fn strauss_accumulate(
 
 		let base_bit = w_idx * window;
 		for (point_idx, subscalar) in subscalars.iter().enumerate() {
-			// Pack this base point's `window`-bit exponent chunk into a selector word, bit by bit
-			// so that windows crossing 64-bit limb boundaries (and bit positions past
-			// `exponent_bits`) are handled uniformly. `multi_wire_multiplex` reads selector bit
-			// `j` as bit `j` of the table index, matching `table[x] = x · P`.
-			let mut sel = b.add_constant(Word::ZERO);
-			for j in 0..window {
-				let bit_index = base_bit + j;
-				if bit_index >= exponent_bits {
-					continue; // past the top of the exponent — contributes a zero bit
+			// Selector = this window's exponent bits, low bit first; bits at or past
+			// `exponent_bits` read as zero. `multi_wire_multiplex` reads bit `j` of `sel` as bit
+			// `j` of the table index, matching `table[x] = x · P`. One masked shift pulls the whole
+			// chunk, where the old code spent a band per bit (two limbs when the chunk straddles a
+			// 64-bit boundary).
+			let sel = if base_bit >= exponent_bits {
+				b.add_constant(Word::ZERO)
+			} else {
+				let n_bits = (base_bit + window).min(exponent_bits) - base_bit;
+				let mask = b.add_constant_64((1u64 << n_bits) - 1);
+				let offset = (base_bit % Word::BITS) as u32;
+				let lo = base_bit / Word::BITS;
+				let hi = (base_bit + n_bits - 1) / Word::BITS;
+				if lo == hi {
+					b.band(b.shr(subscalar[lo], offset), mask)
+				} else {
+					// The halves land in disjoint bit ranges, so XOR joins them before the mask.
+					let low = b.shr(subscalar[lo], offset);
+					let high = b.shl(subscalar[hi], Word::BITS as u32 - offset);
+					b.band(b.bxor(low, high), mask)
 				}
-				let limb = bit_index / Word::BITS;
-				let bit = bit_index % Word::BITS;
-				let bit_val = b.band(b.shr(subscalar[limb], bit as u32), one);
-				// Each iteration sets a distinct bit `j`, disjoint from the bits already in
-				// `sel`, so XOR matches the OR.
-				sel = b.bxor(sel, b.shl(bit_val, j as u32));
-			}
+			};
 
 			let selected =
 				Secp256k1Affine::from_wires(&multi_wire_multiplex(b, &table_refs[point_idx], sel));

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -224,25 +224,23 @@ fn strauss_accumulate(
 		for (point_idx, subscalar) in subscalars.iter().enumerate() {
 			// Selector = this window's exponent bits, low bit first; bits at or past
 			// `exponent_bits` read as zero. `multi_wire_multiplex` reads bit `j` of `sel` as bit
-			// `j` of the table index, matching `table[x] = x · P`. One masked shift pulls the whole
-			// chunk, where the old code spent a band per bit (two limbs when the chunk straddles a
-			// 64-bit boundary).
-			let sel = if base_bit >= exponent_bits {
-				b.add_constant(Word::ZERO)
+			// `j` of the table index, matching `table[x] = x · P`. One masked shift pulls the
+			// whole chunk, joining two limbs when it straddles a 64-bit boundary.
+			let n_bits = (base_bit + window).min(exponent_bits) - base_bit;
+			let mask = b.add_constant_64((1u64 << n_bits) - 1);
+			let offset = (base_bit % Word::BITS) as u32;
+			let lo = base_bit / Word::BITS;
+			let hi = (base_bit + n_bits - 1) / Word::BITS;
+			let sel = if lo == hi {
+				b.band(b.shr(subscalar[lo], offset), mask)
 			} else {
-				let n_bits = (base_bit + window).min(exponent_bits) - base_bit;
-				let mask = b.add_constant_64((1u64 << n_bits) - 1);
-				let offset = (base_bit % Word::BITS) as u32;
-				let lo = base_bit / Word::BITS;
-				let hi = (base_bit + n_bits - 1) / Word::BITS;
-				if lo == hi {
-					b.band(b.shr(subscalar[lo], offset), mask)
-				} else {
-					// The halves land in disjoint bit ranges, so XOR joins them before the mask.
-					let low = b.shr(subscalar[lo], offset);
-					let high = b.shl(subscalar[hi], Word::BITS as u32 - offset);
-					b.band(b.bxor(low, high), mask)
-				}
+				// The halves land in disjoint bit ranges, so XOR joins them before the mask.
+				let low = b.shr(subscalar[lo], offset);
+				// `offset == 0` never reaches this arm: a chunk starting on a limb boundary fits
+				// in `subscalar[lo]` (`n_bits <= window < Word::BITS`, asserted in
+				// `msm_strauss_endo`), so this left shift stays below `Word::BITS`.
+				let high = b.shl(subscalar[hi], Word::BITS as u32 - offset);
+				b.band(b.bxor(low, high), mask)
 			};
 
 			let selected =

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,30 +1,30 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 150,143
-└─ Number of evaluation instructions: 175,961
+├─ Number of gates: 149,311
+└─ Number of evaluation instructions: 175,129
 
 Constraints
-├─ ZERO constraints: 16,088 used (98.2% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 296
-├─ AND constraints: 83,892 used (64.0% of 2^17)
-│  [▓▓▓▓▓▓░░░░] spare: 47,180
+├─ ZERO constraints: 15,896 used (97.0% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 488
+├─ AND constraints: 83,700 used (63.9% of 2^17)
+│  [▓▓▓▓▓▓░░░░] spare: 47,372
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 3,718
-└─ Distinct value indices: 274,434
-   ├─ Distinct shifted value indices: 139,440
-   └─ Distinct unshifted value indices: 134,994
+└─ Distinct value indices: 272,899
+   ├─ Distinct shifted value indices: 138,288
+   └─ Distinct unshifted value indices: 134,611
 
 Value Vector
-├─ Public Section: 93 (not committed)
-│  ├─ Constants: 93
+├─ Public Section: 94 (not committed)
+│  ├─ Constants: 94
 │  └─ Inout: 0
-├─ Private Section: 134,917
+├─ Private Section: 134,533
 │  ├─ Witness: 9
-│  └─ Internal: 134,908
-├─ Committed Trace: 134,917 used (51.5% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 127,227
+│  └─ Internal: 134,524
+├─ Committed Trace: 134,533 used (51.3% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 127,611
 └─ Scratch (uncommitted): 109 (peak live: 109)
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -1,30 +1,30 @@
 ec_msm circuit
 --
 Gates & Instructions
-├─ Number of gates: 208,914
-└─ Number of evaluation instructions: 244,030
+├─ Number of gates: 207,250
+└─ Number of evaluation instructions: 242,366
 
 Constraints
-├─ ZERO constraints: 21,366 used (65.2% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 11,402
-├─ AND constraints: 112,581 used (85.9% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 18,491
+├─ ZERO constraints: 20,982 used (64.0% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 11,786
+├─ AND constraints: 112,197 used (85.6% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 18,875
 ├─ IMUL constraints: 20,524 used (62.6% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,244
 ├─ BMUL constraints: 23,632 used (72.1% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 9,136
-└─ Distinct value indices: 373,577
-   ├─ Distinct shifted value indices: 185,953
-   └─ Distinct unshifted value indices: 187,624
+└─ Distinct value indices: 370,506
+   ├─ Distinct shifted value indices: 183,649
+   └─ Distinct unshifted value indices: 186,857
 
 Value Vector
-├─ Public Section: 52 (not committed)
-│  ├─ Constants: 20
+├─ Public Section: 53 (not committed)
+│  ├─ Constants: 21
 │  └─ Inout: 32
-├─ Private Section: 187,577
+├─ Private Section: 186,809
 │  ├─ Witness: 0
-│  └─ Internal: 187,577
-├─ Committed Trace: 187,577 used (71.6% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 74,567
+│  └─ Internal: 186,809
+├─ Committed Trace: 186,809 used (71.3% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 75,335
 └─ Scratch (uncommitted): 254 (peak live: 254)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,30 +1,30 @@
 ethsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 214,965
-└─ Number of evaluation instructions: 250,294
+├─ Number of gates: 213,301
+└─ Number of evaluation instructions: 248,630
 
 Constraints
-├─ ZERO constraints: 21,342 used (65.1% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 11,426
-├─ AND constraints: 113,992 used (87.0% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 17,080
+├─ ZERO constraints: 20,958 used (64.0% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 11,810
+├─ AND constraints: 113,608 used (86.7% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 17,464
 ├─ IMUL constraints: 20,538 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,230
 ├─ BMUL constraints: 23,874 used (72.9% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 8,894
-└─ Distinct value indices: 387,895
-   ├─ Distinct shifted value indices: 198,554
-   └─ Distinct unshifted value indices: 189,341
+└─ Distinct value indices: 384,823
+   ├─ Distinct shifted value indices: 196,250
+   └─ Distinct unshifted value indices: 188,573
 
 Value Vector
 ├─ Public Section: 114 (not committed)
 │  ├─ Constants: 85
 │  └─ Inout: 29
-├─ Private Section: 189,236
+├─ Private Section: 188,468
 │  ├─ Witness: 0
-│  └─ Internal: 189,236
-├─ Committed Trace: 189,236 used (72.2% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,908
+│  └─ Internal: 188,468
+├─ Committed Trace: 188,468 used (71.9% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 73,676
 └─ Scratch (uncommitted): 256 (peak live: 256)
 


### PR DESCRIPTION
## What

The fixed-window ECDSA scalar mul builds each window's table selector by pulling the exponent bits out one at a time: a `band` with `1` to isolate the bit, then a shift into place. That is one AND constraint per exponent bit. The bits are contiguous, so one masked shift pulls the whole window instead. When a window straddles a 64-bit limb boundary, the two halves land in disjoint bit ranges and XOR joins them before the mask.

The selector values are unchanged, only the constraints that build them: 3 ANDs saved per window over 32 windows per 128-bit subscalar. The msm examples run two points (4 subscalars after the endomorphism split); p2pkh verifies with a single point (2 subscalars), hence half the delta.

## Numbers

Baseline is current `main` (e4a2612d), snapshots re-blessed on top of it.

| example | AND | ZERO | committed trace |
|---|---|---|---|
| ethsign | 113,992 -> 113,608 (-384) | 21,342 -> 20,958 (-384) | 189,236 -> 188,468 (-768) |
| ec_msm | 112,581 -> 112,197 (-384) | 21,366 -> 20,982 (-384) | 187,577 -> 186,809 (-768) |
| bitcoin_p2pkh | 83,892 -> 83,700 (-192) | 16,088 -> 15,896 (-192) | 134,917 -> 134,533 (-384) |

repro:
```
cargo run --release --example ethsign -- stat
```

## Correctness

The selector wire carries the same value as before; the msm tests compare against the k256 reference for windows 1 through 3 (window 3 exercises the limb-straddling path) and the endomorphism test covers the default window 4. All pass unchanged. The three example snapshots are re-blessed and no other snapshot moves. clippy, fmt and typos are clean, and ethsign, ec_msm and bitcoin_p2pkh prove and verify end to end.

## Scope

Only the selector packing in `strauss_accumulate`. The table build and the point additions are untouched.
