### PR TITLE
Split blake3_compress rounds across both 32-bit lanes

### DIFF
--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -8,6 +8,10 @@
 //!
 //! The structure mirrors the [reference implementation] from the BLAKE3 crate.
 //!
+//! Every gadget here fills both 32-bit lanes of a word. Where two compressions are available they
+//! run side by side, one per lane ([`blake3_compress_2x`], [`blake3_compress_2x_seq`]); a lone
+//! compression splits its own round sequence across the lanes instead ([`blake3_compress`]).
+//!
 //! [reference implementation]: https://github.com/BLAKE3-team/BLAKE3/blob/master/src/portable.rs
 
 use std::{array, iter};
@@ -18,7 +22,32 @@ use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire};
 use super::{IV, MSG_SCHEDULE};
 use crate::util::clear_high_bits;
 
+/// Rounds [`blake3_compress`] runs in the high lane, the first half of the split.
+const HIGH_LANE_ROUNDS: usize = 3;
+
+/// Rounds [`blake3_compress`] runs in the low lane, the second half of the split.
+///
+/// The longer half, so it also counts the packed rounds: 8 lane-rounds are evaluated for 7 real
+/// ones, and the high lane spends the last of them idle.
+const LOW_LANE_ROUNDS: usize = 7 - HIGH_LANE_ROUNDS;
+
 /// BLAKE3 compression function.
+///
+/// A single compression, evaluated as two lanes of one packed core: the round sequence is cut in
+/// two and the halves run side by side rather than one after the other.
+///
+/// ```text
+///     high lane (bits [32:64]):  round 0 -> round 1 -> round 2 -> (idle)
+///     low  lane (bits  [0:32]):  round 3 -> round 4 -> round 5 -> round 6
+/// ```
+///
+/// Both halves of the split want the same thing: the state after round 2, which is the low lane's
+/// input and the high lane's output. That circular dependency is broken with a
+/// `Blake3RoundSplitHint` that computes the state off-circuit and feeds it in, then constrains it
+/// word-for-word against what the high lane really computed, so the hint cannot lie.
+///
+/// Four packed rounds replace seven single-lane ones. The high lane sits idle through the last of
+/// them — 7 rounds do not divide evenly in two — and its result is discarded.
 ///
 /// # Arguments
 ///
@@ -30,9 +59,18 @@ use crate::util::clear_high_bits;
 /// - `block_len`: byte count for this block, 0..=64. 32-bit value in low 32 bits.
 /// - `flags`: domain-separation flags. 32-bit value in low 32 bits.
 ///
+/// # Preconditions
+///
+/// - Every 32-bit input holds its value in the low 32 bits; `counter` is a full 64-bit value.
+/// - High halves need not be empty.
+///   - A message word's high half is masked off.
+///   - Every other input's is discarded by the shift that lifts it into the high lane.
+///
 /// # Returns
 ///
