### PR TITLE
Dispatch a gadget to a chip or to gates, by the building circuit's choice

### DIFF
--- a/crates/frontend/src/chip.rs
+++ b/crates/frontend/src/chip.rs
@@ -7,7 +7,7 @@ use binius_core::{
 	m4::{ChipCall, ConstraintSystemM4, EmbeddedConstraintSystem},
 };
 
-use crate::Circuit;
+use crate::{Circuit, CircuitBuilder, Hint, Wire};
 
 /// One chip of a [`CircuitM4`], as the circuit that generates its witness.
 ///
@@ -15,8 +15,8 @@ use crate::Circuit;
 /// positionally, and every value the chip holds beyond them is derived from them. An inout wire the
 /// call does not reach is filled with zero.
 ///
-/// A wire promoted with [`CircuitBuilder::mark_inout`](crate::CircuitBuilder::mark_inout) serves
-/// as well as one declared with [`CircuitBuilder::add_inout`](crate::CircuitBuilder::add_inout).
+/// A wire promoted with [`CircuitBuilder::mark_inout`] serves
+/// as well as one declared with [`CircuitBuilder::add_inout`].
 /// Witness generation assigns every inout wire from the call data, then evaluation recomputes the
 /// promoted ones over it. Nothing checks that the two agree, and nothing has to: where they
 /// disagree the row stops matching the call site, which is what the chip call itself enforces.
@@ -267,9 +267,9 @@ impl CircuitM4 {
 	}
 }
 
-/// A chip of the system a [`CircuitBuilder`](crate::CircuitBuilder) is building.
+/// A chip of the system a [`CircuitBuilder`] is building.
 ///
-/// [`CircuitBuilder::add_chip`](crate::CircuitBuilder::add_chip) returns one for each chip it
+/// [`CircuitBuilder::add_chip`] returns one for each chip it
 /// registers, and a call site names its callee by it. Registering further chips never moves a chip
 /// already registered, so a reference stays good for the rest of the build.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -288,6 +288,71 @@ impl ChipRef {
 	pub const fn chip_id(self) -> usize {
 		self.0
 	}
