### PR TITLE
BINIUS-485: make the bit-index sumcheck and the shift-operator slice reusable

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -9,13 +9,15 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{
+	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, Phase3Output, PreparedOperatorClaims,
 		ShiftIndSumcheck,
-		monster::{build_h, build_monster_segments},
+		monster::{build_monster_segments, shift_operator_table},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
@@ -81,7 +83,10 @@ where
 		(&public, &key_collection.public.dense_shift_enc),
 		(&hidden, &key_collection.hidden.dense_shift_enc),
 	]);
-	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+	// The oblong weights, which phase 1 pushes through every shift and phase 3 runs its rounds
+	// over directly.
+	let oblong_weights = lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
+	let h = shift_operator_table::<F, F, _>(alloc, oblong_weights.as_ref());
 	let Phase1Output {
 		r_j,
 		r_s,
@@ -92,15 +97,8 @@ where
 
 	// Phase 3 binds the bit index the shift indicators read, carrying phase 1's `g` evaluation
 	// through its rounds as a constant.
-	let phase_3 = ShiftIndSumcheck::<P, _>::new(
-		alloc,
-		domain_subspace,
-		prepared.bitand.r_zhat_prime,
-		&r_j,
-		&r_s,
-		&r_v,
-		g_eval,
-	);
+	let phase_3 =
+		ShiftIndSumcheck::<P, _>::new(alloc, oblong_weights.as_ref(), &r_j, &r_s, &r_v, g_eval);
 	debug_assert_eq!(phase_3.beta(), gamma);
 	let Phase3Output {
 		shift_ind_eval,
@@ -221,9 +219,7 @@ mod tests {
 		test_utils::random_scalars,
 		univariate::lagrange_evals_scalars,
 	};
-	use binius_prover::protocols::shift::{
-		DenseShiftEncoding, OperatorData, build_key_collection, monster::build_h,
-	};
+	use binius_prover::protocols::shift::{DenseShiftEncoding, OperatorData, build_key_collection};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
@@ -437,8 +433,8 @@ mod tests {
 	// The phase-1 identity: summing the g·h inner products over the shift variants reconstructs the
 	// lambda-batched operand evaluation claim.
 	//
-	// The g multilinear comes from the batched build_g on the full folded witness; h comes
-	// from the single-instance prover's build_h at the same univariate challenge r_z. Their
+	// The g multilinear comes from the batched build_g on the full folded witness; h comes from
+	// the shift operator table over the oblong weights at the same univariate challenge r_z. Their
 	// inner product must equal the lambda-powers scaling of the batched AND-check operand evals
 	// (the intmul claim is empty, contributing nothing).
 	#[test]
@@ -510,7 +506,10 @@ mod tests {
 		// from the single-instance prover.
 		let public = build_g::<B128, B128>(public_words, &key_collection.public, &prepared);
 		let hidden = build_g_from_folded_words(&hidden_folded, &key_collection.hidden, &prepared);
-		let h = build_h::<B128, B128, _>(&GlobalAllocator, &domain_subspace, r_z);
+		let h = shift_operator_table::<B128, B128, _>(
+			&GlobalAllocator,
+			lagrange_evals(&domain_subspace, r_z).as_ref(),
+		);
 
 		// `g` is zero outside the rows the segments name, so the inner product is those rows
 		// alone — each sitting at `shift_index * Word::BITS` in the phase-1 layout.

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -10,12 +10,14 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
-use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{
+	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		OperatorClaims, OperatorData, build_key_collection,
-		monster::{build_h, build_monster_segments},
+		monster::{build_monster_segments, shift_operator_table},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 		prove,
@@ -309,7 +311,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	};
 
 	let g = build_combined_g();
-	let h = build_h::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime);
+	let oblong_weights = lagrange_evals(&subspace, prepared.bitand.r_zhat_prime);
+	let h = shift_operator_table::<F, P, _>(&GlobalAllocator, oblong_weights.as_ref());
 	let Phase1Output {
 		r_j,
 		r_s,
@@ -344,13 +347,13 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let mut group = c.benchmark_group("shift_reduction_phases");
 	group.sample_size(10);
 
-	// Phase 1. `build_g` / `build_h` take their inputs by reference, so no
+	// Phase 1. `build_g` / `shift_operator_table` take their inputs by reference, so no
 	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g`/`h` by value.
 	group.bench_function("phase1_build_g_parts", |b| {
 		b.iter(&build_combined_g);
 	});
 	group.bench_function("phase1_build_h_parts", |b| {
-		b.iter(|| build_h::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime));
+		b.iter(|| shift_operator_table::<F, P, _>(&GlobalAllocator, oblong_weights.as_ref()));
 	});
 	group.bench_function("phase1_run_sumcheck", |b| {
 		b.iter_batched(

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -70,9 +70,13 @@ impl<F: Field> OuterSlotWeights<F> {
 	}
 }
 
-/// Fills one row of a shift operator table.
+/// Writes the row of a shift operator table that one `(variant, amount)` pair contributes.
 ///
-/// The row holds, for each bit position, the weight that one `(variant, amount)` pair moves there.
+/// The row holds, for each bit position, the weight that pair moves there:
+///
+/// ```text
+///     row[j] = sum_k psi(k) * shift-ind_variant(k, j, amount)
+/// ```
 ///
 /// This is the one place that says what a variant does to a weight vector:
 /// - Logical left and logical right move the weights and leave zeros behind.
@@ -80,7 +84,28 @@ impl<F: Field> OuterSlotWeights<F> {
 /// - Rotate wraps them around instead.
 /// - The half-word forms apply the same rule to each 32-bit half, reading only the low 5 bits of
 ///   the amount.
-fn fill_operator_row<F: Field>(variant: ShiftVariant, amount: usize, row: &mut [F], psi: &[F]) {
+///
+/// # Arguments
+///
+/// The amount is an index over the reduction's amount axis rather than a validated
+/// [`Shift`](binius_core::constraint_system::Shift) amount: that axis spans `Word::BITS` for every
+/// variant, and a half-word variant reads it modulo its own 32-bit width.
+///
+/// Every cell of `row` is written, so the caller need not zero it first. A caller reading one
+/// slice at a time can therefore carry a single scratch row across every pair it visits.
+///
+/// # Panics
+///
+/// Panics unless the row and the weights each hold one entry per bit position of a word.
+pub fn shift_operator_row<F: Field>(
+	variant: ShiftVariant,
+	amount: usize,
+	row: &mut [F],
+	psi: &[F],
+) {
+	assert_eq!(row.len(), Word::BITS, "the row is indexed by bit position");
+	assert_eq!(psi.len(), Word::BITS, "the weights are indexed by bit position");
+
 	// A half-word variant repeats the full-width rule over each half, so both share one closure.
 	let halves = |row: &mut [F], rule: fn(usize, &mut [F], &[F])| {
 		let amount = amount % HALF_WORD_BITS;
@@ -94,9 +119,12 @@ fn fill_operator_row<F: Field>(variant: ShiftVariant, amount: usize, row: &mut [
 	fn sll<F: Field>(amount: usize, row: &mut [F], psi: &[F]) {
 		let width = row.len();
 		row[..width - amount].copy_from_slice(&psi[amount..]);
+		// The positions the weights vacate take no weight at all.
+		row[width - amount..].fill(F::ZERO);
 	}
 	fn srl<F: Field>(amount: usize, row: &mut [F], psi: &[F]) {
 		let width = row.len();
+		row[..amount].fill(F::ZERO);
 		row[amount..].copy_from_slice(&psi[..width - amount]);
 	}
 	fn sar<F: Field>(amount: usize, row: &mut [F], psi: &[F]) {
@@ -155,6 +183,7 @@ fn fill_operator_row<F: Field>(variant: ShiftVariant, amount: usize, row: &mut [
 ///
 /// Every entry is one copy or one accumulation.
 /// So the whole table costs `O(2^15)` field operations, and a single slice `O(2^6)`.
+/// A caller needing one slice rather than the whole table calls [`shift_operator_row`] itself.
 ///
 /// # Panics
 ///
@@ -175,7 +204,7 @@ where
 		iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS))
 	{
 		for (amount, row) in block.chunks_exact_mut(Word::BITS).enumerate() {
-			fill_operator_row(variant, amount, row, psi);
+			shift_operator_row(variant, amount, row, psi);
 		}
 	}
 
@@ -504,6 +533,35 @@ mod tests {
 				.collect::<Vec<F>>();
 
 			prop_assert_eq!(lhs.as_ref(), rhs.as_slice());
+		}
+	}
+
+	// Invariant: the row builder writes exactly the slice the table holds for that pair.
+	//
+	// The reduction's outer phase reads one slice at a time rather than building the table, so the
+	// two paths have to agree entry for entry.
+	//
+	// The scratch row is carried across every pair and starts out non-zero, which is what pins the
+	// full-write contract: a builder that left cells alone would leak the previous pair's weights.
+	#[test]
+	fn shift_operator_row_matches_its_slice_of_the_table() {
+		type F = BinaryField128bGhash;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let psi = random_scalars::<F>(&mut rng, Word::BITS);
+
+		let table = shift_operator_table::<F, F, _>(&GlobalAllocator, &psi);
+		let mut row = vec![F::ONE; Word::BITS];
+		for (variant_idx, variant) in ShiftVariant::ALL.into_iter().enumerate() {
+			for amount in 0..Word::BITS {
+				shift_operator_row(variant, amount, &mut row, &psi);
+				let offset = (variant_idx * Word::BITS + amount) * Word::BITS;
+				assert_eq!(
+					row.as_slice(),
+					&table.as_ref()[offset..offset + Word::BITS],
+					"{variant:?} at amount {amount}"
+				);
+			}
 		}
 	}
 

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -6,10 +6,7 @@ use std::iter;
 use binius_compute::{Allocator, VecLike};
 use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
 use binius_field::{BinaryField, Field, PackedField, WideMul};
-use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval,
-	univariate::lagrange_evals,
-};
+use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use binius_verifier::protocols::shift::{
 	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, ZERO_ARITY,
@@ -211,32 +208,6 @@ where
 	FieldBuffer::from_values_in(alloc, &data)
 }
 
-/// Constructs the "h" multilinear for shift operations at a univariate challenge point.
-///
-/// See the paper for the definition of the h polynomials.
-/// There is one per shift variant, and this returns all of them as a single multilinear.
-/// The layout is the one [`shift_operator_table`] documents.
-///
-/// The weights are the Lagrange evaluations at the univariate challenge.
-/// Those are the oblong weights the reduction's first factor carries.
-///
-/// # Usage in Protocol
-///
-/// Phase 1 runs one sumcheck over this multilinear and its "g" counterpart.
-/// So the variant axis is folded by the sumcheck rather than summed across separate provers.
-#[instrument(skip_all, name = "build_h")]
-pub fn build_h<F, P: PackedField<Scalar = F>, A: Allocator>(
-	alloc: &A,
-	domain_subspace: &BinarySubspace<F>,
-	r_zhat_prime: F,
-) -> FieldVec<P, A>
-where
-	F: BinaryField,
-{
-	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-	shift_operator_table(alloc, l_tilde.as_ref())
-}
-
 /// Constructs the "monster multilinear" that combines all shift operations into a single
 /// multilinear.
 ///
@@ -399,8 +370,8 @@ mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	use binius_math::{
-		inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval,
-		test_utils::random_scalars,
+		BinarySubspace, inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval,
+		test_utils::random_scalars, univariate::lagrange_evals,
 	};
 	use binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT;
 	use proptest::prelude::*;
@@ -432,10 +403,10 @@ mod tests {
 
 			// Method 1: the claim phase 3 starts from, with the carried constant set to one.
 			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
 			let claimed = ShiftIndSumcheck::<P, _>::new(
 				&GlobalAllocator,
-				&subspace,
-				r_zhat_prime,
+				l_tilde.as_ref(),
 				&r_j,
 				&r_s,
 				&r_v,
@@ -444,7 +415,7 @@ mod tests {
 			.beta();
 
 			// Method 2: evaluate the built multilinear at the whole point.
-			let h = build_h(&GlobalAllocator, &subspace, r_zhat_prime);
+			let h = shift_operator_table::<F, P, _>(&GlobalAllocator, l_tilde.as_ref());
 			let evaluation_point = [r_j, r_s, r_v].concat();
 			let tensor = eq_ind_partial_eval::<P>(&evaluation_point);
 			let direct = inner_product_buffers(&h, &tensor);

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -18,9 +18,7 @@ use binius_ip_prover::{
 		round_evaluator::SharedSumcheckProver,
 	},
 };
-use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec, multilinear::fold::fold_highest_var_inplace,
-};
+use binius_math::{FieldBuffer, FieldVec, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::{
 	prelude::*,
 	task_size::{IndexedParallelIteratorExt, WorkPerItem},
@@ -34,7 +32,7 @@ use super::{
 	SegmentWords,
 	claims::PreparedOperatorClaims,
 	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment},
-	monster::build_h,
+	monster::shift_operator_table,
 };
 
 /// The number of variables in the g (and h) multilinear of phase 1.
@@ -72,12 +70,17 @@ pub struct Phase1Output<F> {
 /// Proves the first phase of the shift reduction.
 ///
 /// Builds the g and h multilinears and runs one sumcheck over their product.
+///
+/// # Arguments
+///
+/// - `oblong_weights`: the oblong weights of the reduction's first factor, one per bit position.
+///   `h` is those weights pushed through every shift.
 #[instrument(skip_all, name = "prover_phase_1")]
 pub fn prove_phase_1<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: SegmentWords<'_>,
 	prepared: &PreparedOperatorClaims<F>,
-	domain_subspace: &BinarySubspace<F>,
+	oblong_weights: &[F],
 	channel: &mut Channel,
 	alloc: &A,
 ) -> Phase1Output<F>
@@ -96,8 +99,7 @@ where
 		(&hidden, &key_collection.hidden.dense_shift_enc),
 	]);
 
-	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
-	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+	let h = shift_operator_table(alloc, oblong_weights);
 
 	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
 }
@@ -623,10 +625,8 @@ mod tests {
 	use binius_core::constraint_system::{
 		AndConstraint, ConstraintSystem, InoutSegment, Shift, ShiftedValueIndex, ValueIndex,
 	};
-	use binius_field::{
-		AESTowerField8b, BinaryField128bGhash, Field, PackedBinaryGhash2x128b, Random,
-	};
-	use binius_math::inner_product::inner_product_buffers;
+	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash2x128b};
+	use binius_math::{inner_product::inner_product_buffers, test_utils::random_scalars};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::config::StdChallenger;
 	use rand::{SeedableRng, rngs::StdRng};
@@ -806,7 +806,7 @@ mod tests {
 		(challenges, g_eval * h_eval)
 	}
 
-	/// The phase-1 `g` and `h` of a constraint system, at a pseudo-random univariate challenge.
+	/// The phase-1 `g` and `h` of a constraint system, from pseudo-random weights.
 	///
 	/// `g`'s rows carry arbitrary values rather than ones a witness produces: the sumcheck is a
 	/// statement about whatever multilinears it is handed, so what the rows hold does not bear on
@@ -830,8 +830,8 @@ mod tests {
 			(&hidden, &key_collection.hidden.dense_shift_enc),
 		]);
 
-		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
-		let h = build_h(&GlobalAllocator, &subspace, F::random(&mut rng));
+		// The weights `h` is built from are arbitrary here for the same reason `g`'s rows are.
+		let h = shift_operator_table(&GlobalAllocator, &random_scalars::<F>(&mut rng, Word::BITS));
 
 		(g, h)
 	}

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -6,7 +7,8 @@ use binius_field::{BinaryField, Field, PackedField, util::powers};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
+	BinarySubspace, FieldBuffer, inner_product::inner_product,
+	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
 
 use super::{
@@ -175,24 +177,28 @@ where
 		claims.prepare(|| channel.sample())
 	};
 
+	// The oblong weights the reduction's first factor carries. Phase 1 pushes them through every
+	// shift to build its h multilinear and phase 3 runs its rounds over them directly, so they are
+	// computed once here. All four operations share `r_zhat_prime`, so it is drawn from the BitAnd
+	// claim.
+	let oblong_weights = lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
+
 	// Phases 1 and 2 bind the shift variant, the shift amount and the bit position, outputting
 	// challenges `r_j || r_s || r_v` and the claim `gamma` (see paper).
 	let phase_1_output = prove_phase_1::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
-		domain_subspace,
+		oblong_weights.as_ref(),
 		channel,
 		alloc,
 	);
 
 	// Phase 3 binds the bit index the shift indicators read, carrying phase 1's `g` evaluation
-	// through its rounds as a constant. All four operations share `r_zhat_prime`, so it is drawn
-	// from the BitAnd claim, as phase 1's h multilinear is.
+	// through its rounds as a constant.
 	let phase_3 = ShiftIndSumcheck::<P, _>::new(
 		alloc,
-		domain_subspace,
-		prepared.bitand.r_zhat_prime,
+		oblong_weights.as_ref(),
 		&phase_1_output.r_j,
 		&phase_1_output.r_s,
 		&phase_1_output.r_v,

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -12,10 +12,9 @@ use binius_ip_prover::{
 	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
 };
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec,
+	FieldBuffer, FieldVec,
 	inner_product::inner_product,
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
-	univariate::lagrange_evals,
 };
 
 /// The number of bit variables a half-word (`*32`) shift variant acts over.
@@ -33,21 +32,25 @@ const HALF_WORD_LOG_BITS: usize = Word::LOG_BITS - 1;
 /// $$
 ///
 /// with $G = g(r_j, r_s, r_v)$ the sum over the word index that phase 4 goes on to bind. Unrolling
-/// $h$ exposes these rounds as a sumcheck over two multilinears in the bit index — the Lagrange
-/// weights and the interpolated shift indicators — with $G$ riding along as a constant.
+/// $h$ exposes these rounds as a sumcheck over two multilinears in the bit index — a weight vector
+/// and the interpolated shift indicators — with $G$ riding along as a constant.
 ///
 /// The two are held apart rather than multiplied together, which is what keeps the round
 /// polynomials degree 2. The constant is folded into the weights, so the pair sums to $\beta$ and
 /// the rounds are the ones the verifier's single sumcheck expects. Phase 4 then scales its
 /// monster multilinear by [`Phase3Output::shift_ind_eval`], the evaluation these rounds reduce
 /// the two factors to.
+///
+/// The weights and the point the indicator is read at are the caller's, not this type's: a
+/// reduction peeling two shifts runs these rounds once per shift slot, differing only in those two
+/// arguments.
 pub struct ShiftIndSumcheck<P: PackedField, A: Allocator> {
-	/// The Lagrange evaluations at the univariate challenge, over the bit index, scaled by `G`.
-	scaled_l_tilde: FieldVec<P, A>,
+	/// The weights over the bit index, scaled by `G`.
+	scaled_weights: FieldVec<P, A>,
 	/// The shift indicators interpolated over the shift variant, over the bit index.
 	shift_ind: FieldVec<P, A>,
-	/// The unscaled Lagrange evaluations, kept to evaluate them at the challenge point.
-	l_tilde: Vec<P::Scalar>,
+	/// The unscaled weights, kept to evaluate them at the challenge point.
+	weights: Vec<P::Scalar>,
 	/// The claim these rounds start from: `h(r_j, r_s, r_v) * G`.
 	beta: P::Scalar,
 }
@@ -56,49 +59,45 @@ pub struct ShiftIndSumcheck<P: PackedField, A: Allocator> {
 #[derive(Debug, Clone, Copy)]
 pub struct Phase3Output<F> {
 	/// The product of the two factors at the bit-index challenge point:
-	/// `L(r_i) * shift_ind(r_i, r_j, r_s, r_v)`. Phase 4 scales its monster multilinear by it,
-	/// and the verifier recomputes it from `r_i` alone.
+	/// `weights(r_i) * shift_ind(r_i, r_j, r_s, r_v)`. Phase 4 scales its monster multilinear by
+	/// it, and the verifier recomputes it from `r_i` alone.
 	pub shift_ind_eval: F,
 	/// The claim phase 4 proves: `shift_ind_eval * G`.
 	pub eval: F,
 }
 
 impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<P, A> {
-	/// Builds the two multilinears the rounds run over, from phase 1's challenges and its `g`
-	/// evaluation.
+	/// Builds the two multilinears the rounds run over, from the weights the caller holds and
+	/// phase 1's challenges.
 	///
 	/// # Arguments
 	///
-	/// - `domain_subspace`: the univariate evaluation domain.
-	/// - `r_zhat_prime`: the univariate challenge, shared by every operation.
-	/// - `r_j`, `r_s`, `r_v`: phase 1's challenges — the input bit position, the shift amount and
-	///   the shift variant.
+	/// - `weights`: the weight vector over the bit index, one entry per bit of a word. The
+	///   reduction supplies the oblong Lagrange evaluations at the univariate challenge.
+	/// - `r_j`, `r_s`, `r_v`: the point the shift indicator is read at — phase 1's challenges for
+	///   the input bit position, the shift amount and the shift variant.
 	/// - `g_eval`: `g(r_j, r_s, r_v)`, the constant these rounds carry.
-	pub fn new(
-		alloc: &A,
-		domain_subspace: &BinarySubspace<F>,
-		r_zhat_prime: F,
-		r_j: &[F],
-		r_s: &[F],
-		r_v: &[F],
-		g_eval: F,
-	) -> Self {
-		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-		let l_tilde = l_tilde.as_ref().to_vec();
+	///
+	/// # Panics
+	///
+	/// Panics unless the weights hold one entry per bit position of a word.
+	pub fn new(alloc: &A, weights: &[F], r_j: &[F], r_s: &[F], r_v: &[F], g_eval: F) -> Self {
+		assert_eq!(weights.len(), Word::BITS, "the weights are indexed by bit position");
+
 		let shift_ind = build_shift_ind(r_j, r_s, r_v);
 
 		// Folding the constant into one of the two factors makes the pair sum to the incoming
 		// claim, so the standard bivariate-product prover emits the right rounds.
-		let scaled_l_tilde = l_tilde
+		let scaled_weights = weights
 			.iter()
 			.map(|&weight| weight * g_eval)
 			.collect::<Vec<_>>();
-		let beta = inner_product(scaled_l_tilde.iter().copied(), shift_ind.iter().copied());
+		let beta = inner_product(scaled_weights.iter().copied(), shift_ind.iter().copied());
 
 		Self {
-			scaled_l_tilde: FieldBuffer::from_values_in(alloc, &scaled_l_tilde),
+			scaled_weights: FieldBuffer::from_values_in(alloc, &scaled_weights),
 			shift_ind: FieldBuffer::from_values_in(alloc, &shift_ind),
-			l_tilde,
+			weights: weights.to_vec(),
 			beta,
 		}
 	}
@@ -111,30 +110,30 @@ impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<
 	/// Proves the [`Word::LOG_BITS`] rounds binding the bit index.
 	pub fn prove(self, channel: &mut impl IPProverChannel<F>, alloc: &A) -> Phase3Output<F> {
 		let Self {
-			scaled_l_tilde,
+			scaled_weights,
 			shift_ind,
-			l_tilde,
+			weights,
 			beta,
 		} = self;
 
-		let prover = bivariate_product_prover(alloc, [scaled_l_tilde, shift_ind], beta);
+		let prover = bivariate_product_prover(alloc, [scaled_weights, shift_ind], beta);
 		let ProveSingleOutput {
 			multilinear_evals,
 			mut challenges,
 		} = prove_single(prover, channel);
 		challenges.reverse();
 
-		let [scaled_l_tilde_eval, shift_ind_eval] = multilinear_evals
+		let [scaled_weights_eval, shift_ind_eval] = multilinear_evals
 			.try_into()
 			.expect("prover has 2 multilinear polynomials");
 
 		// The scale rides in the first evaluation, so the unscaled weights are evaluated at the
 		// challenge point separately — the same 64-term inner product the verifier runs.
-		let l_tilde_eval = inner_product(l_tilde, eq_ind_partial_eval_scalars(&challenges));
+		let weights_eval = inner_product(weights, eq_ind_partial_eval_scalars(&challenges));
 
 		Phase3Output {
-			shift_ind_eval: l_tilde_eval * shift_ind_eval,
-			eval: scaled_l_tilde_eval * shift_ind_eval,
+			shift_ind_eval: weights_eval * shift_ind_eval,
+			eval: scaled_weights_eval * shift_ind_eval,
 		}
 	}
 }
@@ -294,7 +293,7 @@ mod tests {
 
 	use binius_field::{BinaryField128bGhash as B128, Field};
 	use binius_math::{
-		multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars,
+		BinarySubspace, multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars,
 		univariate::lagrange_evals_scalars,
 	};
 	use binius_verifier::protocols::shift::{LOG_SHIFT_VARIANT_COUNT, evaluate_shift_inds};
@@ -412,8 +411,8 @@ mod tests {
 		}
 	}
 
-	/// The claim phase 3 starts from is the h evaluation scaled by the constant it carries: the
-	/// Lagrange weights contracted against the indicator multilinear, times `g_eval`.
+	/// The claim phase 3 starts from is the weights contracted against the indicator multilinear,
+	/// scaled by the constant it carries.
 	#[test]
 	fn claimed_sum_is_the_weighted_indicator_sum() {
 		use binius_compute::GlobalAllocator;
@@ -428,18 +427,12 @@ mod tests {
 		let r_v = random_scalars::<B128>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
 
 		let g_eval = B128::random(&mut rng);
-		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
-		let sumcheck = ShiftIndSumcheck::<P, _>::new(
-			&GlobalAllocator,
-			&subspace,
-			r_zhat_prime,
-			&r_j,
-			&r_s,
-			&r_v,
-			g_eval,
-		);
-
+		let subspace =
+			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic::<B128>();
 		let l_tilde = lagrange_evals_scalars(&subspace, &r_zhat_prime);
+		let sumcheck =
+			ShiftIndSumcheck::<P, _>::new(&GlobalAllocator, &l_tilde, &r_j, &r_s, &r_v, g_eval);
+
 		let expected = g_eval * inner_product(l_tilde, build_shift_ind(&r_j, &r_s, &r_v));
 		assert_eq!(sumcheck.beta(), expected);
 	}


### PR DESCRIPTION
Groundwork for the six-phase shift reduction of [binius.xyz#124](https://github.com/binius-zk/binius.xyz/pull/124) ([BINIUS-408](https://linear.app/jimpo/issue/BINIUS-408), [BINIUS-485](https://linear.app/jimpo/issue/BINIUS-485)). **Transcript-identical** — no round message, challenge, or verifier behaviour changes; the point is to leave the protocol change that follows as wiring rather than wiring plus new mathematics.

#124 runs two phases with the shape `ShiftIndSumcheck` already has, and its outer phase needs one `(variant, amount)` slice of `T[psi]` at a time rather than the whole table. Both fall out of code that exists.

## Write a shift-operator row through one public entry point

`fill_operator_row` becomes `shift_operator_row`, the documented entry point `shift_operator_table` loops over. It now writes *every* cell rather than relying on the caller having zeroed the row, so a caller reading one slice at a time can carry a single scratch row across every pair it visits — which is what the outer phase does, once per live shift quadruple per round.

It keeps `(variant, amount)` rather than taking a `Shift`, as the issue sketched. The amount is an index over the reduction's 6-bit amount axis, which spans `Word::BITS` for every variant; `Shift::new` caps a half-word (`*32`) variant at 32, so a `Shift` argument would force both callers to bypass it and build the struct literally. The doc comment says so.

## Hand the bit-index sumcheck its weights and indicator point

`ShiftIndSumcheck::new` took the evaluation domain and the univariate challenge and derived its own weights. It now takes the weight vector and the point the indicator is read at. #124 runs these rounds twice, differing in exactly those two arguments:

| phase | binds | weights | indicator at |
|---|---|---|---|
| 4 | `K` | `psi`, the terminal fold of `eta` | `(r_j, r_s1, r_o1)` |
| 5 | `I` | `d`, the oblong weights | `(r_k, r_s2, r_o2)` |

The oblong weights move up to the reduction's entry point, which is where #124 needs them anyway — `eta = T[d]` and phase 5 reads `d` directly. With the caller holding them, `build_h` is `shift_operator_table` with an extra `lagrange_evals` in front, so it goes; `prove_phase_1` takes the weights instead of the domain, and `prove` computes them once instead of `build_h` and `ShiftIndSumcheck` each deriving them.

## Testing

- `shift_operator_row_matches_its_slice_of_the_table` pins the slice path on its own, against the table it is the loop body of. The scratch row is carried across all 512 pairs and starts non-zero, so a builder that left cells alone would leak the previous pair's weights and fail.
- The existing `shift_operator_table` proptests (definition match, linearity, identity at amount zero) cover the row builder through the table.
- `h_op_consistency` and `claimed_sum_is_the_weighted_indicator_sum` hold the generalized sumcheck to its old behaviour when handed today's arguments.
- Full `binius-prover` and `binius-m4-prover` suites green, including `prove_verify` and the shift round trip; workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)