### PR TITLE
State each gate kind once, and dispatch through one checked table

### DIFF
--- a/crates/frontend/src/gates/assert_eq.rs
+++ b/crates/frontend/src/gates/assert_eq.rs
@@ -15,37 +15,27 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire, path::PathSpec},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 2,
-		n_out: 0,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// That two words are equal.
+pub struct AssertEq;
+
+impl GateKind for AssertEq {
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 0);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y] = gate.in_wires();
+
+		// x ⊕ y = 0
+		cb.zero(expr::xor2(x, y));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y] = gate.in_wires();
 
-	// Constraint: x ⊕ y = 0
-	builder.zero(expr::xor2(*x, *y));
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	assertion_path: PathSpec,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	builder.emit_assert_eq(wire_to_reg(*x), wire_to_reg(*y), assertion_path.as_u32());
+		bc.emit_assert_eq(ctx.reg(x), ctx.reg(y), ctx.path().as_u32());
+	}
 }

--- a/crates/frontend/src/gates/assert_eq_cond.rs
+++ b/crates/frontend/src/gates/assert_eq_cond.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Conditional equality assertion.
 //!
 //! Enforces `x = y` when the MSB-bool value of `cond` is true, and no constraint otherwise.
@@ -16,46 +17,29 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire, path::PathSpec},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 3,
-		n_out: 0,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// That two words are equal, where a third is true as an MSB-bool.
+pub struct AssertEqCond;
+
+impl GateKind for AssertEqCond {
+	const SHAPE: OpcodeShape = OpcodeShape::new(3, 0);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y, cond] = gate.in_wires();
+
+		// (x ⊕ y) ∧ (cond ~>> 63) = 0
+		cb.and(expr::xor2(x, y), expr::sar(cond, 63), expr::empty());
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y, cond] = inputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y, cond] = gate.in_wires();
 
-	// Constraint: (x ⊕ y) ∧ (cond ~>> 63) = 0
-	let mask = expr::sar(*cond, 63);
-	builder.and(expr::xor2(*x, *y), mask, expr::empty());
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	assertion_path: PathSpec,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y, cond] = inputs else { unreachable!() };
-
-	// The condition is read as an MSB-bool, and broadcasting the sign bit preserves it.
-	// So the condition is passed as it stands, with no mask to compute or hold.
-	builder.emit_assert_eq_cond(
-		wire_to_reg(*cond),
-		wire_to_reg(*x),
-		wire_to_reg(*y),
-		assertion_path.as_u32(),
-	);
+		// The condition is read as an MSB-bool, and broadcasting the sign bit preserves it.
+		// So the condition is passed as it stands, with no mask to compute or hold.
+		bc.emit_assert_eq_cond(ctx.reg(cond), ctx.reg(x), ctx.reg(y), ctx.path().as_u32());
+	}
 }

--- a/crates/frontend/src/gates/assert_false.rs
+++ b/crates/frontend/src/gates/assert_false.rs
@@ -17,37 +17,27 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire, path::PathSpec},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 1,
-		n_out: 0,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// That a word's most significant bit is clear.
+pub struct AssertFalse;
+
+impl GateKind for AssertFalse {
+	const SHAPE: OpcodeShape = OpcodeShape::new(1, 0);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x] = gate.in_wires();
+
+		// sar(x, 63) = 0
+		cb.zero(expr::sar(x, 63));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x] = inputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x] = gate.in_wires();
 
-	// Constraint: sar(x, 63) = 0
-	builder.zero(expr::sar(*x, 63));
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	assertion_path: PathSpec,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x] = inputs else { unreachable!() };
-	builder.emit_assert_false(wire_to_reg(*x), assertion_path.as_u32());
+		bc.emit_assert_false(ctx.reg(x), ctx.path().as_u32());
+	}
 }

--- a/crates/frontend/src/gates/assert_non_zero.rs
+++ b/crates/frontend/src/gates/assert_non_zero.rs
@@ -34,68 +34,45 @@ use binius_core::word::Word;
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire, path::PathSpec},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		// ALL_ONE is the addend for the carry.
-		const_in: &[Word::ALL_ONE],
-		n_in: 1,
-		n_out: 0,
-		n_aux: 1,
-		n_scratch: 0,
-		n_imm: 0,
+/// That a word is not zero.
+pub struct AssertNonZero;
+
+impl GateKind for AssertNonZero {
+	// The constant is the addend for the carry; the auxiliary wire holds the carry-out.
+	const SHAPE: OpcodeShape = OpcodeShape::new(1, 0)
+		.with_consts(&[Word::ALL_ONE])
+		.with_aux(1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [all_one] = gate.const_wires();
+		let [x] = gate.in_wires();
+		let [cout] = gate.aux_wires();
+
+		let cin = expr::sll(cout, 1);
+
+		// Carry-out: (x ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout
+		cb.and(expr::xor2(x, cin), expr::xor2(all_one, cin), expr::xor2(cin, cout));
+
+		// MSB(cout) = 1, as sar(cout, 63) ⊕ all-1 = 0.
+		// Fusion cannot inline an assertion, so the constant stays out of the carry constraint.
+		cb.zero(expr::xor2(expr::sar(cout, 63), all_one));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants,
-		inputs,
-		aux,
-		..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
-	let [x] = inputs else { unreachable!() };
-	let [cout] = aux else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [all_one] = gate.const_wires();
+		let [x] = gate.in_wires();
+		let [cout] = gate.aux_wires();
 
-	let cin = expr::sll(*cout, 1);
+		// Carry bits of all-1 + x. Only the carries matter, so the sum is not stored.
+		bc.emit_iadd_carry(ctx.reg(cout), ctx.reg(all_one), ctx.reg(x));
 
-	// Constraint 1: Constrain carry-out
-	// (x ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout
-	builder.and(expr::xor2(*x, cin), expr::xor2(*all_one, cin), expr::xor2(cin, *cout));
-
-	// Constraint 2 (ZERO): sar(cout, 63) ⊕ all_one = 0, i.e. MSB(cout) = 1 (x ≠ 0).
-	// sar(cout, 63) sign-extends the MSB across all 64 bits, so it equals all_one iff
-	// MSB(cout) = 1. This is an assertion, which defines no wire, so gate fusion cannot inline it
-	// and substitute the constant back into Constraint 1, reopening the soundness hole.
-	builder.zero(expr::xor2(expr::sar(*cout, 63), *all_one));
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	assertion_path: PathSpec,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		constants,
-		inputs,
-		aux,
-		..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
-	let [x] = inputs else { unreachable!() };
-	let [cout] = aux else { unreachable!() };
-
-	// Carry bits of all_one + x.
-	// Only the carries matter, so the sum is not stored.
-	builder.emit_iadd_carry(wire_to_reg(*cout), wire_to_reg(*all_one), wire_to_reg(*x));
-
-	builder.emit_assert_non_zero(wire_to_reg(*cout), assertion_path.as_u32());
+		bc.emit_assert_non_zero(ctx.reg(cout), ctx.path().as_u32());
+	}
 }
 
 #[cfg(test)]

--- a/crates/frontend/src/gates/assert_true.rs
+++ b/crates/frontend/src/gates/assert_true.rs
@@ -19,40 +19,28 @@ use binius_core::word::Word;
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire, path::PathSpec},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
-		n_in: 1,
-		n_out: 0,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// That a word's most significant bit is set.
+pub struct AssertTrue;
+
+impl GateKind for AssertTrue {
+	const SHAPE: OpcodeShape = OpcodeShape::new(1, 0).with_consts(&[Word::ALL_ONE]);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [all_one] = gate.const_wires();
+		let [x] = gate.in_wires();
+
+		// sar(x, 63) ⊕ all-1 = 0
+		cb.zero(expr::xor2(expr::sar(x, 63), all_one));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants, inputs, ..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
-	let [x] = inputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x] = gate.in_wires();
 
-	// Constraint: sar(x, 63) ⊕ all-1 = 0
-	builder.zero(expr::xor2(expr::sar(*x, 63), *all_one));
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	assertion_path: PathSpec,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x] = inputs else { unreachable!() };
-	builder.emit_assert_true(wire_to_reg(*x), assertion_path.as_u32());
+		bc.emit_assert_true(ctx.reg(x), ctx.path().as_u32());
+	}
 }