+}
+
+/// A gadget the builder emits either as inline gates or as a call to a chip.
+///
+/// The gadget is written once, in [`build`](Self::build), and where it lands is the building
+/// circuit's to decide: [`CircuitBuilder::build_gadget`]
+/// emits the gates unless
+/// [`CircuitBuilder::register_chip`] has made the gadget a
+/// chip, in which case it emits a hint and a call constraining it.
+///
+/// The [`Hint`] half is what the chip path needs of a gadget beyond its gates. Its `NAME` and
+/// `dimensions` name which gadget a registered chip serves; [`shape`](Hint::shape) gives the arity
+/// of the gates and of the chip's interface alike; and [`execute`](Hint::execute) computes the
+/// outputs a call passes alongside its inputs.
+///
+/// So a `Hint::execute` and a `build` of the same gadget must agree on every input the circuit can
+/// reach them with. Where they disagree, the chip instance recomputes a word the call did not name,
+/// and only [`WitnessM4::verify`](binius_core::m4::WitnessM4::verify) reports it.
+///
+/// ```
+/// use binius_core::word::Word;
+/// use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire};
+///
+/// /// The bitwise conjunction of two words.
+/// struct And;
+///
+/// impl Hint for And {
+///     const NAME: &'static str = "doc.and";
+///
+///     fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+///         (2, 1)
+///     }
+///
+///     fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+///         outputs[0] = Word(inputs[0].as_u64() & inputs[1].as_u64());
+///     }
+/// }
+///
+/// impl ChipGadget for And {
+///     fn build(&self, builder: &CircuitBuilder, _dims: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+///         vec![builder.band(inputs[0], inputs[1])]
+///     }
+/// }
+///
+/// // Without a chip the gadget is its gates, and the circuit builds as any other.
+/// let builder = CircuitBuilder::new();
+/// let (a, b) = (builder.add_inout(), builder.add_inout());
+/// builder.build_gadget(And, &[], &[a, b]);
+/// builder.build();
+///
+/// // Registering the gadget is the whole of the opt-in: the same call is now a chip call.
+/// let builder = CircuitBuilder::new();
+/// builder.register_chip(And, &[]);
+/// let (a, b) = (builder.add_inout(), builder.add_inout());
+/// builder.build_gadget(And, &[], &[a, b]);
+/// builder.build_m4().validate().unwrap();
+/// ```
+pub trait ChipGadget: Hint {
+	/// Emits the gadget's gates, returning the outputs its
+	/// [`shape`](Hint::shape) declares.
+	///
+	/// Each returned wire must be gate-created: a chip promotes them with
+	/// [`CircuitBuilder::mark_inout`], which takes no other
+	/// kind. Returning an input or a constant unchanged is what that rules out.
+	fn build(&self, builder: &CircuitBuilder, dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire>;
 }
 
 /// Reason an M4 circuit cannot be populated as it stands.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -2,6 +2,7 @@
 // Copyright 2025 Irreducible Inc.
 use std::{
 	cell::{RefCell, RefMut},
+	collections::HashMap,
 	iter, mem,
 	rc::Rc,
 };
@@ -15,7 +16,7 @@ use cranelift_entity::EntitySet;
 use itertools::chain;
 
 use crate::{
-	chip::{ChipRef, CircuitM4, EmbeddedCircuit},
+	chip::{ChipGadget, ChipRef, CircuitM4, EmbeddedCircuit},
 	compiler::{
 		circuit::Circuit,
 		constraint_builder::ConstraintBuilder,
@@ -104,6 +105,19 @@ pub(crate) struct PendingCall {
 	inout: Vec<Wire>,
 }
 
+/// The chip serving a gadget, and how a call site orders the words it passes.
+#[derive(Clone)]
+pub(crate) struct RegisteredGadget {
+	chip: ChipRef,
+	/// Where each of the chip's inout words sits in the gadget's interface, which is its inputs
+	/// followed by its outputs.
+	///
+	/// The inout segment is ordered by wire creation, so a promoted output lands where its gate
+	/// ran rather than where it was promoted. Registration reads the positions back off the built
+	/// chip, and a call site permutes its words by them.
+	inout_order: Vec<usize>,
+}
+
 pub(crate) struct Shared {
 	pub(crate) graph: GateGraph,
 	pub(crate) opts: Options,
@@ -113,6 +127,8 @@ pub(crate) struct Shared {
 	pub(crate) chips: Vec<EmbeddedCircuit>,
 	/// The calls the built circuit makes, in the order they were emitted.
 	pub(crate) chip_calls: Vec<PendingCall>,
+	/// The chips serving a gadget, keyed by the gadget's name and dimensions.
+	pub(crate) chip_gadgets: HashMap<(&'static str, Vec<usize>), RegisteredGadget>,
 }
 
 /// Circuit builder for constructing zero-knowledge proof circuits.
@@ -228,6 +244,7 @@ impl CircuitBuilder {
 				hint_registry: HintRegistry::new(),
 				chips: Vec::new(),
 				chip_calls: Vec::new(),
+				chip_gadgets: HashMap::new(),
 			}))),
 		}
 	}
@@ -310,6 +327,144 @@ impl CircuitBuilder {
 			chip,
 			inout: inout.to_vec(),
 		});