-/// The updated 8-word chaining value.
+/// The updated 8-word chaining value in the low 32 bits of each word. The high 32 bits carry the
+/// high lane's discarded round and are not cleared, so a caller that reads them must mask them off
+/// — the same treatment a pair's first compression gets from [`blake3_compress_2x_seq`].
 pub fn blake3_compress(
 	builder: &CircuitBuilder,
 	cv: [Wire; 8],
@@ -41,30 +79,85 @@ pub fn blake3_compress(
 	block_len: Wire,
 	flags: Wire,
 ) -> [Wire; 8] {
-	// Split the counter into 32-bit halves.
-	let t_low = clear_high_bits(builder, counter, 32);
-	let t_high = builder.shr(counter, 32);
+	// The hint returns the *merged* initial state directly: each word packs the state after round
+	// `HIGH_LANE_ROUNDS - 1` in the low 32 bits (the low lane's input) and the compression's own
+	// initial state word in the high 32 bits (the high lane's input). Both halves are constrained
+	// below, so the hint itself is untrusted.
+	let mut hint_inputs = Vec::with_capacity(27);
+	hint_inputs.extend_from_slice(&cv);
+	hint_inputs.extend_from_slice(&block);
+	hint_inputs.push(counter);
+	hint_inputs.push(block_len);
+	hint_inputs.push(flags);
+	let merged = builder.call_hint(Blake3RoundSplitHint, &[], &hint_inputs);
+	let mut v: [Wire; 16] = array::from_fn(|i| merged[i]);
 
-	let v: [Wire; 16] = [
-		cv[0],
-		cv[1],
-		cv[2],
-		cv[3],
-		cv[4],
-		cv[5],
-		cv[6],
-		cv[7],
-		builder.add_constant(Word(IV[0] as u64)),
-		builder.add_constant(Word(IV[1] as u64)),
-		builder.add_constant(Word(IV[2] as u64)),
-		builder.add_constant(Word(IV[3] as u64)),
-		t_low,
-		t_high,
-		block_len,
-		flags,
+	// The compression's own initial state, each word already shifted up into the high lane. This is
+	// what the hinted state is checked against, and the shift is why a dirty high half on an input
+	// wire is harmless: it is shifted out rather than masked off.
+	let up = |w: Wire| builder.shl(w, 32);
+	let iv_up = |i: usize| builder.add_constant(Word((IV[i] as u64) << 32));
+	// `t_high` is the counter's high half, which already sits where the high lane wants it. Two
+	// shifts keep it a linear definition, where masking it out would cost an AND constraint.
+	let counter_high = builder.shl(builder.shr(counter, 32), 32);
+	let init_up: [Wire; 16] = [
+		up(cv[0]),
+		up(cv[1]),
+		up(cv[2]),
+		up(cv[3]),
+		up(cv[4]),
+		up(cv[5]),
+		up(cv[6]),
+		up(cv[7]),
+		iv_up(0),
+		iv_up(1),
+		iv_up(2),
+		iv_up(3),
+		// `t_low` needs no masking: shifting up keeps the counter's low half and drops its high
+		// one.
+		up(counter),
+		counter_high,
+		up(block_len),
+		up(flags),
 	];
 
-	compress_core(builder, v, block)
+	// Both lanes read the same message, under different round schedules, so each word is prepared
+	// once for each lane rather than once per round. Only the low lane's copy needs masking; the
+	// high lane's is a shift, which cleans itself.
+	let msg_low: [Wire; 16] = array::from_fn(|i| clear_high_bits(builder, block[i], 32));
+	let msg_high: [Wire; 16] = array::from_fn(|i| up(block[i]));
+
+	for step in 0..LOW_LANE_ROUNDS {
+		// The high lane is `HIGH_LANE_ROUNDS` rounds behind the low one, so a step applies two
+		// different rounds of the schedule at once. The high lane's last step runs past round 6 and
+		// is the discarded one.
+		let high_schedule = MSG_SCHEDULE[step];
+		let low_schedule = MSG_SCHEDULE[step + HIGH_LANE_ROUNDS];
+		let msg: [Wire; 16] =
+			array::from_fn(|k| builder.bxor(msg_low[low_schedule[k]], msg_high[high_schedule[k]]));
+		round(builder, &mut v, &msg);
+
+		// The high lane has now produced the state the low lane started from. Bind the hint to it,
+		// one 64-bit equality per state word — a single equality pins both lanes, since the two
+		// halves never overlap.
+		//
+		//     hinted word:  [ high lane = initial state | low lane = state after round 2 ]
+		//                            must equal                    must equal
+		//                     initial state << 32          ^      high lane >> 32
+		//
+		// The high lane is pinned to the caller's own inputs, and the low lane to the state the
+		// high lane provably reached from them, which together leave the hint no freedom.
+		if step + 1 == HIGH_LANE_ROUNDS {
+			for (hinted, (init, split)) in iter::zip(&merged, iter::zip(init_up, v)) {
+				let expected = builder.bxor(init, builder.shr(split, 32));
+				builder.assert_eq("blake3_compress.split_state", *hinted, expected);
+			}
+		}
+	}
+
+	// The result is the low lane's. The high lane's is the round the split discards, and is left
+	// where it is rather than masked off, as `blake3_chunk` leaves a pair's first compression.
+	array::from_fn(|i| builder.bxor(v[i], v[i + 8]))
 }
 
 /// BLAKE3 compression function running two independent compressions in parallel.
@@ -205,7 +298,8 @@ fn compress_2x_gates(
 /// on how the caller packed `v` and `block`.
 fn compress_core(builder: &CircuitBuilder, mut v: [Wire; 16], block: [Wire; 16]) -> [Wire; 8] {
 	for i in 0..7 {
-		round(builder, &mut v, &block, i);
+		let schedule = MSG_SCHEDULE[i];
+		round(builder, &mut v, &array::from_fn(|k| block[schedule[k]]));
 	}
 	array::from_fn(|i| builder.bxor(v[i], v[i + 8]))
 }
@@ -233,20 +327,21 @@ fn g(
 }
 
 /// One BLAKE3 round: four column G's followed by four diagonal G's.
-fn round(builder: &CircuitBuilder, state: &mut [Wire; 16], msg: &[Wire; 16], round: usize) {
-	let schedule = MSG_SCHEDULE[round];
-
+///
+/// `msg` is the round's message words in schedule order, not the raw block: the two lanes of
+/// [`blake3_compress`] run different rounds at once, so a round cannot pick its own schedule.
+fn round(builder: &CircuitBuilder, state: &mut [Wire; 16], msg: &[Wire; 16]) {
 	// Mix the columns.
-	g(builder, state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
-	g(builder, state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
-	g(builder, state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
-	g(builder, state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+	g(builder, state, 0, 4, 8, 12, msg[0], msg[1]);
+	g(builder, state, 1, 5, 9, 13, msg[2], msg[3]);
+	g(builder, state, 2, 6, 10, 14, msg[4], msg[5]);
+	g(builder, state, 3, 7, 11, 15, msg[6], msg[7]);
 
 	// Mix the diagonals.
-	g(builder, state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
-	g(builder, state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
-	g(builder, state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
-	g(builder, state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+	g(builder, state, 0, 5, 10, 15, msg[8], msg[9]);
+	g(builder, state, 1, 6, 11, 12, msg[10], msg[11]);
+	g(builder, state, 2, 7, 8, 13, msg[12], msg[13]);
+	g(builder, state, 3, 4, 9, 14, msg[14], msg[15]);
 }
 
 /// Two sequential BLAKE3 compressions evaluated as the two lanes of [`blake3_compress_2x`].
@@ -354,6 +449,44 @@ pub fn blake3_compress_2x_seq(
 	out
 }
 
+/// Custom hint computing the merged initial state for [`blake3_compress`].
+///
+/// Runs the compression's first `HIGH_LANE_ROUNDS` rounds off-circuit and packs the state they
+/// reach so the output can be fed directly as the two-lane initial state: the low 32 bits seed the
+/// low lane, which picks the round sequence up from there, and the high 32 bits carry the
+/// compression's own initial state word. Both halves are re-derived in-circuit and constrained, so
+/// the hint only needs to produce the honest result.
+///
+/// Input layout (27 words, value in the low 32 bits of each): `cv[0..8]`, `block[0..16]`,
+/// `counter` (full 64 bits), `block_len`, `flags`. Output: 16 packed words where the low 32 bits
+/// hold the state after round `HIGH_LANE_ROUNDS - 1` and the high 32 bits the initial state.
+struct Blake3RoundSplitHint;
+
+impl Hint for Blake3RoundSplitHint {
+	const NAME: &'static str = "binius.blake3_compress_round_split";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(27, 16)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let cv: [u32; 8] = array::from_fn(|i| inputs[i].as_u64() as u32);
+		let block: [u32; 16] = array::from_fn(|i| inputs[8 + i].as_u64() as u32);
+		let counter = inputs[24].as_u64();
+		let block_len = inputs[25].as_u64() as u32;
+		let flags = inputs[26].as_u64() as u32;
+
+		let init = ref_init_state(&cv, counter, block_len, flags);
+		let mut split = init;
+		for i in 0..HIGH_LANE_ROUNDS {
+			ref_round(&mut split, &block, i);
+		}
+		for (i, slot) in outputs.iter_mut().enumerate() {
+			*slot = Word(split[i] as u64 | ((init[i] as u64) << 32));
+		}
+	}
+}
+
 /// Custom hint computing the merged input chaining value for [`blake3_compress_2x_seq`].
 ///
 /// Runs the first compression off-circuit and packs its result so the output can be fed directly
@@ -418,18 +551,9 @@ const fn ref_round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
 	ref_g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
 }
 
-/// Pure-Rust BLAKE3 compression, matching the in-circuit compression exactly.
-///
-/// - Exposed for callers that use a raw 2-to-1 compression as a tweakable hash.
-/// - It reproduces the same value off-circuit for witness generation.
-pub fn ref_compress(
-	cv: &[u32; 8],
-	block: &[u32; 16],
-	counter: u64,
-	block_len: u32,
-	flags: u32,
-) -> [u32; 8] {
-	let mut v = [
+/// The 16-word state a compression starts from, before any round runs.
+const fn ref_init_state(cv: &[u32; 8], counter: u64, block_len: u32, flags: u32) -> [u32; 16] {
+	[
 		cv[0],
 		cv[1],
 		cv[2],
@@ -446,7 +570,21 @@ pub fn ref_compress(
 		(counter >> 32) as u32,
 		block_len,
 		flags,
-	];
+	]
+}
+
+/// Pure-Rust BLAKE3 compression, matching the in-circuit compression exactly.
+///
+/// - Exposed for callers that use a raw 2-to-1 compression as a tweakable hash.
+/// - It reproduces the same value off-circuit for witness generation.
+pub fn ref_compress(
+	cv: &[u32; 8],
+	block: &[u32; 16],
+	counter: u64,
+	block_len: u32,
+	flags: u32,
+) -> [u32; 8] {
+	let mut v = ref_init_state(cv, counter, block_len, flags);
 	for i in 0..7 {
 		ref_round(&mut v, block, i);
 	}
@@ -501,6 +639,22 @@ mod tests {
 		block_len: u32,
 		flags: u32,
 	) -> [u32; 8] {
+		run_compress_with_dirt(cv, block, counter, block_len, flags, 0)
+	}
+
+	/// As [`run_compress`], with `dirt` OR'd into the high 32 bits of every 32-bit input wire.
+	///
+	/// Nothing range-constrains a wire that carries a 32-bit value, so a witness is free to set the
+	/// half the gadget does not read.
+	fn run_compress_with_dirt(
+		cv: [u32; 8],
+		block: [u32; 16],
+		counter: u64,
+		block_len: u32,
+		flags: u32,
+		dirt: u32,
+	) -> [u32; 8] {
+		let dirt = (dirt as u64) << 32;
 		let builder = CircuitBuilder::new();
 		let cv_wires: [Wire; 8] = array::from_fn(|_| builder.add_witness());
 		let block_wires: [Wire; 16] = array::from_fn(|_| builder.add_witness());
@@ -508,7 +662,10 @@ mod tests {
 		let block_len_w = builder.add_witness();
 		let flags_w = builder.add_witness();
 
+		// The gadget leaves the discarded lane in the high half of each word, so a caller reading a
+		// whole word clears it first, as every real one does.
 		let out = blake3_compress(&builder, cv_wires, block_wires, counter_w, block_len_w, flags_w);
+		let out = out.map(|word| clear_high_bits(&builder, word, 32));
 		let out_inout: [Wire; 8] = array::from_fn(|_| builder.add_inout());
 		for i in 0..8 {
 			builder.assert_eq("out_match", out[i], out_inout[i]);
@@ -517,14 +674,15 @@ mod tests {
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
 		for i in 0..8 {
-			w[cv_wires[i]] = Word(cv[i] as u64);
+			w[cv_wires[i]] = Word(cv[i] as u64 | dirt);
 		}
 		for i in 0..16 {
-			w[block_wires[i]] = Word(block[i] as u64);
+			w[block_wires[i]] = Word(block[i] as u64 | dirt);
 		}
+		// The counter is a genuine 64-bit input, so it has no unused half to dirty.
 		w[counter_w] = Word(counter);
-		w[block_len_w] = Word(block_len as u64);
-		w[flags_w] = Word(flags as u64);
+		w[block_len_w] = Word(block_len as u64 | dirt);
+		w[flags_w] = Word(flags as u64 | dirt);
 
 		let expected = ref_compress(&cv, &block, counter, block_len, flags);
 		for i in 0..8 {
@@ -579,6 +737,32 @@ mod tests {
 		let actual = run_compress(cv, block, 42, 32, super::super::CHUNK_START);
 		let expected = ref_compress(&cv, &block, 42, 32, super::super::CHUNK_START);
 		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn compress_ignores_dirty_input_high_halves() {
+		// Invariant: the result is the compression of the low halves alone.
+		//
+		// The rounds now run in both halves of every word, so the half a 32-bit input does not use
+		// is no longer inert padding — it is where half of the mixing happens. A witness that fills
+		// it must not be able to steer the digest.
+		let cv = [
+			0xDEAD_BEEF,
+			0xCAFE_BABE,
+			0x1234_5678,
+			0x9ABC_DEF0,
+			0x0BAD_F00D,
+			0xFEED_FACE,
+			0x0123_4567,
+			0x89AB_CDEF,
+		];
+		let block: [u32; 16] = array::from_fn(|i| (i as u32).wrapping_mul(0xDEAD_BEEFu32));
+		let counter: u64 = 0x0123_4567_89AB_CDEF;
+		let expected = ref_compress(&cv, &block, counter, 64, CHUNK_END);
+		for dirt in [1, 0xFFFF_FFFF, 0x8000_0000] {
+			let actual = run_compress_with_dirt(cv, block, counter, 64, CHUNK_END, dirt);
+			assert_eq!(actual, expected, "dirt {dirt:#x} changed the result");
+		}
 	}
 
 	// --- 2× SIMD tests -------------------------------------------------------------

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -8,7 +8,8 @@
 //! wrapping structs.
 //!
 //! The entry points are:
-//! - [`blake3_compress`] — single-block compression primitive.
+//! - [`blake3_compress`] — single-block compression primitive, its rounds split across the two
+//!   32-bit lanes.
 //! - [`blake3_compress_2x_seq`] — two sequential compressions sharing one parallel core.
 //! - [`blake3_chunk`] — single-chunk (up to 16 blocks) chaining-value gadget.
 //! - [`blake3_fixed`] — full hash gadget for messages of compile-time-known length, spanning any
@@ -173,16 +174,16 @@ pub fn blake3_chunk(
 		);
 	}
 
-	// A trailing block with no partner runs through the one-lane core.
+	// A trailing block with no partner is compressed on its own.
 	//
 	//     6 blocks: [0,1] [2,3] [4,5]              -> 3 paired cores
-	//     7 blocks: [0,1] [2,3] [4,5] then 6 alone -> 3 paired cores + 1 one-lane core
+	//     7 blocks: [0,1] [2,3] [4,5] then 6 alone -> 3 paired cores + 1 lone compression
 	//
 	// Why not pad to an even count with a dummy block:
-	// - The paired core costs a chaining-value binding on top of its mixing rounds.
-	// - It also packs a second lane's counter, length and flags.
+	// - The paired core runs all 7 rounds, where a lone compression splits its own rounds across
+	//   the two lanes and runs 4.
+	// - The pair also packs a second lane's counter, length and flags.
 	// - All of that would be spent producing a result nothing reads.
-	// - The one-lane core is cheaper even though it leaves half of each word idle.
 	if n_blocks % 2 == 1 {
 		let last = n_blocks - 1;
 		cv = blake3_compress(
@@ -208,6 +209,9 @@ pub fn blake3_chunk(
 /// The parent block is the two children concatenated (16 words); the chaining value is the key (or
 /// the [`IV`] when unkeyed), the counter is 0, the block length is [`BLOCK_BYTES`], and the flags
 /// are [`PARENT`] (plus [`ROOT`] for the tree root).
+///
+/// The result's high halves are cleared, since a parent's value is read whole: the level above
+/// merges it with a shift, and the root is the digest.
 fn blake3_parent(
 	builder: &CircuitBuilder,
 	key: Option<[Wire; 8]>,
@@ -221,7 +225,8 @@ fn blake3_parent(
 	let block_len = builder.add_constant(Word(BLOCK_BYTES as u64));
 	let root_flag = if is_root { ROOT } else { 0 };
 	let flags = builder.add_constant(Word((PARENT | root_flag | key_flag(key)) as u64));
-	blake3_compress(builder, cv, block, counter, block_len, flags)
+	let out = blake3_compress(builder, cv, block, counter, block_len, flags);
+	std::array::from_fn(|i| clear_high_bits(builder, out[i], 32))
 }
 
 /// Two independent BLAKE3 parent-node compressions of one hash, evaluated in the two lanes of
@@ -519,9 +524,11 @@ fn blake3_hash_fixed(
 /// - The block count, the block lengths, the flags and the tree shape all agree.
 /// - So every compression of one hash has exactly one partner in the other.
 ///
-/// The saving lands where a single hash has no partner block to pair with.
-/// - It then spends a whole core on one lane, through [`blake3_compress_2x_seq`].
-/// - A one-block message, the shape a tweakable hash uses, halves.
+/// The saving lands where a single hash has an odd block with no partner to pair with.
+/// - That block goes through [`blake3_compress`], which fills the lanes by splitting its own rounds
+///   across them and so evaluates 3 of its 7 rounds twice.
+/// - Pairing two hashes puts a real second hash in that lane instead, and the duplicated rounds are
+///   what it recovers: 336 AND constraints against 384, for a one-block message.
 ///
 /// # Arguments
 ///
@@ -1223,7 +1230,7 @@ mod tests {
 		//
 		//     0..=64 bytes  one block, the shape a tweakable hash uses
 		//     65..=128      two blocks, where the single-hash path also fills both lanes
-		//     129..=192     three blocks, where it falls back to a one-lane compression
+		//     129..=192     three blocks, where it falls back to a lone compression
 		//     1025+         several chunks, so the parent tree runs too
 		for &len in &[0usize, 1, 64, 65, 128, 192, 1024, 2048] {
 			let (single, paired) = and_counts(len);
@@ -1234,11 +1241,14 @@ mod tests {
 			);
 		}
 
-		// A one-block message is what the gadget exists for: two hashes for the price of one.
+		// A one-block message is the shape the gadget exists for, and the only one where it wins
+		// outright: a lone compression splits its own rounds across the lanes, so the single-hash
+		// path leaves nothing idle for the pair to reclaim, and the pair's saving is the 3 rounds
+		// the split spends twice rather than a whole second core.
 		let (single, paired) = and_counts(BLOCK_BYTES);
 		assert!(
-			2 * paired <= single,
-			"a one-block pair costs {paired} AND constraints, over half of the {single} two \
+			paired < single,
+			"a one-block pair costs {paired} AND constraints, no less than the {single} two \
 			 single hashes cost"
 		);
 	}

--- a/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
@@ -95,10 +95,13 @@ fn hash4_to_cv8(builder: &CircuitBuilder, hash: [Wire; 4]) -> [Wire; CV_WORDS] {
 }
 
 /// Packs the 8-word BLAKE3 output (8x32-bit LE) back into a 32-byte chain value (4x64-bit LE).
+///
+/// The even word's high half is masked: [`blake3_compress`] leaves its discarded lane there, and
+/// this is where the two halves of a result meet.
 fn cv8_to_hash4(builder: &CircuitBuilder, cv: &[Wire; CV_WORDS]) -> [Wire; 4] {
 	std::array::from_fn(|k| {
 		let hi = builder.shl(cv[2 * k + 1], 32);
-		builder.bxor(cv[2 * k], hi)
+		builder.bxor(clear_high_bits(builder, cv[2 * k], 32), hi)
 	})
 }
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -1,30 +1,30 @@
 hashsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 413,745
-└─ Number of evaluation instructions: 414,393
+├─ Number of gates: 394,200
+└─ Number of evaluation instructions: 394,848
 
 Constraints
-├─ ZERO constraints: 118,640 used (90.5% of 2^17)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 12,432
-├─ AND constraints: 135,720 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,424
+├─ ZERO constraints: 114,662 used (87.5% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 16,410
+├─ AND constraints: 118,455 used (90.4% of 2^17)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 12,617
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 2,664 used (65.0% of 2^12)
 │  [▓▓▓▓▓▓░░░░] spare: 1,432
-└─ Distinct value indices: 649,585
-   ├─ Distinct shifted value indices: 393,538
-   └─ Distinct unshifted value indices: 256,047
+└─ Distinct value indices: 599,207
+   ├─ Distinct shifted value indices: 364,403
+   └─ Distinct unshifted value indices: 234,804
 
 Value Vector
 ├─ Public Section: 183 (not committed)
 │  ├─ Constants: 157
 │  └─ Inout: 26
-├─ Private Section: 255,951
+├─ Private Section: 234,708
 │  ├─ Witness: 1,776
-│  └─ Internal: 254,175
-├─ Committed Trace: 255,951 used (97.6% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 6,193
-└─ Scratch (uncommitted): 308,055 (peak live: 595)
+│  └─ Internal: 232,932
+├─ Committed Trace: 234,708 used (89.5% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 27,436
+└─ Scratch (uncommitted): 292,353 (peak live: 65)
 

--- a/crates/examples/src/circuits/independent_hashes.rs
+++ b/crates/examples/src/circuits/independent_hashes.rs
@@ -14,6 +14,7 @@ use binius_circuits::{
 	blake3::{blake3_compress, ref_compress},
 	keccak::permutation::keccak_f1600,
 	sha256::{State as Sha256State, populate_message_block, sha256_compress},
+	util::clear_high_bits,
 };
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
@@ -135,8 +136,10 @@ impl ExampleCircuit for IndependentBlake3Compressions {
 				let block_len = builder.add_witness();
 				let flags = builder.add_witness();
 				let out = blake3_compress(builder, cv, block, counter, block_len, flags);
+				// Unlike SHA-256, this gadget splits its rounds across the two 32-bit lanes and
+				// leaves the discarded one in each word's high half, so the comparison masks it.
+				let out = out.map(|word| clear_high_bits(builder, word, 32));
 				let out_cv = std::array::from_fn(|_| builder.add_inout());
-				// See the SHA-256 note on raw 64-bit equality over 32-bit lanes.
 				builder.assert_eq_v(format!("blake3_compression_out[{i}]"), out, out_cv);
 				Blake3Compression {
 					cv,


### PR DESCRIPTION
Closes [BINIUS-484](https://linear.app/jimpo/issue/BINIUS-484/circuits-blake3-compress-should-split-rounds-into-lanes).

`blake3_compress` ran its 7 rounds in the low 32 bits of each word, leaving the high half idle — the half where the parallel-halves `iadd_32` and `rotr32` gates do a second, independent 32-bit computation for free. `blake3_compress_2x` and `blake3_compress_2x_seq` already fill both lanes, but only when a second compression is available to fill them with.

## The change

Cut the round sequence in two instead, so a lone compression fills both lanes with itself:

```text
    high lane (bits [32:64]):  round 0 -> round 1 -> round 2 -> (idle)
    low  lane (bits  [0:32]):  round 3 -> round 4 -> round 5 -> round 6
```

Four packed rounds replace seven single-lane ones. The two halves meet at the state after round 2, which the low lane needs as its input and the high lane only produces later; the same shape `blake3_compress_2x_seq` and `sha256_compress_2x_seq` already have. A `Blake3RoundSplitHint` supplies that state off-circuit, and one equality per state word pins it: the word's high half against the caller's own inputs, its low half against what the high lane really computed. Both halves are constrained, so the hint has no freedom.

Seven rounds do not divide evenly in two, so the high lane spends the last packed round idle. Its result stays in the returned words' high halves rather than being masked off — `blake3_compress` promises only the low 32 bits, as `blake3_compress_2x_seq` already does for a pair's first compression. The four call sites that read a whole word clear it themselves: `blake3_parent`, `cv8_to_hash4` in `chain_blake3`, the `independent_hashes` example, and the `run_compress` test helper. `blake3_chunk` needed nothing — it already masks once on the way out.

`round` now takes its message words already in schedule order, since the two lanes run different rounds at once and a round can no longer pick its own schedule.

## Cost

AND constraints, measured with `CircuitStat::collect`:

| circuit | before | after |
| -- | --: | --: |
| `blake3_compress` | 336 | **192** |
| `blake3_fixed(64)` | 336 | **192** |
| `blake3_fixed(192)` | 672 | **528** |
| `blake3_fixed(1024)` | 2688 | 2688 |
| `blake3_fixed(2048)` | 5712 | **5568** |

A pair of block compressions through `blake3_compress_2x_seq` still costs 336 for the two, so `blake3_chunk` keeps pairing and only its odd trailing block gets cheaper — 1024 bytes is 16 blocks, all paired, hence unchanged. The comment there explaining why an odd block is not padded to a pair is updated: the reason is now the pair's 7 rounds against a lone compression's 4, not an idle half-word.

The `hashsign` circuit, whose Winternitz chain steps are single BLAKE3 compressions, is where this lands hardest — its snapshot is the one file that moves:

```
- ├─ ZERO constraints: 118,640 used (90.5% of 2^17)
+ ├─ ZERO constraints: 114,662 used (87.5% of 2^17)
- ├─ AND constraints: 135,720 used (51.8% of 2^18)
+ ├─ AND constraints: 118,455 used (90.4% of 2^17)
```

so its AND table halves. The other twelve committed snapshots are unchanged (the `blake3` example hashes a whole number of block pairs in one chunk, so it never reaches a lone compression).

## A note on #2144

`blake3_keyed_fixed_2x` landed while this was in review, and this change moves the ground under its cost claim. Its `keyed_2x_never_costs_more_than_two_single_hashes` asserted `2 * paired <= single`, which held only because a lone compression cost 336. It now costs 192, so for a one-block message two single keyed hashes cost **384** against the pair's **336** — the pair saves 12.5%, not half. The assertion is relaxed to `paired < single` (still true at every length it tests, with equality at even block counts), and the gadget's doc now says what it actually recovers: the 3 rounds a lone compression evaluates twice. Whether the two-lane keyed gadget still earns its complexity at that margin is worth a second look, but not in this PR.

## Testing

- The existing compression tests all pass unchanged: the two spec-trace known answers from draft-aumasson-blake3-00, the `compress_matches_reference` proptest, and the whole-hash tests against the `blake3` crate.
- `compress_ignores_dirty_input_high_halves` is new. The half a 32-bit input does not use is no longer inert padding — it is where half of the mixing now happens — and nothing range-constrains those wires, so a witness filling them must not steer the result. Message words are masked and every other input is lifted by a shift that drops its high half.
- `cargo test -p binius-circuits -p binius-examples`, clippy on both, and the `blake3_compress`-based `protocol_round_trips_with_non_power_of_two_constants` in `binius-m4-prover`, which also covers the new hint under batched witness population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)