### PR TITLE
BINIUS-487: widen the shift reduction to 36 variables and admit doubly shifted terms

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -15,7 +15,7 @@ use binius_math::{
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		KeyCollection, KeySegment, OperatorClaims, Phase3Output, PreparedOperatorClaims,
+		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftIndOutput,
 		ShiftIndSumcheck,
 		monster::{build_monster_segments, shift_operator_table},
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
@@ -100,10 +100,14 @@ where
 	let phase_3 =
 		ShiftIndSumcheck::<P, _>::new(alloc, oblong_weights.as_ref(), &r_j, &r_s, &r_v, g_eval);
 	debug_assert_eq!(phase_3.beta(), gamma);
-	let Phase3Output {
-		shift_ind_eval,
+	let ShiftIndOutput {
+		weights_eval,
+		ind_eval,
 		eval: epsilon,
+		point: _,
 	} = phase_3.prove(channel, alloc);
+	// The monster multilinear is scaled by the product of the two factors phase 3 reduced.
+	let shift_ind_eval = weights_eval * ind_eval;
 
 	// Phase 4: the witness folded at the bit position challenge `r_j`, per segment.
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -17,7 +17,7 @@ use binius_prover::{
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftIndOutput,
 		ShiftIndSumcheck,
-		monster::{build_monster_segments, shift_operator_table},
+		monster::build_monster_segments,
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
@@ -83,31 +83,49 @@ where
 		(&public, &key_collection.public.dense_shift_enc),
 		(&hidden, &key_collection.hidden.dense_shift_enc),
 	]);
-	// The oblong weights, which phase 1 pushes through every shift and phase 3 runs its rounds
+	// The oblong weights, which phase 1 pushes through both shift slots and phase 3 runs its rounds
 	// over directly.
 	let oblong_weights = lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
-	let h = shift_operator_table::<F, F, _>(alloc, oblong_weights.as_ref());
 	let Phase1Output {
 		r_j,
-		r_s,
-		r_v,
+		r_s_inner,
+		r_v_inner,
+		r_s_outer,
+		r_v_outer,
+		psi,
 		gamma,
 		g_eval,
-	} = run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
+	} = run_phase_1_sumcheck::<F, F, _, _>(
+		g,
+		oblong_weights.as_ref(),
+		prepared.batched_eval(),
+		channel,
+		alloc,
+	);
 
-	// Phase 3 binds the bit index the shift indicators read, carrying phase 1's `g` evaluation
-	// through its rounds as a constant.
-	let phase_3 =
-		ShiftIndSumcheck::<P, _>::new(alloc, oblong_weights.as_ref(), &r_j, &r_s, &r_v, g_eval);
-	debug_assert_eq!(phase_3.beta(), gamma);
+	// Phases 2 and 3 bind the two bit indices the shift indicators chain through, working back up
+	// the chain — see the single-instance prover for what each run carries.
+	let inner = ShiftIndSumcheck::<P, _>::new(alloc, &psi, &r_j, &r_s_inner, &r_v_inner, g_eval);
+	debug_assert_eq!(inner.beta(), gamma);
+	let inner_output = inner.prove(channel, alloc);
+
+	let outer = ShiftIndSumcheck::<P, _>::new(
+		alloc,
+		oblong_weights.as_ref(),
+		&inner_output.point,
+		&r_s_outer,
+		&r_v_outer,
+		inner_output.ind_eval * g_eval,
+	);
+	debug_assert_eq!(outer.beta(), inner_output.eval);
 	let ShiftIndOutput {
 		weights_eval,
 		ind_eval,
 		eval: epsilon,
 		point: _,
-	} = phase_3.prove(channel, alloc);
-	// The monster multilinear is scaled by the product of the two factors phase 3 reduced.
-	let shift_ind_eval = weights_eval * ind_eval;
+	} = outer.prove(channel, alloc);
+	// The monster multilinear is scaled by the three bit-index factors the two runs reduced.
+	let shift_ind_eval = weights_eval * ind_eval * inner_output.ind_eval;
 
 	// Phase 4: the witness folded at the bit position challenge `r_j`, per segment.
 
@@ -121,8 +139,10 @@ where
 		key_collection,
 		&prepared,
 		shift_ind_eval,
-		&r_s,
-		&r_v,
+		&r_s_inner,
+		&r_v_inner,
+		&r_s_outer,
+		&r_v_outer,
 	);
 
 	run_sumcheck::<F, P, _, _>(
@@ -223,7 +243,9 @@ mod tests {
 		test_utils::random_scalars,
 		univariate::lagrange_evals_scalars,
 	};
-	use binius_prover::protocols::shift::{DenseShiftEncoding, OperatorData, build_key_collection};
+	use binius_prover::protocols::shift::{
+		DenseShiftEncoding, OperatorData, build_key_collection, monster::shift_operator_table,
+	};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -312,25 +312,27 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	let g = build_combined_g();
 	let oblong_weights = lagrange_evals(&subspace, prepared.bitand.r_zhat_prime);
-	let h = shift_operator_table::<F, P, _>(&GlobalAllocator, oblong_weights.as_ref());
 	let Phase1Output {
 		r_j,
-		r_s,
-		r_v,
+		r_s_inner,
+		r_v_inner,
+		r_s_outer,
+		r_v_outer,
+		psi: _,
 		gamma,
 		g_eval: _,
 	} = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
 		run_phase_1_sumcheck::<F, P, _, _>(
 			g.clone(),
-			h.clone(),
+			oblong_weights.as_ref(),
 			prepared.batched_eval(),
 			&mut transcript,
 			&GlobalAllocator,
 		)
 	};
-	// The bit-index phase's rounds are not benchmarked; phase 4 only needs the scalar they reduce
-	// the two bit-index factors to, so a stand-in value serves.
+	// The bit-index phases' rounds are not benchmarked; the last phase only needs the scalar they
+	// reduce their factors to, so a stand-in value serves.
 	let shift_ind_eval = F::random(&mut rng);
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
@@ -340,15 +342,17 @@ fn bench_shift_phases(c: &mut Criterion) {
 		&key_collection,
 		&prepared,
 		shift_ind_eval,
-		&r_s,
-		&r_v,
+		&r_s_inner,
+		&r_v_inner,
+		&r_s_outer,
+		&r_v_outer,
 	);
 
 	let mut group = c.benchmark_group("shift_reduction_phases");
 	group.sample_size(10);
 
 	// Phase 1. `build_g` / `shift_operator_table` take their inputs by reference, so no
-	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g`/`h` by value.
+	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g` by value.
 	group.bench_function("phase1_build_g_parts", |b| {
 		b.iter(&build_combined_g);
 	});
@@ -357,12 +361,12 @@ fn bench_shift_phases(c: &mut Criterion) {
 	});
 	group.bench_function("phase1_run_sumcheck", |b| {
 		b.iter_batched(
-			|| (g.clone(), h.clone()),
-			|(g, h)| {
+			|| g.clone(),
+			|g| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
 				run_phase_1_sumcheck::<F, P, _, _>(
 					g,
-					h,
+					oblong_weights.as_ref(),
 					prepared.batched_eval(),
 					&mut transcript,
 					&GlobalAllocator,
@@ -381,8 +385,10 @@ fn bench_shift_phases(c: &mut Criterion) {
 				&key_collection,
 				&prepared,
 				shift_ind_eval,
-				&r_s,
-				&r_v,
+				&r_s_inner,
+				&r_v_inner,
+				&r_s_outer,
+				&r_v_outer,
 			)
 		});
 	});

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -12,9 +12,10 @@ use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
 	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
 };
+use binius_verifier::protocols::shift::LOG_SHIFT_COUNT;
 use bytes::{Buf, BufMut};
 
-use super::{DOUBLE_SHIFT_UNSUPPORTED, PreparedOperatorData};
+use super::PreparedOperatorData;
 
 /// Represents the type of operations handled by the shift protocol.
 ///
@@ -105,22 +106,20 @@ impl DenseShiftEncoding {
 		self.shifts.iter().copied()
 	}
 
-	/// Where the inner shift of every sequence the segment uses sits in the space one slot spans,
-	/// in dense index order.
+	/// Where every sequence the segment uses sits in the space two shift slots span, in dense index
+	/// order.
 	///
-	/// The reduction's row axis is one shift slot wide, so a sequence is placed by its inner shift.
-	/// The outer slot holds the identity on every sequence, so distinct sequences have distinct
-	/// inner shifts and the indices come out strictly increasing.
-	/// That is what lets two segments' encodings merge.
+	/// The reduction's row axis is two slots wide and its rounds peel the outer shift first, so a
+	/// sequence is placed **outer-major**: the outer slot's index above the inner slot's, which
+	/// puts the outer bits where the first rounds bind them.
 	///
-	/// # Panics
-	///
-	/// Panics in debug builds if a sequence carries a shift outside its inner slot.
+	/// Distinct sequences land on distinct indices, which is what lets two segments' encodings
+	/// merge. They do not come out ascending — the sequences are sorted by their inner slot first —
+	/// and nothing needs them to be.
 	pub fn shift_indices(&self) -> impl Iterator<Item = usize> + '_ {
-		self.shifts.iter().map(|&[inner, outer]| {
-			debug_assert!(outer.is_identity(), "{DOUBLE_SHIFT_UNSUPPORTED}");
-			inner.index()
-		})
+		self.shifts
+			.iter()
+			.map(|&[inner, outer]| outer.index() << LOG_SHIFT_COUNT | inner.index())
 	}
 
 	/// The dense index of one shift sequence, for lookup while the keys are built.

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -3,13 +3,6 @@
 
 use binius_core::word::Word;
 
-/// Why a shift sequence's outer slot must hold the identity in the two-phase reduction.
-///
-/// The reduction folds one shift axis pair, so it reads the inner slot and ignores the outer one.
-/// A term carrying both would be reduced against the wrong shifted word.
-pub(crate) const DOUBLE_SHIFT_UNSUPPORTED: &str =
-	"the two-phase shift reduction reads only the inner shift of a sequence";
-
 /// The value vector's two committed segments, each at the width the protocol addresses it at.
 ///
 /// A circuit declares fewer values than the reductions address: the public segment is padded to a

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -45,4 +45,4 @@ pub use key_collection::{
 	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
 };
 pub use prove::{OperatorData, PreparedOperatorData, prove};