+	}
+
+	/// Makes a gadget a chip of the circuit being built, so that every emission of it is a call.
+	///
+	/// The chip is the gadget as a system of its own: its inputs declared with
+	/// [`Self::add_inout`], its gates emitted by [`ChipGadget::build`], and its outputs promoted
+	/// with [`Self::mark_inout`]. Building it here rather than taking one built elsewhere is what
+	/// holds the chip's interface and the call sites' words to the same order.
+	///
+	/// The chip's own gates are emitted on a builder of its own, which registers no gadget. So a
+	/// gadget reaching [`Self::build_gadget`] for itself emits its gates inside its chip rather
+	/// than calling back into it.
+	///
+	/// The gadget is keyed by its [`NAME`](Hint::NAME) and `dimensions`: a later
+	/// [`Self::build_gadget`] on the same pair is a call to this chip, and any other emission is
+	/// gates as before. Registering is the whole of the opt-in, and it reaches every subcircuit,
+	/// since they build the same circuit.
+	///
+	/// Registering a gadget the circuit never builds leaves a chip nothing calls, which
+	/// [`CircuitM4::validate`] rejects. So a circuit registers the gadgets it goes on to use.
+	///
+	/// # Panics
+	///
+	/// Panics if the gadget is already registered for these dimensions, if its `build` returns a
+	/// number of outputs other than its [`shape`](Hint::shape) declares, or if its `build`
+	/// declares inout wires of its own, which the interface a call site passes cannot reach.
+	pub fn register_chip<G: ChipGadget>(&self, gadget: G, dimensions: &[usize]) {
+		let (n_in, _) = gadget.shape(dimensions);
+
+		let body = CircuitBuilder::new();
+		let inputs = (0..n_in).map(|_| body.add_inout()).collect::<Vec<_>>();
+		let outputs = body.build_gadget(gadget, dimensions, &inputs);
+		for &wire in &outputs {
+			body.mark_inout(wire);
+		}
+		let built = body.build_m4();
+
+		let interface = chain(&inputs, &outputs).copied().collect::<Vec<_>>();
+		let inout = built.main.circuit.inout();
+		assert_eq!(
+			inout.len(),
+			interface.len(),
+			"register_chip: gadget {} holds inout words beyond the {n_in} inputs and {} outputs \
+			 of its interface",
+			G::NAME,
+			outputs.len(),
+		);
+		let position = interface
+			.iter()
+			.enumerate()
+			.map(|(k, &wire)| (wire, k))
+			.collect::<HashMap<_, _>>();
+		let inout_order = inout.iter().map(|wire| position[wire]).collect::<Vec<_>>();
+
+		let chip = self.add_chip(built);
+
+		let mut shared = self.shared.borrow_mut();
+		let previous = shared
+			.as_mut()
+			.expect("CircuitBuilder used after build")
+			.chip_gadgets
+			.insert((G::NAME, dimensions.to_vec()), RegisteredGadget { chip, inout_order });
+		assert!(
+			previous.is_none(),
+			"register_chip: gadget {} is already a chip for dimensions {dimensions:?}",
+			G::NAME,
+		);
+	}
+
+	/// Emits a gadget, as a call to its chip where [`Self::register_chip`] has made it one and as
+	/// its gates otherwise.
+	///
+	/// A call passes the words the gadget relates rather than computing them, so the outputs come
+	/// from the gadget's own [`Hint`]: [`Self::call_hint`] hands the witness its values, and the
+	/// call is the constraint that makes them the ones the gadget's gates would have produced.
+	///
+	/// Either way the returned wires hold the gadget's outputs, so a caller reads the same wires
+	/// whichever way the gadget landed.
+	///
+	/// # Panics
+	///
+	/// Panics if `inputs.len()` or the gadget's output count differs from its
+	/// [`shape`](Hint::shape).
+	pub fn build_gadget<G: ChipGadget>(
+		&self,
+		gadget: G,
+		dimensions: &[usize],
+		inputs: &[Wire],
+	) -> Vec<Wire> {
+		let (n_in, n_out) = gadget.shape(dimensions);
+		assert_eq!(
+			inputs.len(),
+			n_in,
+			"build_gadget: gadget {} takes {n_in} inputs, given {}",
+			G::NAME,
+			inputs.len(),
+		);
+
+		let outputs = match self.registered_gadget(G::NAME, dimensions) {
+			Some(registered) => {
+				let outputs = self.call_hint(gadget, dimensions, inputs);
+				let interface = chain(inputs, &outputs).copied().collect::<Vec<_>>();
+				let inout = registered
+					.inout_order
+					.iter()
+					.map(|&k| interface[k])
+					.collect::<Vec<_>>();
+				self.call_chip(registered.chip, &inout);
+				outputs
+			}
+			None => gadget.build(self, dimensions, inputs),
+		};
+
+		assert_eq!(
+			outputs.len(),
+			n_out,
+			"build_gadget: gadget {} built {} outputs, its shape declares {n_out}",
+			G::NAME,
+			outputs.len(),
+		);
+		outputs
+	}
+
+	/// The chip serving a gadget, if one is registered for these dimensions.
+	///
+	/// Copies the entry out, since a caller goes on to emit gates against the same shared state.
+	fn registered_gadget(
+		&self,
+		name: &'static str,
+		dimensions: &[usize],
+	) -> Option<RegisteredGadget> {
+		self.shared
+			.borrow()
+			.as_ref()
+			.expect("CircuitBuilder used after build")
+			.chip_gadgets
+			.get(&(name, dimensions.to_vec()))
+			.cloned()
 	}
 
 	/// Returns the circuit built by this builder.

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -1259,3 +1259,222 @@ fn call_chip_commits_a_linear_argument() {
 	assert_eq!(called.value_vec_layout().n_private(), 1);
 	assert_eq!(called.constraint_system().n_zero_constraints(), 1);
 }
