### PR TITLE
BINIUS-482: Make the XMSS tweakable hash a real keyed BLAKE3 hash

### DIFF
--- a/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
@@ -21,7 +21,7 @@
 use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{
-	blake3::{blake3_compress, blake3_compress_2x, ref_compress},
+	blake3::{KEY_BYTES, blake3_compress, blake3_compress_2x, blake3_keyed_fixed, ref_compress},
 	concat::concat,
 	fixed_byte_vec::ByteVec,
 	util::{clear_high_bits, split_u32_words, zeroed_u32_words},
@@ -303,21 +303,27 @@ pub fn hash_chain_blake3(
 	current
 }
 
-/// Maximum domain (tweak) length in bytes that fits the 32-byte chaining value.
-pub const TH_DOMAIN_MAX_BYTES: usize = 32;
+/// Maximum tweak length in bytes, set by the size of a BLAKE3 key.
+pub const TH_DOMAIN_MAX_BYTES: usize = KEY_BYTES;
 
-/// General compress-based BLAKE3 tweakable hash.
+/// BLAKE3 tweakable hash: the keyed hash of `data` under the tweak as key.
 ///
-/// - The domain (tweak) seeds the 8-word chaining value, zero-padded to 32 bytes.
-/// - The data is absorbed in 64-byte blocks, each folded in with one compression.
-/// - The output is the final chaining value, as four 64-bit little-endian wires.
+/// - The tweak is zero-padded to a 32-byte key, which is BLAKE3's native keying.
+/// - The data is the message, hashed by the full BLAKE3 construction.
+/// - The output is the 32-byte digest, as four 64-bit little-endian wires.
 ///
-/// This mirrors the chain step but with the roles generalized:
-/// the chain step is the special case of a 32-byte domain and a single data block.
+/// The full construction, rather than a bare chain of compressions, is what separates the domains:
+/// - Every compression carries the keyed-hash flag.
+/// - A chunk's first and last block are marked, and the root again.
+/// - So no digest extends into the digest of a longer message, which an unpadded chain allows.
+///
+/// A tweak shorter than 32 bytes is zero-padded, so two tweaks equal after padding collide.
+/// Every caller here lays its tweak out at fixed widths, which keeps them apart.
 ///
 /// # Panics
 ///
-/// - If the concatenated domain exceeds 32 bytes.
+/// - If the concatenated tweak exceeds the 32-byte key.
+/// - If any tweak term's length is not fixed at circuit construction time.
 pub fn circuit_blake3_th(
 	builder: &CircuitBuilder,
 	domain_terms: &[ByteVec],
@@ -328,74 +334,37 @@ pub fn circuit_blake3_th(
 	let data_len: usize = data_terms.iter().map(|t| *t.len_range.end()).sum();
 	assert!(
 		domain_len <= TH_DOMAIN_MAX_BYTES,
-		"BLAKE3 tweakable-hash domain ({domain_len} bytes) exceeds the {TH_DOMAIN_MAX_BYTES}-byte chaining value"
+		"BLAKE3 tweakable-hash tweak ({domain_len} bytes) exceeds the {TH_DOMAIN_MAX_BYTES}-byte key"
 	);
 
-	// Seed the chaining value from the domain, zero-padded to 8 words.
-	let domain = concat(builder, domain_terms);
-	let cv_words = zeroed_u32_words(builder, &domain.data, domain_len, CV_WORDS);
-	let mut cv: [Wire; CV_WORDS] = std::array::from_fn(|i| cv_words[i]);
+	// The tweak is the key; `blake3_keyed_fixed` zero-pads it to 32 bytes and masks the rest.
+	let key = concat(builder, domain_terms);
 
-	// Absorb the data in 64-byte blocks, one compression each.
+	// The data is the message, as 32-bit little-endian words with the bytes past its length zeroed.
 	let data = concat(builder, data_terms);
-	let num_blocks = data_len.div_ceil(BLOCK_BYTES).max(1);
-	let data_words = zeroed_u32_words(builder, &data.data, data_len, num_blocks * BLOCK_WORDS);
-	let counter = builder.add_constant_64(0);
-	let flags = builder.add_constant_64(0);
-	for b in 0..num_blocks {
-		let block: [Wire; BLOCK_WORDS] = std::array::from_fn(|i| data_words[b * BLOCK_WORDS + i]);
-		let block_len = (data_len - b * BLOCK_BYTES).min(BLOCK_BYTES);
-		let block_len_w = builder.add_constant_64(block_len as u64);
-		cv = blake3_compress(builder, cv, block, counter, block_len_w, flags);
-	}
-	cv8_to_hash4(builder, &cv)
+	let message = zeroed_u32_words(builder, &data.data, data_len, data_len.div_ceil(4));
+
+	cv8_to_hash4(builder, &blake3_keyed_fixed(builder, &message, data_len, &key))
 }
 
-/// Reference (out-of-circuit) form of `circuit_blake3_th`.
+/// Reference (out-of-circuit) form of [`circuit_blake3_th`].
 ///
-/// - `domain` seeds the chaining value, zero-padded to 32 bytes.
-/// - `data` is absorbed in 64-byte blocks via the compression reference.
+/// One call to the BLAKE3 crate, so the circuit is pinned against the reference implementation
+/// rather than a second hand-written copy of it.
 ///
-/// Built directly on the BLAKE3 compression function used as a tweakable hash:
-/// - the domain replaces the initial chaining value, acting as the key and tweak,
-/// - the data plays the role of the message blocks fed through the compression.
+/// # Panics
+///
+/// - If `domain` exceeds the 32-byte key.
 pub fn ref_blake3_th(domain: &[u8], data: &[u8]) -> [u8; 32] {
-	// The domain seeds the 32-byte chaining value, so it cannot be longer.
-	assert!(domain.len() <= TH_DOMAIN_MAX_BYTES, "domain exceeds 32 bytes");
+	assert!(
+		domain.len() <= TH_DOMAIN_MAX_BYTES,
+		"BLAKE3 tweakable-hash tweak ({} bytes) exceeds the {TH_DOMAIN_MAX_BYTES}-byte key",
+		domain.len(),
+	);
 
-	// Zero-pad the domain to 32 bytes, then read it as the 8-word chaining value (BLAKE3's IV
-	// slot).
-	let mut cv_bytes = [0u8; TH_DOMAIN_MAX_BYTES];
-	cv_bytes[..domain.len()].copy_from_slice(domain);
-	let mut cv: [u32; 8] =
-		std::array::from_fn(|i| u32::from_le_bytes(cv_bytes[4 * i..4 * i + 4].try_into().unwrap()));
-
-	// Absorb the data in 64-byte blocks, chaining each compression into the next.
-	let total = data.len();
-	// At least one compression runs, so empty data still maps to a defined digest.
-	let num_blocks = total.div_ceil(BLOCK_BYTES).max(1);
-	for b in 0..num_blocks {
-		// This block's byte range; the last block may be shorter than 64 bytes.
-		let start = b * BLOCK_BYTES;
-		let end = (start + BLOCK_BYTES).min(total);
-
-		// Pack the block into 16 little-endian words, trailing bytes left zero.
-		let mut block_bytes = [0u8; BLOCK_BYTES];
-		block_bytes[..end - start].copy_from_slice(&data[start..end]);
-		let block: [u32; 16] = std::array::from_fn(|i| {
-			u32::from_le_bytes(block_bytes[4 * i..4 * i + 4].try_into().unwrap())
-		});
-
-		// Bare compression (counter/flags = 0); block_len is the real byte count.
-		cv = ref_compress(&cv, &block, 0, (end - start) as u32, 0);
-	}
-
-	// Serialize the final chaining value to 32 little-endian bytes: the digest.
-	let mut out = [0u8; 32];
-	for (i, word) in cv.iter().enumerate() {
-		out[4 * i..4 * i + 4].copy_from_slice(&word.to_le_bytes());
-	}
-	out
+	let mut key = [0u8; TH_DOMAIN_MAX_BYTES];
+	key[..domain.len()].copy_from_slice(domain);
+	*blake3::keyed_hash(&key, data).as_bytes()
 }
 
 #[cfg(test)]
@@ -448,33 +417,14 @@ mod tests {
 
 		#[test]
 		fn generic_th_matches_reference(
-			domain_len in 1usize..=32,
-			data_len in 1usize..=200,
+			domain_len in 0usize..=32,
+			data_len in 0usize..=200,
 			domain in prop::collection::vec(any::<u8>(), 32),
 			data in prop::collection::vec(any::<u8>(), 200),
 		) {
-			// The generic compress-based tweakable hash must equal its reference for any
-			// domain (<= 32 bytes) and any data length.
-			let b = CircuitBuilder::new();
-			let dom_w: Vec<Wire> = (0..domain_len.div_ceil(8)).map(|_| b.add_inout()).collect();
-			let dat_w: Vec<Wire> = (0..data_len.div_ceil(8)).map(|_| b.add_inout()).collect();
-			let dom_term = ByteVec::new_const_len(&b, dom_w.clone(), domain_len);
-			let dat_term = ByteVec::new_const_len(&b, dat_w.clone(), data_len);
-			let out = circuit_blake3_th(&b, &[dom_term], &[dat_term]);
-			let expected: [Wire; 4] = std::array::from_fn(|_| b.add_inout());
-			for k in 0..4 {
-				b.assert_eq("th_out", out[k], expected[k]);
-			}
-
-			let circuit = b.build();
-			let mut w = circuit.new_witness_filler();
-			w.pack_bytes_le(&dom_w, &domain[..domain_len]);
-			w.pack_bytes_le(&dat_w, &data[..data_len]);
-			let reference = ref_blake3_th(&domain[..domain_len], &data[..data_len]);
-			w.pack_bytes_le(&expected, &reference);
-
-			circuit.populate_wire_witness(&mut w).unwrap();
-			circuit.constraint_system().verify(&w.into_value_vec()).unwrap();
+			// The tweakable hash must equal its reference for any tweak (<= 32 bytes) and any data
+			// length, the empty ones included.
+			check_th(&domain[..domain_len], &data[..data_len]);
 		}
 
 		#[test]
@@ -517,6 +467,66 @@ mod tests {
 			circuit.populate_wire_witness(&mut w).unwrap();
 			circuit.constraint_system().verify(&w.into_value_vec()).unwrap();
 		}
+	}
+
+	/// Build the tweakable hash over `tweak` and `data`, and pin the digest to the reference.
+	fn check_th(tweak: &[u8], data: &[u8]) {
+		let b = CircuitBuilder::new();
+		let tweak_w: Vec<Wire> = (0..tweak.len().div_ceil(8))
+			.map(|_| b.add_inout())
+			.collect();
+		let data_w: Vec<Wire> = (0..data.len().div_ceil(8)).map(|_| b.add_inout()).collect();
+		let tweak_term = ByteVec::new_const_len(&b, tweak_w.clone(), tweak.len());
+		let data_term = ByteVec::new_const_len(&b, data_w.clone(), data.len());
+		let out = circuit_blake3_th(&b, &[tweak_term], &[data_term]);
+		let expected: [Wire; 4] = std::array::from_fn(|_| b.add_inout());
+		for k in 0..4 {
+			b.assert_eq("th_out", out[k], expected[k]);
+		}
+
+		let circuit = b.build();
+		let mut w = circuit.new_witness_filler();
+		w.pack_bytes_le(&tweak_w, tweak);
+		w.pack_bytes_le(&data_w, data);
+		w.pack_bytes_le(&expected, &ref_blake3_th(tweak, data));
+
+		circuit.populate_wire_witness(&mut w).unwrap_or_else(|e| {
+			panic!("th disagreed for tweak_len={}, data_len={}: {e:?}", tweak.len(), data.len())
+		});
+		circuit
+			.constraint_system()
+			.verify(&w.into_value_vec())
+			.unwrap();
+	}
+
+	#[test]
+	fn th_is_the_keyed_hash_of_the_zero_padded_tweak() {
+		// The tweak is the key, so a short tweak must agree with the same key padded by hand.
+		let tweak = b"tweak";
+		let data = b"the quick brown fox";
+		let mut key = [0u8; TH_DOMAIN_MAX_BYTES];
+		key[..tweak.len()].copy_from_slice(tweak);
+		assert_eq!(ref_blake3_th(tweak, data), *blake3::keyed_hash(&key, data).as_bytes());
+	}
+
+	#[test]
+	fn th_spans_chunks_and_blocks() {
+		// Data past 1024 bytes builds a parent tree, a path a bare chain of compressions never has.
+		//
+		//     2304 bytes = 2 full chunks + 256 -> 3 chunk CVs -> 2 parent nodes
+		//
+		// 2304 is the real leaf-hash size for a 72-chain Winternitz instance.
+		for &len in &[63usize, 64, 65, 1023, 1024, 1025, 2304] {
+			let data: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+			check_th(b"chunk-spanning tweak", &data);
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "tweak (33 bytes) exceeds the 32-byte key")]
+	fn th_rejects_an_oversized_tweak() {
+		// The tweak becomes the key, so it cannot outgrow one.
+		ref_blake3_th(&[0u8; TH_DOMAIN_MAX_BYTES + 1], b"data");
 	}
 
 	#[test]

--- a/crates/circuits/src/hash_based_sig/hashing/message.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/message.rs
@@ -10,8 +10,8 @@ pub const MESSAGE_TWEAK: u8 = 0x02;
 /// Computes the message hash, returning its 32-byte digest as four 64-bit little-endian wires.
 ///
 /// Evaluates the BLAKE3 tweakable hash with:
-/// - domain (chaining value) `param || 0x02 || epoch`,
-/// - data (absorbed block) `nonce || message`.
+/// - key (tweak) `param || 0x02 || epoch`,
+/// - message `nonce || message`.
 ///
 /// The codeword coordinates are read out of this digest.
 /// Binding the epoch into the domain makes the encoding epoch-dependent, matching the reference
@@ -22,7 +22,7 @@ pub const MESSAGE_TWEAK: u8 = 0x02;
 ///
 /// * `builder` - Circuit builder.
 /// * `domain_param_wires` - Per-signer parameter, eight bytes per wire (little-endian).
-/// * `domain_param_len` - Parameter length in bytes; at most 23 so the domain fits the 32-byte cv.
+/// * `domain_param_len` - Parameter length in bytes; at most 23 so the tweak fits the 32-byte key.
 /// * `epoch` - Epoch (leaf index) at which the message is signed.
 /// * `nonce_wires` - Nonce wires, eight bytes per wire.
 /// * `nonce_len` - Nonce length in bytes.

--- a/crates/circuits/src/hash_based_sig/hashing/public_key.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/public_key.rs
@@ -14,17 +14,17 @@ pub const PUBLIC_KEY_TWEAK: u8 = 0x03;
 /// Computes the one-time public-key (Merkle leaf) hash, returning its 32-byte digest.
 ///
 /// Evaluates the BLAKE3 tweakable hash with:
-/// - domain (chaining value) `param || 0x03 || epoch`,
-/// - data (absorbed blocks) the concatenation of the Winternitz chain ends.
+/// - key (tweak) `param || 0x03 || epoch`,
+/// - message the concatenation of the Winternitz chain ends.
 ///
-/// The leaf is the larger-than-one-block case: the chain ends are absorbed two per compression.
-/// Mixing the epoch into the domain binds the leaf to its position in the tree.
+/// This is the many-block case, so the message spans several BLAKE3 chunks and a parent tree.
+/// Mixing the epoch into the tweak binds the leaf to its position in the tree.
 ///
 /// # Arguments
 ///
 /// * `builder` - Circuit builder.
 /// * `domain_param_wires` - Per-signer parameter, eight bytes per wire.
-/// * `domain_param_len` - Parameter length in bytes; at most 23 so the domain fits the 32-byte cv.
+/// * `domain_param_len` - Parameter length in bytes; at most 23 so the tweak fits the 32-byte key.
 /// * `epoch` - Epoch (leaf index) this public key sits at.
 /// * `pk_hashes` - Chain-end hashes, 32 bytes each as four 64-bit little-endian wires.
 ///

--- a/crates/circuits/src/hash_based_sig/hashing/tree.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/tree.rs
@@ -10,8 +10,8 @@ pub const TREE_TWEAK: u8 = 0x01;
 /// Computes an internal Merkle-tree node hash, returning its 32-byte digest as four 64-bit wires.
 ///
 /// Evaluates the BLAKE3 tweakable hash with:
-/// - domain (chaining value) `param || 0x01 || level || index`,
-/// - data (absorbed block) `left || right`.
+/// - key (tweak) `param || 0x01 || level || index`,
+/// - message `left || right`.
 ///
 /// The level and index place each node in its own hash domain, so a node at one position can never
 /// be reused at another.
@@ -20,7 +20,7 @@ pub const TREE_TWEAK: u8 = 0x01;
 ///
 /// * `builder` - Circuit builder.
 /// * `domain_param_wires` - Per-signer parameter, eight bytes per wire.
-/// * `domain_param_len` - Parameter length in bytes; at most 23 so the domain fits the 32-byte cv.
+/// * `domain_param_len` - Parameter length in bytes; at most 23 so the tweak fits the 32-byte key.
 /// * `left` - Left child hash, 32 bytes as four 64-bit little-endian wires.
 /// * `right` - Right child hash, 32 bytes as four 64-bit little-endian wires.
 /// * `level` - Tree level, low four bytes used.

--- a/crates/circuits/src/hash_based_sig/xmss.rs
+++ b/crates/circuits/src/hash_based_sig/xmss.rs
@@ -370,7 +370,7 @@ mod tests {
 			message_hash_len: 4,
 			coordinate_resolution_bits: 2,
 			target_sum: 24,
-			// At most 23 bytes so the BLAKE3 tweakable-hash domain fits the 32-byte chaining value.
+			// At most 23 bytes so the BLAKE3 tweakable-hash tweak fits the 32-byte key.
 			domain_param_len: 18,
 		}
 	}

--- a/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
@@ -137,7 +137,7 @@ mod tests {
 			message_hash_len: 4,
 			coordinate_resolution_bits: 2,
 			target_sum: 24,
-			// At most 23 bytes so the BLAKE3 tweakable-hash domain fits the 32-byte chaining value.
+			// At most 23 bytes so the BLAKE3 tweakable-hash tweak fits the 32-byte key.
 			domain_param_len: 18,
 		}
 	}

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -1,30 +1,30 @@
 hashsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 394,200