--- a/crates/frontend/src/gates/assert_zero.rs
+++ b/crates/frontend/src/gates/assert_zero.rs
@@ -11,37 +11,27 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire, path::PathSpec},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::ConstraintBuilder,
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 1,
-		n_out: 0,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// That a word is zero.
+pub struct AssertZero;
+
+impl GateKind for AssertZero {
+	const SHAPE: OpcodeShape = OpcodeShape::new(1, 0);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x] = gate.in_wires();
+
+		// x = 0
+		cb.zero(x);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x] = inputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x] = gate.in_wires();
 
-	// Constraint: x = 0
-	builder.zero(*x);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	assertion_path: PathSpec,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x] = inputs else { unreachable!() };
-	builder.emit_assert_zero(wire_to_reg(*x), assertion_path.as_u32());
+		bc.emit_assert_zero(ctx.reg(x), ctx.path().as_u32());
+	}
 }

--- a/crates/frontend/src/gates/band.rs
+++ b/crates/frontend/src/gates/band.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Bitwise AND operation.
 //!
 //! Returns `z = x & y`.
@@ -14,45 +15,29 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::ConstraintBuilder,
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 2,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// Bitwise AND of two words.
+pub struct Band;
+
+impl GateKind for Band {
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z] = gate.out_wires();
+
+		// x ∧ y = z
+		cb.and(x, y, z);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z] = gate.out_wires();
 
-	// Constraint: Bitwise AND
-	//
-	// x ∧ y = z
-	builder.and(*x, *y, *z);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-
-	builder.emit_band(wire_to_reg(*z), wire_to_reg(*x), wire_to_reg(*y));
+		bc.emit_band(ctx.reg(z), ctx.reg(x), ctx.reg(y));
+	}
 }

--- a/crates/frontend/src/gates/bmul.rs
+++ b/crates/frontend/src/gates/bmul.rs
@@ -6,57 +6,36 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::ConstraintBuilder,
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 4,
-		n_out: 2,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// The product of two GHASH-field elements, each carried by a pair of words.
+pub struct Bmul;
+
+impl GateKind for Bmul {
+	const SHAPE: OpcodeShape = OpcodeShape::new(4, 2);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [a_lo, a_hi, b_lo, b_hi] = gate.in_wires();
+		let [c_lo, c_hi] = gate.out_wires();
+
+		// (a_lo, a_hi) * (b_lo, b_hi) = (c_lo, c_hi) in GF(2^128).
+		cb.bmul(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a_lo, a_hi, b_lo, b_hi] = inputs else {
-		unreachable!()
-	};
-	let [c_lo, c_hi] = outputs else {
-		unreachable!()
-	};
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [a_lo, a_hi, b_lo, b_hi] = gate.in_wires();
+		let [c_lo, c_hi] = gate.out_wires();
 
-	// Create BmulConstraint: (A_LO, A_HI) * (B_LO, B_HI) = (C_LO, C_HI) in GF(2^128).
-	builder.bmul(*a_lo, *a_hi, *b_lo, *b_hi, *c_lo, *c_hi);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a_lo, a_hi, b_lo, b_hi] = inputs else {
-		unreachable!()
-	};
-	let [c_lo, c_hi] = outputs else {
-		unreachable!()
-	};
-	builder.emit_bmul(
-		wire_to_reg(*c_lo),
-		wire_to_reg(*c_hi),
-		wire_to_reg(*a_lo),
-		wire_to_reg(*a_hi),
-		wire_to_reg(*b_lo),
-		wire_to_reg(*b_hi),
-	);
+		bc.emit_bmul(
+			ctx.reg(c_lo),
+			ctx.reg(c_hi),
+			ctx.reg(a_lo),
+			ctx.reg(a_hi),
+			ctx.reg(b_lo),
+			ctx.reg(b_hi),
+		);
+	}
 }

--- a/crates/frontend/src/gates/bor.rs
+++ b/crates/frontend/src/gates/bor.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Bitwise OR operation.
 //!
 //! Returns `z = x | y`.
@@ -15,45 +16,29 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 2,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// Bitwise or of two words.
+pub struct Bor;
+
+impl GateKind for Bor {
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z] = gate.out_wires();
+
+		// x ∧ y = x ⊕ y ⊕ z
+		cb.and(x, y, expr::xor3(x, y, z));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z] = gate.out_wires();
 
-	// Constraint: Bitwise OR
-	//
-	// x ∧ y = x ⊕ y ⊕ z
-	builder.and(*x, *y, expr::xor3(*x, *y, *z));
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-
-	builder.emit_bor(wire_to_reg(*z), wire_to_reg(*x), wire_to_reg(*y));
+		bc.emit_bor(ctx.reg(z), ctx.reg(x), ctx.reg(y));
+	}
 }

--- a/crates/frontend/src/gates/bxor.rs
+++ b/crates/frontend/src/gates/bxor.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Bitwise XOR operation.
 //!
 //! Returns `z = x ^ y`.
@@ -14,45 +15,29 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 2,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// Bitwise exclusive-or of two words.
+pub struct Bxor;
+
+impl GateKind for Bxor {
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z] = gate.out_wires();
+
+		// (x ⊕ y) = z
+		cb.linear(expr::xor2(x, y), z);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z] = gate.out_wires();
 
-	// Constraint: Bitwise XOR (linear)
-	//
-	// (x ⊕ y) = z
-	builder.linear(expr::xor2(*x, *y), *z);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-
-	builder.emit_bxor(wire_to_reg(*z), wire_to_reg(*x), wire_to_reg(*y));
+		bc.emit_bxor(ctx.reg(z), ctx.reg(x), ctx.reg(y));
+	}
 }

--- a/crates/frontend/src/gates/bxor_multi.rs
+++ b/crates/frontend/src/gates/bxor_multi.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! N-way bitwise XOR operation.
 //!
 //! Returns `z = x0 ^ x1 ^ ... ^ xn`.
@@ -10,53 +11,41 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, WireExprTerm, expr},
 };
 
-pub fn shape(dimensions: &[usize]) -> OpcodeShape {
-	let [n_inputs] = dimensions else {
-		unreachable!()
-	};
-	OpcodeShape {
-		const_in: &[],
-		n_in: *n_inputs,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// The exclusive-or of any number of words.
+///
+/// This is the one kind whose arity is not fixed: its single dimension is the input count.
+pub struct BxorMulti;
+
+impl GateKind for BxorMulti {
+	/// The fixed part of the shape; the input count comes from the dimension.
+	const SHAPE: OpcodeShape = OpcodeShape::new(0, 1);
+
+	fn shape(dimensions: &[usize]) -> OpcodeShape {
+		let [n_inputs] = <[usize; 1]>::try_from(dimensions)
+			.expect("a multi-way exclusive-or carries its input count as its one dimension");
+		OpcodeShape::new(n_inputs, 1)
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [z] = outputs else { unreachable!() };
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [z] = gate.out_wires();
 
-	// Constraint: N-way Bitwise XOR (linear)
-	//
-	// (x0 ⊕ x1 ⊕ ... ⊕ xn) = z
-	//
-	// The terms are handed over as an iterator, since the operand collects them itself.
-	// A vector to carry them across would only be allocated to be dropped.
-	let terms = inputs.iter().map(|&wire| WireExprTerm::from(wire));
-	builder.linear(expr::xor_multi(terms), *z);
-}
+		// (x0 ⊕ x1 ⊕ ... ⊕ xn) = z
+		// The terms are handed over as an iterator, since the operand collects them itself.
+		let terms = gate.inputs.iter().map(|&wire| WireExprTerm::from(wire));
+		cb.linear(expr::xor_multi(terms), z);
+	}
 
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [z] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [z] = gate.out_wires();
 
-	let input_regs: Vec<u32> = inputs.iter().map(|&wire| wire_to_reg(wire)).collect();
-	builder.emit_bxor_multi(wire_to_reg(*z), &input_regs);
+		let input_regs: Vec<u32> = gate.inputs.iter().map(|&wire| ctx.reg(wire)).collect();
+		bc.emit_bxor_multi(ctx.reg(z), &input_regs);
+	}
 }
 
 #[cfg(test)]

