### PR TITLE
BINIUS-419: skip the logUp* pushforward sumcheck for transparent tables

### DIFF
--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -12,6 +12,9 @@
 //! unchanged. The pushforwards are the only oracles this protocol introduces, per
 //! [Soukhanov25, Section 3].
 //!
+//! [`prove_transparent`] is the variant for tables the verifier evaluates itself.
+//! It opens each `Y` against both `eq_z` and the table, and so needs no pushforward sumcheck.
+//!
 //! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 
 use binius_compute::Allocator;
@@ -130,34 +133,144 @@ where
 	}
 }
 
+/// The reduced claims of a committed logUp* proof over transparent tables.
+///
+/// Nothing is left on the tables or the pushforwards: both of a table's claims are opened here,
+/// against the one `Y` commitment. Only the index claims are the caller's to prove.
+pub struct LogupTransparentProof<F> {
+	/// The point the index claims are drawn from, spanning the deepest looker.
+	///
+	/// A looker over `n` variables is claimed at its **last `n`** coordinates.
+	pub index_eval_point: Vec<F>,
+	/// One entry per table, in the order the tables were given, holding that table's lookers'
+	/// index claims in its own looker order.
+	pub index_eval_claims: Vec<Vec<F>>,
+}
+
+/// Prove a logUp* reduction over transparent tables, with the pushforwards committed as oracles.
+///
+/// This wraps [`binius_ip_prover::logup_star::prove_reduction_transparent`] the way [`prove`] wraps
+/// the committed-table reduction. The reduction leaves two claims on each pushforward instead of
+/// one, and both are opened here through the channel:
+///
+/// ```text
+///     <Y, eq_z> = Y(z)      the fractional-addition leaf claim
+///     <Y, T>    = e         the product claim, against the transparent table itself
+/// ```
+///
+/// The two are queued in that order, matching
+/// [`binius_iop::logup_star::verify_transparent`](binius_iop::logup_star::verify_transparent).
+///
+/// # Arguments
+///
+/// The arguments of [`prove`]. The tables are transparent, so no oracle is committed for them;
+/// their multilinears are still needed, both by the reduction and by the product relation.
+///
+/// # Preconditions
+///
+/// The preconditions of [`prove`].
+#[tracing::instrument(skip_all, level = "debug", name = "logup* transparent (committed)")]
+pub fn prove_transparent<'a, F, P, Channel, A>(
+	tables: impl IntoIterator<Item = reduction::TableLookup<'a, P>>,
+	channel: &mut Channel,
+	alloc: &A,
+) -> LogupTransparentProof<F>
+where
+	F: BinaryField<Underlier: Divisible<u64>>,
+	P: PackedField<Scalar = F> + 'a,
+	Channel: IOPProverChannel<P, A>,
+	A: Allocator,
+{
+	let tables = tables.into_iter().collect::<Vec<_>>();
+
+	// Sample gamma, build the witnesses, then commit every Y before the reduction, exactly as
+	// [`prove`] does.
+	let gamma = channel.sample();
+	let (numerators, pushforwards) = witness::combined_lookers::<A, F, P>(alloc, gamma, &tables);
+	let oracles = tracing::debug_span!("Commit pushforwards").in_scope(|| {
+		pushforwards
+			.iter()
+			.map(|pushforward| channel.send_oracle(pushforward.as_view()))
+			.collect::<Vec<_>>()
+	});
+
+	let pushforward_slices = pushforwards
+		.iter()
+		.map(FieldBuffer::as_view)
+		.collect::<Vec<_>>();
+	let output = reduction::prove_reduction_transparent(
+		alloc,
+		gamma,
+		&tables,
+		numerators,
+		&pushforward_slices,
+		channel,
+	);
+
+	// Open both of a table's claims against its one pushforward commitment. The product relation
+	// weighs Y against a copy of the table drawn from the caller's allocator, since the channel
+	// owns its transparents until the opening runs.
+	let _open_guard = tracing::debug_span!("Open pushforward relations").entered();
+	for (oracle, pushforward, table, open) in izip!(oracles, pushforwards, &tables, &output.tables)
+	{
+		let leaf_eq = Hypercube::One
+			.expand(&open.pushforward_eval_point)
+			.build_in::<P, A>(alloc);
+		channel.prove_oracle_relation(oracle.clone(), leaf_eq, open.pushforward_eval_claim);
+		channel.prove_oracle_relation(
+			oracle.clone(),
+			FieldBuffer::from_view_in(alloc, table.table),
+			open.product_claim,
+		);
+		channel.finalize_oracle(oracle, pushforward);
+	}
+
+	LogupTransparentProof {
+		index_eval_point: output.index_eval_point,
+		index_eval_claims: output
+			.tables
+			.into_iter()
+			.map(|table| table.index_eval_claims)
+			.collect(),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use std::iter;
 
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
-		BinaryField1b, ExtensionField, Field,
+		BinaryField1b, ExtensionField, Field, PackedBinaryGhash1x128b,
 		arch::{OptimalB128, OptimalPackedB128},
 	};
+	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
+		basefold::compiler::BaseFoldVerifierCompiler,
 		channel::{OracleSpec, naive::NaiveVerifierChannel},
-		logup_star as verify_logup,
+		fri::MinProofSizeStrategy,
+		logup_star::{self as verify_logup, TransparentTableLookup},
+		merkle_tree::BinaryMerkleTreeScheme,
 	};
 	use binius_ip::logup_star::LookerClaim;
 	use binius_math::{
 		FieldBuffer,
-		multilinear::{Multilinear, hypercube::Hypercube},
+		multilinear::{Multilinear, evaluate::evaluate_inplace_scalars, hypercube::Hypercube},
+		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 		test_utils::{random_field_buffer, random_scalars},
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::channel::naive::NaiveProverChannel;
+	use crate::{basefold::compiler::BaseFoldProverCompiler, channel::naive::NaiveProverChannel};
 
 	type F = OptimalB128;
 	type P = OptimalPackedB128;
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	/// The commitment field is the GHASH 128-bit field; BaseFold uses a single-lane packing of it.
+	type BP = PackedBinaryGhash1x128b;
+	type Chal = HasherChallenger<StdDigest>;
 
 	// Embed a table position j into the field through the GF(2)-linear basis, as the protocol does.
 	//
@@ -253,10 +366,8 @@ mod tests {
 		);
 		assert_eq!(prover_proof.tables, verifier_proof.tables, "per-table claims ({shape})");
 
-		// A table's claim is at the first m coordinates of the shared table point; its lookers'
-		// claims are at their own suffixes of the shared index point.
+		// A table's claim is at the first m coordinates of the shared table point.
 		let table_point = &prover_proof.table_eval_point;
-		let index_point = &prover_proof.index_eval_point;
 		for (table_index, table) in tables.iter().enumerate() {
 			let m = table.values.log_len();
 			assert_eq!(
@@ -264,8 +375,29 @@ mod tests {
 				table.values.evaluate(&table_point[..m]),
 				"table claim wrong for table {table_index} ({shape})"
 			);
+		}
 
-			let claims = &prover_proof.tables[table_index].index_eval_claims;
+		let claims_by_table = prover_proof
+			.tables
+			.iter()
+			.map(|table| table.index_eval_claims.clone())
+			.collect::<Vec<_>>();
+		check_index_claims(&prover_proof.index_eval_point, &claims_by_table, tables, shape);
+	}
+
+	// Check every looker's index claim, given the claims grouped by table.
+	//
+	// A looker's claim is at its own suffix of the shared index point.
+	fn check_index_claims<Q>(
+		index_point: &[F],
+		claims_by_table: &[Vec<F>],
+		tables: &[TestTable<F, Q>],
+		shape: &str,
+	) where
+		Q: PackedField<Scalar = F>,
+	{
+		for (table_index, (table, claims)) in iter::zip(tables, claims_by_table).enumerate() {
+			let m = table.values.log_len();
 			assert_eq!(claims.len(), table.lookers.len(), "claim count ({shape})");
 			for (looker, claim) in iter::zip(&table.lookers, claims) {
 				let embedded = looker
@@ -330,6 +462,28 @@ mod tests {
 			.collect()
 	}
 
+	// Build the verifier-side claims for an instance whose tables are transparent.
+	//
+	// A test table is a random buffer, so its "succinct" MLE is just the evaluation of its values.
+	fn transparent_verifier_tables<'a, Q>(
+		tables: &'a [TestTable<F, Q>],
+	) -> Vec<TransparentTableLookup<'a, F>>
+	where
+		Q: PackedField<Scalar = F>,
+	{
+		iter::zip(verifier_tables(tables), tables)
+			.map(|(lookup, table)| {
+				let values = table.values.iter_scalars().collect::<Vec<_>>();
+				TransparentTableLookup {
+					lookup,
+					table_eval: Box::new(move |point: &[F]| {
+						evaluate_inplace_scalars(values.clone(), point)
+					}),
+				}
+			})
+			.collect()
+	}
+
 	/// Round-trip a whole instance over the naive channel and check every reduced claim.
 	fn check_prove_verify(spec: &[(usize, Vec<usize>)], seed: u64) {
 		let tables = random_instance::<F, P>(spec, seed);
@@ -358,6 +512,56 @@ mod tests {
 		verifier_channel.finish();
 
 		check_proofs(&prover_proof, &verifier_proof, &tables, &shape);
+	}
+
+	/// Round-trip a transparent-table instance over the naive channel.
+	///
+	/// The channel checks both relations on every pushforward, so a passing run already proves the
+	/// two claims the reduction left open. Only the index claims need checking here.
+	fn check_prove_verify_transparent(spec: &[(usize, Vec<usize>)], seed: u64) {
+		let tables = random_instance::<F, P>(spec, seed);
+		let shape = format!("{spec:?}");
+
+		// One oracle per table still: the pushforward Y. A transparent table commits nothing.
+		let specs = tables
+			.iter()
+			.map(|table| OracleSpec::new(table.values.log_len()))
+			.collect::<Vec<_>>();
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let mut prover_channel =
+			NaiveProverChannel::<F, _>::new(&mut prover_transcript, specs.clone());
+		let prover_proof = prove_transparent::<F, P, _, _>(
+			prover_tables(&tables),
+			&mut prover_channel,
+			&GlobalAllocator,
+		);
+		prover_channel.finish();
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel =
+			NaiveVerifierChannel::<F, _>::new(&mut verifier_transcript, &specs);
+		let verifier_proof = verify_logup::verify_transparent(
+			transparent_verifier_tables(&tables),
+			&mut verifier_channel,
+		)
+		.expect("verification succeeds");
+		verifier_channel.finish();
+
+		assert_eq!(
+			prover_proof.index_eval_point, verifier_proof.index_eval_point,
+			"index point ({shape})"
+		);
+		assert_eq!(
+			prover_proof.index_eval_claims, verifier_proof.index_eval_claims,
+			"index claims ({shape})"
+		);
+		check_index_claims(
+			&prover_proof.index_eval_point,
+			&prover_proof.index_eval_claims,
+			&tables,
+			&shape,
+		);
 	}
 
 	#[test]
@@ -396,6 +600,24 @@ mod tests {
 	}
 
 	#[test]
+	fn test_prove_verify_transparent_round_trip() {
+		// The transparent variant shares every step but the last, so one spread covers it: m << n,
+		// m == n, a wide table, a one-variable table, several lookers on one pushforward, and
+		// several tables with the deepest instance on either side.
+		for spec in [
+			vec![(2usize, vec![6usize])],
+			vec![(4, vec![4])],
+			vec![(5, vec![3])],
+			vec![(1, vec![4])],
+			vec![(3, vec![5, 5])],
+			vec![(3, vec![5, 3]), (2, vec![2, 6])],
+			vec![(4, vec![1]), (2, vec![3]), (5, vec![2])],
+		] {
+			check_prove_verify_transparent(&spec, 31);
+		}
+	}
+
+	#[test]
 	fn test_verifier_rejects_wrong_eval_claim() {
 		let mut tables = random_instance::<F, P>(&[(3, vec![5])], 3);
 		let specs = vec![OracleSpec::new(3)];
@@ -418,28 +640,73 @@ mod tests {
 		assert!(result.is_err(), "verifier must reject a wrong eval claim");
 	}
 
+	// Run a transparent-table instance over the real BaseFold channel.
+	//
+	// One witness-dependent (ZK) oracle per table — the pushforward Y, with 2^m entries — each
+	// carrying two relations that the channel folds together before its single FRI opening. The
+	// verifier's `finish` is folded into the result, so a caller can tell a rejected opening from
+	// an accepted one.
+	fn run_basefold_transparent(
+		tables: &[TestTable<F, BP>],
+	) -> Result<
+		(LogupTransparentProof<F>, verify_logup::LogupTransparentProof<F>),
+		verify_logup::Error,
+	> {
+		const LOG_INV_RATE: usize = 1;
+		const SECURITY_BITS: usize = 32;
+		let n_test_queries = SECURITY_BITS.div_ceil(LOG_INV_RATE);
+		let oracle_specs = tables
+			.iter()
+			.map(|table| OracleSpec::new_zk(table.values.log_len()))
+			.collect::<Vec<_>>();
+
+		let verifier_compiler = BaseFoldVerifierCompiler::new(
+			&BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
+			oracle_specs,
+			LOG_INV_RATE,
+			n_test_queries,
+			&MinProofSizeStrategy,
+		);
+
+		// Prove: commit the pushforwards with real FRI, run the reduction, open both relations.
+		let domain_context = GaoMateerOnTheFly::generate(verifier_compiler.max_log_domain_size());
+		let ntt = NeighborsLastSingleThread::new(domain_context);
+		let prover_compiler =
+			BaseFoldProverCompiler::<BP, _>::from_verifier_compiler(&verifier_compiler, ntt);
+
+		let mut prover_transcript = ProverTranscript::new(Chal::default());
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, Chal, _, _>(
+				&mut prover_transcript,
+				StdRng::seed_from_u64(8),
+				GlobalAllocator,
+			);
+
+		let alloc = GlobalAllocator;
+		let prover_proof =
+			prove_transparent::<F, BP, _, _>(prover_tables(tables), &mut prover_channel, &alloc);
+		prover_channel.finish();
+
+		// Verify: receive the pushforwards, run the reduction, open both relations for real.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, Chal, _>(&mut verifier_transcript);
+		let verifier_proof = verify_logup::verify_transparent(
+			transparent_verifier_tables(tables),
+			&mut verifier_channel,
+		)?;
+		verifier_channel.finish()?;
+
+		Ok((prover_proof, verifier_proof))
+	}
+
 	#[test]
 	fn test_basefold_round_trip() {
-		use binius_field::PackedBinaryGhash1x128b;
-		use binius_hash::{StdDigest, StdHashSuite};
-		use binius_iop::{
-			basefold::compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy,
-			merkle_tree::BinaryMerkleTreeScheme,
-		};
-		use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly};
-
-		use crate::basefold::compiler::BaseFoldProverCompiler;
-
-		// The commitment field is the GHASH 128-bit field; use a single-lane packing for BaseFold.
-		type BP = PackedBinaryGhash1x128b;
-		type Chal = HasherChallenger<StdDigest>;
-
 		// Two tables of different sizes, so the real FRI path carries one masked oracle per table
 		// and each is opened at its own prefix of the reduced point.
 		let spec = [(2usize, vec![6usize, 2usize]), (4, vec![3])];
 		let tables = random_instance::<F, BP>(&spec, 7);
 
-		// One witness-dependent (ZK) oracle per table: the pushforward Y, with 2^m entries.
 		const LOG_INV_RATE: usize = 1;
 		const SECURITY_BITS: usize = 32;
 		let n_test_queries = SECURITY_BITS.div_ceil(LOG_INV_RATE);
@@ -490,5 +757,40 @@ mod tests {
 		// The FRI openings already bound every Y to its claim.
 		// Cross-check the table and index claims against honest values.
 		check_proofs(&prover_proof, &verifier_proof, &tables, "basefold");
+	}
+
+	#[test]
+	fn test_basefold_transparent_round_trip() {
+		// Two tables of different sizes, so each pushforward oracle carries its own pair of
+		// relations into the one folded FRI opening.
+		let tables = random_instance::<F, BP>(&[(2usize, vec![6usize, 2usize]), (4, vec![3])], 7);
+
+		let (prover_proof, verifier_proof) =
+			run_basefold_transparent(&tables).expect("the batched FRI openings verify");
+
+		assert_eq!(prover_proof.index_eval_point, verifier_proof.index_eval_point, "index point");
+		assert_eq!(
+			prover_proof.index_eval_claims, verifier_proof.index_eval_claims,
+			"index claims"
+		);
+		check_index_claims(
+			&prover_proof.index_eval_point,
+			&prover_proof.index_eval_claims,
+			&tables,
+			"basefold transparent",
+		);
+	}
+
+	#[test]
+	fn test_basefold_transparent_rejects_wrong_eval_claim() {
+		// The transparent reduction hands the product claim back unchecked, so a perturbed
+		// looked-up evaluation survives it. Opening <Y, T> = e is what must reject.
+		let mut tables = random_instance::<F, BP>(&[(3usize, vec![5usize])], 3);
+		tables[0].lookers[0].eval_claim += F::ONE;
+
+		assert!(
+			run_basefold_transparent(&tables).is_err(),
+			"the opening must reject a wrong eval claim"
+		);
 	}
 }

--- a/crates/iop/src/logup_star.rs
+++ b/crates/iop/src/logup_star.rs
@@ -12,6 +12,9 @@
 //! unchanged. The pushforwards are the only oracles this protocol introduces, per
 //! [Soukhanov25, Section 3].
 //!
+//! [`verify_transparent`] is the variant for tables the verifier evaluates itself.
+//! It opens each `Y` against both `eq_z` and the table, and so needs no pushforward sumcheck.
+//!
 //! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 
 use binius_field::{BinaryField1b, ExtensionField, Field};
@@ -19,7 +22,7 @@ use binius_ip::logup_star as reduction;
 use binius_math::multilinear::hypercube::Hypercube;
 use itertools::izip;
 
-use crate::channel::{Error as ChannelError, IOPVerifierChannel};
+use crate::channel::{Error as ChannelError, IOPVerifierChannel, TransparentEvalFn};
 
 /// An error raised while verifying a committed logUp* reduction.
 #[derive(Debug, thiserror::Error)]
@@ -121,5 +124,97 @@ where
 		table_eval_point: output.table_eval_point,
 		index_eval_point: output.index_eval_point,
 		tables: output.tables,
+	})
+}
+
+/// One transparent table, the lookers that read it, and the closure evaluating its MLE.
+pub struct TransparentTableLookup<'a, Elem> {
+	/// The table's variable count and the claims of the lookers reading it.
+	pub lookup: reduction::TableLookup<'a, Elem>,
+	/// Evaluates the table's multilinear extension at a point of `lookup.n_vars` coordinates.
+	pub table_eval: TransparentEvalFn<Elem>,
+}
+
+/// The reduced claims of a committed logUp* verification over transparent tables.
+///
+/// Nothing is left on the tables or the pushforwards: both of a table's claims are opened here,
+/// against the one `Y` commitment. Only the index claims are the caller's to verify.
+pub struct LogupTransparentProof<Elem> {
+	/// The point the index claims are drawn from, spanning the deepest looker.
+	///
+	/// A looker over `n` variables is claimed at its **last `n`** coordinates.
+	pub index_eval_point: Vec<Elem>,
+	/// One entry per table, in the order the tables were given, holding that table's lookers'
+	/// index claims in its own looker order.
+	pub index_eval_claims: Vec<Vec<Elem>>,
+}
+
+/// Verify a logUp* reduction over transparent tables, with the pushforwards committed as oracles.
+///
+/// This wraps [`binius_ip::logup_star::verify_reduction_transparent`] the way [`verify`] wraps the
+/// committed-table reduction. The reduction leaves two claims on each pushforward instead of one,
+/// and both are opened here through the channel:
+///
+/// ```text
+///     <Y, eq_z> = Y(z)      the fractional-addition leaf claim
+///     <Y, T>    = e         the product claim, against the caller's transparent table
+/// ```
+///
+/// The two are queued in that order, so the prover must queue them the same way.
+/// A channel that batches an oracle's relations folds them into one opening.
+///
+/// # Arguments
+///
+/// * `tables` - One [`TransparentTableLookup`] per table, by value.
+/// * `channel` - The IOP verifier channel carrying the `Y` commitments.
+///
+/// # Errors
+///
+/// Returns an error when a pushforward commitment is missing or the reduction identity fails.
+pub fn verify_transparent<'a, F, C>(
+	tables: impl IntoIterator<Item = TransparentTableLookup<'a, C::Elem>>,
+	channel: &mut C,
+) -> Result<LogupTransparentProof<C::Elem>, Error>
+where
+	F: Field + ExtensionField<BinaryField1b>,
+	C: IOPVerifierChannel<F>,
+	C::Elem: From<F> + 'a,
+{
+	// The reduction consumes the lookups, so the transparent closures are split off up front.
+	let (lookups, table_evals): (Vec<_>, Vec<_>) = tables
+		.into_iter()
+		.map(|table| (table.lookup, table.table_eval))
+		.unzip();
+	let table_n_vars = lookups.iter().map(|table| table.n_vars).collect::<Vec<_>>();
+
+	// Sample gamma, then receive the commitments, exactly as [`verify`] does: the prover needs
+	// gamma to build the pushforwards, and the reduction's logUp challenges must bind them.
+	let gamma = channel.sample();
+	let oracles = table_n_vars
+		.iter()
+		.map(|&n_vars| channel.recv_oracle(n_vars, true))
+		.collect::<Result<Vec<_>, _>>()?;
+
+	let output = reduction::verify_reduction_transparent::<F, C>(&gamma, lookups, channel)?;
+
+	// Open both of a table's claims against its one pushforward commitment. The table side never
+	// reaches the caller: the product relation weighs Y directly against the transparent T.
+	for (oracle, table_eval, table) in izip!(oracles, table_evals, &output.tables) {
+		let point = table.pushforward_eval_point.clone();
+		channel.verify_oracle_relation(
+			oracle.clone(),
+			Box::new(move |challenge: &[C::Elem]| Hypercube::One.eq_ind(&point, challenge)),
+			table.pushforward_eval_claim.clone(),
+		)?;
+		channel.verify_oracle_relation(oracle, table_eval, table.product_claim.clone())?;
+	}
+
+	Ok(LogupTransparentProof {
+		index_eval_point: output.index_eval_point,
+		index_eval_claims: output
+			.tables
+			.into_iter()
+			.map(|table| table.index_eval_claims)
+			.collect(),
 	})
 }