-└─ Number of evaluation instructions: 394,848
+├─ Number of gates: 379,188
+└─ Number of evaluation instructions: 379,836
 
 Constraints
-├─ ZERO constraints: 114,662 used (87.5% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 16,410
-├─ AND constraints: 118,455 used (90.4% of 2^17)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 12,617
+├─ ZERO constraints: 110,971 used (84.7% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 20,101
+├─ AND constraints: 117,015 used (89.3% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 14,057
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 2,664 used (65.0% of 2^12)
 │  [▓▓▓▓▓▓░░░░] spare: 1,432
-└─ Distinct value indices: 599,207
-   ├─ Distinct shifted value indices: 364,403
-   └─ Distinct unshifted value indices: 234,804
+└─ Distinct value indices: 584,861
+   ├─ Distinct shifted value indices: 355,188
+   └─ Distinct unshifted value indices: 229,673
 
 Value Vector
 ├─ Public Section: 183 (not committed)
 │  ├─ Constants: 157
 │  └─ Inout: 26
-├─ Private Section: 234,708
+├─ Private Section: 229,577
 │  ├─ Witness: 1,776
-│  └─ Internal: 232,932
-├─ Committed Trace: 234,708 used (89.5% of 2^18)
-│  [▓▓▓▓▓▓▓▓░░] spare: 27,436
-└─ Scratch (uncommitted): 292,353 (peak live: 65)
+│  └─ Internal: 227,801
+├─ Committed Trace: 229,577 used (87.6% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 32,567
+└─ Scratch (uncommitted): 281,080 (peak live: 74)
 


### PR DESCRIPTION
Closes [BINIUS-482](https://linear.app/jimpo/issue/BINIUS-482/xmss-use-regular-keyed-blake3-hash).

Makes the XMSS tweakable hash BLAKE3's own keyed hash, with the tweak zero-padded to a 32-byte key.

### The problem

The tweakable hash behind the Merkle nodes, the leaf, and the message hash was a bare chain of compressions:

```
cv_0     = tweak, zero-padded to 32 bytes
cv_{i+1} = compress(cv_i, block_i, counter = 0, len_i, flags = 0)
digest   = cv_n
```

No counter, no flags, and no length padding — Merkle-Damgard in its plainest form.

That gives length extension: from `th(tweak, A)` you can compute `th(tweak, A || X)` without knowing the tweak.

Every caller fixes its data length at circuit construction time, so no attack on XMSS as configured follows from it. A tweakable hash should still not have the property.

The reference side made it worse: `ref_blake3_th` was a second hand-written copy of the same chain, so the proptests pinned the circuit to a twin of itself rather than to BLAKE3.

### The idea

Use the keying BLAKE3 already has. The tweak is the key, the data is the message:

```
th(tweak, data) = blake3::keyed_hash(zero_pad_32(tweak), data)
```

The domain separation now comes from the construction rather than from the caller:

- Every compression carries the keyed-hash flag.
- A chunk's first and last block are marked, and the root again.
- So no digest extends into the digest of a longer message.

The tweak fits exactly. Every caller lays out `param || sep || fields` at fixed widths, and the widest is 23 + 9 = 32 bytes — the size of a BLAKE3 key.

### The change

```
circuit_blake3_th:
- cv = zero_pad(domain); for each 64B block { cv = compress(cv, block, 0, len, 0) }
+ blake3_keyed_fixed(builder, message_words, data_len, key = domain)

ref_blake3_th:
- 40 lines re-deriving the same chain over ref_compress
+ *blake3::keyed_hash(&zero_pad_32(domain), data).as_bytes()
```

`TH_DOMAIN_MAX_BYTES` is now an alias of `blake3::KEY_BYTES`, so the 23-byte parameter bound traces to a real constant instead of a repeated literal.

The three callers — tree node, leaf, message hash — are unchanged apart from docs that said "domain (chaining value)" and now say "key (tweak)".

### It is also cheaper

The leaf hash absorbs 72 chain ends, 2304 bytes. The old chain spent one single-lane compression per block; the keyed construction pairs blocks through the two lanes of one core inside each chunk.

`hashsign` (3 validators, tree height 3, spec 1):

| | main (`a313e2a6`) | this PR | change |
|---|---|---|---|
| AND constraints | 118,455 | 117,015 | -1.2% |
| ZERO constraints | 114,662 | 110,971 | -3.2% |
| Committed trace | 234,708 | 229,577 | -2.2% |
| Gates | 394,200 | 379,188 | -3.8% |

Tree and message hashes are one block either way, so the whole win is the leaf.

These are measured against `a313e2a6`, which already carries #2142. That change split the single-lane compression across both 32-bit lanes and by itself took the circuit from 135,720 AND constraints to 118,455, landing under `2^17` = 131,072 and halving the padded domain the AND reduction proves over. An earlier revision of this PR claimed that crossing; #2142 now owns it. What remains here is a straight few-percent reduction on top, and the change stands on the construction rather than on the numbers.

### Why the Winternitz chain step is left alone

The chain step is the other bespoke construction: the previous chain value seeds the chaining value and the tweak fills the message block. Converting it too would leave the scheme with one construction instead of two, and would give `blake3_keyed_fixed_2x` from [BINIUS-483](https://linear.app/jimpo/issue/BINIUS-483/circuits-blake3-keyed-fixed-2x) a caller.

I built it and measured it. Against the rest of this PR:

| | AND | ZERO | committed trace | prove time |
|---|---|---|---|---|
| chain step converted | -0.5% | **+16.3%** | **+7.5%** | ~70 ms to ~75 ms |

There is nothing to gain on AND because the chain step **already** pairs two chains through one `blake3_compress_2x` — the two-lane gadget replaces that pairing rather than adding it.

The extra committed words come from the return layout: `blake3_keyed_fixed_2x` hands back two digests one lane each, so the chain step unpacks them and repacks into `4 x 64`-bit wires, where `deinterleave_cv_2x` goes straight there.

So the conversion costs ~7% prove time to buy one construction instead of two. Worth doing once `blake3_keyed_fixed_2x` grows a packed return, not before — filed as a follow-up rather than folded in here.

Converting it would also tighten the chain parameter bound from 57 to 25 bytes, since the tweak becomes a key rather than a message block.

### Soundness

- The digest changes, so this is a scheme change, not a refactor. Circuit and reference move together and every caller goes through them.
- Collision and preimage resistance now rest on BLAKE3's keyed hash rather than on a bespoke chain over its compression function.
- A tweak shorter than 32 bytes is zero-padded, so two tweaks equal after padding collide. Every caller uses fixed-width fields, which keeps them apart — the same property the old code relied on.

### Scope

- **changed:** `circuit_blake3_th` and `ref_blake3_th` in `chain_blake3.rs`, plus docs at the three call sites.
- **re-blessed:** `hashsign.snap`, since the circuit legitimately shrank.
- **untouched:** the Winternitz chain step, for the measured reason above.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-circuits --all-targets` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` — clean.
- `cargo +nightly fmt --all` — applied.
- `cargo test -p binius-circuits` — 359 pass.
- `hashsign prove` — proof generated and verified, 214 KiB.
- `hashsign check-snapshot` — matches.

New tests, covering paths the old chain never had:

- the tweakable-hash proptest now spans empty tweak and empty data, which the old code special-cased,
- data at 63 / 64 / 65 / 1023 / 1024 / 1025 / 2304 bytes, since past 1024 the hash now builds a parent tree,
- a check that the tweak really is the zero-padded key,
- a rejection test for a tweak that outgrows the key.

Rebased onto `a313e2a6`, so #2141 and #2142 are both in the tested base. The snapshot conflicted with main; resolved by taking main's file and re-blessing from this branch, rather than hand-merging generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