--- a/crates/frontend/src/gates/fax.rs
+++ b/crates/frontend/src/gates/fax.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Fused AND-XOR operation.
 //!
 //! Returns `z = (x & y) ^ w`.
@@ -15,46 +16,29 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 3,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// Bitwise and of two words, exclusive-ored with a third.
+pub struct Fax;
+
+impl GateKind for Fax {
+	const SHAPE: OpcodeShape = OpcodeShape::new(3, 1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y, w] = gate.in_wires();
+		let [z] = gate.out_wires();
+
+		// x ∧ y = z ⊕ w, which is z = (x ∧ y) ⊕ w rearranged.
+		cb.and(x, y, expr::xor2(z, w));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y, w] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y, w] = gate.in_wires();
+		let [z] = gate.out_wires();
 
-	// Constraint: Fused AND-XOR
-	//
-	// x & y = t, where t ^ w = z
-	// This can be written as: x & y ^ w = z
-	builder.and(*x, *y, expr::xor2(*z, *w));
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y, w] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-
-	builder.emit_fax(wire_to_reg(*z), wire_to_reg(*x), wire_to_reg(*y), wire_to_reg(*w));
+		bc.emit_fax(ctx.reg(z), ctx.reg(x), ctx.reg(y), ctx.reg(w));
+	}
 }

--- a/crates/frontend/src/gates/iadd32.rs
+++ b/crates/frontend/src/gates/iadd32.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Parallel 32-bit unsigned integer addition without carry-in.
 //!
 //! Performs simultaneous independent 32-bit additions on the upper and lower 32-bit halves of
@@ -22,60 +23,39 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 2,
-		n_out: 2,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// Two independent 32-bit sums, one per half of the word.
+pub struct Iadd32;
+
+impl GateKind for Iadd32 {
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 2);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y] = gate.in_wires();
+		let [z, cout] = gate.out_wires();
+
+		let cout_shifted = expr::sll32(cout, 1);
+
+		// Carry propagation:
+		// (x ⊕ (cout <<₃₂ 1)) ∧ (y ⊕ (cout <<₃₂ 1)) = cout ⊕ (cout <<₃₂ 1)
+		cb.and(
+			expr::xor2(x, cout_shifted),
+			expr::xor2(y, cout_shifted),
+			expr::xor2(cout, cout_shifted),
+		);
+
+		// Result: z = x ⊕ y ⊕ (cout <<₃₂ 1)
+		cb.linear(expr::xor3(x, y, cout_shifted), z);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z, cout] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [a, b] = gate.in_wires();
+		let [sum, cout] = gate.out_wires();
 
-	let cout_shifted = expr::sll32(*cout, 1);
-
-	// Constraint 1: Carry propagation
-	//
-	// (x ⊕ (cout <<₃₂ 1)) ∧ (y ⊕ (cout <<₃₂ 1)) = cout ⊕ (cout <<₃₂ 1)
-	builder.and(
-		expr::xor2(*x, cout_shifted),
-		expr::xor2(*y, cout_shifted),
-		expr::xor2(*cout, cout_shifted),
-	);
-
-	// Constraint 2: Result
-	//
-	// z = x ⊕ y ⊕ (cout <<₃₂ 1)
-	builder.linear(expr::xor3(*x, *y, cout_shifted), *z);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a, b] = inputs else { unreachable!() };
-	let [sum, cout] = outputs else { unreachable!() };
-	builder.emit_iadd32_cout(
-		wire_to_reg(*sum),
-		wire_to_reg(*cout),
-		wire_to_reg(*a),
-		wire_to_reg(*b),
-	);
+		bc.emit_iadd32_cout(ctx.reg(sum), ctx.reg(cout), ctx.reg(a), ctx.reg(b));
+	}
 }

--- a/crates/frontend/src/gates/iadd32_cin_cout.rs
+++ b/crates/frontend/src/gates/iadd32_cin_cout.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Parallel 32-bit unsigned integer addition with carry-in and carry-out.
 //!
 //! Performs simultaneous independent 32-bit additions on the upper and lower 32-bit halves of
@@ -25,63 +26,40 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 3,
-		n_out: 2,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// Two independent 32-bit sums with per-half carry-in, one per half of the word.
+pub struct Iadd32CinCout;
+
+impl GateKind for Iadd32CinCout {
+	const SHAPE: OpcodeShape = OpcodeShape::new(3, 2);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y, cin] = gate.in_wires();
+		let [z, cout] = gate.out_wires();
+
+		let cout_shifted = expr::sll32(cout, 1);
+		let cin_bit = expr::srl32(cin, 31);
+
+		// Carry propagation, for ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂ 31):
+		// (x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci
+		cb.and(
+			expr::xor3(x, cout_shifted, cin_bit),
+			expr::xor3(y, cout_shifted, cin_bit),
+			expr::xor3(cout, cout_shifted, cin_bit),
+		);
+
+		// Result: z = x ⊕ y ⊕ ci
+		cb.linear(expr::xor4(x, y, cout_shifted, cin_bit), z);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y, cin] = inputs else { unreachable!() };
-	let [z, cout] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [a, b, cin] = gate.in_wires();
+		let [sum, cout] = gate.out_wires();
 
-	let cout_shifted = expr::sll32(*cout, 1);
-	let cin_bit = expr::srl32(*cin, 31);
-
-	// Constraint 1: Carry propagation
-	//
-	// (x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci
-	// where ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂ 31)
-	builder.and(
-		expr::xor3(*x, cout_shifted, cin_bit),
-		expr::xor3(*y, cout_shifted, cin_bit),
-		expr::xor3(*cout, cout_shifted, cin_bit),
-	);
-
-	// Constraint 2: Result
-	//
-	// z = x ⊕ y ⊕ ci
-	builder.linear(expr::xor4(*x, *y, cout_shifted, cin_bit), *z);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a, b, cin] = inputs else { unreachable!() };
-	let [sum, cout] = outputs else { unreachable!() };
-	builder.emit_iadd32_cin_cout(
-		wire_to_reg(*sum),
-		wire_to_reg(*cout),
-		wire_to_reg(*a),
-		wire_to_reg(*b),
-		wire_to_reg(*cin),
-	);
+		bc.emit_iadd32_cin_cout(ctx.reg(sum), ctx.reg(cout), ctx.reg(a), ctx.reg(b), ctx.reg(cin));
+	}
 }

--- a/crates/frontend/src/gates/iadd_cin_cout.rs
+++ b/crates/frontend/src/gates/iadd_cin_cout.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! 64-bit unsigned integer addition with carry propagation.
 //!
 //! # Wires
@@ -29,62 +30,40 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 3,
-		n_out: 2,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// The 64-bit sum of two words and a carry-in, with its carry word.
+pub struct IaddCinCout;
+
+impl GateKind for IaddCinCout {
+	const SHAPE: OpcodeShape = OpcodeShape::new(3, 2);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [a, b, cin] = gate.in_wires();
+		let [sum, cout] = gate.out_wires();
+
+		let cout_sll_1 = expr::sll(cout, 1);
+		let cin_msb = expr::srl(cin, 63);
+
+		// Carry propagation:
+		// (a ⊕ (cout << 1) ⊕ cin_msb) ∧ (b ⊕ (cout << 1) ⊕ cin_msb) = cout ⊕ (cout << 1) ⊕ cin_msb
+		cb.and(
+			expr::xor3(a, cout_sll_1, cin_msb),
+			expr::xor3(b, cout_sll_1, cin_msb),
+			expr::xor3(cout, cout_sll_1, cin_msb),
+		);
+
+		// Sum equality (linear): (a ⊕ b ⊕ (cout << 1) ⊕ cin_msb) = sum
+		cb.linear(expr::xor4(a, b, cout_sll_1, cin_msb), sum);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a, b, cin] = inputs else { unreachable!() };
-	let [sum, cout] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [a, b, cin] = gate.in_wires();
+		let [sum, cout] = gate.out_wires();
 
