### PR TITLE
Identify a hint by its registry slot, not by a hash of its name

### DIFF
--- a/crates/frontend/src/eval_form/builder.rs
+++ b/crates/frontend/src/eval_form/builder.rs
@@ -5,6 +5,7 @@
 use binius_core::constraint_system::ShiftVariant;
 
 use super::opcode::EvalOpcode;
+use crate::ir::hints::HintId;
 
 /// Builder for constructing bytecode during circuit compilation
 pub struct BytecodeBuilder {
@@ -245,14 +246,14 @@ impl BytecodeBuilder {
 	// Hint calls
 	pub fn emit_hint(
 		&mut self,
-		hint_id: u32,
+		hint_id: HintId,
 		dimensions: &[usize],
 		inputs: &[u32],
 		outputs: &[u32],
 	) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::Hint);
-		self.emit_u32(hint_id);
+		self.emit_u32(hint_id.as_u32());
 		self.emit_u16(dimensions.len() as u16);
 		for &dim in dimensions {
 			self.emit_u32(dim as u32);

--- a/crates/frontend/src/eval_form/const_eval.rs
+++ b/crates/frontend/src/eval_form/const_eval.rs
@@ -7,7 +7,10 @@ use binius_core::{Word, constraint_system::ShiftVariant};
 use super::exec::ghash_mul;
 use crate::{
 	gates::Opcode,
-	ir::{Gate, GateGraph, hints::HintRegistry},
+	ir::{
+		Gate, GateGraph,
+		hints::{HintId, HintRegistry},
+	},
 };
 
 /// Evaluates a gate whose inputs are all constant, returning the values of its output wires.
@@ -157,7 +160,7 @@ pub fn evaluate_gate_constants(
 			Ok(Vec::new())
 		}
 		Opcode::Hint => {
-			let hint_id = data.immediates[0];
+			let hint_id = HintId::from_u32(data.immediates[0]);
 			let (_n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
 			let mut outputs = vec![Word::ZERO; n_out];
 			hint_registry.execute(hint_id, &data.dimensions, constants, &mut outputs);

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -16,7 +16,10 @@ use binius_field::BinaryField128bGhash;
 use smallvec::{SmallVec, smallvec};
 
 use super::opcode::EvalOpcode;
-use crate::ir::{hints::HintRegistry, path::PathSpec};
+use crate::ir::{
+	hints::{HintId, HintRegistry},
+	path::PathSpec,
+};
 
 /// Multiplies two GHASH field elements ($\mathbb{F}_{2^{128}}$), each carried by a `(lo, hi)` pair
 /// of words — `lo` holds the coefficients of $1, X, \ldots, X^{63}$ and `hi` those of
@@ -434,7 +437,7 @@ impl<'a> Executor<'a> {
 
 	// Hint execution
 	fn exec_hint<C: EvalContext>(&mut self, ctx: &mut C) {
-		let hint_id = self.read_u32();
+		let hint_id = HintId::from_u32(self.read_u32());
 
 		// Read dimensions
 		let n_dimensions = self.read_u16() as usize;

--- a/crates/frontend/src/gates/mod.rs
+++ b/crates/frontend/src/gates/mod.rs
@@ -8,7 +8,11 @@
 
 use crate::{
 	eval_form::BytecodeBuilder,
-	ir::{Gate, GateData, GateGraph, GateParam, Wire, hints::HintRegistry, path::PathSpec},
+	ir::{
+		Gate, GateData, GateGraph, GateParam, Wire,
+		hints::{HintId, HintRegistry},
+		path::PathSpec,
+	},
 	lower::ConstraintBuilder,
 };
 
@@ -199,7 +203,7 @@ fn emit_hint(
 	wire_to_reg: impl Fn(Wire) -> u32,
 	hint_registry: &HintRegistry,
 ) {
-	let hint_id = data.immediates[0];
+	let hint_id = HintId::from_u32(data.immediates[0]);
 	let (n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
 	let input_regs: Vec<u32> = data.wires[..n_in].iter().map(|&w| wire_to_reg(w)).collect();
 	let output_regs: Vec<u32> = data.wires[n_in..n_in + n_out]

--- a/crates/frontend/src/ir/hints.rs
+++ b/crates/frontend/src/ir/hints.rs
@@ -8,19 +8,34 @@
 //! to verify.
 
 use std::{
-	collections::HashMap,
-	hash::{DefaultHasher, Hash, Hasher},
+	any::TypeId,
+	collections::{HashMap, hash_map::Entry},
 };
 
 use binius_core::Word;
 
-pub type HintId = u32;
+/// Names one hint by the slot it holds in a registry.
+///
+/// Slots are handed out from zero in registration order.
+/// So an identifier only means something against the registry that issued it.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HintId(u32);
+
+impl HintId {
+	/// The identifier as the bytecode encodes it.
+	pub(crate) const fn as_u32(self) -> u32 {
+		self.0
+	}
+
+	/// Reads an identifier back from its bytecode encoding.
+	pub(crate) const fn from_u32(raw: u32) -> Self {
+		Self(raw)
+	}
+}
 
 /// Hint handler trait for extensible operations.
 ///
-/// Each implementor declares a globally unique `NAME`. The registry identifies hints by the
-/// hash of this name (see [`hint_id_of`]), so registering the same hint twice is a no-op
-/// and every gate using the same hint type shares a single handler entry.
+/// A registry holds one slot per implementing type.
 ///
 /// # The `dimensions` parameter
 ///
@@ -40,7 +55,7 @@ pub type HintId = u32;
 /// - A parameterized hint reads limb counts from `dimensions` and derives its arity from them.
 /// - A fixed-arity hint ignores `dimensions` (an empty slice) and returns a constant shape.
 pub trait Hint: Send + Sync + 'static {
-	/// Globally unique name for this hint. Used to derive a stable [`HintId`].
+	/// A label for this hint, used in diagnostics.
 	const NAME: &'static str;
 
 	/// Compute the gate's input/output arity as a function of `dimensions`.
@@ -62,17 +77,6 @@ pub trait Hint: Send + Sync + 'static {
 	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]);
 }
 
-/// Derive a [`HintId`] from a hint's name.
-///
-/// Hashes the name with `std::hash::DefaultHasher` (fixed seed, deterministic across runs)
-/// and folds the resulting 64-bit value down to 32 bits by XORing its two halves.
-pub fn hint_id_of(name: &str) -> HintId {
-	let mut hasher = DefaultHasher::new();
-	name.hash(&mut hasher);
-	let h = hasher.finish();
-	(h as u32) ^ ((h >> 32) as u32)
-}
-
 /// Object-safe adapter so the registry can store hints behind `Box<dyn _>`.
 ///
 /// `Hint` itself is not dyn-compatible because it carries an associated `const NAME`.
@@ -92,34 +96,51 @@ impl<T: Hint> ErasedHint for T {
 	}
 }
 
-/// Registry for hint handlers keyed by [`HintId`].
-///
-/// Registration is idempotent: the same hint type always hashes to the same id, so a second
-/// call to [`HintRegistry::register`] with the same concrete type is a no-op.
+/// Holds the hints a circuit calls, one slot per hint type.
 pub struct HintRegistry {
-	handlers: HashMap<HintId, Box<dyn ErasedHint>>,
+	/// The registered hints, in registration order.
+	///
+	/// An identifier indexes this vector directly.
+	handlers: Vec<Box<dyn ErasedHint>>,
+	/// The slot each hint type holds.
+	///
+	/// The concrete type is a hint's identity, which no two distinct hints can share.
+	slots: HashMap<TypeId, HintId>,
 }
 
 impl HintRegistry {
 	pub fn new() -> Self {
 		Self {
-			handlers: HashMap::new(),
+			handlers: Vec::new(),
+			slots: HashMap::new(),
 		}
 	}
 
-	/// Register a hint, returning its stable [`HintId`]. No-op if the same hint is already
-	/// registered.
+	/// Registers a hint and returns its identifier.
+	///
+	/// A hint already registered keeps its identifier.
+	/// The handler passed here is then dropped.
 	pub fn register<T: Hint>(&mut self, handler: T) -> HintId {
-		let id = hint_id_of(T::NAME);
-		self.handlers.entry(id).or_insert_with(|| Box::new(handler));
-		id
+		// Borrowing the two fields apart lets the vacant arm append while the map entry is held.
+		let Self { handlers, slots } = self;
+		match slots.entry(TypeId::of::<T>()) {
+			Entry::Occupied(slot) => *slot.get(),
+			Entry::Vacant(slot) => {
+				let id = HintId::from_u32(
+					u32::try_from(handlers.len()).expect("a circuit calls fewer than 2^32 hints"),
+				);
+				handlers.push(Box::new(handler));
+				*slot.insert(id)
+			}
+		}
 	}
 
-	/// Compute the `(n_in, n_out)` arity of the hint identified by `hint_id`.
+	/// Computes the input and output arity of one hint, for the given dimensions.
 	pub fn shape(&self, hint_id: HintId, dimensions: &[usize]) -> (usize, usize) {
-		self.handlers[&hint_id].shape(dimensions)
+		self.handler(hint_id).shape(dimensions)
 	}
 
+	/// Runs one hint over its inputs, filling every output slot.
 	pub fn execute(
 		&self,
 		hint_id: HintId,
@@ -127,12 +148,127 @@ impl HintRegistry {
 		inputs: &[Word],
 		outputs: &mut [Word],
 	) {
-		self.handlers[&hint_id].execute(dimensions, inputs, outputs);
+		self.handler(hint_id).execute(dimensions, inputs, outputs);
+	}
+
+	/// The hint one identifier names.
+	///
+	/// # Panics
+	///
+	/// Panics unless this registry issued the identifier.
+	fn handler(&self, hint_id: HintId) -> &dyn ErasedHint {
+		self.handlers
+			.get(hint_id.as_u32() as usize)
+			.map(Box::as_ref)
+			.unwrap_or_else(|| {
+				panic!("no hint is registered under id {}", hint_id.as_u32());
+			})
 	}
 }
 
 impl Default for HintRegistry {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// Doubles its input.
+	struct Doubler;
+
+	impl Hint for Doubler {
+		// This name and "hint_50152" both fold to 407677619 under a 32-bit hash of the name.
+		// So a name cannot serve as an identity.
+		const NAME: &'static str = "hint_33476";
+
+		fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+			(1, 1)
+		}
+
+		fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+			outputs[0] = Word::from_u64(inputs[0].as_u64().wrapping_mul(2));
+		}
+	}
+
+	// Splits its input into low and high halves, for an arity the doubler does not share.
+	struct SplitHalves;
+
+	impl Hint for SplitHalves {
+		const NAME: &'static str = "hint_50152";
+
+		fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+			(1, 2)
+		}
+
+		fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+			outputs[0] = Word::from_u64(inputs[0].as_u64() & 0xffff_ffff);
+			outputs[1] = Word::from_u64(inputs[0].as_u64() >> 32);
+		}
+	}
+
+	#[test]
+	fn hints_whose_names_share_a_hash_keep_their_own_slots() {
+		// Invariant: a hint's identity is its concrete type, not its name.
+		//
+		// Both names fold to one 32-bit hash.
+		// Keying on that hash would give the two hints a single slot.
+		// The second registration would then resolve to the first hint's handler.
+		let mut registry = HintRegistry::new();
+		let doubler = registry.register(Doubler);
+		let split = registry.register(SplitHalves);
+
+		//     slot 0 <- Doubler
+		//     slot 1 <- SplitHalves
+		assert_ne!(doubler, split);
+
+		// Each identifier reports the arity of its own hint.
+		assert_eq!(registry.shape(doubler, &[]), (1, 1));
+		assert_eq!(registry.shape(split, &[]), (1, 2));
+
+		// 0x0000_000b_0000_0007 doubles to 0x0000_0016_0000_000e, and splits to (7, 11).
+		let input = [Word::from_u64(0x0000_000b_0000_0007)];
+
+		let mut doubled = [Word::ZERO];
+		registry.execute(doubler, &[], &input, &mut doubled);
+		assert_eq!(doubled, [Word::from_u64(0x0000_0016_0000_000e)]);
+
+		let mut halves = [Word::ZERO; 2];
+		registry.execute(split, &[], &input, &mut halves);
+		assert_eq!(halves, [Word::from_u64(7), Word::from_u64(11)]);
+	}
+
+	#[test]
+	fn registering_one_hint_twice_reuses_its_slot() {
+		// Invariant: registration is idempotent, so a hint called from many gates costs one slot.
+		let mut registry = HintRegistry::new();
+
+		let first = registry.register(Doubler);
+		let second = registry.register(Doubler);
+
+		assert_eq!(first, second);
+		assert_eq!(registry.handlers.len(), 1);
+	}
+
+	#[test]
+	fn slots_are_handed_out_from_zero_in_registration_order() {
+		// Invariant: an identifier is a position.
+		// So resolving one is an index, not a probe.
+		let mut registry = HintRegistry::new();
+
+		assert_eq!(registry.register(Doubler), HintId::from_u32(0));
+		assert_eq!(registry.register(SplitHalves), HintId::from_u32(1));
+	}
+
+	#[test]
+	#[should_panic(expected = "no hint is registered under id 7")]
+	fn an_identifier_this_registry_never_issued_names_the_id_it_rejects() {
+		// A registry holding one hint has only slot 0, so slot 7 cannot resolve.
+		let mut registry = HintRegistry::new();
+		registry.register(Doubler);
+
+		registry.shape(HintId::from_u32(7), &[]);
 	}
 }

--- a/crates/frontend/src/ir/mod.rs
+++ b/crates/frontend/src/ir/mod.rs
@@ -203,16 +203,9 @@ impl GateData {
 	pub fn shape(&self, registry: &HintRegistry) -> OpcodeShape {
 		match self.opcode {
 			Opcode::Hint => {
-				let hint_id = self.immediates[0];
+				let hint_id = HintId::from_u32(self.immediates[0]);
 				let (n_in, n_out) = registry.shape(hint_id, &self.dimensions);
-				OpcodeShape {
-					const_in: &[],
-					n_in,
-					n_out,
-					n_aux: 0,
-					n_scratch: 0,
-					n_imm: 1,
-				}
+				OpcodeShape::new(n_in, n_out).with_imm(1)
 			}
 			_ => self.opcode.shape(&self.dimensions),
 		}
@@ -403,7 +396,7 @@ impl GateGraph {
 			opcode: Opcode::Hint,
 			wires,
 			dimensions: dimensions.to_vec(),
-			immediates: smallvec![hint_id],
+			immediates: smallvec![hint_id.as_u32()],
 		};
 		let gate = self.gates.push(data);
 		self.gate_origin[gate] = gate_origin;


### PR DESCRIPTION
Makes a hint's identity its concrete type instead of a hash of its name.

This kills a latent bug that produced a silently wrong witness. No hint in the tree
triggers it today.

### The problem

A hint id was derived by hashing the hint's name and folding the 64-bit result to 32 bits:

```
hint_id_of(name) = (h as u32) ^ ((h >> 32) as u32)    where h = hash(name)
```

Two names that fold to the same value name the same hint.

Registration was `entry(id).or_insert_with(...)`, so on a collision the second hint's handler
was **dropped** and the first one kept its slot.

Every later call to the second hint then ran the first hint's code.

Nothing detected it: no panic, no shape mismatch, just wrong witness values.

The collision is easy to hit — two names 10 characters long:

| name | id |
|---|---|
| `hint_33476` | 407677619 |
| `hint_50152` | 407677619 |

### The idea

An id stops being a digest and becomes a **position**.

The registry hands out consecutive slots from zero, and keys its dedup map on the hint's
concrete type:

```
before:  HashMap<HintId, Box<dyn ErasedHint>>     keyed by hash(NAME)
after:   Vec<Box<dyn ErasedHint>>                 indexed by slot
       + HashMap<TypeId, HintId>                  keyed by the concrete type
```

Two distinct types cannot share a `TypeId`.

So the bug does not get patched — it stops being expressible.

### The change

```
- pub type HintId = u32;
+ pub struct HintId(u32);        // the slot this hint holds, mirroring PathSpec

- let id = hint_id_of(T::NAME);
- self.handlers.entry(id).or_insert_with(|| Box::new(handler));
+ match slots.entry(TypeId::of::<T>()) { ... }    // vacant arm appends and takes the next slot
```

`hint_id_of` is deleted outright — it had zero callers outside its own file.

A name is no longer an identity, so `NAME` is now documented as a diagnostic label and no
longer has to be unique.

Resolving a hint goes through one accessor that names the id it rejects, replacing two bare
`[]` indexings that panicked with a bare map-key message.

### What this is not

This is not a perf change, and the `Vec` is not the point.

Resolving a hint is now an index rather than a hash lookup, which does remove a SipHash and a
probe from each per-instance step of hint execution. That path is a handful of instructions
next to the hint body itself, so no measurable win is claimed.

### Soundness

- Hint semantics are untouched: same trait, same `shape`, same `execute`.
- The bytecode encoding is unchanged — an id still crosses as a `u32`.
- Ids are internal, so no snapshot or artifact encodes one. All 13 circuit-statistics snapshots re-bless to identical bytes.
- The only observable change is *which* handler a colliding pair resolves to, which is the bug.

### Scope

- **changed:** `ir/hints.rs` (the id type and the registry), and the 4 sites that carry an id — `ir/mod.rs`, `gates/mod.rs`, `eval_form/builder.rs`, `eval_form/exec.rs`, `eval_form/const_eval.rs`
- **narrowed:** the raw-integer accessors are `pub(crate)`, since callers only receive an id and hand it back. The old `u32` alias exposed arithmetic that nothing used.
- **left untouched:** every `Hint` impl in `circuits`, `recursion` and `m4-*`. They call `call_hint` and never name an id.

### Verification

The regression test was checked in both directions.

It passes here, and it **fails on the old identity** — confirmed by temporarily keying
`register` on the name digest:

```
assertion `left != right` failed
  left: HintId(0)
 right: HintId(0)
```

Both hints collapsed onto slot 0, which is the bug reproduced.

| gate | result |
|---|---|
| `cargo test -p binius-frontend` | 248 passed / 0 failed, incl. `crc64_chip` |
| `cargo test -p binius-circuits` | 359 passed / 0 failed |
| `cargo check --workspace --all-targets` | clean |
| `cargo clippy -p binius-frontend --all-targets -D warnings` | clean |
| nightly `cargo fmt --all` | applied |
| `RUSTDOCFLAGS=-D warnings cargo doc` | clean |

`binius-circuits` is included beyond the touched crate because it is the only place real hints
execute — endomorphism split, bignum division, BLAKE3 and SHA-256 compression. A compile check
would not catch a misrouted handler.

### Note on #2151

This overlaps textually with #2151 in `ir/hints.rs` and `gates/mod.rs`, though the two changes
are independent.

Landing #2151 first is the cheaper order: its `GateBody::Hint(HintId)` deletes all three
`HintId::from_u32(data.immediates[0])` sites this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