--- a/crates/ip-prover/src/logup_star/mod.rs
+++ b/crates/ip-prover/src/logup_star/mod.rs
@@ -32,6 +32,10 @@ mod prove;
 mod pushforward;
 pub mod witness;
 
-pub use binius_ip::logup_star::{LogupOutput, LogupTableOutput};
+pub use binius_ip::logup_star::{
+	LogupOutput, LogupTableOutput, LogupTransparentOutput, LogupTransparentTableOutput,
+};
 
-pub use self::prove::{Looker, TableLookup, prove, prove_reduction};
+pub use self::prove::{
+	Looker, TableLookup, prove, prove_reduction, prove_reduction_transparent, prove_transparent,
+};

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -8,7 +8,9 @@ use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, PackedField};
 use binius_ip::{
 	fracaddcheck::FracAddEvalClaim,
-	logup_star::{LogupOutput, LogupTableOutput},
+	logup_star::{
+		LogupOutput, LogupTableOutput, LogupTransparentOutput, LogupTransparentTableOutput,
+	},
 };
 use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univariate};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -117,6 +119,40 @@ where
 	prove_reduction(alloc, gamma, &tables, numerators, &pushforward_slices, channel)
 }
 
+/// Prove a logUp* reduction over transparent tables, leaving the table side open.
+///
+/// This is the prover for [`binius_ip::logup_star::verify_reduction_transparent`], the counterpart
+/// of [`prove`] for a caller that evaluates its tables itself. It runs the same reduction and stops
+/// before the pushforward sumcheck, returning each table's two open claims on its pushforward.
+///
+/// # Arguments
+///
+/// The arguments of [`prove`]. The table multilinears are still needed: the reduction reads each
+/// one to build its table-side fractional-addition circuit.
+///
+/// # Preconditions
+///
+/// The preconditions of [`prove`].
+pub fn prove_transparent<'a, A, F, P>(
+	alloc: &A,
+	gamma: F,
+	tables: impl IntoIterator<Item = TableLookup<'a, P>>,
+	channel: &mut impl IPProverChannel<F>,
+) -> LogupTransparentOutput<F>
+where
+	A: Allocator,
+	F: BinaryField<Underlier: Divisible<u64>>,
+	P: PackedField<Scalar = F> + 'a,
+{
+	let tables = tables.into_iter().collect::<Vec<_>>();
+	let (numerators, pushforwards) = witness::combined_lookers::<A, F, P>(alloc, gamma, &tables);
+	let pushforward_slices = pushforwards
+		.iter()
+		.map(FieldBuffer::as_view)
+		.collect::<Vec<_>>();
+	prove_reduction_transparent(alloc, gamma, &tables, numerators, &pushforward_slices, channel)
+}
+
 /// Run the logUp* reduction over the pre-built witnesses `numerators` and pushforwards `Y_t`.
 ///
 /// This is the reduction core of [`prove`], split out so a caller can build the `Y_t` once and