-	let cout_sll_1 = expr::sll(*cout, 1);
-	let cin_msb = expr::srl(*cin, 63);
-
-	// Constraint 1: Carry propagation
-	//
-	// (a ⊕ (cout << 1) ⊕ cin_msb) ∧ (b ⊕ (cout << 1) ⊕ cin_msb) = cout ⊕ (cout << 1) ⊕ cin_msb
-	builder.and(
-		expr::xor3(*a, cout_sll_1, cin_msb),
-		expr::xor3(*b, cout_sll_1, cin_msb),
-		expr::xor3(*cout, cout_sll_1, cin_msb),
-	);
-
-	// Constraint 2: Sum equality (linear)
-	//
-	// (a ⊕ b ⊕ (cout << 1) ⊕ cin_msb) = sum
-	builder.linear(expr::xor4(*a, *b, cout_sll_1, cin_msb), *sum);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a, b, cin] = inputs else { unreachable!() };
-	let [sum, cout] = outputs else { unreachable!() };
-	builder.emit_iadd_cin_cout(
-		wire_to_reg(*sum),
-		wire_to_reg(*cout),
-		wire_to_reg(*a),
-		wire_to_reg(*b),
-		wire_to_reg(*cin),
-	);
+		bc.emit_iadd_cin_cout(ctx.reg(sum), ctx.reg(cout), ctx.reg(a), ctx.reg(b), ctx.reg(cin));
+	}
 }

--- a/crates/frontend/src/gates/icmp_eq.rs
+++ b/crates/frontend/src/gates/icmp_eq.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! 64-bit equality test that returns an MSB-bool indicating equality.
 //!
 //! Returns a wire whose value, as an MSB-bool, is true if `x == y` and false otherwise.
@@ -37,76 +38,46 @@ use binius_core::word::Word;
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[Word::ALL_ONE, Word::MSB_ONE],
-		n_in: 2,
-		n_out: 1,
-		n_aux: 1,     // carry-out register used in eval bytecode
-		n_scratch: 1, // Holds the difference of the two operands
-		n_imm: 0,
+/// Whether two words are equal, as an MSB-bool.
+pub struct IcmpEq;
+
+impl GateKind for IcmpEq {
+	// The auxiliary wire is the carry-out; the scratch wire holds the operands' difference.
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 1)
+		.with_consts(&[Word::ALL_ONE, Word::MSB_ONE])
+		.with_aux(1)
+		.with_scratch(1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [all_one, msb_one] = gate.const_wires();
+		let [x, y] = gate.in_wires();
+		let [out] = gate.out_wires();
+
+		let cin = expr::sll(out, 1);
+
+		// Carry-out: (x ⊕ y ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout
+		cb.and(expr::xor3(x, y, cin), expr::xor2(all_one, cin), expr::xor3(cin, out, msb_one));
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		..
-	} = data.gate_param();
-	let [all_one, msb_one] = constants else {
-		unreachable!()
-	};
-	let [x, y] = inputs else { unreachable!() };
-	let [out_wire] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [all_one, msb_one] = gate.const_wires();
+		let [x, y] = gate.in_wires();
+		let [out] = gate.out_wires();
+		let [cout] = gate.aux_wires();
+		let [diff] = gate.scratch_wires();
 
-	let cin = expr::sll(*out_wire, 1);
+		// diff = x ⊕ y
+		bc.emit_bxor(ctx.reg(diff), ctx.reg(x), ctx.reg(y));
 
-	// Constraint 1: Constrain carry-out
-	// (x ⊕ y ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout
-	builder.and(
-		expr::xor3(*x, *y, cin),
-		expr::xor2(*all_one, cin),
-		expr::xor3(cin, *out_wire, *msb_one),
-	);
-}
+		// Carry bits of all-1 + diff. Only the carries matter, so the sum is not stored.
+		bc.emit_iadd_carry(ctx.reg(cout), ctx.reg(all_one), ctx.reg(diff));
 
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		aux,
-		scratch,
-		..
-	} = data.gate_param();
-	let [all_one, msb_one] = constants else {
-		unreachable!()
-	};
-	let [x, y] = inputs else { unreachable!() };
-	let [out_wire] = outputs else { unreachable!() };
-	let [cout] = aux else { unreachable!() };
-	let [scratch_diff] = scratch else {
-		unreachable!()
-	};
-
-	// Compute diff = x ^ y
-	builder.emit_bxor(wire_to_reg(*scratch_diff), wire_to_reg(*x), wire_to_reg(*y));
-
-	// Carry bits of all_one + diff.
-	// Only the carries matter, so the sum is not stored.
-	builder.emit_iadd_carry(wire_to_reg(*cout), wire_to_reg(*all_one), wire_to_reg(*scratch_diff));
-
-	// Invert: out_wire = out_wire ^ msb_one
-	builder.emit_bxor(wire_to_reg(*out_wire), wire_to_reg(*cout), wire_to_reg(*msb_one));
+		// Invert the most significant bit, turning "differ" into "equal".
+		bc.emit_bxor(ctx.reg(out), ctx.reg(cout), ctx.reg(msb_one));
+	}
 }

--- a/crates/frontend/src/gates/icmp_ult.rs
+++ b/crates/frontend/src/gates/icmp_ult.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Unsigned less-than test returning a mask.
 //!
 //! Returns a wire whose value as an MSB-bool is true if `x < y`, and false otherwise.
@@ -24,65 +25,44 @@ use binius_core::word::Word;
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
-		n_in: 2,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 1, // Holds the negated left operand
-		n_imm: 0,
+/// Whether one word is less than another, as an MSB-bool.
+pub struct IcmpUlt;
+
+impl GateKind for IcmpUlt {
+	// The scratch wire holds the negated left operand during evaluation.
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 1)
+		.with_consts(&[Word::ALL_ONE])
+		.with_scratch(1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [all_one] = gate.const_wires();
+		let [x, y] = gate.in_wires();
+		let [bout] = gate.out_wires();
+
+		// Carry propagation for the comparison:
+		// ((x ⊕ all-1) ⊕ (bout << 1)) ∧ (y ⊕ (bout << 1)) = bout ⊕ (bout << 1)
+		cb.and(
+			expr::xor3(x, all_one, expr::sll(bout, 1)),
+			expr::xor2(y, expr::sll(bout, 1)),
+			expr::xor2(bout, expr::sll(bout, 1)),
+		);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs,
-		outputs,
-		constants,
-		..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
-	let [x, y] = inputs else { unreachable!() };
-	let [bout] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [all_one] = gate.const_wires();
+		let [x, y] = gate.in_wires();
+		let [bout] = gate.out_wires();
+		let [negated_x] = gate.scratch_wires();
 
-	// Constraint 1: Carry propagation for comparison
-	// ((x ⊕ all-1) ⊕ (bout << 1)) ∧ (y ⊕ (bout << 1)) = bout ⊕ (bout << 1)
-	builder.and(
-		expr::xor3(*x, *all_one, expr::sll(*bout, 1)),
-		expr::xor2(*y, expr::sll(*bout, 1)),
-		expr::xor2(*bout, expr::sll(*bout, 1)),
-	);
-}
+		// ¬x, as x exclusive-ored with all-1.
+		bc.emit_bxor(ctx.reg(negated_x), ctx.reg(x), ctx.reg(all_one));
 
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		scratch,
-		..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
-	let [x, y] = inputs else { unreachable!() };
-	let [bout] = outputs else { unreachable!() };
-	let [scratch_nx] = scratch else {
-		unreachable!()
-	};
-
-	// Compute ¬x (x XOR all_one)
-	builder.emit_bxor(wire_to_reg(*scratch_nx), wire_to_reg(*x), wire_to_reg(*all_one));
-
-	// Carry bits of ¬x + y.
-	// Only the carries matter, so the sum is not stored.
-	builder.emit_iadd_carry(wire_to_reg(*bout), wire_to_reg(*scratch_nx), wire_to_reg(*y));
+		// Carry bits of ¬x + y. Only the carries matter, so the sum is not stored.
+		bc.emit_iadd_carry(ctx.reg(bout), ctx.reg(negated_x), ctx.reg(y));
+	}
 }