+
+/// A gadget returning its outputs in the reverse of the order their gates ran.
+///
+/// The inout segment is ordered by wire creation, so a chip built from this holds the exclusive-or
+/// before the conjunction while the gadget's interface holds them the other way round. A call site
+/// that passed its words in interface order would name them crosswise.
+struct AndThenXor;
+
+impl Hint for AndThenXor {
+	const NAME: &'static str = "test.and_then_xor";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(2, 2)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		outputs[0] = Word(inputs[0].as_u64() & inputs[1].as_u64());
+		outputs[1] = Word(inputs[0].as_u64() ^ inputs[1].as_u64());
+	}
+}
+
+impl ChipGadget for AndThenXor {
+	fn build(&self, builder: &CircuitBuilder, _dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+		let xor = builder.bxor(inputs[0], inputs[1]);
+		let and = builder.band(inputs[0], inputs[1]);
+		vec![and, xor]
+	}
+}
+
+/// A gadget built out of [`AndThenXor`], which is what reaches a gadget from inside a chip body.
+struct XorOfAndThenXor;
+
+impl Hint for XorOfAndThenXor {
+	const NAME: &'static str = "test.xor_of_and_then_xor";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(2, 1)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let (a, b) = (inputs[0].as_u64(), inputs[1].as_u64());
+		outputs[0] = Word((a & b) ^ (a ^ b));
+	}
+}
+
+impl ChipGadget for XorOfAndThenXor {
+	fn build(&self, builder: &CircuitBuilder, dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+		let inner = builder.build_gadget(AndThenXor, dimensions, inputs);
+		vec![builder.bxor(inner[0], inner[1])]
+	}
+}
+
+/// The words `AndThenXor` relates, as the circuit that registers no chip computes them.
+const AND_THEN_XOR_CASE: [u64; 4] = [0b1100, 0b1010, 0b1000, 0b0110];
+
+// A builder that no chip serves builds the gadget's gates, so a circuit that never registers one
+// is the circuit it was before the gadget became registrable.
+#[test]
+fn build_gadget_emits_gates_where_no_chip_serves_the_gadget() {
+	let builder = CircuitBuilder::new();
+	let (a, b) = (builder.add_inout(), builder.add_inout());
+	let out = builder.build_gadget(AndThenXor, &[], &[a, b]);
+
+	// `build` accepts this builder, which is what says no chip was registered.
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	w[a] = Word(AND_THEN_XOR_CASE[0]);
+	w[b] = Word(AND_THEN_XOR_CASE[1]);
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	assert_eq!(w[out[0]], Word(AND_THEN_XOR_CASE[2]));
+	assert_eq!(w[out[1]], Word(AND_THEN_XOR_CASE[3]));
+}
+
+// The same gadget, on a builder holding its chip. Main computes nothing: the hint hands it the
+// outputs and the call is the only thing relating them to the inputs.
+#[test]
+fn build_gadget_calls_the_chip_serving_the_gadget() {
+	let builder = CircuitBuilder::new();
+	builder.register_chip(AndThenXor, &[]);
+	let (a, b) = (builder.add_inout(), builder.add_inout());
+	let out = builder.build_gadget(AndThenXor, &[], &[a, b]);
+	let circuit = builder.build_m4();
+
+	circuit.validate().unwrap();
+	let cs = circuit.to_constraint_system();
+	cs.validate().unwrap();
+
+	// The chip holds the exclusive-or before the conjunction, so the call passes its last two
+	// words the other way round from the order the gadget returns them.
+	let main = &circuit.main.circuit;
+	let operands = circuit.main.chip_calls[0]
+		.inout
+		.iter()
+		.map(|operand| operand.as_slice())
+		.collect::<Vec<_>>();
+	assert_eq!(
+		operands,
+		[
+			[ShiftedValueIndex::plain(main.witness_index(a))].as_slice(),
+			[ShiftedValueIndex::plain(main.witness_index(b))].as_slice(),
+			[ShiftedValueIndex::plain(main.witness_index(out[1]))].as_slice(),
+			[ShiftedValueIndex::plain(main.witness_index(out[0]))].as_slice(),
+		]
+	);
+
+	let witness = circuit
+		.generate_witness(|filler| {
+			filler[a] = Word(AND_THEN_XOR_CASE[0]);
+			filler[b] = Word(AND_THEN_XOR_CASE[1]);
+		})
+		.unwrap();
+
+	// The gadget's caller reads the same wires it would have read from the gates.
+	assert_eq!(witness.main[main.witness_index(out[0])], Word(AND_THEN_XOR_CASE[2]));
+	assert_eq!(witness.main[main.witness_index(out[1])], Word(AND_THEN_XOR_CASE[3]));
+
+	// The chip instance recomputes both outputs over the words the call named, so this is what
+	// holds the hint to the gates.
+	witness.verify(&cs).unwrap();
+}
+
+// Registering reaches the subcircuits of the builder that registered, since they build the same
+// circuit. A gadget deep in a hierarchy needs nothing threaded down to it.
+#[test]
+fn a_subcircuit_reaches_a_chip_the_root_builder_registered() {
+	let builder = CircuitBuilder::new();
+	builder.register_chip(AndThenXor, &[]);
+	let (a, b) = (builder.add_inout(), builder.add_inout());
+	builder
+		.subcircuit("nested")
+		.build_gadget(AndThenXor, &[], &[a, b]);
+
+	let circuit = builder.build_m4();
+	assert_eq!(circuit.main.chip_calls.len(), 1);
+	circuit.validate().unwrap();
+}
+
+// A chip's own gates are emitted on a builder registering nothing, so a gadget inside a chip body
+// lands as gates however the outer circuit builds the same gadget.
+#[test]
+fn a_chip_body_emits_the_gadgets_it_uses_as_gates() {
+	let builder = CircuitBuilder::new();
+	builder.register_chip(AndThenXor, &[]);
+	builder.register_chip(XorOfAndThenXor, &[]);
+	let (a, b) = (builder.add_inout(), builder.add_inout());
+	builder.build_gadget(AndThenXor, &[], &[a, b]);
+	builder.build_gadget(XorOfAndThenXor, &[], &[a, b]);
+
+	let circuit = builder.build_m4();
+	assert_eq!(circuit.main.chip_calls.len(), 2);
+	assert!(
+		circuit
+			.chips
+			.iter()
+			.all(|(chip, _)| chip.chip_calls.is_empty())
+	);
+	circuit.validate().unwrap();
+
+	let cs = circuit.to_constraint_system();
+	let witness = circuit
+		.generate_witness(|filler| {
+			filler[a] = Word(AND_THEN_XOR_CASE[0]);
+			filler[b] = Word(AND_THEN_XOR_CASE[1]);
+		})
+		.unwrap();
+	witness.verify(&cs).unwrap();
+}
+
+// Two chips for one gadget shape would each hold a table, serving calls that could have shared one.
+#[test]
+#[should_panic(expected = "already a chip for dimensions []")]
+fn register_chip_rejects_a_gadget_it_already_serves() {
+	let builder = CircuitBuilder::new();
+	builder.register_chip(AndThenXor, &[]);
+	builder.register_chip(AndThenXor, &[]);
+}
+
+// A gadget's shape is what its interface is built from, so gates disagreeing with it would leave
+// the chip and its call sites different sizes.
+#[test]
+#[should_panic(expected = "built 1 outputs, its shape declares 2")]
+fn register_chip_rejects_a_gadget_disagreeing_with_its_shape() {
+	struct Miscounted;
+
+	impl Hint for Miscounted {
+		const NAME: &'static str = "test.miscounted";
+
+		fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+			(1, 2)
+		}
+
+		fn execute(&self, _dimensions: &[usize], _inputs: &[Word], outputs: &mut [Word]) {
+			outputs.fill(Word::ZERO);
+		}
+	}
+
+	impl ChipGadget for Miscounted {
+		fn build(
+			&self,
+			builder: &CircuitBuilder,
+			_dimensions: &[usize],
+			inputs: &[Wire],
+		) -> Vec<Wire> {
+			vec![builder.shl(inputs[0], 1)]
+		}
+	}
+
+	CircuitBuilder::new().register_chip(Miscounted, &[]);
+}
+
+// The inputs are passed positionally, so the wrong number of them would shift every word past the
+// gap, whether they reach the gates or a call.
+#[test]
+#[should_panic(expected = "takes 2 inputs, given 1")]
+fn build_gadget_rejects_the_wrong_number_of_inputs() {
+	let builder = CircuitBuilder::new();
+	builder.build_gadget(AndThenXor, &[], &[builder.add_inout()]);
+}

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -34,7 +34,7 @@ pub mod ops;
 pub mod stat;
 
 pub use batch::BatchWitnessFiller;
