### PR TITLE
BINIUS-469: drive the Fiat-Shamir challenger from the recursion channel

### DIFF
--- a/crates/recursion/src/challenger.rs
+++ b/crates/recursion/src/challenger.rs
@@ -140,12 +140,15 @@ enum Channel {
 /// Every sampled wire then carries the value the native challenger would have produced.
 ///
 /// Each call emits its gates immediately rather than deferring them.
-/// That is why the builder is borrowed for this object's whole life.
+///
+/// The builder is held by value rather than borrowed.
+/// A `CircuitBuilder` is a handle, so a clone emits into the same circuit.
+/// That lets a channel own both the builder and a challenger over it.
 ///
 /// See the [module docs](self) for the byte-packing conventions and the constraint cost.
-pub struct Sha256Challenger<'a> {
+pub struct Sha256Challenger {
 	/// Where this gadget's gates are emitted.
-	builder: &'a CircuitBuilder,
+	builder: CircuitBuilder,
 	/// Midstate over the blocks of the current epoch already compressed.
 	state: State,
 	/// A completed block held back so the next one can share a two-lane compression core.
@@ -164,17 +167,17 @@ pub struct Sha256Challenger<'a> {
 	n_cores: usize,
 }
 
-impl<'a> Sha256Challenger<'a> {
+impl Sha256Challenger {
 	/// Creates a challenger in the state a freshly defaulted native challenger starts in.
 	///
 	/// The seed digest is a constant, so nothing is committed and nothing is compressed yet.
-	pub fn new(builder: &'a CircuitBuilder) -> Self {
+	pub fn new(builder: &CircuitBuilder) -> Self {
 		// The seed is fixed by the protocol, so it enters as constants and costs no constraints.
 		let buffer = array::from_fn(|i| builder.add_constant_64(SEED[i] as u64));
 
 		// Fresh state: an empty epoch, a full sample buffer, and the sampler live.
 		let mut this = Self {
-			builder,
+			builder: builder.clone(),
 			state: State::iv(builder),
 			pending: None,
 			block: [builder.add_constant(Word::ZERO); BLOCK_WORDS],
@@ -356,9 +359,9 @@ impl<'a> Sha256Challenger<'a> {
 		// A two-lane core leaves its partner's state in the high half, and sampling reads all
 		// 64 bits, so the digest is the one place a clean high half is required.
 		let digest: [Wire; DIGEST_WORDS] =
-			array::from_fn(|i| clear_high_bits(self.builder, self.state.0[i], 32));
+			array::from_fn(|i| clear_high_bits(&self.builder, self.state.0[i], 32));
 
-		self.state = State::iv(self.builder);
+		self.state = State::iv(&self.builder);
 		self.block = [self.builder.add_constant(Word::ZERO); BLOCK_WORDS];
 		self.absorbed = 0;
 		self.buffer = digest;
@@ -382,8 +385,8 @@ impl<'a> Sha256Challenger<'a> {
 		}
 		// Reversing the bytes of each 32-bit half turns the little-endian pair into the two
 		// big-endian schedule words, already in order.
-		let swapped = swap_bytes_32(self.builder, word);
-		let first = clear_high_bits(self.builder, swapped, 32);
+		let swapped = swap_bytes_32(&self.builder, word);
+		let first = clear_high_bits(&self.builder, swapped, 32);
 		let second = self.builder.shr(swapped, 32);
 		self.absorb_be32(first);
 		self.absorb_be32(second);

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -4,7 +4,7 @@
 
 use std::{array, rc::Rc};
 
-use binius_circuits::multiplexer::multi_wire_multiplex;
+use binius_circuits::{bytes::swap_bytes_32, multiplexer::multi_wire_multiplex};
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash as B128, Field, FieldOps, util::FieldFn};
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
@@ -16,6 +16,7 @@ use binius_iop::{
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
 
 use crate::{
+	challenger::Sha256Challenger,
 	merkle::{self, Digest, ELEMENT_WORDS, Element},
 	shared::Shared,
 	symbolic::{SymbolicElem, SymbolicWord},
@@ -57,6 +58,11 @@ pub struct Recorded {
 /// See the crate docs for what this does and does not constrain.
 pub struct Binius64BuilderChannel {
 	shared: Rc<Shared>,
+	/// The Fiat-Shamir state, over wires.
+	///
+	/// Every observed byte the native challenger absorbs is absorbed here too, in the same order.
+	/// A missed absorb desyncs it, and every challenge after that point is wrong.
+	challenger: Sha256Challenger,
 	/// How many assertions have been recorded, so each gets a distinct name.
 	n_assertions: usize,
 	/// Consulted only for the layer depth an opening decommits to, so no tree is ever built.
@@ -70,8 +76,12 @@ pub struct Binius64BuilderChannel {
 impl Binius64BuilderChannel {
 	/// Creates a channel over a fresh builder.
 	pub fn new() -> Self {
+		let shared = Rc::new(Shared::new());
+		// The challenger opens on its protocol seed, which is constant and so costs nothing.
+		let challenger = Sha256Challenger::new(shared.builder());
 		Self {
-			shared: Rc::new(Shared::new()),
+			shared,
+			challenger,
 			n_assertions: 0,
 			scheme: BinaryMerkleTreeScheme::new(),
 			n_merkle_checks: 0,
@@ -127,12 +137,6 @@ impl Binius64BuilderChannel {
 		array::from_fn(|_| self.shared.input_wire(kind))
 	}
 
-	/// Allocates one field element as circuit inputs, in the form the protocol reads.
-	fn input_elem(&mut self, kind: &'static str) -> SymbolicElem {
-		let element = self.input_element(kind);
-		self.elem(element)
-	}
-
 	/// Lifts a wire pair to the element type the protocol sees.
 	fn elem(&self, [lo, hi]: Element) -> SymbolicElem {
 		SymbolicElem::wires(&self.shared, lo, hi)
@@ -157,18 +161,24 @@ impl IPVerifierChannel<B128> for Binius64BuilderChannel {
 	type Elem = SymbolicElem;
 
 	fn recv_one(&mut self) -> Result<SymbolicElem, binius_ip::channel::Error> {
-		Ok(self.input_elem("recv_one"))
+		// A received element is read through the transcript's *message* reader, which observes it.
+		// Its two halves are already the little-endian words the challenger absorbs.
+		let element = self.input_element("recv_one");
+		self.challenger.observe_words(&element);
+		Ok(self.elem(element))
 	}
 
 	fn sample(&mut self) -> SymbolicElem {
-		// UNCONSTRAINED: a challenge is the Fiat-Shamir state's output, which needs the
-		// challenger's hashing in-circuit. Until then it is an input the replay supplies.
-		self.input_elem("sample")
+		// Sixteen bytes of sampler output, packed little-endian into an element's two halves.
+		let (lo, hi) = self.challenger.sample_b128();
+		self.elem([lo, hi])
 	}
 
 	fn observe_one(&mut self, _val: B128) -> SymbolicElem {
-		// UNCONSTRAINED: nothing absorbs the value.
-		self.input_elem("observe_one")
+		// Absorbed as wires the replay fills, so the circuit is not tied to one value.
+		let element = self.input_element("observe_one");
+		self.challenger.observe_words(&element);
+		self.elem(element)
 	}
 
 	fn assert_zero(&mut self, val: SymbolicElem) -> Result<(), binius_ip::channel::Error> {
@@ -213,15 +223,16 @@ impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 	type Word = SymbolicWord;
 
 	fn observe_words(&mut self, words: &[Word]) -> Vec<SymbolicWord> {
-		// The statement enters the circuit here, one input wire per word, so everything downstream
-		// reads it symbolically instead of baking it in as constants. That is what makes the
-		// recorded circuit verify a *statement* rather than one fixed instance of it.
-		//
-		// UNCONSTRAINED: nothing feeds these into a Fiat-Shamir state yet, so the circuit is not
-		// yet bound to the statement it claims to verify.
-		words
+		// The statement enters as wires the replay fills, not as constants.
+		// Absorbing them binds every challenge below to this statement.
+		let wires = words
 			.iter()
-			.map(|_| SymbolicWord::wire(&self.shared, self.shared.input_wire("observe_words")))
+			.map(|_| self.shared.input_wire("observe_words"))
+			.collect::<Vec<_>>();
+		self.challenger.observe_words(&wires);
+		wires
+			.into_iter()
+			.map(|wire| SymbolicWord::wire(&self.shared, wire))
 			.collect()
 	}
 
@@ -277,9 +288,14 @@ impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 		SymbolicElem::wires(&self.shared, selected[0], selected[1])
 	}
 
-	fn sample_bits(&mut self, _bits: usize) -> SymbolicWord {
-		// UNCONSTRAINED, twice over: the index should come from the Fiat-Shamir state, and it
-		// should be masked to `bits` bits, which the FRI code relies on rather than asserting.
+	fn sample_bits(&mut self, bits: usize) -> SymbolicWord {
+		// The draw happens even though the result is thrown away.
+		// It consumes four sampler bytes, and that count is what the next observe appends.
+		// Skipping it desyncs every challenge after the first bit sample.
+		let _ = self.challenger.sample_bits(bits);
+
+		// UNCONSTRAINED: the index is still the prover's choice, which is BINIUS-470.
+		// The gadget's masked draw above is discarded rather than returned.
 		SymbolicWord::wire(&self.shared, self.shared.input_wire("sample_bits"))
 	}
 
@@ -310,6 +326,17 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 		depth: usize,
 	) -> Result<Commitment, merkle_channel::Error> {
 		let root = self.input_digest("merkle_root");
+
+		// A root is read through the message reader, so the challenger absorbs it.
+		//
+		// The wires hold the digest packed big-endian, which the hashing gadgets read.
+		// The challenger absorbs the tape's little-endian words, so each wire is reversed back.
+		let stream = {
+			let builder = self.shared.builder();
+			root.map(|word| swap_bytes_32(builder, word))
+		};
+		self.challenger.observe_words(&stream);
+
 		Ok(Commitment {
 			root,
 			leaf_size,
@@ -385,5 +412,76 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 		merkle::verify_vector(&builder, commitment.root, &data, commitment.leaf_size);
 
 		Ok(data.into_iter().map(|element| self.elem(element)).collect())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_transcript::{
+		Buf,
+		fiat_shamir::{Challenger, HasherChallenger, sample_bits_reader},
+	};
+	use sha2::Sha256;
+
+	use super::*;
+	use crate::merkle::element_words;
+
+	/// Draws a challenge, two query indices, then a second challenge, on both channels.
+	///
+	/// A bit sample reads from the same buffer a challenge reads from.
+	/// A channel that skipped the gadget for one would hand the next challenge spent bytes.
+	///
+	/// The index itself is still unconstrained, which is why only the challenges are pinned.
+	#[test]
+	fn a_challenge_after_a_bit_sample_matches_the_native_challenger() {
+		let mut native = HasherChallenger::<Sha256>::default();
+		let mut channel = Binius64BuilderChannel::new();
+
+		// The widths are arbitrary, but 11 and 5 are not multiples of eight, so the mask is live.
+		// A 128-bit challenge deserializes from sixteen little-endian sampler bytes.
+		let draw = |native: &mut HasherChallenger<Sha256>| {
+			let mut bytes = [0u8; 16];
+			native.sampler().copy_to_slice(&mut bytes);
+			u128::from_le_bytes(bytes)
+		};
+		let first = draw(&mut native);
+		sample_bits_reader(native.sampler(), 11);
+		sample_bits_reader(native.sampler(), 5);
+		let second = draw(&mut native);
+
+		let one = IPVerifierChannel::<B128>::sample(&mut channel);
+		WordIPVerifierChannel::<B128>::sample_bits(&mut channel, 11);
+		WordIPVerifierChannel::<B128>::sample_bits(&mut channel, 5);
+		let two = IPVerifierChannel::<B128>::sample(&mut channel);
+
+		// Each challenge is pinned to a public wire carrying the native value.
+		// A divergence then fails witness population rather than a Rust comparison.
+		let pins = {
+			let builder = channel.shared.builder();
+			[(one, first), (two, second)]
+				.iter()
+				.enumerate()
+				.map(|(i, (elem, want))| {
+					let (lo, hi) = elem.to_wires(builder);
+					let claimed = [builder.add_inout(), builder.add_inout()];
+					builder.assert_eq_v(format!("challenge[{i}]"), [lo, hi], claimed);
+					(claimed, *want)
+				})
+				.collect::<Vec<_>>()
+		};
+
+		// Every symbolic value must be dropped before the circuit is built.
+		let recorded = channel.build();
+		let mut w = recorded.circuit.new_witness_filler();
+		for (claimed, want) in pins {
+			for (wire, word) in claimed.iter().zip(element_words(want)) {
+				w[*wire] = Word(word);
+			}
+		}
+		// The discarded index draws are the only recorded inputs, and nothing reads their values.
+		for input in &recorded.inputs {
+			w[input.wire] = Word::ZERO;
+		}
+		recorded.circuit.populate_wire_witness(&mut w).unwrap();
 	}
 }

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -34,9 +34,9 @@ use crate::{
 /// diverging in opposite directions still add up, and every later value would land in the wrong
 /// wire silently.
 ///
-/// It exists because the skeleton leaves the Fiat-Shamir state unconstrained.
-/// Those wires carry values the circuit ought to derive.
-/// As gadgets land the recorded list shrinks, until only the proof itself remains.
+/// Most of what it fills is proof data the circuit cannot derive.
+/// The exception is the FRI query index, a value the circuit ought to derive and does not yet.
+/// When that lands, only the proof itself remains.
 ///
 /// The transcript is read directly rather than through a `VerifierMerkleTranscriptChannel`.
 /// That channel consumes the layer and branch digests internally, never handing them back.
@@ -117,9 +117,9 @@ where
 	}
 
 	fn sample(&mut self) -> B128 {
-		let value = IPVerifierChannel::<B128>::sample(self.transcript.borrow_mut());
-		self.fill_elem("sample", value);
-		value
+		// The circuit derives its own challenges now, so the build records no wire to fill here.
+		// The draw still has to happen, since it advances the native Fiat-Shamir state.
+		IPVerifierChannel::<B128>::sample(self.transcript.borrow_mut())
 	}
 
 	fn observe_one(&mut self, val: B128) -> B128 {

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -22,24 +22,29 @@
 //! [`bind_public`](Binius64BuilderChannel::bind_public) ties chosen ones to public inputs.
 //! That is what lets whoever checks an outer proof see which statement was verified.
 //!
-//! # Status: a skeleton, and not sound
+//! # Status: one hole left
 //!
-//! One gadget is still missing, so a value that ought to be derived is left as a circuit input:
+//! One value that ought to be derived is still a circuit input:
 //!
-//! - **The Fiat-Shamir state.** `sample` and `sample_bits` return free wires rather than the
-//!   challenger's output, so nothing ties a challenge to the transcript that produced it.
+//! - **The FRI query index.** `sample_bits` returns a free wire, so a prover chooses where its
+//!   committed data is opened.
 //!
-//! What *is* constrained is the verifier's arithmetic: the sumcheck folding, the eq-indicator and
-//! Lagrange evaluations, the monster multilinear, every `assert_zero` along the way, and both field
-//! gadgets that used to be bare hints.
+//! Everything else is constrained:
 //!
-//! The Merkle commitments are constrained too, by [`merkle`].
+//! - the verifier's arithmetic, down to every `assert_zero` along the way
+//! - the two field gadgets that used to be bare hints
+//! - the Merkle commitments, by [`merkle`]
+//! - the Fiat-Shamir state, by [`challenger`]
+//!
 //! An opened leaf is hashed and climbed to a decommitted layer the root fixes.
 //! A committed vector has its tree rebuilt over it.
 //! Both keep their values as circuit inputs, since those values are proof data.
 //!
-//! A circuit built here still accepts proofs it should reject: a prover picks its own challenges.
-//! Driving [`challenger`] from `sample` and `sample_bits` is what removes the bullet above.
+//! Every byte the native challenger observes is absorbed here too.
+//! A challenge is therefore derived from the transcript rather than supplied.
+//!
+//! So a circuit built here still accepts proofs it should reject, at one point only.
+//! Deriving and masking the query indices is what closes the bullet above.
 
 pub mod challenger;
 mod channel;


### PR DESCRIPTION
Closes [BINIUS-469](https://linear.app/jimpo/issue/BINIUS-469).

The recursive circuit derives its own challenges now, instead of being handed them.

### The problem

The challenger gadget landed in BINIUS-429 (#2103) but nothing called it. The channel returned a free wire where each challenge belongs:

```
challenge  <-  a blank the replay fills in
```

A proof works because the prover commits before it learns the challenge. Here it learned it first — it *chose* it. So every constraint the circuit does enforce was enforced at a point of the prover's choosing, which is worth nothing.

### The idea

Rebuild the hashing in-circuit, so a challenge becomes a gate output. That works only if the circuit absorbs the same bytes in the same order as the native verifier: one byte out of place and every later challenge differs.

### Five sites, not three

The issue named three. A transcript's **message** reader observes what it reads, while its **decommitment** reader does not — so two proof reads absorb too:

| site | in the issue | absorbs |
|---|---|---|
| `sample` | yes | — now derived |
| `observe_one` | yes | the element's two words |
| `observe_words` | yes | the statement's words |
| **`recv_one`** | no | the element's two words |
| **`recv_merkle_commitment`** | no | the root, byte-reversed |

Both were found by deleting the absorb and watching the end-to-end test break, not by reading. The Merkle openings and the committed vector stay unabsorbed, correctly: they come through the decommitment reader.

The root needs one reversal per wire. It is stored in the packed big-endian form the hashing gadgets read, while the challenger absorbs the tape's little-endian words.

### The bit-sample trap, and why the acceptance test cannot see it

`sample_bits` still returns a free wire, but the gadget runs for it and the result is discarded:

```
buffer = 32 bytes                          cursor = 0
draw a 128-bit challenge   16 bytes        cursor = 16
draw a query index          4 bytes        cursor = 20
draw a 128-bit challenge   16 bytes        bytes 20..32, refill, then 4 more
```

Skip the middle draw and the cursor sits at 16, so the second challenge reads bytes 16..32 and no refill happens. A different number, failing far from its cause. The call is not about the value — it moves the cursor.

The issue says this desyncs "at the first bit sample". It does not, here: **all 88 challenge draws in the CRC-64 pipeline precede all 232 index draws**, so removing the advance leaves the acceptance test passing. Verified by tracing the call order.

So a channel unit test covers it instead. It draws a challenge, two bit samples, then a second challenge, and pins both challenges against the native challenger. It fails with the advance removed and passes with it.

### One structural change

`Sha256Challenger` borrowed its builder, which cannot live in a channel that owns the builder through an `Rc`. It holds the builder by value now — a `CircuitBuilder` is a handle whose clone emits into the same circuit. The constructor signature is unchanged and the type just loses its lifetime parameter.

### Cost

| | before | after |
|---|---|---|
| AND | 316,285 | 404,700 |
| gates | 1,459,181 | 1,803,527 |
| recorded inputs | 4,687 | 4,511 |

The +88,415 AND is the SHA-256, in the range #2103 predicted for this many observed blocks.

The issue predicted −179 wires, as `sample` 174 plus `observe_words` 5. Actual is **−176**, all from `sample`:

- `sample` is 176 wires now, not 174. Main moved since the issue was written.
- `observe_words` **stays**. That prediction predates [BINIUS-472](https://linear.app/jimpo/issue/BINIUS-472) (#2130), which made the statement a replay-filled wire bindable through `bind_public`. Absorbing it as constants instead would bake the statement back into the gates and undo that.

### What is left

`sample_bits` returns a free wire, so the remaining hole is exactly "the query index is the prover's choice" — [BINIUS-470](https://linear.app/jimpo/issue/BINIUS-470). The `UNCONSTRAINED` marker now says only that, and the crate docs no longer describe the Fiat-Shamir state as unconstrained.

### Scope

- **changed:** the five call sites and the challenger field in `channel.rs`; the discarded `sample` fill in `filler.rs`; the builder ownership in `challenger.rs`; the crate and filler docs
- **new:** one channel unit test, for the interleaving the acceptance test cannot reach
- **left untouched:** the challenger gadget's own logic and tests

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-recursion --no-deps` — clean
- `cargo test -p binius-recursion` — 29 unit + 6 integration passed

The end-to-end test is the real check. The circuit's derived challenges feed constraints that are checked against a real proof, so any divergence from the native byte stream fails witness population. That it passes is a byte-for-byte equality check on the whole protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