--- a/crates/frontend/src/gates/imul.rs
+++ b/crates/frontend/src/gates/imul.rs
@@ -1,45 +1,33 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Imul gate implements 64-bit × 64-bit → 128-bit unsigned multiplication.
 //! Uses the ImulConstraint: X * Y = (HI << 64) | LO
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::ConstraintBuilder,
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 2,
-		n_out: 2,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// The 128-bit unsigned product of two words.
+pub struct Imul;
+
+impl GateKind for Imul {
+	const SHAPE: OpcodeShape = OpcodeShape::new(2, 2);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x, y] = gate.in_wires();
+		let [hi, lo] = gate.out_wires();
+
+		// x * y = (hi << 64) | lo
+		cb.imul(x, y, hi, lo);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [hi, lo] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x, y] = gate.in_wires();
+		let [hi, lo] = gate.out_wires();
 
-	// Create ImulConstraint: X * Y = (HI << 64) | LO
-	builder.imul(*x, *y, *hi, *lo);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [hi, lo] = outputs else { unreachable!() };
-	builder.emit_imul(wire_to_reg(*hi), wire_to_reg(*lo), wire_to_reg(*x), wire_to_reg(*y));
+		bc.emit_imul(ctx.reg(hi), ctx.reg(lo), ctx.reg(x), ctx.reg(y));
+	}
 }

--- a/crates/frontend/src/gates/isub_bin_bout.rs
+++ b/crates/frontend/src/gates/isub_bin_bout.rs
@@ -1,72 +1,52 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+//! 64-bit unsigned subtraction with borrow propagation.
+//!
+//! # Constraints
+//!
+//! The gate generates 1 AND constraint and 1 linear constraint, for `bi = (bout << 1) ⊕ bin_msb`:
+//! 1. Borrow propagation: `(¬a ⊕ bi) ∧ (b ⊕ bi) = bout ⊕ bi`
+//! 2. Result: `diff = a ⊕ b ⊕ bi`
+
 use binius_core::word::Word;
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
-		n_in: 3,
-		n_out: 2,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// The 64-bit difference of two words and a borrow-in, with its borrow word.
+pub struct IsubBinBout;
+
+impl GateKind for IsubBinBout {
+	const SHAPE: OpcodeShape = OpcodeShape::new(3, 2).with_consts(&[Word::ALL_ONE]);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [all_one] = gate.const_wires();
+		let [a, b, bin] = gate.in_wires();
+		let [diff, bout] = gate.out_wires();
+
+		let bout_sll_1 = expr::sll(bout, 1);
+		let bin_msb = expr::srl(bin, 63);
+
+		// Borrow propagation:
+		// (¬a ⊕ (bout << 1) ⊕ bin_msb) ∧ (b ⊕ (bout << 1) ⊕ bin_msb) = bout ⊕ (bout << 1) ⊕ bin_msb
+		cb.and(
+			expr::xor4(all_one, a, bout_sll_1, bin_msb),
+			expr::xor3(b, bout_sll_1, bin_msb),
+			expr::xor3(bout, bout_sll_1, bin_msb),
+		);
+
+		// Difference (linear): (a ⊕ b ⊕ (bout << 1) ⊕ bin_msb) = diff
+		cb.linear(expr::xor4(a, b, bout_sll_1, bin_msb), diff);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
-	let [a, b, bin] = inputs else { unreachable!() };
-	let [diff, bout] = outputs else {
-		unreachable!()
-	};
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [a, b, bin] = gate.in_wires();
+		let [diff, bout] = gate.out_wires();
 
-	let bout_sll_1 = expr::sll(*bout, 1);
-	let bin_msb = expr::srl(*bin, 63);
-
-	// Constraint 1: Borrow propagation
-	//
-	// (¬a ⊕ (bout << 1) ⊕ bin_msb) ∧ (b ⊕ (bout << 1) ⊕ bin_msb) = bout ⊕ (bout << 1) ⊕ bin_msb
-	builder.and(
-		expr::xor4(*all_one, *a, bout_sll_1, bin_msb),
-		expr::xor3(*b, bout_sll_1, bin_msb),
-		expr::xor3(*bout, bout_sll_1, bin_msb),
-	);
-
-	// Constraint 2: Diff equality (linear)
-	//
-	// (a ⊕ b ⊕ (bout << 1) ⊕ bin_msb) = diff
-	builder.linear(expr::xor4(*a, *b, bout_sll_1, bin_msb), *diff);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [a, b, bin] = inputs else { unreachable!() };
-	let [diff, bout] = outputs else {
-		unreachable!()
-	};
-	builder.emit_isub_bin_bout(
-		wire_to_reg(*diff),
-		wire_to_reg(*bout),
-		wire_to_reg(*a),
-		wire_to_reg(*b),
-		wire_to_reg(*bin),
-	);
+		bc.emit_isub_bin_bout(ctx.reg(diff), ctx.reg(bout), ctx.reg(a), ctx.reg(b), ctx.reg(bin));
+	}
 }

--- a/crates/frontend/src/gates/mod.rs
+++ b/crates/frontend/src/gates/mod.rs
@@ -1,14 +1,20 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
+
+//! The gate kinds: what each carries, what it constrains, and how it evaluates.
+//!
+//! One impl states all three, so a kind's shape and the code reading it sit together.
+//! A table maps an opcode to the kind serving it.
+
 use crate::{
 	eval_form::BytecodeBuilder,
-	ir::{Gate, GateData, GateGraph, Wire, hints::HintRegistry},
+	ir::{Gate, GateData, GateGraph, GateParam, Wire, hints::HintRegistry, path::PathSpec},
 	lower::ConstraintBuilder,
 };
 
 pub mod opcode;
 
-pub use opcode::Opcode;
+pub use opcode::{Opcode, OpcodeShape};
 
 pub mod assert_eq;
 pub mod assert_eq_cond;
@@ -32,36 +38,134 @@ pub mod isub_bin_bout;
 pub mod select;
 pub mod shift;
 
-pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder) {
-	let data = &graph.gates[gate];
-	match data.opcode {
-		Opcode::Band => band::constrain(data, builder),
-		Opcode::Bxor => bxor::constrain(data, builder),
-		Opcode::BxorMulti => bxor_multi::constrain(data, builder),
-		Opcode::Bor => bor::constrain(data, builder),
-		Opcode::Fax => fax::constrain(data, builder),
-		Opcode::Select => select::constrain(data, builder),
-		Opcode::IaddCinCout => iadd_cin_cout::constrain(data, builder),
-		Opcode::Iadd32 => iadd32::constrain(data, builder),
-		Opcode::Iadd32CinCout => iadd32_cin_cout::constrain(data, builder),
-		Opcode::IsubBinBout => isub_bin_bout::constrain(data, builder),
-		Opcode::Shift => shift::constrain(data, builder),
-		Opcode::AssertEq => assert_eq::constrain(data, builder),
-		Opcode::AssertZero => assert_zero::constrain(data, builder),
-		Opcode::AssertNonZero => assert_non_zero::constrain(data, builder),
-		Opcode::AssertFalse => assert_false::constrain(data, builder),
-		Opcode::AssertTrue => assert_true::constrain(data, builder),
-		Opcode::AssertEqCond => assert_eq_cond::constrain(data, builder),
-		Opcode::Imul => imul::constrain(data, builder),
-		Opcode::Bmul => bmul::constrain(data, builder),
-		Opcode::IcmpUlt => icmp_ult::constrain(data, builder),
-		Opcode::IcmpEq => icmp_eq::constrain(data, builder),
-		// Hints do not introduce constraints
-		Opcode::Hint => (),
+/// One kind of gate: what it carries, what it constrains, and how it evaluates.
+///
+/// The shape settles the arity, so the code destructuring against it belongs in the same impl.
+pub trait GateKind {
+	/// The wires and immediates a gate of this kind carries.
+	const SHAPE: OpcodeShape;
+
+	/// The shape for the dimensions a gate was emitted with.
+	///
+	/// Only a kind whose arity is a function of its dimensions overrides this.
+	fn shape(dimensions: &[usize]) -> OpcodeShape {
+		debug_assert!(dimensions.is_empty(), "a fixed-shape gate carries no dimensions");
+		Self::SHAPE
+	}
+
+	/// The constraints this gate contributes, over its own wires.
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder);
+
+	/// The instructions that derive this gate's outputs at witness time.
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder);
+}
+
+/// What a gate's emission needs beyond its own wires.
+///
+/// Every kind takes one, so an assertion reads its path through the signature all gates share.
+pub struct EmitCtx<'a> {
+	resolve: &'a dyn Fn(Wire) -> u32,
+	path: PathSpec,
+}
+
+impl EmitCtx<'_> {
+	/// The register the interpreter addresses this wire by.
+	pub fn reg(&self, wire: Wire) -> u32 {
+		(self.resolve)(wire)
+	}
+
+	/// The circuit path an assertion failure of this gate is reported under.
+	pub const fn path(&self) -> PathSpec {
+		self.path
 	}
 }
 
