### PR TITLE
Delete the dead surface a usage census turns up in the frontend

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -13,7 +13,6 @@ binius-field = { path = "../field" }
 binius-utils = { path = "../utils" }
 cranelift-entity = { workspace = true }
 itertools.workspace = true
-rand.workspace = true
 petgraph.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -92,6 +92,8 @@ impl WitnessFiller<'_> {
 	}
 
 	/// Returns a mutable reference to the underlying value vector.
+	///
+	/// Raw access is what plants a witness the evaluator would never produce.
 	pub const fn value_vec_mut(&mut self) -> &mut ValueVec {
 		&mut self.value_vec
 	}
@@ -309,7 +311,7 @@ impl Circuit {
 	/// If any instance is not satisfiable, returns an error naming a failing instance and its
 	/// assertion failures. The reported instance is not guaranteed to be the lowest failing
 	/// instance across all stripes.
-	pub fn populate_wire_witness_batched_parallel(
+	pub(crate) fn populate_wire_witness_batched_parallel(
 		&self,
 		mut values: StridedArray2DViewMut<'_, Word>,
 		stripe_width: usize,

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -26,6 +26,9 @@
 //! The gate generates 2 constraints:
 //! - AND: `(x ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout`
 //! - ZERO: `sar(cout, 63) ⊕ all-1 = 0` (forces `MSB(cout) = 1`, i.e. `x ≠ 0`)
+//!
+//! No gadget in the workspace calls this gate.
+//! It is kept as a primitive, and because the two-constraint split is easy to get wrong.
 
 use binius_core::word::Word;
 

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -1,4 +1,7 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+use std::collections::hash_map::Entry;
+
 use binius_core::word::Word;
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap, entity_impl};
 use rustc_hash::FxHashMap;
@@ -9,29 +12,6 @@ use crate::compiler::{
 	hints::{HintId, HintRegistry},
 	pathspec::{PathSpec, PathSpecTree},
 };
-
-#[derive(Default)]
-pub struct ConstPool {
-	/// Interning table mapping each constant value to the wire that holds it.
-	///
-	/// Keyed by a 64-bit word, so a fast integer hasher beats the default SipHash here.
-	pub pool: FxHashMap<Word, Wire>,
-}
-
-impl ConstPool {
-	pub fn new() -> Self {
-		ConstPool::default()
-	}
-
-	pub fn get(&self, value: Word) -> Option<Wire> {
-		self.pool.get(&value).copied()
-	}
-
-	pub fn insert(&mut self, word: Word, wire: Wire) {
-		let prev = self.pool.insert(word, wire);
-		assert!(prev.is_none());
-	}
-}
 
 /// A wire through which a value flows in and out of gates.
 ///
@@ -203,9 +183,10 @@ pub struct GateGraph {
 	pub gate_origin: SecondaryMap<Gate, PathSpec>,
 	pub assertion_names: SecondaryMap<Gate, PathSpec>,
 
-	pub const_pool: ConstPool,
-	pub n_witness: usize,
-	pub n_inout: usize,
+	/// Interning table mapping each constant value to the wire that holds it.
+	///
+	/// Keyed by a 64-bit word, so a fast integer hasher beats the default SipHash here.
+	pub const_pool: FxHashMap<Word, Wire>,
 
 	/// The all-one constant wire, seeded as the first constant at construction.
 	///
@@ -238,9 +219,7 @@ impl GateGraph {
 			path_spec_tree,
 			gate_origin: SecondaryMap::with_default(root),
 			assertion_names: SecondaryMap::with_default(root),
-			const_pool: ConstPool::new(),
-			n_witness: 0,
-			n_inout: 0,
+			const_pool: FxHashMap::default(),
 			// Placeholder; overwritten by the seeding call below before any other wire exists.
 			all_one: Wire::from_u32(0),
 			wire_def: SecondaryMap::new(),
@@ -262,33 +241,28 @@ impl GateGraph {
 	}
 
 	pub fn add_inout(&mut self) -> Wire {
-		self.n_inout += 1;
 		self.wires.push(WireKind::Inout)
 	}
 
 	pub fn add_witness(&mut self) -> Wire {
-		self.n_witness += 1;
 		self.wires.push(WireKind::Witness)
 	}
 
 	pub fn add_internal(&mut self) -> Wire {
-		// Internal wires are treated as witnesses for allocation purposes
-		self.n_witness += 1;
 		self.wires.push(WireKind::Internal)
 	}
 
 	pub fn add_scratch(&mut self) -> Wire {
-		// Scratch wires are temporary storage, not part of witness
 		self.wires.push(WireKind::Scratch)
 	}
 
+	/// Returns the wire holding the given constant, creating it on first use.
 	pub fn add_constant(&mut self, word: Word) -> Wire {
-		if let Some(wire) = self.const_pool.get(word) {
-			return wire;
+		// One hash whether or not a wire already holds the word.
+		match self.const_pool.entry(word) {
+			Entry::Occupied(entry) => *entry.get(),
+			Entry::Vacant(entry) => *entry.insert(self.wires.push(WireKind::Constant(word))),
 		}
-		let wire = self.wires.push(WireKind::Constant(word));
-		self.const_pool.insert(word, wire);
-		wire
 	}
 
 	/// Emits a gate with the given opcode, inputs and outputs.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -74,6 +74,12 @@ pub struct Options {
 	/// Apply algebraic identities that let a gate return one of its operands.
 	pub enable_algebraic_folding: bool,
 	/// Share scratch slots between values whose lifetimes do not overlap.
+	///
+	/// - Shrinks the uncommitted segment to the most values alive at once, saved once per
+	///   instance.
+	/// - Changes no constraint, since an uncommitted value appears in no operand.
+	/// - Stops slots being one-to-one with values, so only committed values read back
+	///   meaningfully.
 	pub enable_scratch_pooling: bool,
 	/// Forward past the gates a zero operand turns into the identity.
 	pub enable_zero_propagation: bool,
@@ -654,41 +660,6 @@ impl CircuitBuilder {
 		// reads only the pinned set: without this it would inline a linear definition and leave the
 		// public word with no constraint defining it.
 		self.force_commit(wire);
-	}
-
-	/// Shares the value-vector slots of values the constraint system never references.
-	///
-	/// # Overview
-	///
-	/// Gate fusion inlines a linear operation into its consumers, leaving its result uncommitted.
-	/// Such a result only has to survive until the gate that last reads it.
-	///
-	/// - Without sharing, each one holds a slot for the whole run.
-	/// - With sharing, the segment shrinks to the largest number of them alive at once.
-	///
-	/// The batched witness buffer holds one column per instance.
-	/// So each slot dropped is saved once per instance.
-	///
-	/// No constraint changes.
-	/// An uncommitted value appears in no constraint operand.
-	/// Only the recorded length of the segment moves.
-	///
-	/// # Reading values back
-	///
-	/// Slots stop being one-to-one with values.
-	/// Looking one up afterwards yields whatever now occupies its slot.
-	///
-	/// Only committed values read back meaningfully:
-	/// - public inputs and outputs,
-	/// - private witnesses,
-	/// - anything pinned with [`force_commit`](Self::force_commit).
-	pub fn enable_scratch_pooling(&self) {
-		self.shared
-			.borrow_mut()
-			.as_mut()
-			.expect("CircuitBuilder used after build")
-			.opts
-			.enable_scratch_pooling = true;
 	}
 
 	fn graph_mut(&self) -> RefMut<'_, GateGraph> {

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -712,6 +712,14 @@ const fn chain_shl(i: u32) -> u32 {
 /// That is what makes slot sharing observable.
 const CHAIN_ROUNDS: u32 = 48;
 
+/// The default pass set with scratch-slot sharing turned on.
+fn pooled_opts() -> Options {
+	Options {
+		enable_scratch_pooling: true,
+		..Options::default()
+	}
+}
+
 /// Builds a chain of rotates, shifts and exclusive-ors, pinned by an equality assertion.
 ///
 /// Every intermediate result is linear, so gate fusion inlines it and leaves it uncommitted.
@@ -762,8 +770,7 @@ fn test_scratch_pooling_preserves_the_committed_witness() {
 	let (x_unpooled, expected_unpooled) = build_chain(&unpooled);
 	let unpooled = unpooled.build();
 
-	let pooled = CircuitBuilder::new();
-	pooled.enable_scratch_pooling();
+	let pooled = CircuitBuilder::with_opts(pooled_opts());
 	let (x_pooled, expected_pooled) = build_chain(&pooled);
 	let pooled = pooled.build();
 
@@ -847,8 +854,7 @@ fn test_scratch_pooling_rejects_a_bad_assignment() {
 	// A wrong assignment is rejected exactly as it would be under one slot per value.
 	//
 	// Fixture state: the 48-round chain, compiled with slots shared.
-	let builder = CircuitBuilder::new();
-	builder.enable_scratch_pooling();
+	let builder = CircuitBuilder::with_opts(pooled_opts());
 	let (x, expected) = build_chain(&builder);
 	let circuit = builder.build();
 
@@ -883,8 +889,7 @@ fn test_scratch_pooling_matches_scalar_per_instance_batched() {
 	//
 	//     value 0  [ inst0 | inst1 | ... | inst7 ]
 	//     value 1  [ inst0 | inst1 | ... | inst7 ]
-	let builder = CircuitBuilder::new();
-	builder.enable_scratch_pooling();
+	let builder = CircuitBuilder::with_opts(pooled_opts());
 	let (x, expected) = build_chain(&builder);
 	let circuit = builder.build();
 


### PR DESCRIPTION
Deletes six items in `binius-frontend` that nothing reads, and narrows one accessor whose visibility overstated its audience.
Pure cleanup — no behavior change, no constraint change.

### The problem

`pub` carries no information in this crate today.
`mod compiler` is private, so `pub` inside it is unreachable from outside — `rustc -W unreachable_pub` counts **299** such items against the **17** the crate root actually re-exports.
With that much noise, "is this used?" stops being answerable by reading, and `dead_code` never fires on items that are `pub` for no reason.

A usage census over the workspace turns up six items with zero readers.

### The change

Two counters on the gate graph, incremented on every wire creation and read by nobody:

```
 pub fn add_inout(&mut self) -> Wire {
-    self.n_inout += 1;
     self.wires.push(WireKind::Inout)
 }
```

The only other matches for those names in the crate belong to `ValueVecLayout`, which keeps its own.

`CircuitBuilder::enable_scratch_pooling` duplicated the `Options` field of the same name, and set it *after* construction — against what the `Options` doc calls the only knob:

```
- let pooled = CircuitBuilder::new();
- pooled.enable_scratch_pooling();
+ let pooled = CircuitBuilder::with_opts(pooled_opts());
```

Its three callers were all in-crate tests.
Its documentation explained the knob rather than the setter, so that content moved onto the `Options` field where the knob lives.

`ConstPool` wrapped a single map and hashed each constant twice — once to look it up, once to insert it:

```
- if let Some(wire) = self.const_pool.get(word) {
-     return wire;
- }
- let wire = self.wires.push(WireKind::Constant(word));
- self.const_pool.insert(word, wire);   // asserts the key was absent
- wire
+ match self.const_pool.entry(word) {
+     Entry::Occupied(entry) => *entry.get(),
+     Entry::Vacant(entry) => *entry.insert(self.wires.push(WireKind::Constant(word))),
+ }
```

One hash instead of two, and the no-overwrite invariant the wrapper asserted becomes structural.

`rand` was a normal dependency whose every use sits inside `cfg(test)`.
It is already a dev-dependency, so the `[dependencies]` entry just goes.

### On the one `pub(crate)`

`populate_wire_witness_batched_parallel` has one in-crate caller and no external one.

`CONTRIBUTING.md` says to prefer ancestor-module visibility and reach for `pub(crate)` sparingly.
That does not apply here: `Circuit` is re-exported from the crate root, so its inherent `pub` methods are public API even though the defining module is private.
`-W unreachable_pub` confirms it — 299 hits across the crate, **zero** in `circuit.rs`.

A method on a publicly reachable type has no ancestor-module escape hatch, which is the same situation as the guide's "field of a `pub` struct" exception.
So this is the one item here that needs the modifier.

### What stays, and why

Two items have no caller but are kept, each with a line of doc recording the reason so the next sweep does not re-derive it.

- `assert_non_zero` — a primitive a circuit may reach for, and why its MSB check has to be a separate constraint is easy to get wrong.
- `WitnessFiller::value_vec_mut` — its one caller is a soundness regression test that plants `x = 0, cout = 0` to check the verifier rejects it. It needs raw access because `populate_wire_witness` panics on that input, and there is no fill-constants-only API.

### Scope

- **deleted:** two gate-graph counters, one builder setter, the constant-pool wrapper, one dependency entry
- **narrowed:** one `Circuit` method to `pub(crate)`
- **changed:** three tests build through `Options` instead of the setter
- **untouched:** the remaining 298 `unreachable_pub` items, which want their own pass

### Verification

| gate | result |
|---|---|
| `cargo check --workspace --all-targets` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo machete crates/frontend` | no unused dependencies |
| `cargo test -p binius-frontend` | 234 passed, 0 failed — same as before |
| `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` | clean |
| `cargo +nightly-2026-07-01 fmt --check` | clean |

Net −46 lines across 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