-pub use shift_ind::{Phase3Output, ShiftIndSumcheck};
+pub use shift_ind::{ShiftIndOutput, ShiftIndSumcheck};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -8,16 +8,14 @@ use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-use binius_verifier::protocols::shift::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, ZERO_ARITY,
-};
+use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 use bytemuck::zeroed_vec;
 use tracing::instrument;
 
 use super::{
 	claims::PreparedOperatorClaims,
 	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation},
-	phase_1::PHASE_1_LOG_LEN,
+	phase_1::SHIFT_OPERATOR_LOG_LEN,
 };
 
 /// The width the half-word (`*32`) shift variants act over.
@@ -47,16 +45,11 @@ struct OuterSlotWeights<F: Field> {
 }
 
 impl<F: Field> OuterSlotWeights<F> {
-	/// The weights that select the identity and reject every other outer shift.
-	///
-	/// This is the equality indicator at the all-zero point, where no challenges were drawn over
-	/// the outer axes.
-	/// Every key's outer slot holds [`Shift::IDENTITY`], spelled `(Sll, 0)`.
-	/// So a well-formed key weighs one, and the scalars match what a single-shift reduction builds.
-	fn identity_selecting() -> Self {
+	/// The equality indicators of the outer slot's challenge point.
+	fn new(r_s_outer: &[F], r_v_outer: &[F]) -> Self {
 		Self {
-			variant: eq_ind_partial_eval::<F>(&[F::ZERO; LOG_SHIFT_VARIANT_COUNT]),
-			amount: eq_ind_partial_eval::<F>(&[F::ZERO; Word::LOG_BITS]),
+			variant: eq_ind_partial_eval::<F>(r_v_outer),
+			amount: eq_ind_partial_eval::<F>(r_s_outer),
 		}
 	}
 
@@ -168,7 +161,7 @@ pub fn shift_operator_row<F: Field>(
 ///
 /// # Returns
 ///
-/// One multilinear over [`PHASE_1_LOG_LEN`] variables, indexed from the low variables up:
+/// One multilinear over [`SHIFT_OPERATOR_LOG_LEN`] variables, indexed from the low variables up:
 ///
 /// ```text
 ///     low     Word::LOG_BITS             the bit position
@@ -196,7 +189,7 @@ where
 	assert_eq!(psi.len(), Word::BITS, "the weights are indexed by bit position");
 
 	// One row of `Word::BITS` weights per `(variant, amount)`, variant most significant.
-	let mut data = zeroed_vec::<F>(1 << PHASE_1_LOG_LEN);
+	let mut data = zeroed_vec::<F>(1 << SHIFT_OPERATOR_LOG_LEN);
 	for (variant, block) in
 		iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS))
 	{
@@ -243,19 +236,22 @@ where
 /// hidden piece over `log_witness_words` variables (the hidden words at the base, zeros above).
 /// The sparse first sumcheck round consumes them without materializing the combined buffer.
 #[instrument(skip_all, name = "build_monster_segments")]
+#[allow(clippy::too_many_arguments)]
 pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	key_collection: &KeyCollection,
 	prepared: &PreparedOperatorClaims<F>,
 	h_eval: F,
-	r_s: &[F],
-	r_v: &[F],
+	r_s_inner: &[F],
+	r_v_inner: &[F],
+	r_s_outer: &[F],
+	r_v_outer: &[F],
 ) -> (FieldVec<P, A>, FieldVec<P, A>)
 where
 	F: BinaryField,
 {
-	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
-	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
+	let r_v_tensor = eq_ind_partial_eval::<F>(r_v_inner);
+	let r_s_tensor = eq_ind_partial_eval::<F>(r_s_inner);
 
 	// Invariant: a key's sequence weight factorizes across its two slots.
 	//
@@ -263,10 +259,7 @@ where
 	//     \______ inner slot _________/     \______ outer slot ________/
 	//
 	// So one table per slot suffices, at `2 * SHIFT_COUNT` entries instead of `SHIFT_COUNT^2`.
-	//
-	// Challenges are drawn over the inner axes only, so the outer slot sits at the all-zero point.
-	// There the indicator selects the identity, the only outer shift a key may carry.
-	let outer = OuterSlotWeights::<F>::identity_selecting();
+	let outer = OuterSlotWeights::<F>::new(r_s_outer, r_v_outer);
 
 	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
 	// weights for one `key.dense_shift_idx` form a contiguous chunk that [`Key::accumulate_wide`]
@@ -438,7 +431,7 @@ mod tests {
 
 	/// The operator table computed straight from the indicator definition, one entry at a time.
 	fn reference_table<F: Field>(psi: &[F]) -> Vec<F> {
-		let mut table = vec![F::ZERO; 1 << PHASE_1_LOG_LEN];
+		let mut table = vec![F::ZERO; 1 << SHIFT_OPERATOR_LOG_LEN];
 		for (variant_idx, variant) in ShiftVariant::ALL.into_iter().enumerate() {
 			for amount in 0..Word::BITS {
 				for j in 0..Word::BITS {

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -23,7 +23,7 @@ use binius_utils::rayon::{
 	prelude::*,
 	task_size::{IndexedParallelIteratorExt, WorkPerItem},
 };
-use binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT;
+use binius_verifier::protocols::shift::LOG_SHIFT_COUNT;
 use bytemuck::zeroed_vec;
 use itertools::izip;
 use tracing::instrument;
@@ -33,20 +33,27 @@ use super::{
 	claims::PreparedOperatorClaims,
 	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment},
 	monster::shift_operator_table,
+	outer::OuterShiftStage,
 };
 
-/// The number of variables in the g (and h) multilinear of phase 1.
+/// The number of variables the shift-and-bit phases of the reduction span.
 ///
-/// The axes run, from the low index positions up: the bit position within a word, the shift
-/// amount, and the shift variant.
-pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_VARIANT_COUNT;
+/// The axes run, from the low index positions up: the bit position within a word, then the inner
+/// shift slot, then the outer one. The `g` multilinear spans all of them; no single table the
+/// prover forms does, which is what the outer rounds exist to avoid.
+pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + LOG_SHIFT_ROWS;
 
 /// The number of variables of the phase-1 multilinears that index the shift.
 ///
-/// Both multilinears hold one row of `Word::BITS` scalars per `(shift variant, shift amount)`
-/// pair, the bit position running within a row. These are the variables above that row: the shift
-/// amount, then the shift variant.
-pub const LOG_SHIFT_ROWS: usize = PHASE_1_LOG_LEN - Word::LOG_BITS;
+/// A term names a sequence of two shifts, so the row axis is two slots wide. It is indexed
+/// **outer-major**, since the rounds peel the outer shift first.
+pub const LOG_SHIFT_ROWS: usize = 2 * LOG_SHIFT_COUNT;
+
+/// The number of variables one shift operator table spans.
+///
+/// Such a table holds one row of `Word::BITS` weights per `(variant, amount)` pair of a single
+/// slot, the bit position running within a row.
+pub const SHIFT_OPERATOR_LOG_LEN: usize = Word::LOG_BITS + LOG_SHIFT_COUNT;
 
 /// What phase 1 leaves the phases after it: its sumcheck's challenge point, split into the axes
 /// it binds, and the two evaluations it reduced to.
@@ -54,27 +61,37 @@ pub const LOG_SHIFT_ROWS: usize = PHASE_1_LOG_LEN - Word::LOG_BITS;
 pub struct Phase1Output<F> {
 	/// The bit position within a word.
 	pub r_j: Vec<F>,
-	/// The shift amount.
-	pub r_s: Vec<F>,
-	/// The shift variant, called the operation in the paper.
-	pub r_v: Vec<F>,
+	/// The inner shift's amount.
+	pub r_s_inner: Vec<F>,
+	/// The inner shift's variant, called the operation in the paper.
+	pub r_v_inner: Vec<F>,
+	/// The outer shift's amount.
+	pub r_s_outer: Vec<F>,
+	/// The outer shift's variant.
+	pub r_v_outer: Vec<F>,
+	/// The oblong weights carried through the outer shift, at the outer challenge point.
+	///
+	/// This is the terminal fold of the outer rounds' table, and it is the weight vector the
+	/// rounds binding the intermediate bit index run against.
+	pub psi: Vec<F>,
 	/// The evaluation claim the next phase proves, called gamma in the paper: the product of the
 	/// two evaluations below.
 	pub gamma: F,
-	/// `g(r_j, r_s, r_v)`, the sum over the word index of the constraint matrix against the
-	/// witness. It is the scalar the bit-index phase carries through its rounds, so the sum never
-	/// has to be formed a second time.
+	/// `g` at the bound shift and bit point, the sum over the word index of the constraint matrix
+	/// against the witness. It is the scalar the bit-index phases carry through their rounds, so
+	/// the sum never has to be formed a second time.
 	pub g_eval: F,
 }
 
 /// Proves the first phase of the shift reduction.
 ///
-/// Builds the g and h multilinears and runs one sumcheck over their product.
+/// Builds the g multilinear and runs one sumcheck over its product with `h`, which is never formed
+/// as a table — see [`run_phase_1_sumcheck`].
 ///
 /// # Arguments
 ///
 /// - `oblong_weights`: the oblong weights of the reduction's first factor, one per bit position.
-///   `h` is those weights pushed through every shift.
+///   `h` is those weights pushed through both shift slots.
 #[instrument(skip_all, name = "prover_phase_1")]
 pub fn prove_phase_1<F, P, Channel, A>(
 	key_collection: &KeyCollection,
@@ -99,9 +116,7 @@ where
 		(&hidden, &key_collection.hidden.dense_shift_enc),
 	]);
 
-	let h = shift_operator_table(alloc, oblong_weights);
-
-	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
+	run_phase_1_sumcheck::<_, P, _, _>(g, oblong_weights, prepared.batched_eval(), channel, alloc)
 }
 
 /// The number of packed elements one row of `Word::BITS` scalars occupies.
@@ -308,12 +323,15 @@ impl<'alloc, A: Allocator, F: Field, P: PackedField<Scalar = F>>
 {
 	/// Creates a prover for the claim that `g * h` sums to `sum` over the hypercube.
 	///
+	/// The outer shift slot is already bound by the time this runs, so `h` is the shift operator
+	/// over the weights those rounds left behind, and `g`'s remaining row index is the inner slot.
+	///
 	/// # Panics
 	///
-	/// Panics unless `g` and `h` both span the whole phase-1 hypercube.
+	/// Panics unless `g` and `h` both span one shift slot and the bit position.
 	pub fn new(g: SparseShiftRows<P>, h: FieldVec<P, A>, sum: F, alloc: &'alloc A) -> Self {
-		assert_eq!(h.log_len(), PHASE_1_LOG_LEN, "h spans the whole phase-1 hypercube");
-		assert_eq!(g.log_rows(), LOG_SHIFT_ROWS, "g spans the whole shift space");
+		assert_eq!(h.log_len(), SHIFT_OPERATOR_LOG_LEN, "h spans one shift slot");
+		assert_eq!(g.log_rows(), LOG_SHIFT_COUNT, "g's rows span one shift slot");
 
 		Self {
 			alloc,
@@ -406,15 +424,29 @@ impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckProver<F>
 /// Runs the phase 1 sumcheck protocol for shift constraint verification.
 ///
 /// One sumcheck over the product of `g` and `h`, multilinears of [`PHASE_1_LOG_LEN`] variables,
-/// driven by [`Phase1SumcheckProver`]. The shift variant is the high
-/// [`LOG_SHIFT_VARIANT_COUNT`] variables of each, so the sumcheck folds the variant axis rather
-/// than the prover summing a separate claim per variant.
+/// binding the outer shift slot, then the inner one, then the bit position. Each slot's variant is
+/// the high
+/// [`LOG_SHIFT_VARIANT_COUNT`](binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT)
+/// variables of its run, so the sumcheck folds the variant axis rather than the prover summing a
+/// separate claim per variant.
 ///
-/// The `g` multilinear carries the witness and the batching randomness; `h` encodes what each
-/// shift does at the univariate challenge point.
+/// The `g` multilinear carries the witness and the batching randomness; `h` says what each shift
+/// *sequence* does at the univariate challenge point. A table of `h` would hold `2^24` entries and
+/// is never formed:
+///
+/// - The [`LOG_SHIFT_COUNT`] rounds binding the outer slot run against [`OuterShiftStage`], which
+///   derives each live row from a folded `2^15` table one slice at a time.
+/// - Those rounds leave the weights `psi`, and `h` over what remains is the shift operator applied
+///   to them — a `2^15` table, which the remaining rounds fold as an ordinary multilinear through
+///   [`Phase1SumcheckProver`].
+///
+/// The outer rounds are driven here rather than folded into [`Phase1SumcheckProver`] because
+/// `prove_single` consumes its prover, and `psi` has to outlive it: the rounds binding the
+/// intermediate bit index run against those same weights.
 ///
 /// # Arguments
 ///
+/// - `oblong_weights`: the oblong weights of the reduction's first factor, one per bit position.
 /// - `sum`: the claim being proved, as the operations' batched evaluations give it. This is the
 ///   same value the verifier feeds its own sumcheck, so the prover proves the statement it was
 ///   handed rather than whatever `g · h` happens to come to.
@@ -426,32 +458,57 @@ impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckProver<F>
 ///
 /// # Returns
 ///
-/// `SumcheckOutput` containing the challenge vector and the final evaluation `gamma`.
+/// The challenge point split into the axes the rounds bound, the weights the next phase runs
+/// against, and the evaluations this one reduced to.
 #[instrument(skip_all, name = "run_sumcheck")]
 pub fn run_phase_1_sumcheck<
-	F: Field,
+	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 >(
-	g: SparseShiftRows<P>,
-	h: FieldVec<P, A>,
+	mut g: SparseShiftRows<P>,
+	oblong_weights: &[F],
 	sum: F,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> Phase1Output<F> {
+	assert_eq!(g.log_rows(), LOG_SHIFT_ROWS, "g's rows span both shift slots");
+
+	// The rounds binding the outer slot, driven a round at a time.
+	let mut outer = OuterShiftStage::new(alloc, oblong_weights);
+	let mut claim = sum;
+	let mut outer_point = Vec::with_capacity(LOG_SHIFT_COUNT);
+	for _ in 0..LOG_SHIFT_COUNT {
+		let round_coeffs = outer.round_coeffs(&g, claim);
+		channel.send_many(round_coeffs.clone().truncate().coeffs());
+		let challenge = channel.sample();
+		claim = round_coeffs.evaluate(&challenge);
+		outer.fold(challenge);
+		g.fold(challenge);
+		outer_point.push(challenge);
+	}
+	let psi = outer.psi().to_vec();
+
+	// What is left is one shift slot and the bit position, against the operator over those weights.
+	let h = shift_operator_table(alloc, &psi);
 	let ProveSingleOutput {
 		multilinear_evals,
 		mut challenges,
-	} = prove_single(Phase1SumcheckProver::new(g, h, sum, alloc), channel);
-	// Reverse the challenges into the evaluation point, then split it into the axes the rounds
-	// bound: the bit position within a word, then the shift amount, then the shift variant, in
-	// increasing order of significance.
+	} = prove_single(Phase1SumcheckProver::new(g, h, claim, alloc), channel);
+
+	// Reverse each run of challenges into its evaluation point, whose coordinates then run in
+	// increasing order of significance: the bit position within a word, then the inner shift slot's
+	// amount and variant, then the outer slot's.
 	challenges.reverse();
-	assert_eq!(challenges.len(), PHASE_1_LOG_LEN);
+	assert_eq!(challenges.len(), SHIFT_OPERATOR_LOG_LEN);
 	let mut r_j = challenges;
-	let r_v = r_j.split_off(Word::LOG_BITS * 2);
-	let r_s = r_j.split_off(Word::LOG_BITS);
+	let r_v_inner = r_j.split_off(Word::LOG_BITS * 2);
+	let r_s_inner = r_j.split_off(Word::LOG_BITS);
+
+	outer_point.reverse();
+	let mut r_s_outer = outer_point;
+	let r_v_outer = r_s_outer.split_off(Word::LOG_BITS);
 
 	let [g_eval, h_eval] = multilinear_evals
 		.try_into()
@@ -459,8 +516,11 @@ pub fn run_phase_1_sumcheck<
 
 	Phase1Output {
 		r_j,
-		r_s,
-		r_v,
+		r_s_inner,
+		r_v_inner,
+		r_s_outer,
+		r_v_outer,
+		psi,
 		gamma: g_eval * h_eval,
 		g_eval,
 	}
@@ -662,24 +722,14 @@ mod tests {
 	type F = BinaryField128bGhash;
 
 	impl<P: PackedField> SparseShiftRows<P> {
-		/// Spreads the rows over the full shift space, as a dense multilinear of
-		/// [`PHASE_1_LOG_LEN`] variables. Rows at a repeated index add up; every row the system
-		/// does not name stays zero.
+		/// Spreads the rows over the space they still span, as a dense multilinear. Rows at a
+		/// repeated index add up; every row the system does not name stays zero.
 		///
 		/// The prover never needs this — [`Phase1SumcheckProver`] reads the rows where they are.
 		/// It is the dense `g` these tests measure the sparse rounds against.
-		///
-		/// ## Preconditions
-		///
-		/// * `self.log_rows() == LOG_SHIFT_ROWS`, so the rows still span the whole shift space
 		fn scatter<A: Allocator>(&self, alloc: &A) -> FieldVec<P, A> {
-			assert_eq!(
-				self.log_rows, LOG_SHIFT_ROWS,
-				"precondition: no row-index variable is bound"
-			);
-
 			let row_len = row_len::<P>();
-			let mut g = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
+			let mut g = FieldBuffer::zeros_in(alloc, self.log_rows + Word::LOG_BITS);
 			for (index, row) in self.rows() {
 				// A row is a whole number of packed elements, so it lands at row alignment.
 				let slots = &mut g.as_mut()[index * row_len..][..row_len];
@@ -743,8 +793,9 @@ mod tests {
 			(&hidden, &key_collection.hidden.dense_shift_enc),
 		]);
 
-		// The public segment's two shifts, then the hidden segment's three. `(Sll, 0)` is the first
-		// row of both, so index 0 appears twice.
+		// The public segment's two shifts, then the hidden segment's three. Every term here is
+		// singly shifted, so its outer slot is the identity and its quadruple index is its inner
+		// shift's. `(Sll, 0)` is the first row of both segments, so index 0 appears twice.
 		let row_index = |shift: Shift| shift.index() as u32;
 		assert_eq!(
 			g.indices,
@@ -764,50 +815,82 @@ mod tests {
 		}
 
 		// Where `g` is read, the two rows at the identity add up.
-		let dense = g.scatter(&GlobalAllocator);
-		let at = |shift: Shift| dense.get(shift.index() * Word::BITS);
+		let at = |shift: Shift| {
+			g.rows()
+				.filter(|&(index, _)| index == shift.index())
+				.map(|(_, row)| row[0])
+				.sum::<F>()
+		};
 		assert_eq!(at(Shift::IDENTITY), F::new(0x100) + F::new(0x200));
 		assert_eq!(at(Shift::srl(3)), F::new(0x101));
 		assert_eq!(at(Shift::sar(7)), F::new(0x201));
 		assert_eq!(at(Shift::rotr(1)), F::new(0x202));
 	}
 
+	/// A sequence is placed outer-major, so the outer slot lands where the first rounds bind it.
+	#[test]
+	fn a_sequence_is_keyed_outer_major() {
+		let hidden = ValueIndex::private(1);
+		let sequence = [Shift::srl(3), Shift::sll(5)];
+		let cs = ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_inout: 0,
+			n_private: 4,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![ShiftedValueIndex::new(hidden, sequence)],
+				Vec::new(),
+				Vec::new(),
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		};
+
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let [inner, outer] = sequence;
+		assert_eq!(
+			key_collection
+				.hidden
+				.dense_shift_enc
+				.shift_indices()
+				.collect::<Vec<_>>(),
+			[outer.index() << LOG_SHIFT_COUNT | inner.index()]
+		);
+	}
+
 	/// The scatter puts every row where its shift index names, and leaves the rest zero.
+	///
+	/// The outer rounds are past by the time the dense reference below is taken, so the rows span
+	/// one shift slot here rather than the quadruple `from_segments` keys on.
 	#[test]
 	fn scatter_places_rows_at_their_shift_index() {
-		let key_collection =
-			build_key_collection(&overlapping_shift_system(), InoutSegment::Public);
-		let hidden_enc = &key_collection.hidden.dense_shift_enc;
-
-		// One non-zero row per shift the hidden segment names, and an empty public segment.
-		let hidden = (0..hidden_enc.len() * Word::BITS)
+		let indices = [Shift::IDENTITY, Shift::sar(7), Shift::rotr(1)]
+			.map(|shift| shift.index() as u32)
+			.to_vec();
+		let values = (0..indices.len() * Word::BITS)
 			.map(|i| F::new(1 + (i / Word::BITS) as u128))
 			.collect::<Vec<F>>();
-		let merged = SparseShiftRows::<F>::from_segments([
-			(&[], &DenseShiftEncoding::default()),
-			(&hidden, hidden_enc),
-		]);
+		let rows = SparseShiftRows::<F>::new(indices.clone(), values, LOG_SHIFT_COUNT);
 
-		let g = merged.scatter(&binius_compute::GlobalAllocator);
-		assert_eq!(g.log_len(), PHASE_1_LOG_LEN);
+		let g = rows.scatter(&GlobalAllocator);
+		assert_eq!(g.log_len(), SHIFT_OPERATOR_LOG_LEN);
 
-		// Exactly the named rows are non-zero, and each holds what the merged list held.
-		for (row, shift_index) in hidden_enc.shift_indices().enumerate() {
-			let offset = shift_index * Word::BITS;
+		// Exactly the named rows are non-zero, and each holds what the list held.
+		for (row, &shift_index) in indices.iter().enumerate() {
+			let offset = shift_index as usize * Word::BITS;
 			for bit in 0..Word::BITS {
 				assert_eq!(g.get(offset + bit), F::new(1 + row as u128));
 			}
 		}
-		let named = hidden_enc.shift_indices().collect::<Vec<_>>();
-		for row in (0..1 << LOG_SHIFT_ROWS).filter(|row| !named.contains(row)) {
+		for row in (0..1 << LOG_SHIFT_COUNT).filter(|row| !indices.contains(&(*row as u32))) {
 			assert!((0..Word::BITS).all(|bit| g.get(row * Word::BITS + bit) == F::ZERO));
 		}
 	}
 
-	/// Runs the phase-1 sumcheck the dense way: one bivariate-product prover over the scattered
-	/// `g` and the whole of `h`, with no round of it special-cased.
+	/// Runs the sparse row and bit rounds the dense way: one bivariate-product prover over the
+	/// scattered `g` and the whole of `h`, with no round of it special-cased.
 	///
-	/// This is what [`run_phase_1_sumcheck`] replaces, kept here as the reference its round
+	/// This is what [`Phase1SumcheckProver`] replaces, kept here as the reference its round
 	/// messages have to reproduce.
 	fn run_dense_reference<P: PackedField<Scalar = F>>(
 		g: &SparseShiftRows<P>,
@@ -831,9 +914,10 @@ mod tests {
 		(challenges, g_eval * h_eval)
 	}
 
-	/// The phase-1 `g` and `h` of a constraint system, from pseudo-random weights.
+	/// The `g` and `h` the row and bit rounds run over, from pseudo-random weights.
 	///
-	/// `g`'s rows carry arbitrary values rather than ones a witness produces: the sumcheck is a
+	/// The outer rounds are past by this point, so `g`'s rows sit at the inner shift each sequence
+	/// names. They carry arbitrary values rather than ones a witness produces: the sumcheck is a
 	/// statement about whatever multilinears it is handed, so what the rows hold does not bear on
 	/// whether the sparse rounds reproduce the dense ones.
 	fn phase_1_multilinears<P: PackedField<Scalar = F>>(
@@ -843,17 +927,15 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(seed);
 		let key_collection = build_key_collection(cs, InoutSegment::Public);
 
-		let segment_rows = |enc: &DenseShiftEncoding, rng: &mut StdRng| {
-			(0..enc.len() * row_len::<P>())
-				.map(|_| P::random(&mut *rng))
-				.collect::<Vec<P>>()
-		};
-		let public = segment_rows(&key_collection.public.dense_shift_enc, &mut rng);
-		let hidden = segment_rows(&key_collection.hidden.dense_shift_enc, &mut rng);
-		let g = SparseShiftRows::from_segments([
-			(&public, &key_collection.public.dense_shift_enc),
-			(&hidden, &key_collection.hidden.dense_shift_enc),
-		]);
+		let mut indices = Vec::new();
+		let mut values = Vec::new();
+		for segment in [&key_collection.public, &key_collection.hidden] {
+			for [inner, _] in segment.dense_shift_enc.iter() {
+				indices.push(inner.index() as u32);
+				values.extend((0..row_len::<P>()).map(|_| P::random(&mut rng)));
+			}
+		}
+		let g = SparseShiftRows::new(indices, values, LOG_SHIFT_COUNT);
 
 		// The weights `h` is built from are arbitrary here for the same reason `g`'s rows are.
 		let h = shift_operator_table(&GlobalAllocator, &random_scalars::<F>(&mut rng, Word::BITS));
@@ -872,22 +954,23 @@ mod tests {
 		let sum = inner_product_buffers(&g.scatter(&GlobalAllocator), &h);
 
 		let mut sparse_transcript = ProverTranscript::<StdChallenger>::default();
-		let sparse = run_phase_1_sumcheck::<F, P, _, _>(
-			g.clone(),
-			h.clone(),
-			sum,
+		let ProveSingleOutput {
+			multilinear_evals,
+			challenges: mut sparse_challenges,
+		} = prove_single(
+			Phase1SumcheckProver::new(g.clone(), h.clone(), sum, &GlobalAllocator),
 			&mut sparse_transcript,
-			&GlobalAllocator,
 		);
+		sparse_challenges.reverse();
+		let [g_eval, h_eval] = multilinear_evals
+			.try_into()
+			.expect("prover has 2 multilinear polynomials");
 
 		let mut dense_transcript = ProverTranscript::<StdChallenger>::default();
 		let (dense_challenges, dense_eval) = run_dense_reference(&g, h, sum, &mut dense_transcript);
 
-		// The sparse prover splits its challenge point into the axes the rounds bound; the dense
-		// reference leaves it whole.
-		let sparse_challenges = [sparse.r_j, sparse.r_s, sparse.r_v].concat();
 		assert_eq!(sparse_challenges, dense_challenges);
-		assert_eq!(sparse.gamma, dense_eval);
+		assert_eq!(g_eval * h_eval, dense_eval);
 		assert_eq!(sparse_transcript.finalize(), dense_transcript.finalize());
 	}
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -29,7 +29,7 @@ use tracing::instrument;
 
 use super::{
 	SegmentWords, claims::PreparedOperatorClaims, key_collection::KeyCollection,
-	monster::build_monster_segments, phase_1::Phase1Output, shift_ind::Phase3Output,
+	monster::build_monster_segments, phase_1::Phase1Output,
 };
 use crate::fold_word::fold_words;
 
@@ -51,20 +51,23 @@ use crate::fold_word::fold_words;
 /// - `words`: The value vector words
 /// - `prepared`: The prepared claim of each operation, indexed by the operation a key names
 /// - `phase_1_output`: Challenges and evaluation from the first phase
-/// - `h_eval`: The h evaluation weighting every shift key, from
-///   [`ShiftIndSumcheck`](super::ShiftIndSumcheck)
+/// - `shift_ind_eval`: the scalar weighting every shift key, the product of the bit-index rounds'
+///   two factor evaluations ([`ShiftIndSumcheck`](super::ShiftIndSumcheck))
+/// - `epsilon`: the claim these rounds prove, which those rounds reduced to
 /// - `channel`: The prover's channel
 ///
 /// # Returns
 /// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and the witness
 /// evaluation, or an error if the protocol fails.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "prove_phase_2")]
 pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
 	key_collection: &KeyCollection,
 	words: SegmentWords<'_>,
 	prepared: &PreparedOperatorClaims<F>,
 	phase_1_output: Phase1Output<F>,
-	phase_3_output: Phase3Output<F>,
+	shift_ind_eval: F,
+	epsilon: F,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F>
@@ -80,10 +83,6 @@ where
 		gamma: _,
 		g_eval: _,
 	} = phase_1_output;
-	let Phase3Output {
-		shift_ind_eval,
-		eval: epsilon,
-	} = phase_3_output;
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -78,8 +78,11 @@ where
 {
 	let Phase1Output {
 		r_j,
-		r_s,
-		r_v,
+		r_s_inner,
+		r_v_inner,
+		r_s_outer,
+		r_v_outer,
+		psi: _,
 		gamma: _,
 		g_eval: _,
 	} = phase_1_output;
@@ -91,8 +94,16 @@ where
 	let public_folded = fold_words::<_, P, _>(alloc, words.public, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<_, P, _>(alloc, words.hidden, r_j_tensor.as_ref());
 
-	let (public_monster, hidden_monster) =
-		build_monster_segments(alloc, key_collection, prepared, shift_ind_eval, &r_s, &r_v);
+	let (public_monster, hidden_monster) = build_monster_segments(
+		alloc,
+		key_collection,
+		prepared,
+		shift_ind_eval,
+		&r_s_inner,
+		&r_v_inner,
+		&r_s_outer,
+		&r_v_outer,
+	);
 
 	// Both halves of the sumcheck share one word-index address space, spanning the wider of the
 	// two segments. The hidden segment is normally the wider one, but a system with more public

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -128,12 +128,13 @@ impl<F: Field> PreparedOperatorData<F> {
 ///
 /// The result is a single multilinear evaluation claim on the witness.
 ///
-/// One sumcheck runs, in four prover phases:
+/// One sumcheck runs, in five prover phases. A shifted value index names two shifts applied in
+/// sequence, and the reduction peels them from the output end inward:
 ///
-/// 1. phases 1 and 2 prove the batched claims over the shift variants, the shift amounts and the
-///    bit positions, sparsely and then densely;
-/// 2. phase 3 binds the bit index the shift indicators read;
-/// 3. phase 4 reduces what is left to a witness evaluation, against the monster multilinear.
+/// 1. phase 1 binds the outer shift slot, then the inner one, then the bit position within a word;
+/// 2. phase 2 binds the bit index of the intermediate word, where the two shift indicators meet;
+/// 3. phase 3 binds the output bit index the oblong weights attach to;
+/// 4. phase 4 reduces what is left to a witness evaluation, against the monster multilinear.
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
@@ -194,29 +195,49 @@ where
 		alloc,
 	);
 
-	// Phase 3 binds the bit index the shift indicators read, carrying phase 1's `g` evaluation
-	// through its rounds as a constant.
-	let phase_3 = ShiftIndSumcheck::<P, _>::new(
+	// Phases 3 and 4 bind the two bit indices the shift indicators chain through, working back up
+	// the chain: first the intermediate word's, where the inner indicator meets the outer one, then
+	// the output bit the oblong weights attach to. Both are the same rounds over a weight vector
+	// and an indicator, differing only in those two arguments.
+	//
+	// Phase 3 runs against the weights the outer rounds left behind, carrying phase 1's `g`
+	// evaluation as a constant.
+	let inner = ShiftIndSumcheck::<P, _>::new(
 		alloc,
-		oblong_weights.as_ref(),
+		&phase_1_output.psi,
 		&phase_1_output.r_j,
-		&phase_1_output.r_s,
-		&phase_1_output.r_v,
+		&phase_1_output.r_s_inner,
+		&phase_1_output.r_v_inner,
 		phase_1_output.g_eval,
 	);
-	debug_assert_eq!(phase_3.beta(), phase_1_output.gamma);
-	let phase_3_output = phase_3.prove(channel, alloc);
+	debug_assert_eq!(inner.beta(), phase_1_output.gamma);
+	let inner_output = inner.prove(channel, alloc);
 
-	// Phase 4 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
+	// Phase 4 runs against the oblong weights themselves. The constant it carries collects what is
+	// already fixed: the inner indicator's evaluation and `g`'s. Its own weights evaluate to the
+	// Lagrange factor the verifier recomputes, and `psi(r_k)` is what the two runs agree on, so no
+	// division is needed to pass between them.
+	let outer = ShiftIndSumcheck::<P, _>::new(
+		alloc,
+		oblong_weights.as_ref(),
+		&inner_output.point,
+		&phase_1_output.r_s_outer,
+		&phase_1_output.r_v_outer,
+		inner_output.ind_eval * phase_1_output.g_eval,
+	);
+	debug_assert_eq!(outer.beta(), inner_output.eval);
+	let outer_output = outer.prove(channel, alloc);
+
+	// Phase 5 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
 	// the univariate variable `r_j` and the multilinear variable `r_y`. Its monster multilinear is
-	// scaled by the product of the two factors phase 3 reduced.
+	// scaled by the three bit-index factors the two runs reduced.
 	prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
 		phase_1_output,
-		phase_3_output.weights_eval * phase_3_output.ind_eval,
-		phase_3_output.eval,
+		outer_output.weights_eval * outer_output.ind_eval * inner_output.ind_eval,
+		outer_output.eval,
 		channel,
 		alloc,
 	)

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -208,13 +208,15 @@ where
 	let phase_3_output = phase_3.prove(channel, alloc);
 
 	// Phase 4 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
-	// the univariate variable `r_j` and the multilinear variable `r_y`.
+	// the univariate variable `r_j` and the multilinear variable `r_y`. Its monster multilinear is
+	// scaled by the product of the two factors phase 3 reduced.
 	prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared,
 		phase_1_output,
-		phase_3_output,
+		phase_3_output.weights_eval * phase_3_output.ind_eval,
+		phase_3_output.eval,
 		channel,
 		alloc,
 	)

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -38,8 +38,8 @@ const HALF_WORD_LOG_BITS: usize = Word::LOG_BITS - 1;
 /// The two are held apart rather than multiplied together, which is what keeps the round
 /// polynomials degree 2. The constant is folded into the weights, so the pair sums to $\beta$ and
 /// the rounds are the ones the verifier's single sumcheck expects. Phase 4 then scales its
-/// monster multilinear by [`Phase3Output::shift_ind_eval`], the evaluation these rounds reduce
-/// the two factors to.
+/// monster multilinear by the product of the two evaluations these rounds reduce their factors to,
+/// which [`ShiftIndOutput`] reports separately.
 ///
 /// The weights and the point the indicator is read at are the caller's, not this type's: a
 /// reduction peeling two shifts runs these rounds once per shift slot, differing only in those two
@@ -55,15 +55,23 @@ pub struct ShiftIndSumcheck<P: PackedField, A: Allocator> {
 	beta: P::Scalar,
 }
 
-/// What phase 3 leaves phase 4.
-#[derive(Debug, Clone, Copy)]
-pub struct Phase3Output<F> {
-	/// The product of the two factors at the bit-index challenge point:
-	/// `weights(r_i) * shift_ind(r_i, r_j, r_s, r_v)`. Phase 4 scales its monster multilinear by
-	/// it, and the verifier recomputes it from `r_i` alone.
-	pub shift_ind_eval: F,
-	/// The claim phase 4 proves: `shift_ind_eval * G`.
+/// What one run of these rounds leaves the phases after it.
+///
+/// The two factor evaluations are reported apart rather than as their product. A reduction peeling
+/// two shifts runs these rounds once per slot and needs them separately: the indicator evaluation
+/// alone is the constant the next run carries, while the products of both runs are what scale the
+/// monster multilinear at the end.
+#[derive(Debug, Clone)]
+pub struct ShiftIndOutput<F> {
+	/// The weight vector at the challenge point, `weights(r_i)`.
+	pub weights_eval: F,
+	/// The interpolated shift indicator at the challenge point,
+	/// `shift_ind(r_i, r_j, r_s, r_v)`. The verifier recomputes it from the point alone.
+	pub ind_eval: F,
+	/// The claim the next phase proves: the two evaluations above times the carried constant.
 	pub eval: F,
+	/// The point these rounds bound, in evaluation order.
+	pub point: Vec<F>,
 }
 
 impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<P, A> {
@@ -108,7 +116,7 @@ impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<
 	}
 
 	/// Proves the [`Word::LOG_BITS`] rounds binding the bit index.
-	pub fn prove(self, channel: &mut impl IPProverChannel<F>, alloc: &A) -> Phase3Output<F> {
+	pub fn prove(self, channel: &mut impl IPProverChannel<F>, alloc: &A) -> ShiftIndOutput<F> {
 		let Self {
 			scaled_weights,
 			shift_ind,
@@ -127,13 +135,15 @@ impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<
 			.try_into()
 			.expect("prover has 2 multilinear polynomials");
 
-		// The scale rides in the first evaluation, so the unscaled weights are evaluated at the
-		// challenge point separately — the same 64-term inner product the verifier runs.
+		// The carried constant rides in the first evaluation, so the unscaled weights are evaluated
+		// at the challenge point separately — the same 64-term inner product the verifier runs.
 		let weights_eval = inner_product(weights, eq_ind_partial_eval_scalars(&challenges));
 
-		Phase3Output {
-			shift_ind_eval: weights_eval * shift_ind_eval,
+		ShiftIndOutput {
+			weights_eval,
+			ind_eval: shift_ind_eval,
 			eval: scaled_weights_eval * shift_ind_eval,
+			point: challenges,
 		}
 	}
 }

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -105,6 +105,100 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	(circuit.constraint_system().clone(), witness_filler.into_value_vec())
 }
 
+/// A system whose operands carry genuinely doubly shifted value indices, with a witness.
+///
+/// The frontend still lowers every term to a single shift, so nothing a circuit builds reaches
+/// this path. It is built by hand instead, which is what lets the reduction be exercised over two
+/// shift slots ahead of the compiler emitting them.
+///
+/// Each pair is one AND constraint `a & b ^ c = 0`, with `a` doubly shifted, `b` a second private
+/// word and `c` the word the witness sets to their AND. One operand also mixes an unshifted, a
+/// singly shifted and a doubly shifted term, since that is what a compiler emitting pairs would
+/// produce.
+pub fn create_double_shift_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	use binius_core::constraint_system::{Composition, Shift, ShiftedValueIndex, ValueIndex};
+	use rand::RngExt;
+
+	/// The word a shift sequence carries its operand to, inner slot first.
+	fn apply(sequence: [Shift; 2], word: Word) -> Word {
+		let [inner, outer] = sequence;
+		outer.apply(inner.apply(word))
+	}
+
+	// Sequences that genuinely need both slots: a sign extension of a sub-word field, a shift under
+	// a rotate, a byte masked off one end and back, and the half-word family's own sign extension.
+	// `sar` is the case worth covering in either slot, being the one shift whose vacated positions
+	// all read a single input bit. Two shifts of one variant chain into one, so no pair here shares
+	// a variant — the assertion below is what holds that to the composition rule rather than to
+	// this comment.
+	let sequences = [
+		[Shift::sll(40), Shift::sar(40)],
+		[Shift::rotr(1), Shift::sll(9)],
+		[Shift::sll(8), Shift::srl(8)],
+		[Shift::sll32(11), Shift::sra32(11)],
+		[Shift::sar(7), Shift::sll(3)],
+	];
+	for [inner, outer] in sequences {
+		assert_eq!(
+			Shift::compose(inner, outer),
+			Composition::Pair,
+			"a collapsible sequence is not a doubly shifted term: {inner:?} then {outer:?}"
+		);
+	}
+
+	// Three private words per sequence: the shifted operand, the mask, and their AND.
+	let mut rng = StdRng::seed_from_u64(7);
+	let mut private = (0..3 * sequences.len())
+		.map(|_| Word::from_u64(rng.random()))
+		.collect::<Vec<_>>();
+
+	let mut and_constraints = Vec::new();
+	for (i, sequence) in sequences.into_iter().enumerate() {
+		let base = 3 * i as u32;
+		// The witness makes the constraint hold: the product word is what `a & b` comes to.
+		private[base as usize + 2] =
+			apply(sequence, private[base as usize]) & private[base as usize + 1];
+		and_constraints.push(AndConstraint([
+			vec![ShiftedValueIndex::new(ValueIndex::private(base), sequence)],
+			vec![ShiftedValueIndex::plain(ValueIndex::private(base + 1))],
+			vec![ShiftedValueIndex::plain(ValueIndex::private(base + 2))],
+		]));
+	}
+
+	// One more constraint whose first operand mixes all three term classes, since that is what a
+	// compiler emitting pairs would produce. Its terms XOR to one word, which the other two
+	// operands are then set to.
+	{
+		let sign_extend = [Shift::sll(40), Shift::sar(40)];
+		let terms = vec![
+			ShiftedValueIndex::plain(ValueIndex::private(0)),
+			ShiftedValueIndex::srl(ValueIndex::private(3), 17),
+			ShiftedValueIndex::new(ValueIndex::private(1), sign_extend),
+		];
+		let mixed = private[0] ^ (private[3] >> 17) ^ apply(sign_extend, private[1]);
+		let base = private.len() as u32;
+		private.push(mixed);
+		private.push(mixed);
+		and_constraints.push(AndConstraint([
+			terms,
+			vec![ShiftedValueIndex::plain(ValueIndex::private(base))],
+			vec![ShiftedValueIndex::plain(ValueIndex::private(base + 1))],
+		]));
+	}
+
+	let cs = ConstraintSystem {
+		constants: vec![Word::ZERO; 4],
+		n_inout: 0,
+		n_private: private.len(),
+		zero_constraints: Vec::new(),
+		and_constraints,
+		imul_constraints: Vec::new(),
+		bmul_constraints: Vec::new(),
+	};
+	let value_vec = ValueVec::new_from_data(4, &[Word::ZERO; 4], &private);
+	(cs, value_vec)
+}
+
 pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	use binius_circuits::slice::{assert_slice_eq, slice};
 
@@ -238,6 +332,7 @@ fn test_shift_prove_and_verify() {
 		create_sha256_cs_with_witness(),
 		create_slice_cs_with_witness(),
 		create_concat_cs_with_witness(),
+		create_double_shift_cs_with_witness(),
 	];
 	for (constraint_system, _) in constraint_systems_to_test.iter() {
 		constraint_system.validate().unwrap();

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -12,10 +12,11 @@ pub const SHIFT_VARIANT_COUNT: usize = 1 << LOG_SHIFT_VARIANT_COUNT;
 
 /// The number of variables the shift reduction's sumcheck binds outside the word index.
 ///
-/// The claim sums over five axes: the shift variant, the shift amount, the bit position within a
-/// word, the bit index the shift indicators read, and the word index. This counts the first four;
-/// the word index is sized by the constraint system.
-pub const SHIFT_LOG_VARS: usize = Word::LOG_BITS * 3 + LOG_SHIFT_VARIANT_COUNT;
+/// A shifted value index names two shifts applied in sequence, so the claim sums over two shift
+/// slots — a variant and an amount each — and three bit indices: the witness bit the inner shift
+/// reads, the intermediate-word bit the two indicators meet at, and the output bit the oblong
+/// weights attach to. This counts all of those; the word index is sized by the constraint system.
+pub const SHIFT_LOG_VARS: usize = Word::LOG_BITS * 3 + 2 * LOG_SHIFT_COUNT;
 
 /// The number of index bits one shift slot occupies: the variant above the amount.
 ///

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -19,13 +19,6 @@ use binius_utils::{
 
 use super::SHIFT_COUNT;
 
-/// Why a term's outer shift slot must hold the identity in the two-phase reduction.
-///
-/// A shift key names one shift, so the reduction reads the inner slot and ignores the outer one.
-/// A term carrying both would verify against the wrong shifted word.
-const DOUBLE_SHIFT_UNSUPPORTED: &str =
-	"the two-phase shift reduction reads only the inner shift of a term";
-
 /// A [`FieldFn`] evaluating one operation's monster multilinear polynomial.
 ///
 /// The monster multilinear encodes all `ARITY`-operand constraints of a single operation (BitAnd,
@@ -177,7 +170,6 @@ where
 			let mut constraint_eval = E::zero();
 			for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 				for svi in operand {
-					assert!(!svi.is_doubly_shifted(), "{DOUBLE_SHIFT_UNSUPPORTED}");
 					let inner = svi.inner().index() * ARITY + operand_id;
 					let outer = svi.outer().index();
 					constraint_eval += operand_shift_scalars[inner].clone()
@@ -224,7 +216,6 @@ where
 				let mut constraint_eval = F::ZERO;
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
-						assert!(!svi.is_doubly_shifted(), "{DOUBLE_SHIFT_UNSUPPORTED}");
 						let inner = svi.inner().index() * ARITY + operand_id;
 						let outer = svi.outer().index();
 						constraint_eval += operand_shift_scalars[inner]
@@ -309,7 +300,11 @@ mod tests {
 	/// one array of operands per constraint.
 	///
 	/// Every term names a private word, so the constant and inout runs of the word-index tensor
-	/// stay empty.
+	/// stay empty. Terms are drawn across all three classes — unshifted, singly shifted and doubly
+	/// shifted — so both slots' tables are read at more than one index.
+	///
+	/// The evaluation is a sum over whatever terms it is handed, so the sequences here need not be
+	/// canonical or non-collapsible the way a real constraint system's do.
 	fn random_and_constraints(
 		rng: &mut StdRng,
 		n_constraints: usize,
@@ -325,21 +320,25 @@ mod tests {
 			ShiftVariant::Sra32,
 			ShiftVariant::Rotr32,
 		];
+		let random_shift = |rng: &mut StdRng| Shift {
+			variant: shift_variants[rng.random_range(0..SHIFT_VARIANT_COUNT)],
+			amount: rng.random_range(0..Word::BITS) as u8,
+		};
 		(0..n_constraints)
 			.map(|_| {
 				AndConstraint(std::array::from_fn(|_| {
 					(0..rng.random_range(0..=3))
 						.map(|_| {
-							// The reduction reads the inner slot, so the fixture leaves the outer
-							// one at the identity.
-							ShiftedValueIndex::single(
-								ValueIndex::private(rng.random_range(0..n_words) as u32),
-								Shift {
-									variant: shift_variants
-										[rng.random_range(0..SHIFT_VARIANT_COUNT)],
-									amount: rng.random_range(0..Word::BITS) as u8,
-								},
-							)
+							let value_index =
+								ValueIndex::private(rng.random_range(0..n_words) as u32);
+							let inner = random_shift(rng);
+							// A third of the terms carry a second shift, so the outer table is read
+							// away from the identity as well as at it.
+							if rng.random_range(0..3) == 0 {
+								ShiftedValueIndex::new(value_index, [inner, random_shift(rng)])
+							} else {
+								ShiftedValueIndex::single(value_index, inner)
+							}
 						})
 						.collect()
 				}))
@@ -349,10 +348,12 @@ mod tests {
 
 	#[test]
 	fn evaluate_monster_scales_by_the_outer_slot_weight() {
-		// Invariant: the outer slot's weight reaches the evaluation, and reaches it as a factor.
+		// Invariant: the outer slot's weight reaches every term, and reaches it as a factor.
 		//
-		// Every term the fixture builds carries an identity outer shift, so index 0 is the only
-		// entry read. Scaling it must scale the whole evaluation by the same factor.
+		// The evaluation is linear in the outer table, and each term reads exactly one of its
+		// entries, so scaling the whole table scales the evaluation by the same factor. That holds
+		// however the fixture's terms are spread across the table, which is what lets the fixture
+		// carry doubly shifted terms rather than reading index 0 alone.
 		type F = BinaryField128bGhash;
 		let mut rng = StdRng::seed_from_u64(7);
 
@@ -374,27 +375,43 @@ mod tests {
 			eval_fn.call_native(&input)
 		};
 
-		// The identity-selecting table, which is what the two-phase reduction supplies.
-		let mut identity_selecting = [F::ZERO; SHIFT_COUNT];
-		identity_selecting[0] = F::ONE;
-		let baseline = eval_with_outer(&identity_selecting);
+		let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
+		let baseline = eval_with_outer(&outer);
 		// A non-degenerate fixture, or the scaling below proves nothing.
 		assert_ne!(baseline, F::ZERO);
 
-		// Scaling the entry every term reads scales the evaluation by the same factor.
+		// Scaling every entry scales the evaluation by the same factor.
 		let scale = F::random(&mut rng);
-		let mut scaled = [F::ZERO; SHIFT_COUNT];
-		scaled[0] = scale;
-		assert_eq!(eval_with_outer(&scaled), baseline * scale);
+		assert_eq!(eval_with_outer(&outer.map(|weight| weight * scale)), baseline * scale);
 
-		// Zeroing it kills the evaluation, so no term slipped past the outer factor.
+		// Zeroing the table kills the evaluation, so no term slipped past the outer factor.
 		assert_eq!(eval_with_outer(&[F::ZERO; SHIFT_COUNT]), F::ZERO);
 
-		// The weight of a shift the fixture never names must not enter. Only index 0 is read, so
-		// filling every other entry changes nothing.
-		let mut noise = [F::random(&mut rng); SHIFT_COUNT];
-		noise[0] = F::ONE;
-		assert_eq!(eval_with_outer(&noise), baseline);
+		// The identity-selecting table is what a term with no outer shift is weighed by, and it
+		// reproduces what a reduction over one shift slot would give the same terms.
+		let mut identity_selecting = [F::ZERO; SHIFT_COUNT];
+		identity_selecting[0] = F::ONE;
+		let singly_shifted_only = constraints
+			.iter()
+			.map(|constraint| {
+				AndConstraint(std::array::from_fn(|operand| {
+					constraint.0[operand]
+						.iter()
+						.filter(|svi| !svi.is_doubly_shifted())
+						.copied()
+						.collect()
+				}))
+			})
+			.collect::<Vec<_>>();
+		let shift_scalars = ShiftScalars {
+			inner: &inner,
+			outer: &identity_selecting,
+		};
+		let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
+		assert_eq!(
+			eval_with_outer(&identity_selecting),
+			OperationEvalFn::new(&singly_shifted_only, 0, 0, n_words).call_native(&input)
+		);
 	}
 
 	/// The native `WideMul` variant must produce exactly the same result as the generic

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -14,19 +14,22 @@ use binius_ip::{
 };
 use binius_math::{
 	BinarySubspace,
-	inner_product::inner_product_scalars,
 	line::extrapolate_line,
-	multilinear::eq::{
-		eq_ind_partial_eval_scalars, eq_ind_zero, eq_one_var, scaled_eq_ind_partial_eval,
-		scaled_eq_ind_partial_eval_scalars,
+	multilinear::{
+		eq::{
+			eq_ind_partial_eval_scalars, eq_ind_zero, eq_one_var, scaled_eq_ind_partial_eval,
+			scaled_eq_ind_partial_eval_scalars,
+		},
+		evaluate::evaluate_inplace_scalars,
 	},
 	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
 use getset::Getters;
 
 use super::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperationEvalFn, SHIFT_COUNT, SHIFT_LOG_VARS,
-	ShiftScalars, ZERO_ARITY, encode_operation_input, error::Error, shift_ind::evaluate_shift_inds,
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_COUNT, OperationEvalFn, SHIFT_COUNT,
+	SHIFT_LOG_VARS, ShiftScalars, ZERO_ARITY, encode_operation_input, error::Error,
+	shift_ind::evaluate_shift_inds,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -108,15 +111,25 @@ pub struct VerifyOutput<F> {
 	intmul_lambda: F,
 	/// Random coefficient for batching BMUL constraint evaluations.
 	binmul_lambda: F,
-	/// Challenge point for the bit index variables (length `Word::LOG_BITS`).
+	/// Challenge point for the witness bit index (length `Word::LOG_BITS`).
 	pub r_j: Vec<F>,
-	/// Challenge point for the shift-amount variables (length `Word::LOG_BITS`).
-	pub r_s: Vec<F>,
-	/// Challenge point for the shift-variant variables (length `LOG_SHIFT_VARIANT_COUNT`).
-	pub r_v: Vec<F>,
+	/// Challenge point for the inner shift's amount variables (length `Word::LOG_BITS`).
+	pub r_s_inner: Vec<F>,
+	/// Challenge point for the inner shift's variant variables (length
+	/// `LOG_SHIFT_VARIANT_COUNT`).
+	pub r_v_inner: Vec<F>,
+	/// Challenge point for the outer shift's amount variables (length `Word::LOG_BITS`).
+	pub r_s_outer: Vec<F>,
+	/// Challenge point for the outer shift's variant variables (length
+	/// `LOG_SHIFT_VARIANT_COUNT`).
+	pub r_v_outer: Vec<F>,
 	/// Challenge point for the word index variables (length `log_segment_words`).
 	pub r_y: Vec<F>,
-	/// Challenge point for the bit index the shift indicators read (length `Word::LOG_BITS`).
+	/// Challenge point for the bit index of the intermediate word, where the two shift indicators
+	/// meet (length `Word::LOG_BITS`).
+	pub r_k: Vec<F>,
+	/// Challenge point for the output bit index the oblong weights attach to (length
+	/// `Word::LOG_BITS`).
 	pub r_i: Vec<F>,
 	/// Challenge for the witness's segment selector variable.
 	pub r_segment: F,
@@ -136,14 +149,6 @@ impl<F> VerifyOutput<F> {
 		&self.r_j
 	}
 
-	/// Returns the challenge point for shift variables.
-	///
-	/// This corresponds to `Word::LOG_BITS` variables encoding
-	/// the shift operations in the constraint system.
-	pub fn r_s(&self) -> &[F] {
-		&self.r_s
-	}
-
 	/// Returns the challenge point for word index variables.
 	///
 	/// This corresponds to `log_word_count` variables indexing
@@ -159,13 +164,15 @@ impl<F> VerifyOutput<F> {
 /// 1. **Sampling Phase**: Samples random lambda coefficients for batching bitand, intmul and binmul
 ///    evaluation claims across operands.
 /// 2. **Sumcheck**: Verifies the batched evaluation claim over all `SHIFT_LOG_VARS +
-///    log_word_count` variables of the claim, degree 2 in each. The rounds bind the shift variant,
-///    then the shift amount, then the bit position within a word, then the bit index the shift
-///    indicators read, and last the word index — the order the prover's four phases need.
-/// 3. **Challenge Splitting**: Splits the challenge point into its `r_v`, `r_s`, `r_j`, `r_i` and
-///    `r_y` runs
+///    log_word_count` variables of the claim, degree 2 in each. A shifted value index names two
+///    shifts applied in sequence, and the rounds peel them from the output end inward: the outer
+///    shift's variant and amount, then the inner shift's, then the bit position within a word, then
+///    the intermediate word's bit index where the two shift indicators meet, then the output bit
+///    index, and last the word index — the order the prover's phases need.
+/// 3. **Challenge Splitting**: Splits the challenge point into its per-slot shift runs, its three
+///    bit-index runs and `r_y`
 /// 4. **Monster Multilinear Verification**: Checks that the claim the sumcheck reduced to matches
-///    the product of its four factors, for AND constraints (bitand), IMUL constraints (intmul) and
+///    the product of its five factors, for AND constraints (bitand), IMUL constraints (intmul) and
 ///    BMUL constraints (binmul)
 ///
 /// # Parameters
@@ -219,14 +226,22 @@ where
 	} = verify_sumcheck(SHIFT_LOG_VARS + log_word_count, 2, eval, channel)?;
 
 	// Reverse the challenges into the evaluation point, whose coordinates then run in increasing
-	// order of significance: the word index, the bit index the shift indicators read, the bit
-	// position within a word, the shift amount, and the shift variant. The rounds bind them in
-	// the opposite order — variant first, word index last — which is what admits the prover's
-	// four phases.
+	// order of significance: the word index, the output bit index, the intermediate bit index, the
+	// witness bit index, then the inner shift slot and the outer one. The rounds bind them in the
+	// opposite order — the outer shift first, the word index last — which is what admits the
+	// prover's phases, and which peels the two shifts from the output end inward.
 	point.reverse();
-	let r_v = point.split_off(log_word_count + Word::LOG_BITS * 3);
-	let r_s = point.split_off(log_word_count + Word::LOG_BITS * 2);
-	let r_j = point.split_off(log_word_count + Word::LOG_BITS);
+	debug_assert_eq!(point.len(), SHIFT_LOG_VARS + log_word_count);
+	// Where each run starts, counting up from the word index. `split_off` cuts from the top, so
+	// the runs come off in decreasing significance.
+	let bit_indices = log_word_count + Word::LOG_BITS * 3;
+	let inner_slot = bit_indices + LOG_SHIFT_COUNT;
+	let r_v_outer = point.split_off(inner_slot + Word::LOG_BITS);
+	let r_s_outer = point.split_off(inner_slot);
+	let r_v_inner = point.split_off(bit_indices + Word::LOG_BITS);
+	let r_s_inner = point.split_off(bit_indices);
+	let r_j = point.split_off(log_word_count + Word::LOG_BITS * 2);
+	let r_k = point.split_off(log_word_count + Word::LOG_BITS);
 	let r_i = point.split_off(log_word_count);
 	let mut r_y = point;
 	let r_segment = r_y.pop().expect("log_word_count >= 1");
@@ -241,8 +256,11 @@ where
 		r_j,
 		r_y,
 		r_segment,
-		r_s,
-		r_v,
+		r_s_inner,
+		r_v_inner,
+		r_s_outer,
+		r_v_outer,
+		r_k,
 		r_i,
 		eval,
 		witness_eval,
@@ -308,37 +326,45 @@ where
 		binmul_lambda,
 		eval,
 		r_j,
-		r_s,
-		r_v,
+		r_s_inner,
+		r_v_inner,
+		r_s_outer,
+		r_v_outer,
 		r_y,
 		r_segment,
+		r_k,
 		r_i,
 		witness_eval,
 	} = output;
 
-	// Two of the sumcheck's four factors depend on the bit index the middle rounds bound: the
-	// Lagrange weights of the univariate challenge, and the shift indicators interpolated over the
-	// variant axis. Both are evaluated at `r_i` alone.
-	let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime);
-	let l_tilde_eval = inner_product_scalars(l_tilde, eq_ind_partial_eval_scalars(r_i));
-	let shift_ind_eval =
-		inner_product_scalars(evaluate_shift_inds(r_i, r_j, r_s), eq_ind_partial_eval_scalars(r_v));
+	// Three of the sumcheck's five factors are the verifier's to evaluate from the bit-index
+	// challenges alone: the Lagrange weights of the univariate challenge at `r_i`, and the two
+	// shift indicators, one per slot of a term's shift sequence. The indicators chain through the
+	// intermediate word — the outer one carries the output bit down to `r_k`, the inner one carries
+	// `r_k` down to the witness bit — which is what makes a sequence of two shifts one index entry.
+	let l_tilde_eval =
+		evaluate_inplace_scalars(lagrange_evals_scalars(subspace, r_zhat_prime), r_i);
+	let outer_ind_eval =
+		evaluate_inplace_scalars(&mut evaluate_shift_inds(r_i, r_k, r_s_outer)[..], r_v_outer);
+	let inner_ind_eval =
+		evaluate_inplace_scalars(&mut evaluate_shift_inds(r_k, r_j, r_s_inner)[..], r_v_inner);
+	let shift_ind_eval = outer_ind_eval * inner_ind_eval;
 
 	// `monster_eval` is a function of purely public-channel-derived elements
-	// (`bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime` vectors, `r_s`, `r_v`,
-	// `r_y`) plus the constant `constraint_system`. Trade those Elems for plain field values, run
-	// the MLE evaluation in plaintext, and materialize the result as a single inout wire instead
-	// of building the entire sub-circuit in wrapper channels.
+	// (`bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime` vectors, both shift slots'
+	// challenges, `r_y`) plus the constant `constraint_system`. Trade those Elems for plain field
+	// values, run the MLE evaluation in plaintext, and materialize the result as a single inout
+	// wire instead of building the entire sub-circuit in wrapper channels.
 	//
-	// The two bit-index factors scale every shift scalar of the monster; they multiply the result
-	// out here rather than entering the function, which keeps its input free of `r_i`.
+	// The three bit-index factors scale every shift scalar of the monster; they multiply the result
+	// out here rather than entering the function, which keeps its input free of `r_i` and `r_k`.
 	let monster_eval = {
 		let zero_r_x_prime_len = zero_data.r_x_prime.len();
 		let bitand_r_x_prime_len = bitand_data.r_x_prime.len();
 		let intmul_r_x_prime_len = intmul_data.r_x_prime.len();
 		let binmul_r_x_prime_len = binmul_data.r_x_prime.len();
-		let r_s_len = r_s.len();
-		let r_v_len = r_v.len();
+		let r_s_len = r_s_inner.len();
+		let r_v_len = r_v_inner.len();
 		let r_y_len = r_y.len();
 
 		let inputs: Vec<C::Elem> = iter::once(zero_lambda.clone())
@@ -349,8 +375,10 @@ where
 			.chain(bitand_data.r_x_prime.iter().cloned())
 			.chain(intmul_data.r_x_prime.iter().cloned())
 			.chain(binmul_data.r_x_prime.iter().cloned())
-			.chain(r_s.iter().cloned())
-			.chain(r_v.iter().cloned())
+			.chain(r_s_inner.iter().cloned())
+			.chain(r_v_inner.iter().cloned())
+			.chain(r_s_outer.iter().cloned())
+			.chain(r_v_outer.iter().cloned())
 			.chain(r_y.iter().cloned())
 			.chain(iter::once(r_segment.clone()))
 			.collect();
@@ -388,13 +416,14 @@ where
 /// The inputs are the flat concatenation of these sections, in order:
 ///
 /// ```text
-/// zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_s.. | r_v.. | r_y..
+/// zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_s_inner.. | r_v_inner.. | r_s_outer.. | r_v_outer.. | r_y..
 /// ```
 ///
-/// The stored lengths recover each variable-length section from that flat slice.
+/// The stored lengths recover each variable-length section from that flat slice. Both shift slots
+/// have the same shape, so one pair of lengths covers the two.
 ///
-/// The h evaluation every shift scalar is scaled by is left out: it is a prover message, so
-/// [`check_eval`] multiplies it in outside.
+/// The bit-index factors every shift scalar is scaled by are left out: they depend on prover
+/// messages, so [`check_eval`] multiplies them in outside.
 struct MonsterEvalFn<'a> {
 	/// The AND, IMUL and BMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,
@@ -408,9 +437,9 @@ struct MonsterEvalFn<'a> {
 	intmul_r_x_prime_len: usize,
 	/// Length of the BinMul operator's `r_x_prime` section.
 	binmul_r_x_prime_len: usize,
-	/// Length of the `r_s` section (the shift-amount challenges).
+	/// Length of each `r_s` section (one shift slot's amount challenges).
 	r_s_len: usize,
-	/// Length of the `r_v` section (the shift-variant challenges).
+	/// Length of each `r_v` section (one shift slot's variant challenges).
 	r_v_len: usize,
 	/// Length of the `r_y` section (the column challenges).
 	r_y_len: usize,
@@ -481,9 +510,13 @@ impl MonsterEvalFn<'_> {
 		off += self.intmul_r_x_prime_len;
 		let binmul_r_x_prime_v = &vals[off..off + self.binmul_r_x_prime_len];
 		off += self.binmul_r_x_prime_len;
-		let r_s_v = &vals[off..off + self.r_s_len];
+		let r_s_inner_v = &vals[off..off + self.r_s_len];
 		off += self.r_s_len;
-		let r_v_v = &vals[off..off + self.r_v_len];
+		let r_v_inner_v = &vals[off..off + self.r_v_len];
+		off += self.r_v_len;
+		let r_s_outer_v = &vals[off..off + self.r_s_len];
+		off += self.r_s_len;
+		let r_v_outer_v = &vals[off..off + self.r_v_len];
 		off += self.r_v_len;
 		let r_y_v = &vals[off..off + self.r_y_len];
 		off += self.r_y_len;
@@ -532,24 +565,17 @@ impl MonsterEvalFn<'_> {
 		// sequence space — see the two-table split on the scalars type.
 		//
 		// Both are built once, so the Zero, BitAnd, IntMul and BinMul monster evaluations share
-		// them. Each is indexed by `variant * Word::BITS + amount`. The h evaluation scaling all of
-		// them is left for `check_eval` to multiply in.
-		let eq_r_v = eq_ind_partial_eval_scalars(r_v_v);
-		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
-		let inner_shift_scalars = Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
-			eq_r_v[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
-		}));
-
-		// The outer slot's table sits at the all-zero point: no challenges are drawn over its axes.
-		// There the indicator selects the identity, the only outer shift a term may carry.
-		//
-		//     index 0 = (Sll, 0) -> one
-		//     every other index  -> zero
-		//
-		// So a well-formed term's weight is what a single-shift reduction gives it.
-		let outer_shift_scalars = Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
-			if i == 0 { E::one() } else { E::zero() }
-		}));
+		// them. Each is indexed by `variant * Word::BITS + amount`. The bit-index factors scaling
+		// all of them are left for `check_eval` to multiply in.
+		let slot_scalars = |r_s: &[E], r_v: &[E]| {
+			let eq_r_v = eq_ind_partial_eval_scalars(r_v);
+			let eq_r_s = eq_ind_partial_eval_scalars(r_s);
+			Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
+				eq_r_v[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
+			}))
+		};
+		let inner_shift_scalars = slot_scalars(r_s_inner_v, r_v_inner_v);
+		let outer_shift_scalars = slot_scalars(r_s_outer_v, r_v_outer_v);
 		let shift_scalars = ShiftScalars {
 			inner: &inner_shift_scalars,
 			outer: &outer_shift_scalars,


### PR DESCRIPTION
Rebased onto main now that #2146 has merged. The lockstep change that turns the shift reduction into the one [binius.xyz#124](https://github.com/binius-zk/binius.xyz/pull/124) specifies ([BINIUS-487](https://linear.app/jimpo/issue/BINIUS-487)). Prover and verifier move together — the transcript changes. **This is where doubly shifted value indices first verify.**

## The sumcheck

One sumcheck over `36 + ℓ_words` variables, degree 2 in each, binding

```
O₂, S₂, O₁, S₁, J, K, I, Y
```

and closing on five factors:

```
δ_D~(r_î, r_i) · Z_cons~(r'_x, r_y, r_s₁, r_o₁, r_s₂, r_o₂)
              · shift-ind~(r_i, r_k, r_s₂, r_o₂)      the outer slot
              · shift-ind~(r_k, r_j, r_s₁, r_o₁)      the inner slot
              · w~(r_j, r_y)
```

Every variable occurs in exactly two of the five, which is what holds the degree at 2. The two indicators chain through the bits of the intermediate word — the outer carries the output bit down to `r_k`, the inner carries `r_k` down to the witness bit — and that word is never materialized; `K` is just one more sumcheck variable.

## Prover

Phase 1's new rounds landed in #2146. The rest is remapping:

| #124 phase | binds | here |
|---|---|---|
| 1 | `O₂, S₂` | `OuterShiftStage`, driven from `run_phase_1_sumcheck` |
| 2 | `O₁, S₁` | `Phase1SumcheckProver::Stage::Rows`, against `T[psi]` |
| 3 | `J` | `Stage::Bits` |
| 4 | `K` | `ShiftIndSumcheck` with weights `psi`, indicator at `(r_j, r_s₁, r_v₁)` |
| 5 | `I` | `ShiftIndSumcheck` again, weights `d`, indicator at `(r_k, r_s₂, r_v₂)` |
| 6 | `Y` | `prove_phase_2`, unchanged but for the outer weights |

**The row axis widens from 9 bits to 18**, keyed on the quadruple **outer-major** (`outer.index() << LOG_SHIFT_COUNT | inner.index()`), so the high bits are the ones the first rounds bind. `SparseShiftRows::fold` is index-space agnostic and needed no change; after the nine outer rounds the surviving indices *are* the inner shift indices, which is exactly what phase 2 wants. `DOUBLE_SHIFT_UNSUPPORTED` and its `debug_assert` are gone.

**The outer rounds are driven directly** rather than as a third `Stage`, which is the one place I departed from the issue's sketch. `prove_single` consumes its prover, and `psi` — the weights those rounds leave behind — has to outlive it, since phase 4 runs against them. `run_sumcheck` already drives its own sparse first round this way, so it's the existing idiom rather than a new one.

**No divisions.** Every scalar a later phase needs is a terminal fold: `G` from `g`, `psi` from `η`, the inner indicator's evaluation from `χ`. The handoff between the two `ShiftIndSumcheck` runs is `psi(r_k) = Σ_i d(i)·shift-ind(i, r_k, r_s₂, r_o₂)` — the same quantity from either side — which is why phase 5's claim is phase 4's `eval` with no inversion in between. Both handoffs are `debug_assert`ed in `prove`.

## Verifier

Small, because the structure was already there:

- `SHIFT_LOG_VARS` 21 → 36.
- The reversed point splits into eight runs instead of five; `VerifyOutput` grows `r_k` and the outer slot's `r_s`/`r_v`. `r_j` and `r_y` keep their meaning, so ring-switching and everything downstream is untouched.
- `evaluate_shift_inds` is called twice, each contracted against its own slot's variant tensor.
- `MonsterEvalFn` takes the outer slot's challenges and builds its table from them, in place of the identity-selecting constant. The slot-factorized `ShiftScalars` split was already in place, so this is one closure over both slots rather than a rewrite.
- Both `assert!(!svi.is_doubly_shifted())` are gone.

## `DenseShiftEncoding` ordering

`shift_indices` stops being ascending: the sequences sort lexicographically by `[inner, outer]` while the index is outer-major. Distinctness — the property `from_segments` actually needs — survives, so per your call on BINIUS-408 the doc comment is relaxed rather than the sort key changed.

## Costs

Prover: one extra `2^15` table build, nine extra sparse rounds at `O(2^6 · n_shift)`, six extra bit rounds at `O(2^6)`. `build_g` and phase 6 — the two that scale with the circuit — are untouched, so this should be lost in the noise.

Proof: 15 extra degree-2 round polynomials. At two coefficients each that's 30 field elements, ~480 bytes, plus 15 verifier rounds — paid by every circuit whether or not it uses double shifts, which is the tax you accepted on BINIUS-408. BINIUS-452 measures what it buys once the frontend emits pairs.

## Testing

The backend is fully exercisable here without the frontend, which still lowers at depth 1.

- **`create_double_shift_cs_with_witness`** in `prover/tests/shift.rs` is a hand-built system with five genuinely non-collapsible sequences — sign extension, a shift under a rotate, a byte masked off one end and back, the half-word family's own sign extension, and `sar` in the inner slot — plus one operand mixing unshifted, singly shifted and doubly shifted terms, which is what a compiler emitting pairs would produce. It asserts each sequence really is a `Composition::Pair` rather than trusting the comment, and it goes through `cs.validate()`, `cs.verify(&value_vec)` and the full prove/verify round trip.
- The verifier's monster fixture now draws a third of its terms doubly shifted, and `evaluate_monster_scales_by_the_outer_slot_weight` was rewritten around it: scaling the *whole* outer table scales the evaluation, which holds however the terms are spread, and the identity-selecting table is separately checked to reproduce what the singly shifted terms alone would give.
- `sparse_rounds_match_the_dense_prover` retargets to `Phase1SumcheckProver` directly, since `run_phase_1_sumcheck` now runs the outer rounds ahead of it.

Green on the rebase: `binius-prover` (60 + 15 + 1), `binius-m4-prover` (42), `binius-verifier` (10), and before it `binius-m4-verifier` (2) and `binius-recursion` (30 + 4). The recursion suite is the one worth naming — it builds a circuit mirroring the verifier, so 15 extra rounds was exactly the kind of thing that could have broken it. Workspace clippy clean over `--tests --benches --examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)