-/// Emit bytecode for a single gate
+/// The three functions dispatch needs of a gate kind, as one row of the table.
+///
+/// A trait object cannot carry an associated const, so the row holds function pointers.
+struct GateVTable {
+	/// The opcode this row serves, which pins the row to its slot.
+	opcode: Opcode,
+	shape: fn(&[usize]) -> OpcodeShape,
+	constrain: fn(GateParam<'_>, &mut ConstraintBuilder),
+	emit: fn(GateParam<'_>, EmitCtx<'_>, &mut BytecodeBuilder),
+}
+
+/// The row serving one gate kind.
+const fn row<G: GateKind>(opcode: Opcode) -> GateVTable {
+	GateVTable {
+		opcode,
+		shape: G::shape,
+		constrain: G::constrain,
+		emit: G::emit,
+	}
+}
+
+/// Every gate kind, indexed by its opcode.
+///
+/// - The hint gate has no row: its shape lives in the hint registry, not in a type.
+/// - It is the last opcode declared, so it indexes one past the table.
+/// - A lookup reads that as absent, and the tests below pin both facts.
+static GATE_KINDS: [GateVTable; 21] = [
+	row::<band::Band>(Opcode::Band),
+	row::<bxor::Bxor>(Opcode::Bxor),
+	row::<bxor_multi::BxorMulti>(Opcode::BxorMulti),
+	row::<bor::Bor>(Opcode::Bor),
+	row::<fax::Fax>(Opcode::Fax),
+	row::<select::Select>(Opcode::Select),
+	row::<iadd_cin_cout::IaddCinCout>(Opcode::IaddCinCout),
+	row::<iadd32::Iadd32>(Opcode::Iadd32),
+	row::<iadd32_cin_cout::Iadd32CinCout>(Opcode::Iadd32CinCout),
+	row::<isub_bin_bout::IsubBinBout>(Opcode::IsubBinBout),
+	row::<imul::Imul>(Opcode::Imul),
+	row::<bmul::Bmul>(Opcode::Bmul),
+	row::<shift::Shift>(Opcode::Shift),
+	row::<icmp_ult::IcmpUlt>(Opcode::IcmpUlt),
+	row::<icmp_eq::IcmpEq>(Opcode::IcmpEq),
+	row::<assert_eq::AssertEq>(Opcode::AssertEq),
+	row::<assert_zero::AssertZero>(Opcode::AssertZero),
+	row::<assert_non_zero::AssertNonZero>(Opcode::AssertNonZero),
+	row::<assert_false::AssertFalse>(Opcode::AssertFalse),
+	row::<assert_true::AssertTrue>(Opcode::AssertTrue),
+	row::<assert_eq_cond::AssertEqCond>(Opcode::AssertEqCond),
+];
+
+impl Opcode {
+	/// The gate kind serving this opcode, or `None` for the hint gate.
+	fn vtable(self) -> Option<&'static GateVTable> {
+		let row = GATE_KINDS.get(self as usize)?;
+		debug_assert_eq!(
+			row.opcode, self,
+			"the gate table row does not serve the opcode indexing it"
+		);
+		Some(row)
+	}
+
+	/// The shape a gate of this opcode carries, for the dimensions it was emitted with.
+	///
+	/// # Panics
+	///
+	/// Panics for the hint gate, whose shape the hint registry settles instead.
+	/// Reading a gate's shape rather than its opcode's covers that case too.
+	pub fn shape(self, dimensions: &[usize]) -> OpcodeShape {
+		let vtable = self
+			.vtable()
+			.expect("Opcode::Hint shape requires the HintRegistry; use GateData::shape instead");
+		(vtable.shape)(dimensions)
+	}
+}
+
+/// Appends the constraints one gate contributes.
+///
+/// A hint contributes none: the surrounding circuit constrains the value it computes.
+pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder) {
+	let data = &graph.gates[gate];
+	if let Some(vtable) = data.opcode.vtable() {
+		(vtable.constrain)(data.gate_param(), builder);
+	}
+}
+
+/// Emits the instructions that derive one gate's outputs at witness time.
 pub fn emit_gate_bytecode(
 	gate: Gate,
 	graph: &GateGraph,
@@ -70,46 +174,25 @@ pub fn emit_gate_bytecode(
 	hint_registry: &HintRegistry,
 ) {
 	let data = &graph.gates[gate];
-
-	// The assertion gates take the path their failure is reported under; the rest do not.
-	let path = graph.assertion_names[gate];
-	match data.opcode {
-		Opcode::Band => band::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Bxor => bxor::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::BxorMulti => bxor_multi::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Bor => bor::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Fax => fax::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Select => select::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::IaddCinCout => iadd_cin_cout::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Iadd32 => iadd32::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Iadd32CinCout => iadd32_cin_cout::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::IsubBinBout => isub_bin_bout::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Shift => shift::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Imul => imul::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::Bmul => bmul::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::IcmpUlt => icmp_ult::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::IcmpEq => icmp_eq::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::AssertEq => assert_eq::emit_eval_bytecode(data, path, builder, wire_to_reg),
-		Opcode::AssertZero => assert_zero::emit_eval_bytecode(data, path, builder, wire_to_reg),
-		Opcode::AssertNonZero => {
-			assert_non_zero::emit_eval_bytecode(data, path, builder, wire_to_reg)
+	match data.opcode.vtable() {
+		Some(vtable) => {
+			let ctx = EmitCtx {
+				resolve: &wire_to_reg,
+				path: graph.assertion_names[gate],
+			};
+			(vtable.emit)(data.gate_param(), ctx, builder);
 		}
-		Opcode::AssertEqCond => {
-			assert_eq_cond::emit_eval_bytecode(data, path, builder, wire_to_reg)
-		}
-		Opcode::AssertFalse => assert_false::emit_eval_bytecode(data, path, builder, wire_to_reg),
-		Opcode::AssertTrue => assert_true::emit_eval_bytecode(data, path, builder, wire_to_reg),
-		Opcode::Hint => emit_hint(data, builder, wire_to_reg, hint_registry),
+		None => emit_hint(data, builder, wire_to_reg, hint_registry),
 	}
 }
 
-/// Emits a hint call, the one gate with no module of its own.
+/// Emits a hint call, the one gate with no kind of its own.
 ///
-/// The hint itself already lives in the registry, put there by `CircuitBuilder::call_hint`.
-/// The gate carries only its id, in `immediates[0]`, plus the user dimensions in `dimensions`.
+/// The hint already lives in the registry, put there when the circuit called it.
+/// The gate carries only its id and the dimensions the caller passed.
 ///
-/// `gate_param()` would panic for a hint, since its shape is not known statically.
-/// So the wires are sliced directly, using the shape read back from the registry.
+/// A hint's shape is not known statically, so the wires are sliced with the arity the registry
+/// reports rather than through the usual accessor.
 fn emit_hint(
 	data: &GateData,
 	builder: &mut BytecodeBuilder,
@@ -124,4 +207,29 @@ fn emit_hint(
 		.map(|&w| wire_to_reg(w))
 		.collect();
 	builder.emit_hint(hint_id, &data.dimensions, &input_regs, &output_regs);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// Invariant: a row sits at the slot its own opcode indexes.
+	// A misplaced row would constrain one gate as another, and no circuit test would say why.
+	#[test]
+	fn every_row_sits_at_the_slot_its_opcode_indexes() {
+		for (slot, row) in GATE_KINDS.iter().enumerate() {
+			assert_eq!(row.opcode as usize, slot, "{:?} is not at slot {slot}", row.opcode);
+		}
+	}
+
+	// Invariant: the hint is the one opcode without a row, and it is declared last.
+	// A new opcode appended after it would silently take its slot.
+	#[test]
+	fn the_hint_is_the_one_opcode_with_no_row() {
+		assert_eq!(Opcode::Hint as usize, GATE_KINDS.len());
+		assert!(Opcode::Hint.vtable().is_none());
+		for row in &GATE_KINDS {
+			assert!(row.opcode.vtable().is_some(), "{:?} has no row", row.opcode);
+		}
+	}
 }

--- a/crates/frontend/src/gates/opcode.rs
+++ b/crates/frontend/src/gates/opcode.rs
@@ -80,58 +80,40 @@ pub struct OpcodeShape {
 	pub n_imm: usize,
 }
 
-impl Opcode {
-	pub fn shape(self, dimensions: &[usize]) -> OpcodeShape {
-		assert_eq!(self.is_const_shape(), dimensions.is_empty());
-
-		match self {
-			// Bitwise operations
-			Opcode::Band => super::band::shape(),
-			Opcode::Bxor => super::bxor::shape(),
-			// TODO: Can we get rid of this gate? This is the only non-hint one with dimensions
-			Opcode::BxorMulti => super::bxor_multi::shape(dimensions),
-			Opcode::Bor => super::bor::shape(),
-			Opcode::Fax => super::fax::shape(),
-
-			// Selection
-			Opcode::Select => super::select::shape(),
-
-			// Arithmetic
-			Opcode::IaddCinCout => super::iadd_cin_cout::shape(),
-			Opcode::Iadd32 => super::iadd32::shape(),
-			Opcode::Iadd32CinCout => super::iadd32_cin_cout::shape(),
-			Opcode::IsubBinBout => super::isub_bin_bout::shape(),
-			Opcode::Imul => super::imul::shape(),
-			Opcode::Bmul => super::bmul::shape(),
-
-			// Shifts
-			Opcode::Shift => super::shift::shape(),
-
-			// Comparisons
-			Opcode::IcmpUlt => super::icmp_ult::shape(),
-			Opcode::IcmpEq => super::icmp_eq::shape(),
-
-			// Assertions (no outputs)
-			Opcode::AssertEq => super::assert_eq::shape(),
-			Opcode::AssertZero => super::assert_zero::shape(),
-			Opcode::AssertNonZero => super::assert_non_zero::shape(),
-			Opcode::AssertFalse => super::assert_false::shape(),
-			Opcode::AssertTrue => super::assert_true::shape(),
-			Opcode::AssertEqCond => super::assert_eq_cond::shape(),
-
-			// Hints (no constraints)
-			Opcode::Hint => {
-				panic!("Opcode::Hint shape requires the HintRegistry; use GateData::shape instead")
-			}
+impl OpcodeShape {
+	/// A shape reading `n_in` inputs and producing `n_out` outputs, carrying nothing else.
+	pub const fn new(n_in: usize, n_out: usize) -> Self {
+		Self {
+			const_in: &[],
+			n_in,
+			n_out,
+			n_aux: 0,
+			n_scratch: 0,
+			n_imm: 0,
 		}
 	}
 
-	pub const fn is_const_shape(self) -> bool {
-		#[allow(clippy::match_like_matches_macro)]
-		match self {
-			Opcode::BxorMulti => false,
-			Opcode::Hint => false,
-			_ => true,
-		}
+	/// The same shape, reading the given constants ahead of its inputs.
+	pub const fn with_consts(mut self, const_in: &'static [Word]) -> Self {
+		self.const_in = const_in;
+		self
+	}
+
+	/// The same shape, with wires the constraint system references but no caller passes.
+	pub const fn with_aux(mut self, n_aux: usize) -> Self {
+		self.n_aux = n_aux;
+		self
+	}
+
+	/// The same shape, with wires only witness evaluation reads.
+	pub const fn with_scratch(mut self, n_scratch: usize) -> Self {
+		self.n_scratch = n_scratch;
+		self
+	}
+
+	/// The same shape, with compile-time parameters carried alongside the wires.
+	pub const fn with_imm(mut self, n_imm: usize) -> Self {
+		self.n_imm = n_imm;
+		self
 	}
 }

--- a/crates/frontend/src/gates/select.rs
+++ b/crates/frontend/src/gates/select.rs
@@ -22,56 +22,39 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::GateParam,
 	lower::{ConstraintBuilder, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 3,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 0,
+/// One of two words, chosen by the most significant bit of a third.
+pub struct Select;
+
+impl GateKind for Select {
+	const SHAPE: OpcodeShape = OpcodeShape::new(3, 1);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [cond, t, f] = gate.in_wires();
+		let [out] = gate.out_wires();
+
+		// (cond >> 63) · (t ⊕ f) = out ⊕ f, over the GHASH field.
+		// Every factor fits in the low word, so each high word is the empty operand.
+		cb.bmul(
+			expr::srl(cond, 63),
+			expr::empty(),
+			expr::xor2(t, f),
+			expr::empty(),
+			expr::xor2(out, f),
+			expr::empty(),
+		);
 	}
-}
 
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [cond, t, f] = inputs else { unreachable!() };
-	let [out] = outputs else { unreachable!() };
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [cond, t, f] = gate.in_wires();
+		let [out] = gate.out_wires();
 
-	// Constraint: Select operation
-	//
-	// (cond >> 63) · (t ⊕ f) = out ⊕ f, over the GHASH field.
-	//
-	// Every factor fits in the low word, so each high word is the empty operand.
-	builder.bmul(
-		expr::srl(*cond, 63),
-		expr::empty(),
-		expr::xor2(*t, *f),
-		expr::empty(),
-		expr::xor2(*out, *f),
-		expr::empty(),
-	);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs, outputs, ..
-	} = data.gate_param();
-	let [cond, t, f] = inputs else { unreachable!() };
-	let [out] = outputs else { unreachable!() };
-
-	builder.emit_select(wire_to_reg(*out), wire_to_reg(*cond), wire_to_reg(*t), wire_to_reg(*f));
+		bc.emit_select(ctx.reg(out), ctx.reg(cond), ctx.reg(t), ctx.reg(f));
+	}
 }
 
 #[cfg(test)]

--- a/crates/frontend/src/gates/shift.rs
+++ b/crates/frontend/src/gates/shift.rs
@@ -19,23 +19,37 @@ use binius_core::constraint_system::ShiftVariant;
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	gates::opcode::OpcodeShape,
-	ir::{GateData, GateParam, Wire},
+	gates::{EmitCtx, GateKind, OpcodeShape},
+	ir::{GateParam, Wire},
 	lower::{ConstraintBuilder, WireExprTerm, expr},
 };
 
-pub const fn shape() -> OpcodeShape {
-	OpcodeShape {
-		const_in: &[],
-		n_in: 1,
-		n_out: 1,
-		n_aux: 0,
-		n_scratch: 0,
-		n_imm: 2,
+/// One word shifted or rotated by a constant amount.
+pub struct Shift;
+
+impl GateKind for Shift {
+	const SHAPE: OpcodeShape = OpcodeShape::new(1, 1).with_imm(2);
+
+	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
+		let [x] = gate.in_wires();
+		let [z] = gate.out_wires();
+		let [variant, n] = gate.imms();
+
+		// shift(x, n) = z, with the shift folded into the operand.
+		cb.linear(shifted_term(variant_of(variant), x, n), z);
+	}
+
+	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
+		let [x] = gate.in_wires();
+		let [z] = gate.out_wires();
+		let [variant, n] = gate.imms();
+
+		// One instruction carrying the variant and the amount.
+		bc.emit_shift(ctx.reg(z), ctx.reg(x), variant_of(variant), n as u8);
 	}
 }
 
-/// Decodes the variant immediate into its [`ShiftVariant`].
+/// Decodes the variant immediate.
 ///
 /// The builder always emits a discriminant in `0..=7`, so an out-of-range value is a bug.
 const fn variant_of(imm: u32) -> ShiftVariant {
@@ -54,39 +68,4 @@ const fn shifted_term(variant: ShiftVariant, x: Wire, n: u32) -> WireExprTerm {
 		ShiftVariant::Sra32 => expr::sra32(x, n),
 		ShiftVariant::Rotr32 => expr::rotr32(x, n),
 	}
-}
-
-pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		inputs,
-		outputs,
-		imm,
-		..
-	} = data.gate_param();
-	let [x] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-	let [variant, n] = imm else { unreachable!() };
-
-	// Constraint: shift(x, n) = z, with the shift folded into the operand.
-	let term = shifted_term(variant_of(*variant), *x, *n);
-	builder.linear(term, *z);
-}
-
-pub fn emit_eval_bytecode(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-) {
-	let GateParam {
-		inputs,
-		outputs,
-		imm,
-		..
-	} = data.gate_param();
-	let [x] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-	let [variant, n] = imm else { unreachable!() };
-
-	// Emit a single shift instruction carrying the variant and amount.
-	builder.emit_shift(wire_to_reg(*z), wire_to_reg(*x), variant_of(*variant), *n as u8);
 }

--- a/crates/frontend/src/ir/mod.rs
+++ b/crates/frontend/src/ir/mod.rs
@@ -60,7 +60,10 @@ pub struct Gate(u32);
 
 entity_impl!(Gate);
 
-/// A handy struct that allows a more type safe destructure.
+/// One gate's wires and immediates, sliced into the groups its shape declares.
+///
+/// A gate of fixed arity reads its groups as arrays, which destructure irrefutably.
+/// The slices serve a gate whose arity depends on its dimensions.
 pub struct GateParam<'a> {
 	pub constants: &'a [Wire],
 	pub inputs: &'a [Wire],
@@ -68,6 +71,50 @@ pub struct GateParam<'a> {
 	pub aux: &'a [Wire],
 	pub scratch: &'a [Wire],
 	pub imm: &'a [u32],
+}
+
+impl GateParam<'_> {
+	/// The gate's constant wires.
+	pub fn const_wires<const N: usize>(&self) -> [Wire; N] {
+		fixed(self.constants, "constant")
+	}
+
+	/// The gate's input wires.
+	pub fn in_wires<const N: usize>(&self) -> [Wire; N] {
+		fixed(self.inputs, "input")
+	}
+
+	/// The gate's output wires.
+	pub fn out_wires<const N: usize>(&self) -> [Wire; N] {
+		fixed(self.outputs, "output")
+	}
+
+	/// The gate's auxiliary wires, which the constraint system references but no caller passes.
+	pub fn aux_wires<const N: usize>(&self) -> [Wire; N] {
+		fixed(self.aux, "auxiliary")
+	}
+
+	/// The gate's scratch wires, which only witness evaluation reads.
+	pub fn scratch_wires<const N: usize>(&self) -> [Wire; N] {
+		fixed(self.scratch, "scratch")
+	}
+
+	/// The gate's immediates.
+	pub fn imms<const N: usize>(&self) -> [u32; N] {
+		fixed(self.imm, "immediate")
+	}
+}
+
+/// Reads one group of a gate as the fixed-size array its shape declares.
+///
+/// # Panics
+///
+/// Panics unless the group holds exactly `N` entries.
+/// Emission checks a gate against its own shape, so a built graph cannot reach this.
+fn fixed<T: Copy, const N: usize>(group: &[T], what: &str) -> [T; N] {
+	<[T; N]>::try_from(group).unwrap_or_else(|_| {
+		panic!("a gate carries {} {what} entries, but its shape declares {N}", group.len())
+	})
 }
 
 /// Describes a particular gate in the gate graph, it's type, input and output wires and