-pub use chip::{ChipRef, CircuitM4, CircuitM4Error, EmbeddedCircuit};
+pub use chip::{ChipGadget, ChipRef, CircuitM4, CircuitM4Error, EmbeddedCircuit};
 pub use chip_witness::PopulateM4Error;
 pub use compiler::{
 	CircuitBuilder, Options, Wire,


### PR DESCRIPTION
A gadget written for inline gates and the same gadget as a chip were two copies of the circuit: a standalone chip-building function, a hint, and a hand-ordered `call_chip` argument list at every site. Nothing in `binius-circuits` paid that, so no production gadget used chips at all.

This makes a gadget one thing the builder emits either way.

## The trait

`ChipGadget` is a `Hint` plus a `build` method, which is all `Hint` was missing:

```rust
pub trait ChipGadget: Hint {
    fn build(&self, builder: &CircuitBuilder, dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire>;
}
```

`Hint` already carries everything else the chip path needs. `NAME` and `dimensions` key which gadget a chip serves, `shape` gives the arity of the gates and of the chip interface alike, and `execute` computes the outputs a call passes alongside its inputs.

## The two builder methods

- `register_chip(gadget, dimensions)` builds the gadget as a system of its own — inputs declared with `add_inout`, gates from `build`, outputs promoted with `mark_inout` — and keys the chip by `(NAME, dimensions)`. The body builds on a builder registering nothing, so a gadget inside a chip body lands as gates.
- `build_gadget(gadget, dimensions, inputs)` emits a chip call where one is registered and the gates otherwise. Either way it returns the gadget's outputs, so a caller reads the same wires whichever way it landed.

Registering is the whole of the opt-in:

```rust
let builder = CircuitBuilder::new();
builder.register_chip(And, &[]);
let (a, b) = (builder.add_inout(), builder.add_inout());
builder.build_gadget(And, &[], &[a, b]);   // now a chip call
builder.build_m4();
```

## Why the chip is built here rather than taken

This is the part that makes it safe. `Circuit::inout()` is ordered by **wire creation**, not by promotion order, so a hand-written chip and a hand-ordered `call_chip` can disagree while the circuit still builds and still generates a witness — the mismatch surfaces only at `WitnessM4::verify`. `register_chip` reads the positions back off the built chip and a call site permutes its words by them.

`build_gadget_calls_the_chip_serving_the_gadget` pins this: its gadget returns its outputs in the reverse of the order their gates ran, and the test asserts the emitted call names its last two words crosswise. An identity ordering would pass every earlier check.

## Notes

- The registry lives on the builder's shared state, so registering reaches every subcircuit. A gadget deep in a hierarchy needs nothing threaded down to it.
- A gadget registered but never built leaves an uncalled chip, which `CircuitM4::validate` rejects. Opt-in is therefore per circuit shape, not blanket. Documented on `register_chip`.
- `Hint::execute` and `build` are two sources of truth for one relation, and only `WitnessM4::verify` reports a disagreement. A gadget should come with a test holding them to each other.
- The known costs are unchanged and out of scope here: a call commits one word per interface wire, and a linear argument costs a committed word plus a ZERO constraint where a constraint operand would have fused it in for free. Making chip calls a gate-fusion rewrite site is what recovers that.

## Testing

New tests in `compiler/tests.rs` cover: gates when nothing is registered, a chip call when something is, the interface permutation above, dispatch reaching a subcircuit, a chip body inlining its own gadgets, and the three panics (double registration, a `build` disagreeing with its `shape`, the wrong input count). A doctest on `ChipGadget` builds the same gadget both ways.

`cargo test --workspace` and `cargo check --workspace --all-targets` are clean at this commit; `clippy -D warnings` and `cargo doc` are clean for `binius-frontend`.

Stacked below #2141, which makes `blake3_compress_2x` the first gadget to use this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)