### PR TITLE
BINIUS-470: derive and mask the FRI query index in sample_bits

### DIFF
--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -289,14 +289,10 @@ impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 	}
 
 	fn sample_bits(&mut self, bits: usize) -> SymbolicWord {
-		// The draw happens even though the result is thrown away.
-		// It consumes four sampler bytes, and that count is what the next observe appends.
-		// Skipping it desyncs every challenge after the first bit sample.
-		let _ = self.challenger.sample_bits(bits);
-
-		// UNCONSTRAINED: the index is still the prover's choice, which is BINIUS-470.
-		// The gadget's masked draw above is discarded rather than returned.
-		SymbolicWord::wire(&self.shared, self.shared.input_wire("sample_bits"))
+		// The gadget masks the draw with a real gate, so the result provably lies below 2^bits.
+		// The FRI code takes that bound as given rather than asserting it.
+		// So deriving the index and masking it are one change, not two.
+		SymbolicWord::wire(&self.shared, self.challenger.sample_bits(bits))
 	}
 
 	fn pack_words(&mut self, words: &[SymbolicWord]) -> Vec<SymbolicElem> {
@@ -425,6 +421,69 @@ mod tests {
 
 	use super::*;
 	use crate::merkle::element_words;
+
+	/// Every query index the channel hands out is the native one, and fits the width it asked for.
+	///
+	/// Four sampler bytes are read whatever the width, so a narrow one almost always overflows.
+	/// An unmasked draw would then differ from the native value and fail the pin below.
+	///
+	/// The bound matters on its own.
+	/// The FRI code takes it as given, so a wide index could point a query anywhere satisfiable.
+	#[test]
+	fn a_sampled_index_is_the_native_one_and_fits_its_width() {
+		// Widths where the mask drops bits, one that needs no mask, and one that clamps to 32.
+		let widths = [1usize, 3, 7, 8, 11, 16, 31, 32, 33];
+
+		let mut native = HasherChallenger::<Sha256>::default();
+		let mut channel = Binius64BuilderChannel::new();
+
+		let expected = widths
+			.iter()
+			.map(|&bits| sample_bits_reader(native.sampler(), bits))
+			.collect::<Vec<_>>();
+		let sampled = widths
+			.iter()
+			.map(|&bits| WordIPVerifierChannel::<B128>::sample_bits(&mut channel, bits))
+			.collect::<Vec<_>>();
+
+		// The reference values are in range, so pinning to them is what carries the bound.
+		for (&bits, &want) in widths.iter().zip(&expected) {
+			let width = bits.min(u32::BITS as usize);
+			assert!(
+				u64::from(want) < 1u64 << width,
+				"the native index must fit the width it was drawn at"
+			);
+		}
+
+		let pins = {
+			let builder = channel.shared.builder();
+			sampled
+				.iter()
+				.zip(&expected)
+				.enumerate()
+				.map(|(i, (word, &want))| {
+					let claimed = builder.add_inout();
+					builder.assert_eq(format!("index[{i}]"), word.to_wire(builder), claimed);
+					(claimed, want)
+				})
+				.collect::<Vec<_>>()
+		};
+
+		// Every symbolic value must be dropped before the circuit is built.
+		drop(sampled);
+		let recorded = channel.build();
+		assert!(
+			recorded.inputs.is_empty(),
+			"a derived index records nothing for a replay to fill: {:?}",
+			recorded.inputs
+		);
+
+		let mut w = recorded.circuit.new_witness_filler();
+		for (claimed, want) in pins {
+			w[claimed] = Word(u64::from(want));
+		}
+		recorded.circuit.populate_wire_witness(&mut w).unwrap();
+	}
 
 	/// Draws a challenge, two query indices, then a second challenge, on both channels.
 	///

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -34,9 +34,8 @@ use crate::{
 /// diverging in opposite directions still add up, and every later value would land in the wrong
 /// wire silently.
 ///
-/// Most of what it fills is proof data the circuit cannot derive.
-/// The exception is the FRI query index, a value the circuit ought to derive and does not yet.
-/// When that lands, only the proof itself remains.
+/// What it fills is proof data the circuit cannot derive, plus the statement being verified.
+/// Every value the circuit ought to derive, it now does.
 ///
 /// The transcript is read directly rather than through a `VerifierMerkleTranscriptChannel`.
 /// That channel consumes the layer and branch digests internally, never handing them back.
@@ -167,9 +166,9 @@ where
 	}
 
 	fn sample_bits(&mut self, bits: usize) -> Word {
-		let value = WordIPVerifierChannel::<B128>::sample_bits(self.transcript.borrow_mut(), bits);
-		self.fill_word("sample_bits", value);
-		value
+		// Derived in-circuit now, so the build records no wire to fill here.
+		// The draw still has to happen, since it advances the native Fiat-Shamir state.
+		WordIPVerifierChannel::<B128>::sample_bits(self.transcript.borrow_mut(), bits)
 	}
 
 	// The build pairs up wires it already has, allocating none, so there is nothing to fill.

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -22,14 +22,9 @@
 //! [`bind_public`](Binius64BuilderChannel::bind_public) ties chosen ones to public inputs.
 //! That is what lets whoever checks an outer proof see which statement was verified.
 //!
-//! # Status: one hole left
+//! # Status: nothing the channel hands out is free
 //!
-//! One value that ought to be derived is still a circuit input:
-//!
-//! - **The FRI query index.** `sample_bits` returns a free wire, so a prover chooses where its
-//!   committed data is opened.
-//!
-//! Everything else is constrained:
+//! Every value a verifier reads here is derived in-circuit, or bound to something that is:
 //!
 //! - the verifier's arithmetic, down to every `assert_zero` along the way
 //! - the two field gadgets that used to be bare hints
@@ -42,9 +37,10 @@
 //!
 //! Every byte the native challenger observes is absorbed here too.
 //! A challenge is therefore derived from the transcript rather than supplied.
+//! A query index is derived the same way, and masked to the width it was asked for.
 //!
-//! So a circuit built here still accepts proofs it should reject, at one point only.
-//! Deriving and masking the query indices is what closes the bullet above.
+//! What a replay still fills is the proof itself, and the statement being verified.
+//! Both are given rather than derived, which is why they are the inputs that remain.
 
 pub mod challenger;
 mod channel;


### PR DESCRIPTION
Closes [BINIUS-470](https://linear.app/jimpo/issue/BINIUS-470).

The circuit picks its own FRI query indices now, masked to the width they were asked for.

### The problem

`sample_bits` returned a free wire, marked `UNCONSTRAINED` twice over:

```
index  <-  a blank the replay fills in
```

Two separate holes, one line. The index was the prover's choice, so a query could be pointed anywhere the arithmetic happened to be satisfiable. And nothing bounded it, even though the FRI code takes the `bits`-bit bound as given rather than asserting it.

### The idea

[BINIUS-469](https://linear.app/jimpo/issue/BINIUS-469) (#2138) already calls the challenger here and discards the result, to keep the sampled byte count and the buffer occupancy in step with the native challenger. This stops discarding it.

Both halves close at once, because the gadget masks with a real gate — #2103 masks precisely so a query index can be used without a separate range check.

### The change

```
- let _ = self.challenger.sample_bits(bits);
- SymbolicWord::wire(&self.shared, self.shared.input_wire("sample_bits"))
+ SymbolicWord::wire(&self.shared, self.challenger.sample_bits(bits))
```

The replay stops filling the wire, since there is no longer one to fill.

### What the recorded input list looks like now

| kind | wires | what it is |
|---|---|---|
| `opening` | 1856 | proof |
| `merkle_layer` | 1024 | proof |
| `recv_one` | 874 | proof |
| `committed_vector` | 512 | proof |
| `merkle_root` | 8 | proof |
| `observe_words` | 5 | the statement |

No `sample`, no `sample_bits`, no `observe_one`. **No `UNCONSTRAINED` marker is left in the crate.**

That is the end condition the crate docs have promised since #2093: every value a verifier reads from the channel is derived in-circuit or bound to something that is, and what a replay still fills is the proof and the statement. `hints.rs` was checked too — its inverse hint is pinned by the gadget that calls it, per #2106.

### Cost

| | before | after |
|---|---|---|
| recorded inputs | 4,511 | 4,279 |
| AND | 404,700 | 425,836 |

The −232 wires are what the issue predicted.

The +21,136 AND wants an explanation, being far more than the four per bit sample the cost table implies. The discarded draws were **dead code**: nothing read the index, so the compressions behind it were eliminated. Live now, 232 samples consume 928 sampler bytes, which is about 29 buffer refills:

```
29 refills x ~700 AND  =  ~20,300
232 samples x 4 AND    =      928
                          -------
                           ~21,228   against 21,136 measured
```

### Soundness

- The index is a gate output, so a prover no longer chooses where its committed data is opened.
- The mask is a gate, so the result provably lies below `2^bits` and the FRI code's assumption holds rather than being hoped for.
- The end-to-end test is the sharp check: the circuit derives its own indices and the Merkle openings still verify. An index differing by one bit would climb to the wrong layer entry.

### Scope

- **changed:** `sample_bits` on the builder channel, the matching fill in the replay, the crate and filler docs
- **new:** one channel unit test
- **left untouched:** the challenger gadget, which already masked

### The test

The issue asks for a test that a too-large index fails rather than silently indexing. Under this design a too-large index is unrepresentable — nobody supplies one — so the test pins the property that replaces it.

Nine widths are drawn on both channels and compared: `1, 3, 7, 8, 11, 16, 31, 32, 33`. That covers widths the mask narrows, one that needs no mask, and the clamp above 32. The circuit is also asserted to record no input at all.

Deleting the mask from the gadget makes this test fail while #2138's challenge test still passes, so the two isolate different properties rather than overlapping.

### Verification

Rebased onto `main` after #2138 merged, so this is now a single commit. Re-run there:

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-recursion --no-deps` — clean
- `cargo test -p binius-recursion` — 30 unit + 6 integration passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
