### PR TITLE
Take the hint out of the opcode enum

### DIFF
--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 244,030
 
 Constraints
-├─ ZERO constraints: 21,926 used (66.9% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 10,842
-├─ AND constraints: 112,695 used (86.0% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 18,377
-├─ IMUL constraints: 20,548 used (62.7% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,220
+├─ ZERO constraints: 21,878 used (66.8% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 10,890
+├─ AND constraints: 112,581 used (85.9% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 18,491
+├─ IMUL constraints: 20,524 used (62.6% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,244
 ├─ BMUL constraints: 23,632 used (72.1% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 9,136
-└─ Distinct value indices: 374,994
-   ├─ Distinct shifted value indices: 186,660
-   └─ Distinct unshifted value indices: 188,334
+└─ Distinct value indices: 374,601
+   ├─ Distinct shifted value indices: 186,465
+   └─ Distinct unshifted value indices: 188,136
 
 Value Vector
 ├─ Public Section: 52 (not committed)
 │  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 188,287
+├─ Private Section: 188,089
 │  ├─ Witness: 0
-│  └─ Internal: 188,287
-├─ Committed Trace: 188,287 used (71.8% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 73,857
-└─ Scratch (uncommitted): 145,377 (peak live: 190)
+│  └─ Internal: 188,089
+├─ Committed Trace: 188,089 used (71.8% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 74,055
+└─ Scratch (uncommitted): 145,575 (peak live: 254)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 250,294
 
 Constraints
-├─ ZERO constraints: 21,921 used (66.9% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 10,847
-├─ AND constraints: 114,068 used (87.0% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 17,004
-├─ IMUL constraints: 20,554 used (62.7% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,214
+├─ ZERO constraints: 21,889 used (66.8% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 10,879
+├─ AND constraints: 113,992 used (87.0% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 17,080
+├─ IMUL constraints: 20,538 used (62.7% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,230
 ├─ BMUL constraints: 23,874 used (72.9% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 8,894
-└─ Distinct value indices: 389,239
-   ├─ Distinct shifted value indices: 199,219
-   └─ Distinct unshifted value indices: 190,020
+└─ Distinct value indices: 388,977
+   ├─ Distinct shifted value indices: 199,089
+   └─ Distinct unshifted value indices: 189,888
 
 Value Vector
 ├─ Public Section: 114 (not committed)
 │  ├─ Constants: 85
 │  └─ Inout: 29
-├─ Private Section: 189,915
+├─ Private Section: 189,783
 │  ├─ Witness: 0
-│  └─ Internal: 189,915
-├─ Committed Trace: 189,915 used (72.4% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,229
-└─ Scratch (uncommitted): 149,996 (peak live: 192)
+│  └─ Internal: 189,783
+├─ Committed Trace: 189,783 used (72.4% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,361
+└─ Scratch (uncommitted): 150,128 (peak live: 256)
 

--- a/crates/frontend/src/artifact/dump.rs
+++ b/crates/frontend/src/artifact/dump.rs
@@ -3,10 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::ser::SerializeStruct;
 
-use crate::{
-	gates::opcode::Opcode,
-	ir::{Gate, GateGraph, path::PathSpec},
-};
+use crate::ir::{Gate, GateBody, GateGraph, path::PathSpec};
 
 struct PathSpecData {
 	name: String,
@@ -32,43 +29,44 @@ impl PathSpecData {
 
 #[derive(Clone)]
 struct GateBreakdown {
-	/// Shows how many opcodes of every type there is.
-	by_opcode: BTreeMap<Opcode, usize>,
+	/// How many gates of each kind there are.
+	by_kind: BTreeMap<GateBody, usize>,
 }
 
 impl GateBreakdown {
 	fn count(gg: &GateGraph, gates: &[Gate]) -> GateBreakdown {
 		let mut breakdown = GateBreakdown {
-			by_opcode: BTreeMap::new(),
+			by_kind: BTreeMap::new(),
 		};
 		for gate in gates {
-			*breakdown
-				.by_opcode
-				.entry(gg.gates[*gate].opcode)
-				.or_insert(0) += 1;
+			*breakdown.by_kind.entry(gg.gates[*gate].body).or_insert(0) += 1;
 		}
 		breakdown
 	}
 
 	fn merge(mut self, other: &GateBreakdown) -> GateBreakdown {
-		for (&opcode, count) in &other.by_opcode {
-			*self.by_opcode.entry(opcode).or_insert(0) += count;
+		for (&kind, count) in &other.by_kind {
+			*self.by_kind.entry(kind).or_insert(0) += count;
 		}
 		self
 	}
 }
 
 impl serde::Serialize for GateBreakdown {
-	/// Serializes the counts under opcode names.
+	/// Serializes the counts under the name of each kind.
 	///
 	/// Names are rendered here rather than while counting.
-	/// So a circuit with a million gates names each opcode once, not once per gate.
+	/// So a circuit with a million gates names each kind once, not once per gate.
 	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-		let by_name: BTreeMap<String, usize> = self
-			.by_opcode
-			.iter()
-			.map(|(opcode, count)| (format!("{opcode:?}"), *count))
-			.collect();
+		// Every hint reports under one name, since its id is an opaque hash.
+		let mut by_name: BTreeMap<String, usize> = BTreeMap::new();
+		for (kind, count) in &self.by_kind {
+			let name = match kind {
+				GateBody::Op(opcode) => format!("{opcode:?}"),
+				GateBody::Hint(_) => "Hint".to_string(),
+			};
+			*by_name.entry(name).or_insert(0) += count;
+		}
 
 		let mut breakdown = serializer.serialize_struct("GateBreakdown", 1)?;
 		breakdown.serialize_field("by_opcode", &by_name)?;
@@ -221,13 +219,7 @@ impl Cx {
 		}
 
 		// Calculate total gates from cumulative breakdown
-		let n_gates = data
-			.cum_breakdown
-			.as_ref()
-			.unwrap()
-			.by_opcode
-			.values()
-			.sum();
+		let n_gates = data.cum_breakdown.as_ref().unwrap().by_kind.values().sum();
 
 		SubcircuitInfo {
 			name: data.name.clone(),
@@ -258,4 +250,32 @@ pub(crate) fn dump_composition(gg: &GateGraph) -> String {
 
 	let subcircuit_info = cx.build_subcircuit_info(gg);
 	serde_json::to_string_pretty(&subcircuit_info).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{gates::Opcode, ir::hints::hint_id_of};
+
+	#[test]
+	fn every_hint_is_counted_under_one_name() {
+		// Invariant: a hint id is an opaque hash, so the breakdown reports hints as one kind.
+		// Two distinct hints and one operation therefore render as two names, not three.
+		let mut graph = GateGraph::new();
+		let root = graph.path_spec_tree.root();
+		let x = graph.add_inout();
+		let y = graph.add_inout();
+
+		let o1 = graph.add_internal();
+		graph.emit_hint_gate(root, hint_id_of("dump.test.a"), &[], vec![x], vec![o1]);
+		let o2 = graph.add_internal();
+		graph.emit_hint_gate(root, hint_id_of("dump.test.b"), &[], vec![x], vec![o2]);
+		let o3 = graph.add_internal();
+		graph.emit_gate(root, Opcode::Band, vec![x, y], vec![o3]);
+
+		let dump = dump_composition(&graph);
+
+		assert!(dump.contains("\"Hint\": 2"), "{dump}");
+		assert!(dump.contains("\"Band\": 1"), "{dump}");
+	}
 }

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -599,7 +599,7 @@ impl CircuitBuilder {
 			{
 				continue;
 			}
-			gates::constrain(gate_id, &graph, &mut builder);
+			gates::constrain(gate_id, &graph, &mut builder, &shared.hint_registry);
 		}
 
 		// Perform fusion if the corresponding feature flag is turned on.

--- a/crates/frontend/src/eval_form/const_eval.rs
+++ b/crates/frontend/src/eval_form/const_eval.rs
@@ -7,15 +7,13 @@ use binius_core::{Word, constraint_system::ShiftVariant};
 use super::exec::ghash_mul;
 use crate::{
 	gates::Opcode,
-	ir::{Gate, GateGraph, hints::HintRegistry},
+	ir::{Gate, GateBody, GateGraph, hints::HintRegistry},
 };
 
 /// Evaluates a gate whose inputs are all constant, returning the values of its output wires.
 ///
 /// `constants` holds the values of the gate's input wires, in order. `hint_registry` must contain
-/// any hint referenced by the gate. For [`Opcode::Hint`] gates this is the registry populated by
-/// [`CircuitBuilder::call_hint`](crate::builder::CircuitBuilder::call_hint); for other gates an
-/// empty registry is fine.
+/// any hint the gate references. Only a hint gate reads it, so an empty registry serves the rest.
 ///
 /// Assertion gates have no outputs. They return an empty vector when the constant inputs satisfy
 /// the assertion, and the violation message otherwise.
@@ -26,7 +24,19 @@ pub fn evaluate_gate_constants(
 	hint_registry: &HintRegistry,
 ) -> Result<Vec<Word>, String> {
 	let data = &graph.gates[gate];
-	match data.opcode {
+
+	// A hint computes its outputs itself; the rest are folded by the operation below.
+	let opcode = match data.body {
+		GateBody::Op(opcode) => opcode,
+		GateBody::Hint(hint_id) => {
+			let (_n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
+			let mut outputs = vec![Word::ZERO; n_out];
+			hint_registry.execute(hint_id, &data.dimensions, constants, &mut outputs);
+			return Ok(outputs);
+		}
+	};
+
+	match opcode {
 		Opcode::Band => {
 			let [x, y] = constants else { unreachable!() };
 			Ok(vec![*x & *y])
@@ -155,13 +165,6 @@ pub fn evaluate_gate_constants(
 				return Err(format!("{x:?} MSB is false"));
 			}
 			Ok(Vec::new())
-		}
-		Opcode::Hint => {
-			let hint_id = data.immediates[0];
-			let (_n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
-			let mut outputs = vec![Word::ZERO; n_out];
-			hint_registry.execute(hint_id, &data.dimensions, constants, &mut outputs);
-			Ok(outputs)
 		}
 	}
 }

--- a/crates/frontend/src/eval_form/mod.rs
+++ b/crates/frontend/src/eval_form/mod.rs
@@ -45,9 +45,8 @@ pub struct EvalForm {
 impl EvalForm {
 	/// Build the evaluation form from the gate graph.
 	///
-	/// `hint_registry` already holds every hint the caller registered via
-	/// [`CircuitBuilder::call_hint`](crate::builder::CircuitBuilder::call_hint); bytecode
-	/// emission only reads from it to resolve `Opcode::Hint` gates.
+	/// The registry already holds every hint the circuit called.
+	/// Emission only reads it to resolve each gate's arity.
 	pub(crate) fn build(
 		gate_graph: &GateGraph,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,

--- a/crates/frontend/src/gates/mod.rs
+++ b/crates/frontend/src/gates/mod.rs
@@ -8,7 +8,11 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	ir::{Gate, GateData, GateGraph, GateParam, Wire, hints::HintRegistry, path::PathSpec},
+	ir::{
+		Gate, GateBody, GateGraph, GateParam, Wire,
+		hints::{HintId, HintRegistry},
+		path::PathSpec,
+	},
 	lower::ConstraintBuilder,
 };
 
@@ -63,6 +67,7 @@ pub trait GateKind {
 /// What a gate's emission needs beyond its own wires.
 ///
 /// Every kind takes one, so an assertion reads its path through the signature all gates share.
+#[derive(Copy, Clone)]
 pub struct EmitCtx<'a> {
 	resolve: &'a dyn Fn(Wire) -> u32,
 	path: PathSpec,
@@ -102,10 +107,6 @@ const fn row<G: GateKind>(opcode: Opcode) -> GateVTable {
 }
 
 /// Every gate kind, indexed by its opcode.
-///
-/// - The hint gate has no row: its shape lives in the hint registry, not in a type.
-/// - It is the last opcode declared, so it indexes one past the table.
-/// - A lookup reads that as absent, and the tests below pin both facts.
 static GATE_KINDS: [GateVTable; 21] = [
 	row::<band::Band>(Opcode::Band),
 	row::<bxor::Bxor>(Opcode::Bxor),
@@ -131,37 +132,37 @@ static GATE_KINDS: [GateVTable; 21] = [
 ];
 
 impl Opcode {
-	/// The gate kind serving this opcode, or `None` for the hint gate.
-	fn vtable(self) -> Option<&'static GateVTable> {
-		let row = GATE_KINDS.get(self as usize)?;
+	/// The gate kind serving this opcode.
+	fn vtable(self) -> &'static GateVTable {
+		let row = &GATE_KINDS[self as usize];
 		debug_assert_eq!(
 			row.opcode, self,
 			"the gate table row does not serve the opcode indexing it"
 		);
-		Some(row)
+		row
 	}
 
 	/// The shape a gate of this opcode carries, for the dimensions it was emitted with.
-	///
-	/// # Panics
-	///
-	/// Panics for the hint gate, whose shape the hint registry settles instead.
-	/// Reading a gate's shape rather than its opcode's covers that case too.
 	pub fn shape(self, dimensions: &[usize]) -> OpcodeShape {
-		let vtable = self
-			.vtable()
-			.expect("Opcode::Hint shape requires the HintRegistry; use GateData::shape instead");
-		(vtable.shape)(dimensions)
+		(self.vtable().shape)(dimensions)
 	}
 }
 
 /// Appends the constraints one gate contributes.
 ///
 /// A hint contributes none: the surrounding circuit constrains the value it computes.
-pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder) {
+pub fn constrain(
+	gate: Gate,
+	graph: &GateGraph,
+	builder: &mut ConstraintBuilder,
+	hint_registry: &HintRegistry,
+) {
 	let data = &graph.gates[gate];
-	if let Some(vtable) = data.opcode.vtable() {
-		(vtable.constrain)(data.gate_param(), builder);
+	match data.body {
+		GateBody::Op(opcode) => {
+			(opcode.vtable().constrain)(data.gate_param(hint_registry), builder);
+		}
+		GateBody::Hint(_) => {}
 	}
 }
 
@@ -174,39 +175,27 @@ pub fn emit_gate_bytecode(
 	hint_registry: &HintRegistry,
 ) {
 	let data = &graph.gates[gate];
-	match data.opcode.vtable() {
-		Some(vtable) => {
-			let ctx = EmitCtx {
-				resolve: &wire_to_reg,
-				path: graph.assertion_names[gate],
-			};
-			(vtable.emit)(data.gate_param(), ctx, builder);
-		}
-		None => emit_hint(data, builder, wire_to_reg, hint_registry),
+	let params = data.gate_param(hint_registry);
+	let ctx = EmitCtx {
+		resolve: &wire_to_reg,
+		path: graph.assertion_names[gate],
+	};
+	match data.body {
+		GateBody::Op(opcode) => (opcode.vtable().emit)(params, ctx, builder),
+		GateBody::Hint(hint_id) => emit_hint(hint_id, params, &data.dimensions, ctx, builder),
 	}
 }
 
-/// Emits a hint call, the one gate with no kind of its own.
-///
-/// The hint already lives in the registry, put there when the circuit called it.
-/// The gate carries only its id and the dimensions the caller passed.
-///
-/// A hint's shape is not known statically, so the wires are sliced with the arity the registry
-/// reports rather than through the usual accessor.
+/// Emits a call to one registered hint.
 fn emit_hint(
-	data: &GateData,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32,
-	hint_registry: &HintRegistry,
+	hint_id: HintId,
+	gate: GateParam<'_>,
+	dimensions: &[usize],
+	ctx: EmitCtx<'_>,
+	bc: &mut BytecodeBuilder,
 ) {
-	let hint_id = data.immediates[0];
-	let (n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
-	let input_regs: Vec<u32> = data.wires[..n_in].iter().map(|&w| wire_to_reg(w)).collect();
-	let output_regs: Vec<u32> = data.wires[n_in..n_in + n_out]
-		.iter()
-		.map(|&w| wire_to_reg(w))
-		.collect();
-	builder.emit_hint(hint_id, &data.dimensions, &input_regs, &output_regs);
+	let regs = |wires: &[Wire]| wires.iter().map(|&w| ctx.reg(w)).collect::<Vec<_>>();
+	bc.emit_hint(hint_id, dimensions, &regs(gate.inputs), &regs(gate.outputs));
 }
 
 #[cfg(test)]
@@ -222,14 +211,11 @@ mod tests {
 		}
 	}
 
-	// Invariant: the hint is the one opcode without a row, and it is declared last.
-	// A new opcode appended after it would silently take its slot.
+	// Invariant: every row's opcode resolves back to that row.
 	#[test]
-	fn the_hint_is_the_one_opcode_with_no_row() {
-		assert_eq!(Opcode::Hint as usize, GATE_KINDS.len());
-		assert!(Opcode::Hint.vtable().is_none());
+	fn every_opcode_in_the_table_resolves_to_its_own_row() {
 		for row in &GATE_KINDS {
-			assert!(row.opcode.vtable().is_some(), "{:?} has no row", row.opcode);
+			assert_eq!(row.opcode.vtable().opcode, row.opcode);
 		}
 	}
 }

--- a/crates/frontend/src/gates/opcode.rs
+++ b/crates/frontend/src/gates/opcode.rs
@@ -35,12 +35,6 @@ pub enum Opcode {
 	AssertFalse,
 	AssertTrue,
 	AssertEqCond,
-
-	/// Generic hint gate. The hint's [`HintId`](crate::ir::hints::HintId) is stored in
-	/// `immediates[0]` and the user dimensions (passed to
-	/// [`Hint::shape`](crate::ir::hints::Hint::shape) /
-	/// [`Hint::execute`](crate::ir::hints::Hint::execute)) are `&dimensions`.
-	Hint,
 }
 
 /// The shape of an opcode is a description of it's inputs and outputs. It allows treating a gate as

--- a/crates/frontend/src/ir/mod.rs
+++ b/crates/frontend/src/ir/mod.rs
@@ -8,7 +8,7 @@ use std::collections::hash_map::Entry;
 use binius_core::word::Word;
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap, entity_impl};
 use rustc_hash::FxHashMap;
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 
 use crate::{
 	gates::opcode::{Opcode, OpcodeShape},
@@ -64,6 +64,7 @@ entity_impl!(Gate);
 ///
 /// A gate of fixed arity reads its groups as arrays, which destructure irrefutably.
 /// The slices serve a gate whose arity depends on its dimensions.
+#[derive(Copy, Clone)]
 pub struct GateParam<'a> {
 	pub constants: &'a [Wire],
 	pub inputs: &'a [Wire],
@@ -117,11 +118,20 @@ fn fixed<T: Copy, const N: usize>(group: &[T], what: &str) -> [T; N] {
 	})
 }
 
+/// What a gate does.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GateBody {
+	/// A fixed-shape operation.
+	Op(Opcode),
+	/// A prover-side computation, named by its entry in the hint registry.
+	Hint(HintId),
+}
+
 /// Describes a particular gate in the gate graph, it's type, input and output wires and
 /// immediate parameters.
 pub struct GateData {
-	/// The code of operation of this gate.
-	pub opcode: Opcode,
+	/// What this gate does.
+	pub body: GateBody,
 
 	/// The input and output wires of this gate.
 	///
@@ -147,7 +157,7 @@ pub struct GateData {
 	///
 	/// The length of the immediates is specified by the opcode's shape.
 	///
-	/// Two inline slots cover every opcode: `Shift` declares two, `Hint` one, the rest none.
+	/// Two inline slots cover every gate: the shift declares two, the rest none.
 	/// At that width a `SmallVec` is the same 24 bytes as a vector, so this is free.
 	pub immediates: SmallVec<[u32; 2]>,
 
@@ -160,18 +170,8 @@ pub struct GateData {
 }
 
 impl GateData {
-	/// Slice this gate's wire vector into its semantic portions.
-	///
-	/// Panics for [`Opcode::Hint`] gates — those carry their shape in the [`HintRegistry`]
-	/// and must use [`gate_param_with_registry`](Self::gate_param_with_registry) instead.
-	/// The ~25 per-gate-module callers never see `Opcode::Hint`, so they use this method.
-	pub fn gate_param(&self) -> GateParam<'_> {
-		self.gate_param_for_shape(self.opcode.shape(&self.dimensions))
-	}
-
-	/// Like [`gate_param`](Self::gate_param) but works for [`Opcode::Hint`] gates by looking
-	/// up the shape in the provided registry.
-	pub fn gate_param_with_registry(&self, registry: &HintRegistry) -> GateParam<'_> {
+	/// Slices this gate's wire vector into the groups its shape declares.
+	pub fn gate_param(&self, registry: &HintRegistry) -> GateParam<'_> {
 		self.gate_param_for_shape(self.shape(registry))
 	}
 
@@ -196,25 +196,14 @@ impl GateData {
 		}
 	}
 
-	/// The gate shape (takes dimensions into account).
-	///
-	/// For [`Opcode::Hint`] the shape is looked up via `registry`; the hint id lives in
-	/// `immediates[0]` and the user dimensions are `&self.dimensions`.
+	/// This gate's shape, for the dimensions it was emitted with.
 	pub fn shape(&self, registry: &HintRegistry) -> OpcodeShape {
-		match self.opcode {
-			Opcode::Hint => {
-				let hint_id = self.immediates[0];
+		match self.body {
+			GateBody::Op(opcode) => opcode.shape(&self.dimensions),
+			GateBody::Hint(hint_id) => {
 				let (n_in, n_out) = registry.shape(hint_id, &self.dimensions);
-				OpcodeShape {
-					const_in: &[],
-					n_in,
-					n_out,
-					n_aux: 0,
-					n_scratch: 0,
-					n_imm: 1,
-				}
+				OpcodeShape::new(n_in, n_out)
 			}
-			_ => self.opcode.shape(&self.dimensions),
 		}
 	}
 
@@ -344,12 +333,6 @@ impl GateGraph {
 		dimensions: &[usize],
 		immediates: &[u32],
 	) -> Gate {
-		// Hint gates go through `emit_hint_gate`, which knows the hint's shape from the
-		// `Hint` impl directly without needing the registry here.
-		assert!(
-			opcode != Opcode::Hint,
-			"emit_gate_generic does not handle Opcode::Hint; use emit_hint_gate"
-		);
 		let shape = opcode.shape(dimensions);
 		let mut wires: SmallVec<[Wire; 5]> = SmallVec::with_capacity(
 			shape.const_in.len() + shape.n_in + shape.n_out + shape.n_aux + shape.n_scratch,
@@ -367,7 +350,7 @@ impl GateGraph {
 			wires.push(self.add_scratch());
 		}
 		let data = GateData {
-			opcode,
+			body: GateBody::Op(opcode),
 			wires,
 			dimensions: dimensions.to_vec(),
 			immediates: SmallVec::from_slice(immediates),
@@ -385,9 +368,9 @@ impl GateGraph {
 		gate
 	}
 
-	/// Emit a generic [`Opcode::Hint`] gate. Caller has already validated input arity
-	/// against the hint's [`Hint::shape`](crate::ir::hints::Hint::shape) and allocated
-	/// `n_out` output wires.
+	/// Emits a gate calling one registered hint.
+	///
+	/// The caller has already checked the input arity and allocated the output wires.
 	pub fn emit_hint_gate(
 		&mut self,
 		gate_origin: PathSpec,
@@ -400,10 +383,10 @@ impl GateGraph {
 		wires.extend(inputs);
 		wires.extend(outputs);
 		let data = GateData {
-			opcode: Opcode::Hint,
+			body: GateBody::Hint(hint_id),
 			wires,
 			dimensions: dimensions.to_vec(),
-			immediates: smallvec![hint_id],
+			immediates: SmallVec::new(),
 		};
 		let gate = self.gates.push(data);
 		self.gate_origin[gate] = gate_origin;
@@ -414,11 +397,11 @@ impl GateGraph {
 	///
 	/// A gate defines its outputs and its auxiliary wires.
 	///
-	/// `hint_registry` must contain the hint of every [`Opcode::Hint`] gate.
+	/// `hint_registry` must contain the hint of every hint gate.
 	pub fn rebuild_wire_defs(&mut self, hint_registry: &HintRegistry) {
 		self.wire_def.clear();
 		for (gate, data) in self.gates.iter() {
-			let param = data.gate_param_with_registry(hint_registry);
+			let param = data.gate_param(hint_registry);
 			for &wire in param.outputs.iter().chain(param.aux) {
 				self.wire_def[wire] = Some(gate);
 			}
@@ -454,7 +437,7 @@ impl GateGraph {
 		// prefix-summed in place into run starts.
 		let mut offsets = vec![0u32; n_wires + 1];
 		for (gate, data) in self.gates.iter() {
-			let param = data.gate_param_with_registry(hint_registry);
+			let param = data.gate_param(hint_registry);
 			for &wire in param.constants.iter().chain(param.inputs) {
 				if last_seen[wire] != Some(gate) {
 					last_seen[wire] = Some(gate);
@@ -473,7 +456,7 @@ impl GateGraph {
 		let mut cursor = offsets.clone();
 		last_seen.clear();
 		for (gate, data) in self.gates.iter() {
-			let param = data.gate_param_with_registry(hint_registry);
+			let param = data.gate_param(hint_registry);
 			for &wire in param.constants.iter().chain(param.inputs) {
 				if last_seen[wire] != Some(gate) {
 					last_seen[wire] = Some(gate);
@@ -489,7 +472,7 @@ impl GateGraph {
 
 	/// Rebuilds both halves of the use-def analysis.
 	///
-	/// `hint_registry` must contain the hint of every [`Opcode::Hint`] gate.
+	/// `hint_registry` must contain the hint of every hint gate.
 	pub fn rebuild_use_def_chains(&mut self, hint_registry: &HintRegistry) {
 		self.rebuild_wire_defs(hint_registry);
 		self.rebuild_wire_uses(hint_registry);
@@ -622,7 +605,7 @@ mod tests {
 
 	fn get_gate_inputs(graph: &GateGraph, gate: Gate) -> Vec<Wire> {
 		let gate_data = &graph.gates[gate];
-		let gate_param = gate_data.gate_param();
+		let gate_param = gate_data.gate_param(&HintRegistry::new());
 
 		let mut inputs = Vec::new();
 		inputs.extend_from_slice(gate_param.constants);
@@ -632,7 +615,7 @@ mod tests {
 
 	fn get_gate_outputs(graph: &GateGraph, gate: Gate) -> Vec<Wire> {
 		let gate_data = &graph.gates[gate];
-		let gate_param = gate_data.gate_param();
+		let gate_param = gate_data.gate_param(&HintRegistry::new());
 
 		let mut outputs = Vec::new();
 		outputs.extend_from_slice(gate_param.outputs);

--- a/crates/frontend/src/pass/const_prop.rs
+++ b/crates/frontend/src/pass/const_prop.rs
@@ -53,7 +53,7 @@ pub fn constant_propagation(graph: &mut GateGraph, hint_registry: &HintRegistry)
 				Ok(output_values) => {
 					let output_wires = {
 						let gate_data = graph.gate_data(gate);
-						let gate_param = gate_data.gate_param_with_registry(hint_registry);
+						let gate_param = gate_data.gate_param(hint_registry);
 						gate_param.outputs.to_vec()
 					};
 					for (i, &output_wire) in output_wires.iter().enumerate() {
@@ -100,7 +100,7 @@ fn try_evaluate_gate_with_constants(
 	hint_registry: &HintRegistry,
 ) -> Option<Result<Vec<binius_core::word::Word>, String>> {
 	let gate_data = graph.gate_data(gate);
-	let gate_param = gate_data.gate_param_with_registry(hint_registry);
+	let gate_param = gate_data.gate_param(hint_registry);
 
 	let mut input_constants = Vec::new();
 	for &input_wire in gate_param.inputs {
@@ -163,7 +163,7 @@ mod tests {
 		// But the gates that used them should now use constant wires
 		// Check that and_gate now uses a constant wire with value 6 instead of xor_out
 		let and_gate_data = &graph.gates[and_gate];
-		let and_inputs = and_gate_data.gate_param().inputs;
+		let and_inputs = and_gate_data.gate_param(&HintRegistry::new()).inputs;
 		// First input should be a constant with value 6 (5 ^ 3)
 		match graph.wires[and_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(6)),
@@ -172,7 +172,7 @@ mod tests {
 
 		// Check that test_gate now uses a constant wire with value 0 instead of and_out
 		let test_gate_data = &graph.gates[test_gate];
-		let test_inputs = test_gate_data.gate_param().inputs;
+		let test_inputs = test_gate_data.gate_param(&HintRegistry::new()).inputs;
 		// Both inputs should be constants with value 0 (6 & 1)
 		match graph.wires[test_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(0)),
@@ -225,7 +225,7 @@ mod tests {
 
 		// Check that shl_gate now uses a constant wire with value 4 (16 >> 2)
 		let shl_gate_data = &graph.gates[shl_gate];
-		let shl_inputs = shl_gate_data.gate_param().inputs;
+		let shl_inputs = shl_gate_data.gate_param(&HintRegistry::new()).inputs;
 		match graph.wires[shl_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(4)),
 			_ => panic!("Expected shl_gate's input to be constant 4"),
@@ -233,7 +233,7 @@ mod tests {
 
 		// Check that test_gate now uses a constant wire with value 8 (4 << 1)
 		let test_gate_data = &graph.gates[test_gate];
-		let test_inputs = test_gate_data.gate_param().inputs;
+		let test_inputs = test_gate_data.gate_param(&HintRegistry::new()).inputs;
 		match graph.wires[test_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(8)),
 			_ => panic!("Expected test_gate's input to be constant 8"),
@@ -300,12 +300,16 @@ mod tests {
 		assert!(matches!(graph.wires[quotient], WireKind::Witness));
 		assert!(matches!(graph.wires[remainder], WireKind::Witness));
 
-		let test_q_inputs = graph.gates[test_q_gate].gate_param().inputs;
+		let test_q_inputs = graph.gates[test_q_gate]
+			.gate_param(&HintRegistry::new())
+			.inputs;
 		match graph.wires[test_q_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(14)), // 100 / 7 = 14
 			_ => panic!("Expected test_q_gate's input to be constant 14"),
 		}
-		let test_r_inputs = graph.gates[test_r_gate].gate_param().inputs;
+		let test_r_inputs = graph.gates[test_r_gate]
+			.gate_param(&HintRegistry::new())
+			.inputs;
 		match graph.wires[test_r_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(2)), // 100 % 7 = 2
 			_ => panic!("Expected test_r_gate's input to be constant 2"),

--- a/crates/frontend/src/pass/cse.rs
+++ b/crates/frontend/src/pass/cse.rs
@@ -2,7 +2,7 @@
 //! Common-subexpression elimination on the gate graph.
 //!
 //! Two gates are structurally identical when they match on all of:
-//! - opcode;
+//! - what the gate does;
 //! - constant and input wires;
 //! - immediates;
 //! - dimensions.
@@ -27,10 +27,7 @@ use cranelift_entity::EntitySet;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
-use crate::{
-	gates::opcode::Opcode,
-	ir::{Gate, GateGraph, Wire, WireKind, hints::HintRegistry},
-};
+use crate::ir::{Gate, GateBody, GateGraph, Wire, WireKind, hints::HintRegistry};
 
 /// Deduplicates structurally-identical gates, returning the gates left dead.
 ///
@@ -56,11 +53,6 @@ pub fn dedup_gates(
 	// Gate ids are collected up front so the graph can be mutated inside the loop.
 	let gate_ids: Vec<Gate> = graph.gates.keys().collect();
 	for gate in gate_ids {
-		// Hint gates carry their shape in the registry and are rarely duplicated, so skip them.
-		if matches!(graph.gate_data(gate).opcode, Opcode::Hint) {
-			continue;
-		}
-
 		// Rewrite this gate's wires to their canonical form.
 		// An input that fed an earlier duplicate is remapped.
 		// Output, aux, and scratch wires are never keys in the map, so they pass through unchanged.
@@ -76,7 +68,7 @@ pub fn dedup_gates(
 		// A gate producing one is never collapsed, though it can still be a canonical target.
 		let produces_observable = graph
 			.gate_data(gate)
-			.gate_param_with_registry(hint_registry)
+			.gate_param(hint_registry)
 			.outputs
 			.iter()
 			.any(|&wire| {
@@ -91,13 +83,9 @@ pub fn dedup_gates(
 		match duplicate_of {
 			// Map each output of the duplicate onto the canonical gate's matching output.
 			Some(canon) => {
-				let param = graph
-					.gate_data(gate)
-					.gate_param_with_registry(hint_registry);
+				let param = graph.gate_data(gate).gate_param(hint_registry);
 				let dup_outputs = param.outputs.to_vec();
-				let canon_param = graph
-					.gate_data(canon)
-					.gate_param_with_registry(hint_registry);
+				let canon_param = graph.gate_data(canon).gate_param(hint_registry);
 				let canon_outputs = canon_param.outputs.to_vec();
 				for (dup_out, canon_out) in dup_outputs.into_iter().zip(canon_outputs) {
 					remap.insert(dup_out, canon_out);
@@ -115,15 +103,15 @@ pub fn dedup_gates(
 	dead
 }
 
-/// A gate's structural identity: opcode, constant and input wires, immediates, dimensions.
+/// A gate's structural identity: what it does, the wires it reads, its immediates and dimensions.
 ///
 /// Output, auxiliary, and scratch wires are excluded.
 /// They are freshly allocated per gate, so including them would make identical gates differ.
 ///
-/// One is built per gate, so each field is held inline at the arity the opcodes actually use.
+/// One is built per gate, so each field is held inline at the arity the gates actually use.
 #[derive(PartialEq, Eq, Hash)]
 struct GateStructure {
-	opcode: Opcode,
+	body: GateBody,
 	/// The constant and input wires, in order, which is what the gate reads.
 	reads: SmallVec<[Wire; 4]>,
 	immediates: SmallVec<[u32; 2]>,
@@ -133,9 +121,9 @@ struct GateStructure {
 /// Extracts the structural identity of a gate.
 fn structure_of(graph: &GateGraph, gate: Gate, hint_registry: &HintRegistry) -> GateStructure {
 	let data = graph.gate_data(gate);
-	let param = data.gate_param_with_registry(hint_registry);
+	let param = data.gate_param(hint_registry);
 	GateStructure {
-		opcode: data.opcode,
+		body: data.body,
 		reads: param
 			.constants
 			.iter()
@@ -149,8 +137,13 @@ fn structure_of(graph: &GateGraph, gate: Gate, hint_registry: &HintRegistry) -> 
 
 #[cfg(test)]
 mod tests {
+	use binius_core::word::Word;
+
 	use super::*;
-	use crate::ir::GateGraph;
+	use crate::{
+		gates::Opcode,
+		ir::{GateGraph, hints::Hint},
+	};
 
 	#[test]
 	fn duplicate_and_gate_is_collapsed() {
@@ -183,7 +176,11 @@ mod tests {
 		assert!(dead.contains(g2), "duplicate gate must be dead");
 
 		// The reader now consumes the canonical output, not the dead duplicate's.
-		let reader_inputs = graph.gate_data(reader).gate_param().inputs.to_vec();
+		let reader_inputs = graph
+			.gate_data(reader)
+			.gate_param(&HintRegistry::new())
+			.inputs
+			.to_vec();
 		assert_eq!(reader_inputs, vec![o1], "reader must be redirected to the canonical wire");
 	}
 
@@ -263,5 +260,110 @@ mod tests {
 
 		let dead = dedup_gates(&mut graph, &force_committed, &registry);
 		assert!(!dead.contains(g2), "gate producing a committed wire must be kept");
+	}
+
+	/// Doubles its input.
+	struct Doubler;
+
+	impl Hint for Doubler {
+		const NAME: &'static str = "cse.test.doubler";
+
+		fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+			(1, 1)
+		}
+
+		fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+			outputs[0] = Word(inputs[0].as_u64() << 1);
+		}
+	}
+
+	/// Negates its input.
+	struct Negate;
+
+	impl Hint for Negate {
+		const NAME: &'static str = "cse.test.negate";
+
+		fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+			(1, 1)
+		}
+
+		fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+			outputs[0] = Word(!inputs[0].as_u64());
+		}
+	}
+
+	#[test]
+	fn duplicate_hint_gate_is_collapsed() {
+		// Invariant: a hint is pure, so calling it twice on one input is redundant.
+		let mut registry = HintRegistry::new();
+		let doubler = registry.register(Doubler);
+
+		let mut graph = GateGraph::new();
+		let root = graph.path_spec_tree.root();
+		let x = graph.add_inout();
+
+		// Fixture: the same hint over the same input, twice, with a reader of the second output.
+		let o1 = graph.add_internal();
+		let g1 = graph.emit_hint_gate(root, doubler, &[], vec![x], vec![o1]);
+		let o2 = graph.add_internal();
+		let g2 = graph.emit_hint_gate(root, doubler, &[], vec![x], vec![o2]);
+		let reader = graph.emit_gate(root, Opcode::AssertZero, vec![o2], vec![]);
+
+		let dead = dedup_gates(&mut graph, &EntitySet::new(), &registry);
+
+		assert!(!dead.contains(g1), "the first hint call is canonical");
+		assert!(dead.contains(g2), "the repeated hint call must collapse");
+
+		// The reader now consumes the canonical output.
+		let inputs = graph
+			.gate_data(reader)
+			.gate_param(&registry)
+			.inputs
+			.to_vec();
+		assert_eq!(inputs, vec![o1]);
+	}
+
+	#[test]
+	fn hints_computing_different_things_are_not_collapsed() {
+		// Invariant: which hint a gate calls is part of its identity.
+		let mut registry = HintRegistry::new();
+		let doubler = registry.register(Doubler);
+		let negate = registry.register(Negate);
+
+		let mut graph = GateGraph::new();
+		let root = graph.path_spec_tree.root();
+		let x = graph.add_inout();
+
+		let o1 = graph.add_internal();
+		let g1 = graph.emit_hint_gate(root, doubler, &[], vec![x], vec![o1]);
+		let o2 = graph.add_internal();
+		let g2 = graph.emit_hint_gate(root, negate, &[], vec![x], vec![o2]);
+
+		let dead = dedup_gates(&mut graph, &EntitySet::new(), &registry);
+
+		assert!(!dead.contains(g1));
+		assert!(!dead.contains(g2), "a different hint is a different gate");
+	}
+
+	#[test]
+	fn one_hint_at_different_dimensions_is_not_collapsed() {
+		// Invariant: a hint's dimensions are part of its identity.
+		// The doubler ignores them, so the two gates differ in nothing else.
+		let mut registry = HintRegistry::new();
+		let doubler = registry.register(Doubler);
+
+		let mut graph = GateGraph::new();
+		let root = graph.path_spec_tree.root();
+		let x = graph.add_inout();
+
+		let o1 = graph.add_internal();
+		let g1 = graph.emit_hint_gate(root, doubler, &[1], vec![x], vec![o1]);
+		let o2 = graph.add_internal();
+		let g2 = graph.emit_hint_gate(root, doubler, &[2], vec![x], vec![o2]);
+
+		let dead = dedup_gates(&mut graph, &EntitySet::new(), &registry);
+
+		assert!(!dead.contains(g1));
+		assert!(!dead.contains(g2), "different dimensions are a different gate");
 	}
 }

--- a/crates/frontend/src/pass/dce.rs
+++ b/crates/frontend/src/pass/dce.rs
@@ -41,12 +41,7 @@ pub fn live_gates(
 	// Seed 1: assertions.
 	// A gate with no output wire produces only a constraint, so it is a root and never dead.
 	for (gate, data) in graph.gates.iter() {
-		if data
-			.gate_param_with_registry(hint_registry)
-			.outputs
-			.is_empty()
-			&& live.insert(gate)
-		{
+		if data.gate_param(hint_registry).outputs.is_empty() && live.insert(gate) {
 			work.push(gate);
 		}
 	}
@@ -70,11 +65,7 @@ pub fn live_gates(
 	// The live set and worklist are locals, so an input slice can stay borrowed while they grow.
 	let graph: &GateGraph = graph;
 	while let Some(gate) = work.pop() {
-		for &input in graph
-			.gate_data(gate)
-			.gate_param_with_registry(hint_registry)
-			.inputs
-		{
+		for &input in graph.gate_data(gate).gate_param(hint_registry).inputs {
 			if let Some(def) = graph.wire_def[input]
 				&& live.insert(def)
 			{

--- a/crates/frontend/src/pass/zero_fold.rs
+++ b/crates/frontend/src/pass/zero_fold.rs
@@ -6,7 +6,7 @@ use cranelift_entity::EntitySet;
 
 use crate::{
 	gates::Opcode,
-	ir::{Gate, GateGraph, Wire, hints::HintRegistry},
+	ir::{Gate, GateBody, GateGraph, Wire, hints::HintRegistry},
 };
 
 /// Rewrites every gate that a zero operand turns into the identity.
@@ -96,8 +96,12 @@ fn zero_identity(
 	hint_registry: &HintRegistry,
 ) -> Option<[(Wire, Wire); 2]> {
 	let data = graph.gate_data(gate);
-	let param = data.gate_param_with_registry(hint_registry);
-	let opcode = data.opcode;
+	let param = data.gate_param(hint_registry);
+
+	// No rule below applies to a hint.
+	let GateBody::Op(opcode) = data.body else {
+		return None;
+	};
 
 	// A force-committed output has to stay a committed wire backed by its own constraint, so
 	// leave the gate alone rather than strand it.


### PR DESCRIPTION
Makes what a gate does a sum type, so a hint stops being an opcode whose shape no opcode can state.

Follows #2148, now merged, so this stands on its own.

### The problem

A hint was a variant of the opcode enum, but its arity is whatever the registered implementation reports. So the one thing an opcode is for — stating its own shape — was exactly the thing that variant could not do, and every reader paid for it.

```
Opcode::shape          panicked for a hint
GateData::gate_param   panicked for a hint, so a second accessor existed to handle it
emit_gate_generic      asserted the opcode was not a hint
cse                    skipped hint gates outright
zero_fold              matched on an opcode a hint could never be
const_eval             carried a hint arm inside its 22-arm operation match
```

The hint's own identity was smuggled through an integer immediate slot, so a hint gate declared one immediate that was not an immediate.

### The idea

```
pub enum GateBody {
    Op(Opcode),      // arity is a property of the operation
    Hint(HintId),    // arity is whatever the registry reports
}
```

The distinction the panics were working around becomes the thing the type says.

### What falls out

- **Both panics go.** Reading a shape and reading a gate's groups are total.
- **One accessor, not two.** The registry-taking one is the only one, so nothing has to remember which to call.
- **The dispatch table covers every opcode**, so its lookup returns a row rather than an option, and the "the hint is last and indexes one past the table" trick #2148 needed is gone.
- **The emission guard has no subject left** — an opcode can no longer be a hint.
- **The constant folder hoists the hint out**, and its match over operations stays exhaustive at 21 arms.
- **A hint gate carries no immediates**, because its id lives in the body.

### The one behaviour change

Common-subexpression elimination skipped hints. The comment said they "carry their shape in the registry and are rarely duplicated" — the first half was the real reason, and it no longer holds, so keeping the skip would need a new justification rather than an old one.

Hints now deduplicate like any other gate. A repeated call on the same inputs costs one gate and one execution instead of two.

This rests on the purity the hint trait already requires: `execute` must be a pure function of its dimensions and inputs. Three tests pin the boundaries:

- a repeated call collapses;
- two different hints over one input do not;
- one hint at two different dimensions does not.

A hint whose output a chip call names is force-committed, and the pass already refuses to collapse a gate producing an observable wire, so the chip path is untouched.

### Two snapshots shrink

The circuit-statistics snapshots for `ethsign` and `ec_msm` move. Both are secp256k1, whose
endomorphism split is a hint that a scalar multiplication calls repeatedly with the same operands.

| snapshot | internal | scratch |
|---|---|---|
| `ethsign` | −132 | +132 |
| `ec_msm` | −198 | +198 |

The two deltas cancel, which is the shape a collapse makes: a deduplicated hint's output stops being
named by any constraint operand, so it moves out of the committed segment into scratch, and the
constraints that defined it go away. ZERO, AND and IMUL counts all drop with it.

Gate and instruction counts are unchanged, because the pass marks a duplicate dead rather than
removing it from the graph.

Every other committed snapshot re-blesses to the same bytes.

### Scope

- **changed:** the gate body type and its two accessors, the dispatch entry points, and the four passes that special-cased a hint
- **new:** 3 CSE tests for the hint boundaries, 1 test pinning the JSON breakdown's names
- **deleted:** 2 panics, 1 emission assert, 1 duplicate accessor, 1 predicate (`is_const_shape`, already gone in #2148), 4 special cases
- **untouched:** the bytecode's own hint opcode, which is a different enum, and every gate's constraint algebra

The JSON breakdown now keys on the body rather than the opcode. Every hint still reports under one name, since its id is an opaque hash, and a test pins that so the dump's keys stay as they were.

### Verification

| gate | result |
|---|---|
| `cargo test -p binius-frontend -p binius-recursion` | **284 passed, 0 failed** |
| `cargo test -p binius-circuits` | 352 passed, 0 failed |
| `crc64_chip` end-to-end test | passed |
| `cargo clippy -p binius-frontend --all-targets -- -D warnings` | clean |
| `cargo +nightly-2026-07-01 fmt --all --check` | clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` | clean |

`binius-recursion` is the only hint user in the workspace, which makes it the check that matters for the CSE change. `binius-circuits` is included because that change reaches every circuit, not only the ones with hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
