### PR TITLE
Drop redundant turbofish on rng.random() where the type is already named

### DIFF
--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -27,8 +27,8 @@ fn test_icmp_ult() {
 	let mut rng = StdRng::seed_from_u64(42);
 	for _ in 0..10000 {
 		let mut w = circuit.new_witness_filler();
-		w[a] = Word(rng.random::<u64>());
-		w[b] = Word(rng.random::<u64>());
+		w[a] = Word(rng.random());
+		w[b] = Word(rng.random());
 		w[expected] = Word(if w[a].0 < w[b].0 { u64::MAX } else { 0 });
 		w.circuit.populate_wire_witness(&mut w).unwrap();
 	}
@@ -49,8 +49,8 @@ fn test_icmp_eq() {
 	let mut rng = StdRng::seed_from_u64(42);
 	for _ in 0..10000 {
 		let mut w = circuit.new_witness_filler();
-		w[a] = Word(rng.random::<u64>());
-		w[b] = Word(rng.random::<u64>());
+		w[a] = Word(rng.random());
+		w[b] = Word(rng.random());
 		w[expected] = Word(if w[a].0 == w[b].0 { u64::MAX } else { 0 });
 		w.circuit.populate_wire_witness(&mut w).unwrap();
 	}

--- a/crates/frontend/src/gates/bxor_multi.rs
+++ b/crates/frontend/src/gates/bxor_multi.rs
@@ -97,11 +97,11 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(123);
 		for _ in 0..1000 {
 			let mut w = circuit.new_witness_filler();
-			w[a] = Word(rng.random::<u64>());
-			w[b] = Word(rng.random::<u64>());
-			w[c] = Word(rng.random::<u64>());
-			w[d] = Word(rng.random::<u64>());
-			w[e] = Word(rng.random::<u64>());
+			w[a] = Word(rng.random());
+			w[b] = Word(rng.random());
+			w[c] = Word(rng.random());
+			w[d] = Word(rng.random());
+			w[e] = Word(rng.random());
 
 			// Expected results
 			w[expected_3] = Word(w[a].0 ^ w[b].0 ^ w[c].0);
@@ -134,10 +134,10 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(456);
 		for _ in 0..100 {
 			let mut w = circuit.new_witness_filler();
-			w[a] = Word(rng.random::<u64>());
-			w[b] = Word(rng.random::<u64>());
+			w[a] = Word(rng.random());
+			w[b] = Word(rng.random());
 			w[expected_2] = Word(w[a].0 ^ w[b].0);
-			w[single] = Word(rng.random::<u64>());
+			w[single] = Word(rng.random());
 
 			w.circuit.populate_wire_witness(&mut w).unwrap();
 		}

--- a/crates/hash/src/blake3.rs
+++ b/crates/hash/src/blake3.rs
@@ -78,7 +78,7 @@ mod tests {
 		let n_leaves = 50;
 		// `u128` serializes to 16 little-endian bytes.
 		let leaves: Vec<Vec<u128>> = (0..n_leaves)
-			.map(|_| (0..4).map(|_| rng.random::<u128>()).collect())
+			.map(|_| (0..4).map(|_| rng.random()).collect())
 			.collect();
 
 		let digest = <ParallelDigestAdapter<blake3::Hasher> as ParallelDigest>::new();
@@ -108,7 +108,7 @@ mod tests {
 		// Leaves are `u8` items (BYTE_SIZE = 1), so `leaf_len` bytes == `leaf_len` items.
 		let mut check = |leaf_len: usize| {
 			let leaves: Vec<Vec<u8>> = (0..n_leaves)
-				.map(|_| (0..leaf_len).map(|_| rng.random::<u8>()).collect())
+				.map(|_| (0..leaf_len).map(|_| rng.random()).collect())
 				.collect();
 
 			// The scalar adapter that walks the Blake3 tree — the reference path.

--- a/crates/hash/src/sha256.rs
+++ b/crates/hash/src/sha256.rs
@@ -331,11 +331,7 @@ mod tests {
 		for n_items_per_input in [1, 2, 3, 4] {
 			let n_leaves = 50;
 			let leaves: Vec<Vec<u128>> = (0..n_leaves)
-				.map(|_| {
-					(0..n_items_per_input)
-						.map(|_| rng.random::<u128>())
-						.collect()
-				})
+				.map(|_| (0..n_items_per_input).map(|_| rng.random()).collect())
 				.collect();
 
 			let digest = ParallelSha256Digest::new();

--- a/crates/prover/benches/fold_across_words.rs
+++ b/crates/prover/benches/fold_across_words.rs
@@ -19,7 +19,7 @@ fn bench_fold_across_words(c: &mut Criterion) {
 		group.bench_with_input(BenchmarkId::from_parameter(n_words), &n_words, |b, &n_words| {
 			let mut rng = rand::rng();
 			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let point = random_scalars::<B128>(&mut rng, log_n_words);
 

--- a/crates/prover/benches/fold_words.rs
+++ b/crates/prover/benches/fold_words.rs
@@ -20,7 +20,7 @@ fn bench_fold_words(c: &mut Criterion) {
 		group.bench_with_input(BenchmarkId::from_parameter(n_words), &n_words, |b, &n_words| {
 			let mut rng = rand::rng();
 			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let vec = random_scalars::<B128>(&mut rng, Word::BITS);
 

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -357,7 +357,7 @@ mod test {
 
 		for n_words in windowing_shapes() {
 			let [a, b] = array::from_fn(|_| {
-				repeat_with(|| Word(rng.random::<u64>()))
+				repeat_with(|| Word(rng.random()))
 					.take(n_words)
 					.collect::<Vec<_>>()
 			});

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -787,7 +787,7 @@ mod tests {
 		let n_words = 1 << log_n;
 
 		let words = (0..n_words)
-			.map(|_| Word::from_u64(rng.random::<u64>()))
+			.map(|_| Word::from_u64(rng.random()))
 			.collect::<Vec<_>>();
 
 		let vec = random_scalars(&mut rng, Word::BITS);
@@ -823,10 +823,10 @@ mod tests {
 		for n_words in [0, 1, width, width + 1, 4 * width, 4 * width + 3, 40] {
 			// Two random operand columns of the chosen length.
 			let a_words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let b_words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			// The reference third column, materialized word-by-word.
 			let c_words = iter::zip(&a_words, &b_words)
@@ -905,7 +905,7 @@ mod tests {
 			(3, 0),
 		] {
 			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let index_scalars = random_scalars::<B128>(&mut rng, Word::BITS);
 			let row_scalars = random_field_buffer::<OptimalPackedB128>(&mut rng, log_rows);
@@ -995,7 +995,7 @@ mod tests {
 			let n_words = 1 << log_n;
 
 			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let point = random_scalars::<B128>(&mut rng, log_n);
 
@@ -1026,7 +1026,7 @@ mod tests {
 			(LOG_CHUNK_SIZE, 0),
 		] {
 			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let point = random_scalars::<B128>(&mut rng, log_rows);
 
@@ -1067,7 +1067,7 @@ mod tests {
 			let n_words = 1 << log_n;
 
 			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 			let point = random_scalars::<B128>(&mut rng, log_n);
 

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -666,7 +666,7 @@ mod tests {
 		let log_words = 3;
 		// A non-power-of-two word count exercises the implicit zero padding.
 		let words = (0..(1 << log_words) - 3)
-			.map(|_| Word::from_u64(rng.random::<u64>()))
+			.map(|_| Word::from_u64(rng.random()))
 			.collect::<Vec<_>>();
 		let r_j = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
 		let r_y = random_scalars::<B128>(&mut rng, log_words);


### PR DESCRIPTION
Removes the explicit type argument from 26 `rng.random::<T>()` calls whose enclosing expression already fixes `T`.
Test-and-bench code only. No behavior change.

### The problem

The type argument on `rng.random::<T>()` is often a restatement of something already on the line:

```rust
w[a] = Word(rng.random::<u64>());                    // struct Word(pub u64)
let words = (0..n).map(|_| Word::from_u64(rng.random::<u64>()));   // fn from_u64(value: u64)
let leaves: Vec<Vec<u128>> = ...map(|_| rng.random::<u128>())...;  // the binding names it
```

`Word` has exactly one field and it is a `u64`; `from_u64` takes exactly a `u64`.
The reader learns nothing from the turbofish, and it costs eight characters on lines that repeat many times.

### The idea

Drop the turbofish exactly where a **nominal** type already pins the parameter, and nowhere else.

That distinction is the whole safety argument. `rng.random()` resolves through `StandardUniform: Distribution<T>`, which is implemented for every integer type — so if the removal left `T` free, inference would fall back to `i32` and **silently** change what the test samples. Requiring a nominal pin rules that out: a tuple-struct field, a function parameter, or a `let` annotation leaves no free variable for fallback to reach.

Three shapes qualify, and all 26 removals are one of them:

- `Word(rng.random())` — the field type is `u64`
- `Word::from_u64(rng.random())` — the parameter type is `u64`
- `let leaves: Vec<Vec<u128>> = …` / `Vec<Vec<u8>>` — the binding annotation reaches the closure through `collect()`

### The change

```diff
-			w[a] = Word(rng.random::<u64>());
-			w[b] = Word(rng.random::<u64>());
+			w[a] = Word(rng.random());
+			w[b] = Word(rng.random());
```

| file | sites |
|---|---|
| `crates/frontend/src/gates/bxor_multi.rs` | 8 |
| `crates/prover/src/fold_word.rs` | 7 |
| `crates/frontend/src/builder/tests.rs` | 4 |
| `crates/hash/src/blake3.rs` | 2 |
| `crates/hash/src/sha256.rs` | 1 |
| `crates/prover/benches/fold_across_words.rs` | 1 |
| `crates/prover/benches/fold_words.rs` | 1 |
| `crates/prover/src/and_reduction/sumcheck_round_messages.rs` | 1 |
| `crates/verifier/src/protocols/shift/verify.rs` | 1 |

### What is deliberately left alone

18 sites keep their turbofish. Each one is load-bearing, and this is the part worth reviewing:

- **`crates/utils/src/random_access_sequence.rs`** — `rng.random::<u64>() as usize`.
  An `as` cast does not constrain inference, so removing this compiles *and* silently falls back to `i32`: a different range, and negative draws become huge `usize` values. The most dangerous case in the file, and the reason for the nominal-pin rule.

- **`B128::from(rng.random::<u128>())`** (3 sites in `binius-recursion`) — the compiler rejects the removal outright:

  ```
  error[E0283]: multiple `impl`s satisfying `BinaryField128bGhash: From<_>` found
    - impl From<AESTowerField8b> for BinaryField128bGhash;
    - impl From<BinaryField1b> for BinaryField128bGhash;
    - impl From<binius_field::arch::M128> for BinaryField128bGhash;
    - impl From<u128> for BinaryField128bGhash;
    - impl<T> From<T> for T;
  ```

  I tried it, read the error, and reverted. `M128`/`M256`/`M512::from` are the same story (`From<u128>`, `From<u64>`, `From<u32>`).

- **`let input_state = rng.random::<[u64; 25]>()`** (5 sites in `keccak/permutation.rs`), **`let input = rng.random::<u64>()`** (`ntt_lookup.rs`) — later use would pin these, but the turbofish is the only place the type appears, so removing it sends the reader hunting for no gain.

- **`rng.random::<u16>() & selector_mask`** (`selector_mle.rs`) — the `u16` documents the bitmask width; the pin would come from a different line via `BitAnd`.

- **`test_mul_packed_random::<PackedBinaryField256x1b>()`** and friends — not `rng.random()` at all, and the parameter is the entire content of the call.

I also checked the neighbouring turbofish clusters and left them: `collect::<Vec<_>>` (318 sites) already uses `_`; `any::<u128>` (proptest), `random_scalars::<F>`, `random_field_buffer::<P>`, `Vec::<T>::deserialize` and `Divisible::<U4>::` all state their type exactly once, so none of them are redundant.

### Scope

- **changed:** 26 expressions across 9 files, all inside `mod tests` or `benches/`.
- **untouched:** every production code path; no signature, no type, no runtime behavior.
- `rustfmt` collapsed one now-shorter closure in `sha256.rs` onto a single line — the only incidental reflow.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-frontend -p binius-hash -p binius-prover -p binius-verifier --all-targets` — clean.
- nightly `cargo fmt --all` — applied.
- No tests were run: `--all-targets` type-checks every test and bench, and a pure type-annotation change can only alter behavior by altering the inferred type, which the three nominal-pin shapes make impossible. If a removal had gone wrong it would have failed to compile, exactly as the `B128::from` sites did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)