### PR DESCRIPTION
Makes each gate kind state its shape, its constraints and its instruction in one impl, and dispatches through one table instead of five hand-written ones.

**This is maintainability, not speed.** A function-pointer table costs an indirect call where a `match` costs a jump table. Measured below: within noise.

### The problem

Adding a gate today means editing **five** tables keyed on the same concept.

| table | arms | compiler catches an omission? |
|---|---:|---|
| `Opcode` | 22 | — |
| `Opcode::shape` | 22 | yes |
| `gates::constrain` | 22 | yes |
| `gates::emit_gate_bytecode` | 22 | yes |
| `EvalOpcode` + `from_byte` | 21 | **no** — guarded by a unit test |

Each gate contributed three loose free functions with no trait tying them together, so a gate's declared shape and the code destructuring against that shape were unrelated pieces of text.

That is where the arity assertions came from:

```
pub const fn shape() -> OpcodeShape { .. n_in: 2, n_out: 1 .. }

pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
    let [x, y] = inputs else { unreachable!() };   // restates n_in, three lines later
    let [z]    = outputs else { unreachable!() };  // restates n_out
```

**86 of them**, across 21 modules, every one a fact the shape above already stated.

And the six assertion gates needed an extra `PathSpec` parameter that no other gate takes, so the dispatch match had to know which six they were.

