### PR TITLE
Parameterize the M4 verifiers and provers by the hash suite

### DIFF
--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -23,6 +23,7 @@ binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
 bytemuck.workspace = true
+digest.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/m4-prover/benches/utils/m4_bench.rs
+++ b/crates/m4-prover/benches/utils/m4_bench.rs
@@ -9,6 +9,7 @@
 //! Published Flock figures include it in the proof path, so the measured unit matches.
 
 use binius_frontend::{BatchWitnessFiller, Circuit};
+use binius_hash::StdHashSuite;
 use binius_m4_prover::Prover;
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
@@ -57,7 +58,7 @@ pub fn bench_m4_proving<F>(
 
 	// The verifier fixes the shape and FRI parameters; the prover inherits them.
 	let verifier = Verifier::setup(&cs, log_instances, log_inv_rate);
-	let prover = Prover::<OptimalPackedB128>::setup(&verifier);
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(&verifier);
 
 	// Correctness gate: prove and verify one batch before timing.
 	// A bench that measures a proof of nothing is worse than no bench.

--- a/crates/m4-prover/src/composite.rs
+++ b/crates/m4-prover/src/composite.rs
@@ -3,7 +3,7 @@
 //! Proving a whole [`ConstraintSystemM4`](binius_core::constraint_system::m4::ConstraintSystemM4):
 //! the main chip and every numbered chip.
 
-use std::iter;
+use std::{iter, marker::PhantomData};
 
 use binius_compute::{Allocator, BufferPool};
 use binius_core::{
@@ -11,14 +11,16 @@ use binius_core::{
 	constraint_system::{InoutSegment, m4::WitnessM4},
 };
 use binius_field::PackedField;
-use binius_hash::StdHashSuite;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::channel::WordIPProverChannel;
 use binius_m4_verifier::{IOPVerifierM4, VerifierM4};
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded};
 use binius_prover::{Error, protocols::shift::build_key_collection};
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
+use binius_utils::SerializeBytes;
 use binius_verifier::config::B128;
+use digest::Output;
 
 use crate::prove::{IOPProver, ProverNtt};
 
@@ -123,9 +125,10 @@ impl IOPProverM4 {
 /// Built from a [`VerifierM4`], so both sides share one set of FRI parameters.
 ///
 /// See [`IOPVerifierM4`] for what a composite proof does and does not establish.
-pub struct ProverM4<P>
+pub struct ProverM4<P, H>
 where
 	P: PackedField<Scalar = B128>,
+	H: HashSuite,
 {
 	iop_prover: IOPProverM4,
 	/// The precomputed BaseFold prover, holding the NTT and the FRI parameters.
@@ -133,17 +136,22 @@ where
 	/// The pool that recycles this prover's working buffers. It lives for the prover's lifetime,
 	/// so blocks freed by one proof are reused by the next.
 	pool: BufferPool,
+	/// The prover creates its Merkle transcript channels with the hash suite `H`, matching the
+	/// verifier it was built from.
+	_hash_marker: PhantomData<H>,
 }
 
-impl<P> ProverM4<P>
+impl<P, H> ProverM4<P, H>
 where
 	P: PackedField<Scalar = B128>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Builds the prover from a verifier, inheriting its sub-systems and FRI parameters.
 	///
 	/// The prover encodes the codeword with the multithreaded NTT, spread across the cores.
 	/// Reusing the verifier's compiler keeps both sides on one set of FRI parameters.
-	pub fn setup(verifier: &VerifierM4) -> Self {
+	pub fn setup(verifier: &VerifierM4<H>) -> Self {
 		// Reuse the verifier's evaluation domain so both sides agree on the code: its compiler
 		// fixed that domain as the Gao-Mateer basis of this dimension.
 		let domain_context =
@@ -161,6 +169,7 @@ where
 			iop_prover: IOPProverM4::new(verifier.iop_verifier()),
 			basefold_compiler,
 			pool: BufferPool::new(),
+			_hash_marker: PhantomData,
 		}
 	}
 
@@ -189,9 +198,7 @@ where
 		// channel draws no randomness.
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _, _>(
-				transcript,
-			);
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript);
 
 		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
 		// by earlier proofs.
@@ -210,6 +217,7 @@ where
 mod tests {
 	use binius_core::{ValueTable, constraint_system::m4::ConstraintSystemM4};
 	use binius_field::PackedBinaryGhash1x128b;
+	use binius_hash::StdHashSuite;
 	use binius_transcript::VerifierTranscript;
 	use binius_verifier::config::StdChallenger;
 
@@ -249,7 +257,7 @@ mod tests {
 	/// Proves `witness` against `cs` and returns the proof bytes.
 	fn prove(cs: &ConstraintSystemM4, witness: &WitnessM4) -> Vec<u8> {
 		let verifier = VerifierM4::setup(cs, LOG_INV_RATE).unwrap();
-		let prover = ProverM4::<P>::setup(&verifier);
+		let prover = ProverM4::<P, StdHashSuite>::setup(&verifier);
 
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove(witness, &mut transcript).unwrap();
@@ -261,7 +269,7 @@ mod tests {
 		let (cs, witness) = fixture();
 		let proof = prove(&cs, &witness);
 
-		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let verifier = VerifierM4::<StdHashSuite>::setup(&cs, LOG_INV_RATE).unwrap();
 		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
 		verifier
 			.verify(witness.main.inout(), &mut transcript)
@@ -272,8 +280,8 @@ mod tests {
 	#[test]
 	fn the_prover_mirrors_the_verifier_sub_system_for_sub_system() {
 		let (cs, _) = fixture();
-		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
-		let prover = ProverM4::<P>::setup(&verifier);
+		let verifier = VerifierM4::<StdHashSuite>::setup(&cs, LOG_INV_RATE).unwrap();
+		let prover = ProverM4::<P, StdHashSuite>::setup(&verifier);
 
 		assert_eq!(prover.iop_prover().chips().len(), cs.chips.len());
 	}
@@ -287,7 +295,7 @@ mod tests {
 		let mut inout = witness.main.inout().to_vec();
 		inout[0] = Word(inout[0].as_u64() ^ 1);
 
-		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let verifier = VerifierM4::<StdHashSuite>::setup(&cs, LOG_INV_RATE).unwrap();
 		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
 		assert!(
 			verifier.verify(&inout, &mut transcript).is_err(),
@@ -310,7 +318,7 @@ mod tests {
 
 		let proof = prove(&cs, &witness);
 
-		let verifier = VerifierM4::setup(&cs, LOG_INV_RATE).unwrap();
+		let verifier = VerifierM4::<StdHashSuite>::setup(&cs, LOG_INV_RATE).unwrap();
 		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
 		assert!(
 			verifier

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -1,13 +1,15 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::marker::PhantomData;
+
 use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, ValueTable},
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
-use binius_hash::StdHashSuite;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::sumcheck::{
 	MleToSumCheckEvaluator,
@@ -33,6 +35,7 @@ use binius_prover::{
 	ring_switch::{self, RingSwitchOutput},
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
+use binius_utils::SerializeBytes;
 use binius_verifier::{
 	config::B128,
 	protocols::{
@@ -41,6 +44,7 @@ use binius_verifier::{
 		zero,
 	},
 };
+use digest::Output;
 
 use crate::{
 	shift::prove as prove_shift,
@@ -352,9 +356,10 @@ impl IOPProver {
 ///
 /// One-time setup builds the shift keys and the BaseFold prover, reusing the verifier's parameters.
 /// A later proving call commits a witness table and proves it satisfies every AND constraint.
-pub struct Prover<P>
+pub struct Prover<P, H>
 where
 	P: PackedField<Scalar = B128>,
+	H: HashSuite,
 {
 	iop_prover: IOPProver,
 	/// The precomputed BaseFold prover, holding the NTT and the FRI parameters.
@@ -362,17 +367,22 @@ where
 	/// The pool that recycles this prover's working buffers. It lives for the prover's lifetime,
 	/// so blocks freed by one `prove` call are reused by the next.
 	pool: BufferPool,
+	/// The prover creates its Merkle transcript channels with the hash suite `H`, matching the
+	/// verifier it was built from.
+	_hash_marker: PhantomData<H>,
 }
 
-impl<P> Prover<P>
+impl<P, H> Prover<P, H>
 where
 	P: PackedField<Scalar = B128>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Builds the prover from a verifier, inheriting its constraint system and FRI parameters.
 	///
 	/// The prover encodes the codeword with the multithreaded NTT, spread across the cores.
 	/// Reusing the verifier's compiler keeps both sides on one set of FRI parameters.
-	pub fn setup(verifier: &Verifier) -> Self {
+	pub fn setup(verifier: &Verifier<H>) -> Self {
 		// Reuse the verifier's evaluation domain so both sides agree on the code: its compiler
 		// fixed that domain as the Gao-Mateer basis of this dimension.
 		let domain_context =
@@ -396,6 +406,7 @@ where
 			iop_prover,
 			basefold_compiler,
 			pool: BufferPool::new(),
+			_hash_marker: PhantomData,
 		}
 	}
 
@@ -417,9 +428,7 @@ where
 	{
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _, _>(
-				transcript,
-			);
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript);
 
 		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
 		// by earlier proofs.
@@ -678,6 +687,7 @@ mod tests {
 	use assert_matches::assert_matches;
 	use binius_field::PackedBinaryGhash1x128b;
 	use binius_frontend::CircuitBuilder;
+	use binius_hash::StdHashSuite;
 	use binius_iop::{
 		basefold::{Error as BaseFoldError, VerificationError as BaseFoldVerificationError},
 		channel::Error as IOPChannelError,
@@ -755,8 +765,8 @@ mod tests {
 			})
 			.unwrap();
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		// One prover, two proofs of the same table: the second reuses the first's freed blocks.
 		let prove_once = || {
@@ -829,8 +839,8 @@ mod tests {
 			})
 			.unwrap();
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -886,8 +896,8 @@ mod tests {
 			})
 			.unwrap();
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -908,8 +918,8 @@ mod tests {
 
 		// Setup once: the verifier fixes the shape and FRI parameters.
 		// The prover inherits them.
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		// Prover: commit, reduce, and open on a fresh transcript.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -967,8 +977,8 @@ mod tests {
 			.unwrap();
 
 		// Setup once: the verifier fixes the shape and FRI parameters, the prover inherits them.
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		// Prover: commit both oracles, reduce, and open on a fresh transcript.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -1032,8 +1042,8 @@ mod tests {
 			"the table commits the inout values with the private ones"
 		);
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -1098,8 +1108,8 @@ mod tests {
 			})
 			.unwrap();
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -1163,8 +1173,8 @@ mod tests {
 			.unwrap();
 
 		// Prove with the wide packing; the verifier is packing-agnostic.
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<WideP>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<WideP, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -1217,8 +1227,8 @@ mod tests {
 			.unwrap();
 
 		// Setup once: the verifier fixes the shape and FRI parameters, the prover inherits them.
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		// Prover: commit the trace, reduce, and open on a fresh transcript.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -1292,8 +1302,8 @@ mod tests {
 			.unwrap();
 
 		// Prove with the wide packing; the verifier is packing-agnostic.
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<WideP>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<WideP, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -1359,8 +1369,8 @@ mod tests {
 			})
 			.unwrap();
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);
@@ -1380,8 +1390,8 @@ mod tests {
 		let log_instances = 6;
 		let (cs, table) = setup_batch(log_instances, 1);
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		// Produce a faithful proof, then collect its bytes.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -1429,8 +1439,8 @@ mod tests {
 			})
 			.unwrap();
 
-		let verifier = Verifier::setup(&cs, log_instances, 1);
-		let prover = Prover::<P>::setup(&verifier);
+		let verifier = Verifier::<StdHashSuite>::setup(&cs, log_instances, 1);
+		let prover = Prover::<P, StdHashSuite>::setup(&verifier);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove_chip(&table, &mut prover_transcript);

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -27,6 +27,7 @@ use std::array;
 use binius_circuits::{blake3::blake3_compress_2x, keccak::permutation::keccak_f1600};
 use binius_core::word::Word;
 use binius_frontend::{BatchWitnessFiller, Circuit, CircuitBuilder, CircuitStat, Wire};
+use binius_hash::StdHashSuite;
 use binius_m4_prover::Prover;
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
@@ -111,7 +112,7 @@ where
 	// Set up the verifier.
 	// Build the prover from it, sharing its FRI parameters.
 	let verifier = Verifier::setup(&cs, log_instances, LOG_INV_RATE);
-	let prover = Prover::<OptimalPackedB128>::setup(&verifier);
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(&verifier);
 
 	// Warm up first, discarding the proof.
 	// This pays the one-time costs — thread-pool spin-up, lazily built tables, page faults on the

--- a/crates/m4-verifier/Cargo.toml
+++ b/crates/m4-verifier/Cargo.toml
@@ -17,6 +17,7 @@ binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
+digest.workspace = true
 
 [dev-dependencies]
 # Building a composite constraint system by hand is impractical, so the tests build one with the

--- a/crates/m4-verifier/src/composite.rs
+++ b/crates/m4-verifier/src/composite.rs
@@ -2,12 +2,14 @@
 
 //! Verifying a whole [`ConstraintSystemM4`]: the main chip and every numbered chip.
 
+use std::marker::PhantomData;
+
 use binius_core::{
 	Word,
 	constraint_system::{InoutSegment, m4::ConstraintSystemM4},
 };
 use binius_field::FieldOps;
-use binius_hash::StdHashSuite;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,
 	channel::{IOPVerifierChannel, OracleSpec},
@@ -15,8 +17,9 @@ use binius_iop::{
 };
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::checked_arithmetics::log2_ceil_usize;
+use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
 use binius_verifier::{Error, SECURITY_BITS, config::B128};
+use digest::Output;
 
 use crate::{
 	commit::BatchCommitLayout,
@@ -146,16 +149,22 @@ impl IOPVerifierM4 {
 ///
 /// See [`IOPVerifierM4`] for what a composite proof does and does not establish.
 ///
-/// The hash suite is fixed to [`StdHashSuite`], as it is for a single-chip
-/// [`Verifier`](crate::Verifier). The Binius64 verifier takes it as a parameter instead.
-pub struct VerifierM4 {
+/// `H` is the hash suite the Merkle commitments and the transcript channel use. One composite
+/// proof commits every sub-system on one channel, so one suite covers the whole system.
+pub struct VerifierM4<H: HashSuite> {
 	/// The IOP verifier, holding the sub-verifier for every sub-system.
 	iop_verifier: IOPVerifierM4,
 	/// The precomputed BaseFold verifier, holding the FRI parameters.
 	iop_compiler: BaseFoldVerifierCompiler<B128>,
+	/// The verifier creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
-impl VerifierM4 {
+impl<H> VerifierM4<H>
+where
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
+{
 	/// Builds the verifier for a composite system at the given code rate.
 	///
 	/// # Arguments
@@ -180,7 +189,7 @@ impl VerifierM4 {
 		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
 
 		let iop_compiler = BaseFoldVerifierCompiler::new(
-			&Scheme::new(),
+			&Scheme::<H>::new(),
 			oracle_specs,
 			log_inv_rate,
 			n_test_queries,
@@ -190,6 +199,7 @@ impl VerifierM4 {
 		Ok(Self {
 			iop_verifier,
 			iop_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -228,7 +238,7 @@ impl VerifierM4 {
 	{
 		let mut channel = self
 			.iop_compiler
-			.create_channel_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		let inout = channel.observe_words(inout);
 		self.iop_verifier.verify(&inout, &mut channel)?;
 		channel.finish()?;
@@ -240,6 +250,7 @@ impl VerifierM4 {
 #[cfg(test)]
 mod tests {
 	use binius_frontend::{CircuitBuilder, CircuitM4, Wire, hints::Hint};
+	use binius_hash::StdHashSuite;
 
 	use super::*;
 
@@ -304,7 +315,7 @@ mod tests {
 	#[test]
 	fn setup_covers_every_sub_system() {
 		let cs = composite_system(4);
-		let verifier = VerifierM4::setup(&cs, 1).unwrap();
+		let verifier = VerifierM4::<StdHashSuite>::setup(&cs, 1).unwrap();
 		let iop_verifier = verifier.iop_verifier();
 
 		// One sub-verifier per chip, alongside main's.
@@ -328,7 +339,7 @@ mod tests {
 	fn the_code_holds_every_sub_system() {
 		let log_inv_rate = 1;
 		let cs = composite_system(4);
-		let verifier = VerifierM4::setup(&cs, log_inv_rate).unwrap();
+		let verifier = VerifierM4::<StdHashSuite>::setup(&cs, log_inv_rate).unwrap();
 
 		// The codeword encodes every oracle, so it is at least the encoding of the longest one. A
 		// setup that had handed the compiler one sub-system's specs would fall short of this.
@@ -350,6 +361,6 @@ mod tests {
 		// Mutation: drop the chip main calls, leaving every call naming a chip that is not there.
 		cs.chips.clear();
 
-		assert!(VerifierM4::setup(&cs, 1).is_err());
+		assert!(VerifierM4::<StdHashSuite>::setup(&cs, 1).is_err());
 	}
 }

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -1,9 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::marker::PhantomData;
+
 use binius_core::constraint_system::{ConstraintSystem, InoutSegment};
 use binius_field::{ExtensionField, FieldOps};
-use binius_hash::StdHashSuite;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,
 	channel::{IOPVerifierChannel, OracleSpec, oracle_setup::OracleSetupChannel},
@@ -12,17 +14,19 @@ use binius_iop::{
 };
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
+use binius_utils::DeserializeBytes;
 use binius_verifier::{
 	Error, SECURITY_BITS,
 	config::{B1, B128},
 	reduction::{Instances, reduce_constraints},
 	ring_switch::{self, RingSwitchVerifyOutput},
 };
+use digest::Output;
 
 use crate::commit::BatchCommitLayout;
 
-/// The Merkle commitment scheme over the committed field.
-pub(crate) type Scheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
+/// The Merkle commitment scheme over the committed field, for a given hash suite.
+pub(crate) type Scheme<H> = BinaryMerkleTreeScheme<B128, H>;
 
 /// IOP verifier for the M4 constraint reduction of a particular constraint system.
 ///
@@ -162,14 +166,23 @@ impl IOPVerifier {
 /// A later verification checks one proof against that fixed setup.
 ///
 /// The prover is built from this verifier, so both sides share one set of FRI parameters.
-pub struct Verifier {
+///
+/// `H` is the hash suite the Merkle commitments and the transcript channel use, as it is for
+/// [`binius_verifier::Verifier`].
+pub struct Verifier<H: HashSuite> {
 	/// The IOP verifier, holding the constraint system and the committed shape.
 	iop_verifier: IOPVerifier,
 	/// The precomputed BaseFold verifier, holding the FRI parameters.
 	iop_compiler: BaseFoldVerifierCompiler<B128>,
+	/// The verifier creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
-impl Verifier {
+impl<H> Verifier<H>
+where
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
+{
 	/// Builds the verifier for `2^log_instances` instances of one circuit at the given code rate.
 	///
 	/// # Arguments
@@ -190,7 +203,7 @@ impl Verifier {
 
 		// Pick the proof-size-optimal FRI fold arity for this codeword length.
 		let log_code_len = layout.log_witness_elems + log_inv_rate;
-		let merkle_scheme = Scheme::new();
+		let merkle_scheme = Scheme::<H>::new();
 		let fri_arity =
 			ConstantArityStrategy::with_optimal_arity::<B128, _>(&merkle_scheme, log_code_len)
 				.arity;
@@ -209,6 +222,7 @@ impl Verifier {
 		Self {
 			iop_verifier,
 			iop_compiler,
+			_hash_marker: PhantomData,
 		}
 	}
 
@@ -253,7 +267,7 @@ impl Verifier {
 	{
 		let mut channel = self
 			.iop_compiler
-			.create_channel_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		self.iop_verifier.verify_chip(&mut channel)?;
 		channel.finish()?;
 


### PR DESCRIPTION
[BINIUS-480](https://linear.app/jimpo/issue/BINIUS-480/m4-parameterize-verifierm4-and-verifier-by-h-hashsuite) — the follow-up you asked for in [#2129](https://github.com/binius-zk/binius64/pull/2129#discussion_r3773767956).

Both M4 verifiers hardcoded `StdHashSuite` through a private `type Scheme = BinaryMerkleTreeScheme<B128, StdHashSuite>`, so a caller on another suite could not use them. They now take it as a type parameter, exactly as `binius_verifier::Verifier<H>` does:

- `binius_m4_verifier::Verifier<H: HashSuite>` and `VerifierM4<H: HashSuite>` — `PhantomData<H>`, `Output<H::LeafHash>: DeserializeBytes` on the impl, and `create_channel_from_transcript::<H, _, _>`.
- `binius_m4_prover::Prover<P, H>` and `ProverM4<P, H>` — same shape with `SerializeBytes`, since they inherit the suite through `from_verifier_compiler` and must create their channels with it. `binius_prover::Prover<P, H>` is the model.
- `Scheme` becomes `Scheme<H>`.

The `IOPVerifier`/`IOPProver` types are untouched: they hold a constraint system and shift keys, and never see the hash suite. Only the compiler-wrapping types needed the parameter.

Call sites take a turbofish — `Verifier::<StdHashSuite>::setup(..)`, `Prover::<P, StdHashSuite>::setup(..)` — matching how `binius_verifier::Verifier::<H>::setup` is called in `binius-examples`. That is the bulk of the diff: tests in both crates, the hash-primitive test, and the bench harness. `digest` becomes a dependency of both crates for `Output`.

Also drops the doc paragraph on `VerifierM4` claiming the suite was fixed, which this makes untrue.

No behaviour change: every caller still selects `StdHashSuite`, so the proofs and transcripts are byte-identical.

Verified green: `cargo build --workspace --tests --benches`, `cargo test -p binius-m4-prover -p binius-m4-verifier` (49 passed), `cargo clippy --all --tests --benches --examples -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)