@@ -154,6 +190,72 @@ pub fn prove_reduction<A, F, P>(
 	pushforwards: &[FieldSlice<'_, P>],
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
+where
+	A: Allocator,
+	F: BinaryField<Underlier: Divisible<u64>>,
+	P: PackedField<Scalar = F>,
+{
+	let LogupTransparentOutput {
+		index_eval_point,
+		tables: open_tables,
+	} = prove_reduction_transparent(alloc, gamma, tables, numerators, pushforwards, channel);
+
+	// Reduce every table's leaf claim on Y_t and its product claim <T_t, Y_t> = e_t to one shared
+	// evaluation point.
+	let table_witnesses =
+		izip!(tables, pushforwards, &open_tables).map(|(table, &pushforward, open)| TableWitness {
+			table: table.table,
+			pushforward,
+			eval_claim: open.product_claim,
+			pushforward_eval_claim: open.pushforward_eval_claim,
+			pushforward_eval_point: &open.pushforward_eval_point,
+		});
+	let PushforwardOutput {
+		table_eval_point,
+		table_eval_claims,
+		pushforward_eval_claims,
+	} = prove_pushforward(alloc, table_witnesses, channel);
+
+	LogupOutput {
+		table_eval_point,
+		index_eval_point,
+		tables: izip!(table_eval_claims, pushforward_eval_claims, open_tables)
+			.map(|(eval_claim, pushforward_claim, open)| LogupTableOutput {
+				eval_claim,
+				pushforward_claim,
+				index_eval_claims: open.index_eval_claims,
+			})
+			.collect(),
+	}
+}
+
+/// Run the transparent-table logUp* reduction over the pre-built witnesses.
+///
+/// This is the prover for [`binius_ip::logup_star::verify_reduction_transparent`], and the
+/// reduction core of [`prove_transparent`] the way [`prove_reduction`] is the core of [`prove`].
+/// It stops before the pushforward sumcheck, returning each table's two open claims on its `Y_t`.
+///
+/// # Arguments
+///
+/// The arguments of [`prove_reduction`].
+///
+/// # Preconditions
+///
+/// The preconditions of [`prove_reduction`].
+#[tracing::instrument(
+	skip_all,
+	level = "debug",
+	name = "logup* fracadd reduction",
+	fields(n_tables = tables.len())
+)]
+pub fn prove_reduction_transparent<A, F, P>(
+	alloc: &A,
+	gamma: F,
+	tables: &[TableLookup<'_, P>],
+	numerators: Vec<Vec<FieldVec<P, A>>>,
+	pushforwards: &[FieldSlice<'_, P>],
+	channel: &mut impl IPProverChannel<F>,
+) -> LogupTransparentOutput<F>
 where
 	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
@@ -330,40 +432,25 @@ where
 	}
 	channel.send_many(&pushforward_evals);
 
-	// Reduce every table's leaf claim on Y_t and its product claim <T_t, Y_t> = e_t to one shared
-	// evaluation point.
-	let table_witnesses =
-		izip!(tables, pushforwards, &table_leaves).map(|(table, &pushforward, leaf)| {
-			// Its lookers are weighted gamma^0, gamma^1, ..., so the combination is the univariate
-			// evaluation of their claims at gamma.
-			let claims = table
-				.lookers
-				.iter()
-				.map(|looker| looker.eval_claim)
-				.collect::<Vec<_>>();
-			let eval_claim = evaluate_univariate(&claims, &gamma);
-			TableWitness {
-				table: table.table,
-				pushforward,
-				eval_claim,
-				pushforward_eval_claim: leaf.num_eval,
-				pushforward_eval_point: &leaf.point,
-			}
-		});
-	let PushforwardOutput {
-		table_eval_point,
-		table_eval_claims,
-		pushforward_eval_claims,
-	} = prove_pushforward(alloc, table_witnesses, channel);
-
-	LogupOutput {
-		table_eval_point,
+	// Every table's two claims on its pushforward: the leaf claim at the leaf point, and the
+	// product claim binding <T_t, Y_t> to the gamma-combination of its lookers' claims.
+	LogupTransparentOutput {
 		index_eval_point,
-		tables: izip!(table_eval_claims, pushforward_eval_claims, index_eval_claims)
-			.map(|(eval_claim, pushforward_claim, index_eval_claims)| LogupTableOutput {
-				eval_claim,
-				pushforward_claim,
-				index_eval_claims,
+		tables: izip!(tables, table_leaves, index_eval_claims)
+			.map(|(table, leaf, index_eval_claims)| {
+				// Its lookers are weighted gamma^0, gamma^1, ..., so the combination is the
+				// univariate evaluation of their claims at gamma.
+				let claims = table
+					.lookers
+					.iter()
+					.map(|looker| looker.eval_claim)
+					.collect::<Vec<_>>();
+				LogupTransparentTableOutput {
+					pushforward_eval_point: leaf.point,
+					pushforward_eval_claim: leaf.num_eval,
+					product_claim: evaluate_univariate(&claims, &gamma),
+					index_eval_claims,
+				}
 			})
 			.collect(),
 	}
@@ -456,20 +543,9 @@ mod tests {
 			.collect()
 	}
 
-	/// Round-trip a whole instance and check every reduced claim against the honest witness.
-	///
-	/// `spec` gives one `(table_n_vars, [looker_n_vars])` per table, so one helper covers the
-	/// single-table, multi-looker, unequal-length and multi-table shapes alike.
-	fn check_round_trip(spec: &[(usize, Vec<usize>)], seed: u64) {
-		let alloc = GlobalAllocator;
-		let tables = random_instance(spec, seed);
-		let shape = format!("{spec:?}");
-
-		// Prove, then replay the transcript through the verifier. Each table's batching challenge
-		// is the caller's to sample, one per table, before the reduction runs.
-		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let gamma = IPProverChannel::<F>::sample(&mut prover_transcript);
-		let prover_tables = tables
+	// The prover-side witnesses of an instance.
+	fn prover_tables(tables: &[TestTable]) -> Vec<TableLookup<'_, P>> {
+		tables
 			.iter()
 			.map(|table| TableLookup {
 				table: table.values.as_view(),
@@ -483,14 +559,12 @@ mod tests {
 					})
 					.collect(),
 			})
-			.collect::<Vec<_>>();
-		let prover_out =
-			prove::<GlobalAllocator, F, P>(&alloc, gamma, prover_tables, &mut prover_transcript);
+			.collect()
+	}
 
-		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verifier_gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
-		assert_eq!(verifier_gamma, gamma, "both sides must draw the same challenge ({shape})");
-		let verifier_tables = tables
+	// The verifier-side claims of an instance.
+	fn verifier_tables(tables: &[TestTable]) -> Vec<logup_star::TableLookup<'_, F>> {
+		tables
 			.iter()
 			.map(|table| logup_star::TableLookup {
 				n_vars: table.values.log_len(),
@@ -503,53 +577,33 @@ mod tests {
 					})
 					.collect(),
 			})
-			.collect::<Vec<_>>();
-		let verifier_out = logup_star::verify_reduction::<F, _>(
-			&verifier_gamma,
-			verifier_tables,
-			&mut verifier_transcript,
-		)
-		.expect("verification succeeds");
+			.collect()
+	}
 
-		// The prover and verifier must derive identical reduced claims from the same transcript.
-		assert_eq!(prover_out, verifier_out, "outputs disagree ({shape})");
-
-		// The table point spans the widest table; table t's claims are at its first m_t
-		// coordinates.
-		let table_point = &prover_out.table_eval_point;
-		for (table_index, table) in tables.iter().enumerate() {
-			let m = table.values.log_len();
-			let own_point = &table_point[..m];
-
-			assert_eq!(
-				prover_out.tables[table_index].eval_claim,
-				table.values.evaluate(own_point),
-				"table claim wrong for table {table_index} ({shape})"
-			);
-
-			// The honest pushforward of this table: its own lookers' numerators, weighted by
-			// gamma^i within the table — the same power series serves every table — scattered onto
-			// its cube.
-			let mut pushforward = vec![F::ZERO; 1usize << m];
-			for (looker, power) in iter::zip(&table.lookers, powers(gamma)) {
-				for (&j, &eq) in iter::zip(&looker.index, &looker.eq_r) {
-					pushforward[j] += power * eq;
-				}
+	// The honest pushforward of one table: its own lookers' numerators, weighted by gamma^i within
+	// the table — the same power series serves every table — scattered onto its cube.
+	fn honest_pushforward(table: &TestTable, gamma: F) -> FieldBuffer<P> {
+		let mut pushforward = vec![F::ZERO; table.values.len()];
+		for (looker, power) in iter::zip(&table.lookers, powers(gamma)) {
+			for (&j, &eq) in iter::zip(&looker.index, &looker.eq_r) {
+				pushforward[j] += power * eq;
 			}
-			let pushforward = FieldBuffer::<P>::from_values(&pushforward);
-			assert_eq!(
-				prover_out.tables[table_index].pushforward_claim,
-				pushforward.evaluate(own_point),
-				"pushforward claim wrong for table {table_index} ({shape})"
-			);
 		}
+		FieldBuffer::from_values(&pushforward)
+	}
 
-		// The index point spans the deepest looker; a looker's claim is at its last n coordinates,
-		// so a shorter looker reads a suffix of it. The claims come back grouped by table.
-		let index_point = &prover_out.index_eval_point;
-		for (table_index, table) in tables.iter().enumerate() {
+	// Check every looker's index claim, given the claims grouped by table.
+	//
+	// The index point spans the deepest looker; a looker's claim is at its last n coordinates, so a
+	// shorter looker reads a suffix of it.
+	fn check_index_claims(
+		index_point: &[F],
+		claims_by_table: &[Vec<F>],
+		tables: &[TestTable],
+		shape: &str,
+	) {
+		for (table_index, (table, claims)) in iter::zip(tables, claims_by_table).enumerate() {
 			let m = table.values.log_len();
-			let claims = &prover_out.tables[table_index].index_eval_claims;
 			assert_eq!(claims.len(), table.lookers.len(), "claim count ({shape})");
 			for (looker, claim) in iter::zip(&table.lookers, claims) {
 				let embedded = looker.index.iter().map(|&j| iota(j, m)).collect::<Vec<_>>();
@@ -563,6 +617,114 @@ mod tests {
 				);
 			}
 		}
+	}
+
+	/// Round-trip a whole instance and check every reduced claim against the honest witness.
+	///
+	/// `spec` gives one `(table_n_vars, [looker_n_vars])` per table, so one helper covers the
+	/// single-table, multi-looker, unequal-length and multi-table shapes alike.
+	fn check_round_trip(spec: &[(usize, Vec<usize>)], seed: u64) {
+		let alloc = GlobalAllocator;
+		let tables = random_instance(spec, seed);
+		let shape = format!("{spec:?}");
+
+		// Prove, then replay the transcript through the verifier. The batching challenge is the
+		// caller's to sample, before the reduction runs.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let gamma = IPProverChannel::<F>::sample(&mut prover_transcript);
+		let prover_out = prove::<GlobalAllocator, F, P>(
+			&alloc,
+			gamma,
+			prover_tables(&tables),
+			&mut prover_transcript,
+		);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let verifier_gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
+		assert_eq!(verifier_gamma, gamma, "both sides must draw the same challenge ({shape})");
+		let verifier_out = logup_star::verify_reduction::<F, _>(
+			&verifier_gamma,
+			verifier_tables(&tables),
+			&mut verifier_transcript,
+		)
+		.expect("verification succeeds");
+
+		// The prover and verifier must derive identical reduced claims from the same transcript.
+		assert_eq!(prover_out, verifier_out, "outputs disagree ({shape})");
+
+		// The table point spans the widest table; table t's claims are at its first m_t
+		// coordinates.
+		let table_point = &prover_out.table_eval_point;
+		for (table_index, table) in tables.iter().enumerate() {
+			let own_point = &table_point[..table.values.log_len()];
+
+			assert_eq!(
+				prover_out.tables[table_index].eval_claim,
+				table.values.evaluate(own_point),
+				"table claim wrong for table {table_index} ({shape})"
+			);
+			assert_eq!(
+				prover_out.tables[table_index].pushforward_claim,
+				honest_pushforward(table, gamma).evaluate(own_point),
+				"pushforward claim wrong for table {table_index} ({shape})"
+			);
+		}
+
+		let claims_by_table = prover_out
+			.tables
+			.iter()
+			.map(|table| table.index_eval_claims.clone())
+			.collect::<Vec<_>>();
+		check_index_claims(&prover_out.index_eval_point, &claims_by_table, &tables, &shape);
+	}
+
+	/// Round-trip the transparent-table variant and check both open claims on every pushforward.
+	fn check_transparent_round_trip(spec: &[(usize, Vec<usize>)], seed: u64) {
+		let alloc = GlobalAllocator;
+		let tables = random_instance(spec, seed);
+		let shape = format!("{spec:?}");
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let gamma = IPProverChannel::<F>::sample(&mut prover_transcript);
+		let prover_out = prove_transparent::<GlobalAllocator, F, P>(
+			&alloc,
+			gamma,
+			prover_tables(&tables),
+			&mut prover_transcript,
+		);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let verifier_gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
+		let verifier_out = logup_star::verify_reduction_transparent::<F, _>(
+			&verifier_gamma,
+			verifier_tables(&tables),
+			&mut verifier_transcript,
+		)
+		.expect("verification succeeds");
+		assert_eq!(prover_out, verifier_out, "outputs disagree ({shape})");
+
+		// Both open claims must be true statements about the honest witness, since the caller opens
+		// them against its Y commitment rather than having them checked here.
+		for (table_index, (table, out)) in iter::zip(&tables, &prover_out.tables).enumerate() {
+			let pushforward = honest_pushforward(table, gamma);
+			assert_eq!(
+				out.pushforward_eval_claim,
+				pushforward.evaluate(&out.pushforward_eval_point),
+				"leaf claim wrong for table {table_index} ({shape})"
+			);
+			assert_eq!(
+				out.product_claim,
+				table.values.inner_product(pushforward.as_view()),
+				"product claim wrong for table {table_index} ({shape})"
+			);
+		}
+
+		let claims_by_table = prover_out
+			.tables
+			.iter()
+			.map(|table| table.index_eval_claims.clone())
+			.collect::<Vec<_>>();
+		check_index_claims(&prover_out.index_eval_point, &claims_by_table, &tables, &shape);
 	}
 
 	#[test]
@@ -633,6 +795,80 @@ mod tests {
 		// Each table carries its own gamma and its own logUp challenge, so two tables holding the
 		// same values but different lookers must still both verify.
 		check_round_trip(&[(3, vec![4, 2]), (3, vec![5])], 29);
+	}
+
+	#[test]
+	fn test_prove_verify_transparent_round_trip() {
+		// The transparent variant shares every step but the last, so one spread covers it: m << n
+		// (the target regime), m == n, a wide table, and a one-variable table.
+		for (n, m) in [(6, 2), (4, 4), (3, 5), (7, 1)] {
+			check_transparent_round_trip(&[(m, vec![n])], 0);
+		}
+	}
+
+	#[test]
+	fn test_transparent_multi_table_round_trip() {
+		// Several tables of differing sizes, mixing looker counts and lengths, with the deepest
+		// instance on either side.
+		for spec in [
+			vec![(3usize, vec![5usize, 3usize]), (2, vec![2, 6])],
+			vec![(4, vec![1]), (2, vec![3]), (5, vec![2])],
+			vec![(1, vec![0]), (4, vec![3])],
+		] {
+			check_transparent_round_trip(&spec, 23);
+		}
+	}
+
+	#[test]
+	fn test_transparent_reduction_leaves_the_product_claim_unchecked() {
+		// The transparent reduction never reads a table, so it cannot catch a wrong looked-up
+		// evaluation: only the caller's opening of <T, Y> = e binds it. This pins that contract.
+		let alloc = GlobalAllocator;
+		let tables = random_instance(&[(3, vec![5])], 3);
+		let table = &tables[0];
+		let looker = &table.lookers[0];
+		let wrong_claim = looker.eval_claim + F::ONE;
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let gamma = IPProverChannel::<F>::sample(&mut prover_transcript);
+		prove_transparent::<GlobalAllocator, F, P>(
+			&alloc,
+			gamma,
+			[TableLookup {
+				table: table.values.as_view(),
+				lookers: vec![Looker {
+					index: &looker.index,
+					eval_point: &looker.eval_point,
+					eval_claim: wrong_claim,
+				}],
+			}],
+			&mut prover_transcript,
+		);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
+		let out = logup_star::verify_reduction_transparent::<F, _>(
+			&gamma,
+			[logup_star::TableLookup {
+				n_vars: 3,
+				lookers: vec![logup_star::LookerClaim {
+					eval_point: &looker.eval_point,
+					eval_claim: wrong_claim,
+				}],
+			}],
+			&mut verifier_transcript,
+		)
+		.expect("the reduction itself still verifies");
+
+		// The wrong claim comes straight back out, and it is not the honest inner product — which
+		// is exactly what the caller's opening would reject.
+		assert_eq!(out.tables[0].product_claim, wrong_claim);
+		assert_ne!(
+			out.tables[0].product_claim,
+			table
+				.values
+				.inner_product(honest_pushforward(table, gamma).as_view())
+		);
 	}
 
 	#[test]

--- a/crates/ip/src/logup_star/mod.rs
+++ b/crates/ip/src/logup_star/mod.rs
@@ -80,6 +80,20 @@
 //! So both can run as one `(m-1)`-variable sumcheck followed by one shared line-fold.
 //! That yields a single evaluation point, collapsing the two `Y` evaluations into one.
 //!
+//! # Transparent tables
+//!
+//! A transparent (succinct) table is one the verifier evaluates itself, without a commitment.
+//! Against such a table the product sumcheck is not needed at all.
+//! Both of the claims it would reduce are linear relations on the one multilinear `Y`:
+//!
+//! ```text
+//!     <Y, eq_z> = Y(z)      the fractional-addition leaf claim
+//!     <Y, T>    = e         the product claim
+//! ```
+//!
+//! A caller holding `Y` as a committed oracle opens the two together against that one commitment.
+//! [`verify_reduction_transparent`] stops the reduction there and hands both claims back.
+//!
 //! # Soundness
 //!
 //! - The logUp identity for a random `c` catches a wrong `Y` except with probability `(n + m) /
@@ -114,6 +128,6 @@ mod verify;
 
 pub use self::{
 	error::{Error, VerificationError},
-	output::{LogupOutput, LogupTableOutput},
-	verify::{LookerClaim, TableLookup, verify_reduction},
+	output::{LogupOutput, LogupTableOutput, LogupTransparentOutput, LogupTransparentTableOutput},
+	verify::{LookerClaim, TableLookup, verify_reduction, verify_reduction_transparent},
 };

--- a/crates/ip/src/logup_star/output.rs
+++ b/crates/ip/src/logup_star/output.rs
@@ -41,3 +41,44 @@ pub struct LogupTableOutput<F> {
 	/// order, each at that looker's own suffix of [`LogupOutput::index_eval_point`].
 	pub index_eval_claims: Vec<F>,
 }
+
+/// The open claims of a logUp* verification that leaves the table side unclosed.
+///
+/// This is what the reduction holds before the pushforward sumcheck runs.
+/// Each table keeps two claims on its pushforward and none on the table itself:
+///
+/// ```text
+///     <Y_t, eq_{z_t}> = Y_t(z_t)      the fractional-addition leaf claim
+///     <Y_t, T_t>      = e_t           the product claim
+/// ```
+///
+/// See [`super::verify_reduction_transparent`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogupTransparentOutput<F> {
+	/// The point the index evaluation claims are drawn from, of `max n` coordinates.
+	///
+	/// A looker whose column has `n` variables is claimed at the **last `n`** coordinates, exactly
+	/// as in [`LogupOutput::index_eval_point`].
+	pub index_eval_point: Vec<F>,
+	/// One entry per table, in the order the tables were given.
+	pub tables: Vec<LogupTransparentTableOutput<F>>,
+}
+
+/// The open claims belonging to one table whose table side is left unclosed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogupTransparentTableOutput<F> {
+	/// The fractional-addition leaf point `z_t`, of this table's own `m_t` coordinates.
+	pub pushforward_eval_point: Vec<F>,
+	/// The leaf claim `Y_t(z_t)` on this table's pushforward.
+	pub pushforward_eval_claim: F,
+	/// The product claim `e_t = <T_t, Y_t>`, an inner product over this table's `m_t`-variable
+	/// cube.
+	///
+	/// It is the gamma-combination of the claims of the lookers that read this table.
+	/// The reduction never reads a table, so this claim arrives unchecked: opening it is what
+	/// proves the lookups.
+	pub product_claim: F,
+	/// The claimed evaluations of this table's lookers' index multilinears `I`, in its own looker
+	/// order, each at that looker's own suffix of [`LogupTransparentOutput::index_eval_point`].
+	pub index_eval_claims: Vec<F>,
+}

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -13,7 +13,7 @@ use itertools::izip;
 
 use super::{
 	error::{Error, VerificationError},
-	output::{LogupOutput, LogupTableOutput},
+	output::{LogupOutput, LogupTableOutput, LogupTransparentOutput, LogupTransparentTableOutput},
 	pushforward::{Pushforward, TableClaim, denominator_eval, verify_pushforward},
 };
 use crate::{
@@ -131,6 +131,86 @@ pub fn verify_reduction<'a, F, C>(
 	tables: impl IntoIterator<Item = TableLookup<'a, C::Elem>>,
 	channel: &mut C,
 ) -> Result<LogupOutput<C::Elem>, Error>
+where
+	F: Field + ExtensionField<BinaryField1b>,
+	C: IPVerifierChannel<F>,
+	C::Elem: From<F> + 'a,
+{
+	let LogupTransparentOutput {
+		index_eval_point,
+		tables,
+	} = verify_reduction_transparent::<F, C>(gamma, tables, channel)?;
+
+	// Reduce every table's leaf claim on Y_t and its product claim <T_t, Y_t> = e_t to one shared
+	// evaluation point.
+	let table_claims = tables.iter().map(|table| TableClaim {
+		eval_claim: table.product_claim.clone(),
+		pushforward_eval_claim: table.pushforward_eval_claim.clone(),
+		pushforward_eval_point: &table.pushforward_eval_point,
+	});
+	let Pushforward {
+		table_eval_point,
+		table_eval_claims,
+		pushforward_eval_claims,
+	} = verify_pushforward::<F, C>(table_claims, channel)?;
+
+	Ok(LogupOutput {
+		table_eval_point,
+		index_eval_point,
+		tables: izip!(table_eval_claims, pushforward_eval_claims, tables)
+			.map(|(eval_claim, pushforward_claim, table)| LogupTableOutput {
+				eval_claim,
+				pushforward_claim,
+				index_eval_claims: table.index_eval_claims,
+			})
+			.collect(),
+	})
+}
+
+/// Verify a logUp* reduction over transparent tables, leaving the table side open.
+///
+/// The same reduction as [`verify_reduction`], stopped one step short of the pushforward sumcheck.
+/// Each table ends with two claims on its pushforward and none on itself:
+///
+/// ```text
+///     <Y_t, eq_{z_t}> = Y_t(z_t)      the fractional-addition leaf claim
+///     <Y_t, T_t>      = e_t           the product claim
+/// ```
+///
+/// Both are linear relations on the one multilinear `Y_t`.
+/// A caller holding `Y_t` as a committed oracle opens the two together against that commitment.
+/// Skipping the sumcheck drops `max m` rounds of round polynomials and two evaluations per table.
+/// It asks the verifier to evaluate `T_t` itself, so a committed table must use
+/// [`verify_reduction`].
+///
+/// # Arguments
+///
+/// * `gamma` - The looker batching challenge, as in [`verify_reduction`].
+/// * `tables` - One [`TableLookup`] per table.
+/// * `channel` - The verifier channel.
+///
+/// # Transcript layout
+///
+/// Steps 1 to 4 of [`verify_reduction`]'s layout, and nothing after them.
+///
+/// # Soundness
+///
+/// The returned product claims are **unchecked**: this routine never reads a table.
+/// A lookup claim is proved only once its caller opens `<Y_t, T_t> = e_t`.
+/// Everything else — the logUp identity that pins `Y_t` to the pushforward — is checked here.
+///
+/// # Preconditions
+///
+/// The preconditions of [`verify_reduction`].
+///
+/// # Errors
+///
+/// The errors of [`verify_reduction`], less the pushforward reduction, which does not run here.
+pub fn verify_reduction_transparent<'a, F, C>(
+	gamma: &C::Elem,
+	tables: impl IntoIterator<Item = TableLookup<'a, C::Elem>>,
+	channel: &mut C,
+) -> Result<LogupTransparentOutput<C::Elem>, Error>
 where
 	F: Field + ExtensionField<BinaryField1b>,
 	C: IPVerifierChannel<F>,
@@ -295,44 +375,32 @@ where
 		.assert_zero(leaf_den - evaluate_inplace_scalars(leaf_dens, selector_coords))
 		.map_err(|_| VerificationError::IncorrectIndexEvaluation)?;
 
-	// Reduce every table's leaf claim on Y_t and its product claim <T_t, Y_t> = e_t to one shared
-	// evaluation point. A table's product check binds it to the gamma-combination of the claims of
-	// the lookers that read it.
-	let table_claims = izip!(&tables, pushforward_evals, &table_points).map(
-		|(table, pushforward_eval_claim, &point)| {
-			// Its lookers are weighted gamma^0, gamma^1, ..., so the combination is the univariate
-			// evaluation of their claims at gamma.
+	// Every table's two claims on its pushforward: the leaf claim just read at the leaf point, and
+	// the product claim binding <T_t, Y_t> to the gamma-combination of the claims of the lookers
+	// that read it.
+	let tables = izip!(&tables, pushforward_evals, &table_points, index_eval_claims)
+		.map(|(table, pushforward_eval_claim, &point, index_eval_claims)| {
+			// Its lookers are weighted gamma^0, gamma^1, ..., so the combination is the
+			// univariate evaluation of their claims at gamma.
 			let claims = table
 				.lookers
 				.iter()
 				.map(|looker| looker.eval_claim.clone())
 				.collect::<Vec<_>>();
-			let eval_claim = evaluate_univariate(&claims, gamma);
-			TableClaim {
-				eval_claim,
+			LogupTransparentTableOutput {
+				pushforward_eval_point: point.to_vec(),
 				pushforward_eval_claim,
-				pushforward_eval_point: point,
+				product_claim: evaluate_univariate(&claims, gamma),
+				index_eval_claims,
 			}
-		},
-	);
-	let Pushforward {
-		table_eval_point,
-		table_eval_claims,
-		pushforward_eval_claims,
-	} = verify_pushforward::<F, C>(table_claims, channel)?;
+		})
+		.collect();
 
-	Ok(LogupOutput {
-		table_eval_point,
+	Ok(LogupTransparentOutput {
 		// Spans the deepest looker, not the whole node point: when a table is deeper than every
 		// looker its extra coordinates belong to the tables alone. A looker reads the last n.
 		index_eval_point: node_point[n_node_vars - max_n..].to_vec(),
-		tables: izip!(table_eval_claims, pushforward_eval_claims, index_eval_claims)
-			.map(|(eval_claim, pushforward_claim, index_eval_claims)| LogupTableOutput {
-				eval_claim,
-				pushforward_claim,
-				index_eval_claims,
-			})
-			.collect(),
+		tables,
 	})
 }
 

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -134,7 +134,8 @@ where
 	///
 	/// The output of this protocol is a set of evaluation claims on the `b` selectors representing
 	/// all of `a`, `b`, `c_lo` and `c_hi` as column-major bit matrices, at a common evaluation
-	/// point. The logup* pushforward commitment is opened through the channel inside phase 5.
+	/// point. The logup* pushforward commitment carries its two relations into the channel inside
+	/// phase 5.
 	pub fn prove(&mut self, witness: Witness<'_, 'alloc, A, P>) -> IntMulOutput<F> {
 		let Witness {
 			a_exponents,
@@ -277,9 +278,9 @@ where
 		drop(columns_guard);
 
 		// Read the N_LIMB_COLUMNS looked-up columns from the shared table via the committed multi-
-		// looker logup* reduction. The pushforward oracle is committed inside; its opening relation
-		// is returned to the caller. The reduction returns one index claim per column, all at the
-		// shared content point.
+		// looker logup* reduction. The pushforward oracle is committed inside; its opening
+		// relations are returned to the caller. The reduction returns one index claim per column,
+		// all at the shared content point.
 		let lookers = izip!(&index_columns, &twisted_claims)
 			.map(|(index, (twisted_point, twisted_eval))| Looker {
 				index,
@@ -288,14 +289,15 @@ where
 			})
 			.collect::<Vec<_>>();
 		let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
-		// Every limb column reads the one shared power table, so the reduction runs over a
-		// single-table list.
-		let logup_proof = logup_star::prove(
+		// The power table is succinct, so the transparent reduction runs: the pushforward is opened
+		// against the table itself instead of a sumcheck reducing the two to a shared point. Every
+		// limb column reads that one shared table.
+		let logup_proof = logup_star::prove_transparent(
 			[logup_star::TableLookup { table, lookers }],
 			self.channel,
 			self.alloc,
 		);
-		let [table_output] = logup_proof.tables.as_slice() else {
+		let [column_index_evals] = logup_proof.index_eval_claims.as_slice() else {
 			unreachable!("the reduction runs over the one power table")
 		};
 
@@ -315,7 +317,7 @@ where
 		// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by
 		// sampling ρ, so the final unification runs over the content variables only.
 		let rho = self.channel.sample_many(log_cols);
-		let mut padded_column_evals = table_output.index_eval_claims.clone();
+		let mut padded_column_evals = column_index_evals.clone();
 		padded_column_evals.resize(1 << log_cols, F::ZERO);
 		let folded_index_claim = FieldBuffer::<P>::from_values(&padded_column_evals).evaluate(&rho);
 		let rho_tensor = Hypercube::One.expand(&rho).build_scalars();

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -5,7 +5,10 @@ use std::iter;
 
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, field::FieldOps};
-use binius_iop::{channel::IOPVerifierChannel, logup_star};
+use binius_iop::{
+	channel::IOPVerifierChannel,
+	logup_star::{self, TransparentTableLookup},
+};
 use binius_ip::{
 	channel::IPVerifierChannel,
 	logup_star::{LookerClaim, TableLookup},
@@ -239,11 +242,12 @@ where
 ///
 /// The per-limb claims from Phase 4 are Frobenius-twisted onto the shared table of generator
 /// powers `i ↦ g^i`, batched to a single stacked lookup claim, and read from the table via a
-/// committed logup* reduction. The reduced table claim is checked against the table's succinct
-/// MLE; the pushforward claim is opened through the channel inside the reduction;
-/// the reduced index claims are carried into a final batched sumcheck — together with the
-/// $\widetilde{b}(r_I^b, \cdot)$ rerandomization and the parity zerocheck $a_0 \cdot b_0 =
-/// c_{\textsf{lo},0}$ — that brings every output claim to one shared point.
+/// committed logup* reduction. The table is succinct, so the reduction's transparent variant runs:
+/// the pushforward oracle carries both its claims into the channel opening, one against `eq_z` and
+/// one against the table's own MLE, and no table claim is left over. The reduced index claims are
+/// carried into a final batched sumcheck — together with the $\widetilde{b}(r_I^b, \cdot)$
+/// rerandomization and the parity zerocheck $a_0 \cdot b_0 = c_{\textsf{lo},0}$ — that brings every
+/// output claim to one shared point.
 fn verify_phase_5<F, C>(
 	phase_4_output: &Phase4Output<C::Elem>,
 	b_eval_point: &[C::Elem],
@@ -273,7 +277,7 @@ where
 		.collect::<Vec<_>>();
 
 	// Read the N_LIMB_COLUMNS looked-up columns from the shared table via the committed multi-
-	// looker logup* reduction. The pushforward oracle is received inside; its opening relation is
+	// looker logup* reduction. The pushforward oracle is received inside; its opening relations are
 	// returned to the caller. The reduction returns one index claim per column, all at the shared
 	// content point.
 	let looker_claims = twisted_claims
@@ -284,27 +288,27 @@ where
 		})
 		.collect::<Vec<_>>();
 	let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
-	// Every limb column reads the one shared power table, so the reduction runs over a single-table
-	// list and returns a single table claim.
-	let logup_proof = logup_star::verify::<F, C>(
-		[TableLookup {
-			n_vars: LIMB_BITS,
-			lookers: looker_claims,
+	// The power table is succinct, so the transparent reduction runs: it weighs the pushforward
+	// against the table's own MLE in the oracle opening rather than through a sumcheck, which
+	// leaves no table claim to check here. Every limb column reads that one shared table.
+	let logup_proof = logup_star::verify_transparent::<F, C>(
+		[TransparentTableLookup {
+			lookup: TableLookup {
+				n_vars: LIMB_BITS,
+				lookers: looker_claims,
+			},
+			table_eval: Box::new(eval_power_table_mle::<F, C::Elem>),
 		}],
 		channel,
 	)?;
-	let [table_output] = logup_proof.tables.as_slice() else {
+	let [column_index_evals] = logup_proof.index_eval_claims.as_slice() else {
 		unreachable!("the reduction runs over the one power table")
 	};
-
-	// The table is succinct: the verifier evaluates its MLE directly.
-	let expected_table_eval = eval_power_table_mle::<F, C::Elem>(&logup_proof.table_eval_point);
-	channel.assert_zero(expected_table_eval - table_output.eval_claim.clone())?;
 
 	// The reduction hands back the per-column embedded-index claims directly, all at the shared
 	// content point (padding columns read row 0, whose embedding is zero).
 	let index_content_point = logup_proof.index_eval_point.as_slice();
-	let mut padded_column_evals = table_output.index_eval_claims.clone();
+	let mut padded_column_evals = column_index_evals.clone();
 	padded_column_evals.resize(1 << log_cols, C::Elem::zero());
 
 	// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by sampling
@@ -460,12 +464,12 @@ where
 ///   shared table $T\colon i \mapsto g^i$ of $2^w$ generator powers (where $w$ is the limb bit
 ///   width). The per-limb claims are Frobenius-twisted onto $T$, batched to one stacked lookup
 ///   claim, and reduced via committed logup* ([Soukhanov25]): the pushforward oracle is committed
-///   mid-protocol and its opening relation returned to the caller; the table claim is checked
-///   against the table's succinct product-of-selects MLE; the index claim is bound to the per-bit
-///   output evals in a final batched sumcheck, together with (a) a single-claim rerandomization of
-///   the recombined $\widetilde{b}(r_I^b, \cdot)$ exponent claim from Phase 3 and (b) a zerocheck
-///   verifying $a_0 \cdot b_0 = c_{\textsf{lo},0}$ (least significant bits), ruling out the
-///   wraparound edge case.
+///   mid-protocol and its two opening relations returned to the caller, the second weighing it
+///   against the table's succinct product-of-selects MLE, so the table needs no claim of its own;
+///   the index claim is bound to the per-bit output evals in a final batched sumcheck, together
+///   with (a) a single-claim rerandomization of the recombined $\widetilde{b}(r_I^b, \cdot)$
+///   exponent claim from Phase 3 and (b) a zerocheck verifying $a_0 \cdot b_0 = c_{\textsf{lo},0}$
+///   (least significant bits), ruling out the wraparound edge case.
 ///
 /// [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 ///
@@ -474,7 +478,8 @@ where
 /// The protocol outputs evaluation claims on $\widetilde{a}_i$, $\widetilde{b}_i$,
 /// $\widetilde{c}_{\textsf{lo},i}$, $\widetilde{c}_{\textsf{hi},i}$ (for $i \in \{0, \ldots,
 /// 2^k - 1\}$) at a common $n$-dimensional evaluation point. The claims are passed to the shift
-/// reduction; the logup* pushforward commitment is opened through the channel inside phase 5.
+/// reduction; the logup* pushforward commitment carries its two relations into the channel inside
+/// phase 5.
 ///
 /// ### Parameters
 ///


### PR DESCRIPTION
@jimpo This one is a bit big because it took the approach of adding couple of new things; not sure if you had a better idea in mind for the approach.

Closes [BINIUS-419](https://linear.app/jimpo/issue/BINIUS-419/logup-special-handling-for-transparent-lookup-tables).

When a logUp* lookup table is transparent, the final pushforward sumcheck is unnecessary work: the two claims it reduces are already linear relations on the one committed pushforward, so the channel opening can carry both. Builds on [BINIUS-420](https://linear.app/jimpo/issue/BINIUS-420) (#2119), which let an oracle hold several relations.

### The problem

A logUp* reduction ends with two claims per table, and both read the **same** multilinear — that table's pushforward $Y_t$:

```
<Y_t, eq_{z_t}> = Y_t(z_t)      the fractional-addition leaf claim
<Y_t, T_t>      = e_t           the product claim
```

Today a batched degree-2 sumcheck over $\max_t m_t$ variables collapses the pair to one shared point.
It ends in one evaluation of $Y_t$ and one of $T_t$, and the caller must then check that table claim itself.

That is the right thing to do when $T_t$ is committed.
It is pure overhead when $T_t$ is **transparent** — a table the verifier evaluates directly from a succinct formula.

### The idea

Both claims are linear in $Y_t$, and $Y_t$ is a committed oracle.
So hand both to the channel as oracle relations and let the opening do the work:

```
relation 1:  <Y, eq_z> = Y(z)      transparent = the equality indicator at the leaf point
relation 2:  <Y, T>    = e         transparent = the table's own MLE
```

BaseFold folds an oracle's relations into one against a batching challenge $\lambda$, then opens once.
No sumcheck, no table claim, no extra FRI opening — $\lambda$ is a sampled challenge, so the second relation is free on the wire.

The saving is only available for a transparent $T_t$: relation 2 asks the verifier to weigh $Y_t$ against $T_t$ itself. A committed table still needs `verify_reduction`.

### Per table

For a table over $m$ variables, dropping the sumcheck removes:

- **before:** $m$ rounds $\times$ 2 round-polynomial coefficients, plus 2 evaluations sent at the end
- **after:** nothing on the wire; one more relation queued into the existing opening

→ $2m + 2$ field elements of proof, and $m$ rounds of folding two $2^m$-element columns of prover work.

### The change

Four paired entrypoints, one pair per layer. Each pair shares every step up to the pushforward checks.

| layer | committed table | transparent table |
|---|---|---|
| `binius-ip` | `verify_reduction` | `verify_reduction_transparent` |
| `binius-ip-prover` | `prove_reduction` / `prove` | `prove_reduction_transparent` / `prove_transparent` |
| `binius-iop` | `verify` | `verify_transparent` |
| `binius-iop-prover` | `prove` | `prove_transparent` |

The transparent function **is** the shared core; the committed one is a thin wrapper over it:

```diff
 pub fn verify_reduction(...) -> Result<LogupOutput<C::Elem>, Error> {
-    // ... the whole reduction, inline ...
-    let table_claims = /* per-table leaf + product claims */;
+    let LogupTransparentOutput { index_eval_point, tables } =
+        verify_reduction_transparent::<F, C>(gamma, tables, channel)?;
+
+    let table_claims = tables.iter().map(|table| TableClaim { ... });
     let Pushforward { .. } = verify_pushforward::<F, C>(table_claims, channel)?;
 }
```

So the two paths cannot drift, and the transcript prefix is bit-identical up to the point where they diverge.

The IOP verifier takes a `TransparentEvalFn` per table and queues both relations in a fixed order, which the prover mirrors:

```
verify_oracle_relation(Y, eq_z, Y(z))     // relation 1
verify_oracle_relation(Y, T,    e)        // relation 2
```

### Soundness

The logUp identity that pins $Y_t$ to the pushforward is checked exactly as before — the GKR, the leaf interpolation, the root denominator, the per-table challenges $c_t$ are all untouched.

What changes is where the product claim is enforced. `verify_reduction_transparent` returns it **unchecked**, because it never reads a table:

- a lookup claim is proved only once the caller opens `<Y_t, T_t> = e_t`;
- the channel's own $\lambda$-batching of an oracle's relations adds at most $\sum_i (k_i - 1)/|\mathbb{F}|$, with $k_i = 2$ here;
- $\lambda$ is drawn after every claim it combines is bound to the transcript, so no claim can be chosen as a function of it.

The contract is documented on the function and on the `product_claim` field, and pinned by two tests:

- `test_transparent_reduction_leaves_the_product_claim_unchecked` — a perturbed looker claim passes the IP reduction and comes back as a `product_claim` that is not the honest inner product;
- `test_basefold_transparent_rejects_wrong_eval_claim` — the real BaseFold opening rejects that same instance.

### Scope

- **new:** `verify_reduction_transparent` + `LogupTransparentOutput` / `LogupTransparentTableOutput` (`binius-ip`); `prove_reduction_transparent` + `prove_transparent` (`binius-ip-prover`); `verify_transparent` + `TransparentTableLookup` + `LogupTransparentProof` (`binius-iop`); `prove_transparent` + `LogupTransparentProof` (`binius-iop-prover`).
- **changed:** `verify_reduction` and `prove_reduction` are now wrappers over the transparent core — same signature, same transcript, same output.
- **changed:** intmul phase 5 (prover and verifier) switches to the transparent path.
- **untouched:** the pushforward sumcheck itself, on both sides. It is still the only path for a committed table.
- **not attempted:** mixing transparent and committed tables in one reduction. Each entrypoint takes one kind.

### intmul, the one transparent-table caller

intmul reads its fixed-base power table $i \mapsto g^i$ through logUp*, and that table is succinct — the verifier already evaluated its MLE as a product of selects. So phase 5 moves over, and the old `assert_zero(eval_power_table_mle(point) - table_claim)` disappears: the table's MLE is now the transparent of relation 2.

Its `LIMB_BITS` is 16, so the removed sumcheck is $16 \times 2 + 2 = 34$ field elements.

### Benchmark

M4 proof size for a circuit with IMUL constraints, measured end-to-end through the real FRI path:

| batch | before | after | saving |
|---|---|---|---|
| `log_instances = 0` | 200096 B | 199552 B | 544 B |
| `log_instances = 6` | 210752 B | 210208 B | 544 B |

Exactly the predicted $34 \times 16$ bytes, independent of batch size — the saving is per table, not per row. Prover-side, 16 rounds of folding two $2^{16}$-element columns also go away.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy` on the six touched crates, `--all-targets` — clean.
- nightly `cargo fmt --all` — applied.
- `binius-ip`, `binius-ip-prover`, `binius-iop-prover` logUp* tests: 34 pass, including new transparent round-trips over the naive channel **and** real BaseFold (multi-table, multi-looker, unequal-length, one-variable-table shapes), plus the two contract tests above.
- `binius-prover` intmul: 7 pass. `binius-m4-prover` IMUL end-to-end: 1 pass.
- logUp* and intmul sets re-run with `--features rayon`.

One thing worth a reviewer's eye: the recursive-verifier channels (`IronSpartanBuilderChannel`, `zk_wrapped_channel`) materialize one inout wire per relation, so each pushforward oracle now allocates one more. Both sides do it symmetrically per call, and `binius-verifier` compiles for those channels — but no test in the repo drives a recursive circuit with IMUL constraints, so that path is as unexercised as it was before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)