### The idea

One trait states all three facts, so they live or die together:

```
impl GateKind for Band {
    const SHAPE: OpcodeShape = OpcodeShape::new(2, 1);

    fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
        let [x, y] = gate.in_wires();
        let [z] = gate.out_wires();
        cb.and(x, y, z);                    // x ^ y = z
    }

    fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
        let [x, y] = gate.in_wires();
        let [z] = gate.out_wires();
        bc.emit_band(ctx.reg(z), ctx.reg(x), ctx.reg(y));
    }
}
```

`EmitCtx` carries the register resolver and the assertion path, so every kind has the same `emit` signature and the assertion special case disappears.

### How the arity assertions died

`&[Wire; Self::N_IN]` is not expressible on stable Rust — that needs generic const expressions.

So the group accessor is const-generic and converts once, with `N` inferred from the destructuring pattern:

```
pub fn in_wires<const N: usize>(&self) -> [Wire; N] {
    fixed(self.inputs, "input")
}
```

The call site destructures irrefutably and names no arity. 86 fallible patterns became 6 accessors, each with one `expect` that emission already checks against the gate's own shape.

### Per gate kind

- **before:** 3 free functions, 2 rows across 2 hand-written matches, ~4 `unreachable!()`
- **after:** 1 impl, 1 table row

→ 65 free functions become **2** (the module's two entry points), and 86 `unreachable!()` become **0**.

### The table is checked — the old ones were not

R7 called these "the two tables the compiler cannot currently check". The new one is checked three ways:

- each row carries the opcode it serves, so a row and its slot are not independent facts;
- the lookup reads that back under `debug_assert_eq!`;
- two tests pin that every row sits at the slot its opcode indexes, and that the hint gate is the one opcode with no row.

A misordered table now fails a test instead of silently constraining one gate as another.

### Scope

- **changed:** all 21 gate modules, the dispatch module, the opcode module, and `GateParam`
- **new:** `GateKind`, `EmitCtx`, the dispatch table, `OpcodeShape` const builders, 2 tests
- **deleted:** two 22-arm matches, `Opcode::is_const_shape`, the assertion special case
- **untouched:** every gate's constraint algebra and every emitted instruction — the shapes, operands and bytecode are the same
- the hint gate keeps its own branch: its shape lives in the registry rather than in a type, which is a separate change

The declarative macro for `Opcode` / `EvalOpcode` was considered and skipped. The constraint side is where the interesting code lives and it stays greppable; the bytecode correspondence is still test-guarded, exactly as before.

### Verification

| gate | result |
|---|---|
| `cargo test -p binius-frontend -p binius-circuits` | **596 passed, 0 failed** |
| `cargo check --workspace --all-targets` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo +nightly-2026-07-01 fmt --all --check` | clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` | clean |

The frontend suite includes the gate-fusion `insta` snapshots, which pin the exact rendered constraint system operand by operand. Those passing unchanged is the evidence that the conversion is behaviour-preserving. Gate counts also match the base exactly: 66,240 and 264,960.

### Benchmark — compile time, where the dispatch runs

`build()` calls both dispatch paths once per gate and reads a gate's shape many times per gate. Interleaved against the merge base, best of 7, three rounds, on an Apple M1 Pro.

| fixture | before | after |
|---|---|---|
| 24 keccak-f1600 permutations, 66,240 gates | 55.3 / 53.3 / 55.2 ms | 54.1 / 52.5 / 53.4 ms |
| 96 keccak-f1600 permutations, 264,960 gates | 231.8 / 230.1 / 232.0 ms | 225.8 / 229.3 / 227.9 ms |

The table costs nothing observable. The consistent 1–3% edge to "after" has a cause worth naming rather than claiming as a win: the old shape lookup ran `assert_eq!(self.is_const_shape(), dimensions.is_empty())` in release on every call, and shape is looked up many times per gate. That is now a `debug_assert!` on the trait's default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
