### PR TITLE
Make blake3_compress_2x a gadget, so a circuit can compress in a chip

### DIFF
--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -13,7 +13,7 @@
 use std::{array, iter};
 
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Hint, Wire};
+use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire};
 
 use super::{IV, MSG_SCHEDULE};
 use crate::util::clear_high_bits;
@@ -92,7 +92,76 @@ pub fn blake3_compress(
 /// # Returns
 ///
 /// The updated 8-word chaining value, with each word packing both lanes.
+///
+/// # Chips
+///
+/// This is a [`ChipGadget`]. A circuit that calls
+/// [`register_chip`](CircuitBuilder::register_chip) with [`Blake3Compress2x`] before building
+/// turns every compression under it into a chip call, including the ones
+/// [`blake3_compress_2x_seq`] and the chunk and tree gadgets reach.
 pub fn blake3_compress_2x(
+	builder: &CircuitBuilder,
+	cv: [Wire; 8],
+	block: [Wire; 16],
+	counter_lo: Wire,
+	counter_hi: Wire,
+	block_len: Wire,
+	flags: Wire,
+) -> [Wire; 8] {
+	let inputs = cv
+		.into_iter()
+		.chain(block)
+		.chain([counter_lo, counter_hi, block_len, flags])
+		.collect::<Vec<_>>();
+
+	let outputs = builder.build_gadget(Blake3Compress2x, &[], &inputs);
+	array::from_fn(|i| outputs[i])
+}
+
+/// [`blake3_compress_2x`] as a gadget, so that a circuit can make it a chip.
+///
+/// Its interface is the flat 28 input words `cv[0..8]`, `block[0..16]`, `counter_lo`,
+/// `counter_hi`, `block_len`, `flags`, and the 8 output chaining-value words, all packing two
+/// lanes as [`blake3_compress_2x`] documents.
+pub struct Blake3Compress2x;
+
+impl Hint for Blake3Compress2x {
+	const NAME: &'static str = "binius.blake3_compress_2x";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(28, 8)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		// Each lane is a 32-bit half of every input word, and the halves never interact: the
+		// core's adds and rotates are 32-bit and its exclusive-ors are bitwise. So a lane is the
+		// reference compression of its own halves.
+		let compress_lane = |i: usize| {
+			let lane = |word: Word| (word.as_u64() >> (32 * i)) as u32;
+			let cv: [u32; 8] = array::from_fn(|j| lane(inputs[j]));
+			let block: [u32; 16] = array::from_fn(|j| lane(inputs[8 + j]));
+			let counter = lane(inputs[24]) as u64 | ((lane(inputs[25]) as u64) << 32);
+			ref_compress(&cv, &block, counter, lane(inputs[26]), lane(inputs[27]))
+		};
+
+		let (lane_0, lane_1) = (compress_lane(0), compress_lane(1));
+		for (slot, (low, high)) in iter::zip(outputs, iter::zip(lane_0, lane_1)) {
+			*slot = Word(low as u64 | ((high as u64) << 32));
+		}
+	}
+}
+
+impl ChipGadget for Blake3Compress2x {
+	fn build(&self, builder: &CircuitBuilder, _dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+		let cv: [Wire; 8] = array::from_fn(|i| inputs[i]);
+		let block: [Wire; 16] = array::from_fn(|i| inputs[8 + i]);
+		compress_2x_gates(builder, cv, block, inputs[24], inputs[25], inputs[26], inputs[27])
+			.to_vec()
+	}
+}
+
+/// [`blake3_compress_2x`] in gates, whatever the building circuit does with the gadget.
+fn compress_2x_gates(
 	builder: &CircuitBuilder,
 	cv: [Wire; 8],
 	block: [Wire; 16],
@@ -395,6 +464,33 @@ mod tests {
 	use crate::blake3::{CHUNK_END, CHUNK_START, PARENT, ROOT};
 
 	// --- Circuit-level tests --------------------------------------------------------
+
+	/// Runs `blake3_compress_2x` in gates over its flat packed-word interface.
+	fn run_compress_2x_words(inputs: [u64; 28]) -> [u64; 8] {
+		let builder = CircuitBuilder::new();
+		let wires: [Wire; 28] = array::from_fn(|_| builder.add_witness());
+		let out = compress_2x_gates(
+			&builder,
+			array::from_fn(|i| wires[i]),
+			array::from_fn(|i| wires[8 + i]),
+			wires[24],
+			wires[25],
+			wires[26],
+			wires[27],
+		);
+		for wire in out {
+			builder.mark_inout(wire);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for (wire, word) in iter::zip(wires, inputs) {
+			w[wire] = Word(word);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		array::from_fn(|i| w[out[i]].as_u64())
+	}
 
 	/// Build a circuit that computes `blake3_compress` on witness inputs, populate the
 	/// witness with the given values, and return the evaluated 8-word output.
@@ -876,6 +972,20 @@ mod tests {
 			// Each lane is checked against a reference run of its own inputs alone.
 			prop_assert_eq!(actual[0], ref_compress(&cv0, &b0, t0, l0, f0));
 			prop_assert_eq!(actual[1], ref_compress(&cv1, &b1, t1, l1, f1));
+		}
+
+		// The chip path takes the outputs from `Blake3Compress2x::execute` and the chip recomputes
+		// them from its gates, so the two have to agree on every word a circuit can reach them
+		// with. Words drawn at random are lane pairs no caller would pass, which is the point:
+		// nothing about the interface stops one.
+		#[test]
+		fn compress_2x_hint_matches_its_gates(words in prop::collection::vec(any::<u64>(), 28)) {
+			let inputs: [u64; 28] = array::from_fn(|i| words[i]);
+
+			let mut hinted = [Word::ZERO; 8];
+			Blake3Compress2x.execute(&[], &inputs.map(Word), &mut hinted);
+
+			prop_assert_eq!(hinted.map(|word| word.as_u64()), run_compress_2x_words(inputs));
 		}
 
 		#[test]

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -25,7 +25,9 @@ use crate::{
 
 pub mod compress;
 
-pub use compress::{blake3_compress, blake3_compress_2x, blake3_compress_2x_seq, ref_compress};
+pub use compress::{
+	Blake3Compress2x, blake3_compress, blake3_compress_2x, blake3_compress_2x_seq, ref_compress,
+};
 
 /// BLAKE3 initial chaining value. Same as the SHA-256 IV.
 pub const IV: [u32; 8] = [
@@ -753,5 +755,74 @@ mod tests {
 			let input: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
 			check(&input);
 		}
+	}
+
+	/// Hashes `input` with [`Blake3Compress2x`] as a chip, and checks the digest and the system.
+	///
+	/// The digest wires are public and filled with the reference digest, as in [`check`], so a
+	/// disagreement fails to populate. What the chip adds is checked after: the calls each
+	/// compression made have to be served by an instance that recomputes the same words.
+	fn check_with_compress_chip(input: &[u8]) {
+		let builder = CircuitBuilder::new();
+		builder.register_chip(Blake3Compress2x, &[]);
+
+		let message: Vec<Wire> = (0..input.len().div_ceil(4))
+			.map(|_| builder.add_witness())
+			.collect();
+		let digest = blake3_fixed(&builder, &message, input.len());
+		let digest_out: [Wire; 8] = std::array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("digest_match", digest[i], digest_out[i]);
+		}
+
+		let circuit = builder.build_m4();
+		circuit.validate().unwrap();
+		let cs = circuit.to_constraint_system();
+		cs.validate().unwrap();
+
+		let expected = blake3::hash(input);
+		let expected_words: [u32; 8] = std::array::from_fn(|i| {
+			u32::from_le_bytes(expected.as_bytes()[i * 4..i * 4 + 4].try_into().unwrap())
+		});
+
+		let witness = circuit
+			.generate_witness(|w| {
+				for (wire, word) in message.iter().zip(bytes_to_le_words(input)) {
+					w[*wire] = Word(word);
+				}
+				for i in 0..8 {
+					w[digest_out[i]] = Word(expected_words[i] as u64);
+				}
+			})
+			.unwrap_or_else(|e| panic!("blake3_fixed failed for len_bytes={}: {e:?}", input.len()));
+
+		witness.verify(&cs).unwrap();
+	}
+
+	// The gadgets between `blake3_fixed` and `blake3_compress_2x` are untouched by the chip: the
+	// compressions the chunk pairs reach and the ones the parent tree reaches both land as calls
+	// because the builder holds the chip, not because anything in between was told.
+	//
+	// Lengths run from two blocks, which is the shortest message reaching a paired compression at
+	// all, up through an odd chunk count, whose tree carries a two-lane parent as well as a
+	// single-lane one.
+	#[test]
+	fn a_registered_chip_serves_every_compression() {
+		for &len in &[128usize, 320, 1025, 5121] {
+			let input: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+			check_with_compress_chip(&input);
+		}
+	}
+
+	// A message short enough to compress one block at a time never reaches the paired gadget, so
+	// its chip goes uncalled and the system it leaves is not one that can be populated.
+	#[test]
+	fn a_chip_no_compression_reaches_leaves_an_uncalled_chip() {
+		let builder = CircuitBuilder::new();
+		builder.register_chip(Blake3Compress2x, &[]);
+		blake3_fixed(&builder, &[builder.add_witness()], 4);
+
+		let error = builder.build_m4().validate().unwrap_err();
+		assert!(matches!(error, binius_frontend::CircuitM4Error::NeverCalled { .. }), "{error:?}");
 	}
 }


### PR DESCRIPTION
Stacked on #2140, which adds `ChipGadget` and `CircuitBuilder::{register_chip, build_gadget}`. This is the first production gadget to use it.

`blake3_fixed` reaches `blake3_compress_2x` through three layers — the chunk loop, the sequential pair, the parent tree — and none of them should have to know whether a compression is gates or a chip call.

## The change

`blake3_compress_2x` becomes a `ChipGadget` and everything above it is left alone. Its gates move to a private `compress_2x_gates`; the public function flattens its arguments and calls `build_gadget`, which is where the choice is made. `Blake3Compress2x` supplies the hint the chip path needs, running the existing `ref_compress` once per lane — the paired core's adds and rotates are 32-bit and its exclusive-ors are bitwise, so a lane is the reference compression of its own halves.

`blake3_fixed`, `blake3_chunk`, `blake3_compress_2x_seq` and `blake3_parent_2x` are unchanged and all compress through a chip when the circuit registers one:

```rust
let builder = CircuitBuilder::new();
builder.register_chip(Blake3Compress2x, &[]);
let digest = blake3_fixed(&builder, &message, len_bytes);
let circuit = builder.build_m4();
```

## Testing

- `a_registered_chip_serves_every_compression` hashes at four lengths — two blocks, five blocks, two chunks, five chunks — so the compressions the chunk pairs reach and the ones the parent tree reaches are both covered. Each builds, validates, generates a witness against the reference digest, and passes `WitnessM4::verify`, which is what says every call was served by an instance recomputing the same words.
- `compress_2x_hint_matches_its_gates` holds `Blake3Compress2x::execute` to `compress_2x_gates` over words drawn at random. The hint and the gates are two sources of truth for one relation and a disagreement surfaces only at verify time, so this is the test that matters. Random words are lane pairs no caller would pass, which is the point — nothing about the interface stops one.
- `a_chip_no_compression_reaches_leaves_an_uncalled_chip` pins the sharp edge: a message short enough to compress one block at a time never reaches the paired gadget, so registering the chip there leaves it uncalled and `validate()` rejects the system. Opt-in is per circuit shape.

## Costs

A call commits 36 words per instance (28 in, 8 out). The packing expressions `blake3_compress_2x_seq` and `blake3_parent_2x` hand it each cost a committed word and a ZERO constraint where a constraint operand would have fused them in for free. Making chip calls a gate-fusion rewrite site is what recovers that; it is the expected next step, not this PR.

Single-lane `blake3_compress` is left inline. Routing it through the 2x chip with a dead lane is a later call, once there is a measurement to make it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)