### PR TITLE
Allocate Merkle tree inner nodes through an Allocator

### DIFF
--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-compute = { path = "../compute" }
 binius-field = { path = "../field" }
 binius-utils = { path = "../utils" }
 blake3 = { workspace = true, features = ["traits-preview"] }

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -1,6 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::fmt;
+
+use binius_compute::{Allocator, GlobalAllocator, VecLike};
 use binius_field::Field;
 use binius_utils::{
 	checked_arithmetics::checked_log_2,
@@ -82,27 +85,41 @@ pub enum Error {
 /// A binary tree is then folded over those leaf digests.
 ///
 /// All committed vectors must have the same length, and that length must be a power of two.
-#[derive(Debug, Clone)]
-pub struct BinaryMerkleTree<D> {
+///
+/// The nodes are drawn from an [`Allocator`], so a prover can back the whole tree with pooled
+/// memory instead of the global heap. The default is [`GlobalAllocator`], which is a plain [`Vec`].
+pub struct BinaryMerkleTree<D: Send, A: Allocator = GlobalAllocator> {
 	/// Base-2 logarithm of the number of leaves.
 	pub log_len: usize,
 	/// The inner nodes, arranged as a flattened array of layers with the root at the end.
-	pub inner_nodes: Vec<D>,
+	pub inner_nodes: A::Vec<D>,
 }
 
-impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
+/// Written through the node slice rather than the buffer, so no allocator has to be [`Debug`]
+/// itself for a tree over it to be.
+impl<D: fmt::Debug + Send, A: Allocator> fmt::Debug for BinaryMerkleTree<D, A> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("BinaryMerkleTree")
+			.field("log_len", &self.log_len)
+			.field("inner_nodes", &&*self.inner_nodes)
+			.finish()
+	}
+}
+
+impl<N: ArraySize, A: Allocator> BinaryMerkleTree<Array<u8, N>, A> {
 	/// Commits a slice of values, cutting it into consecutive leaves.
 	///
 	/// # Arguments
 	///
 	/// * `elements` - the values to commit, in leaf order.
 	/// * `batch_size` - how many consecutive values are hashed together into one leaf.
+	/// * `alloc` - the allocator the tree's nodes are drawn from.
 	///
 	/// # Errors
 	///
 	/// * The value count is not a multiple of the batch size.
 	/// * The resulting leaf count is not a power of two.
-	pub fn new<F, H>(elements: &[F], batch_size: usize) -> Result<Self, Error>
+	pub fn new<F, H>(elements: &[F], batch_size: usize, alloc: &A) -> Result<Self, Error>
 	where
 		F: Field,
 		H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>,
@@ -128,6 +145,7 @@ impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
 				.par_chunks(batch_size)
 				.map(|chunk| chunk.iter().copied()),
 			batch_size,
+			alloc,
 		))
 	}
 
@@ -149,11 +167,12 @@ impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
 	///
 	/// * `leaves` - one iterator per leaf, each yielding that leaf's values.
 	/// * `n_items_per_input` - how many values every leaf iterator yields.
+	/// * `alloc` - the allocator the tree's nodes are drawn from.
 	///
 	/// # Panics
 	///
 	/// Panics unless the number of leaves is a power of two.
-	pub fn from_leaves<F, H, ParIter>(leaves: ParIter, n_items_per_input: usize) -> Self
+	pub fn from_leaves<F, H, ParIter>(leaves: ParIter, n_items_per_input: usize, alloc: &A) -> Self
 	where
 		F: Field,
 		H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>,
@@ -163,8 +182,9 @@ impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
 		let log_len = checked_log_2(leaves.len());
 
 		// A binary tree over 2^log_len leaves has 2^(log_len+1) - 1 nodes in total.
+		// The whole tree is one allocation, which the layer loop then fills front to back.
 		let total_length = (1 << (log_len + 1)) - 1;
-		let mut inner_nodes = Vec::with_capacity(total_length);
+		let mut inner_nodes = alloc.alloc::<Array<u8, N>>(total_length);
 
 		// Fill the widest layer first, straight into uninitialized capacity.
 		{
@@ -213,7 +233,7 @@ impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
 	}
 }
 
-impl<D: Clone> BinaryMerkleTree<D> {
+impl<D: Clone + Send, A: Allocator> BinaryMerkleTree<D, A> {
 	/// Clones the root digest, which sits last in the flattened layers.
 	pub fn root(&self) -> D {
 		self.inner_nodes
@@ -285,7 +305,7 @@ mod tests {
 		let elements = (0..n_values)
 			.map(|i| B128::new(i as u128))
 			.collect::<Vec<_>>();
-		BinaryMerkleTree::new::<B128, Sha256HashSuite>(&elements, batch_size)
+		BinaryMerkleTree::new::<B128, Sha256HashSuite>(&elements, batch_size, &GlobalAllocator)
 	}
 
 	#[test]

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -1,6 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::GlobalAllocator;
 use binius_field::Field;
 use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment};
@@ -70,7 +71,9 @@ where
 	where
 		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 	{
-		let tree = BinaryMerkleTree::from_leaves::<F, H, _>(leaves, n_items_per_input);
+		// The global heap for now; BINIUS-490 threads a pool allocator down to here.
+		let tree =
+			BinaryMerkleTree::from_leaves::<F, H, _>(leaves, n_items_per_input, &GlobalAllocator);
 
 		let commitment = Commitment {
 			root: tree.root(),


### PR DESCRIPTION
Closes [BINIUS-489](https://linear.app/jimpo/issue/BINIUS-489/merkle-tree-use-generic-allocator-for-inner-node-buffers), the first half of [BINIUS-490](https://linear.app/jimpo/issue/BINIUS-490/use-bufferpool-to-allocate-basefold-merkle-tree-nodes).

`BinaryMerkleTree` held its nodes in a plain `Vec`. It now holds an `A::Vec<D>` for an `A: Allocator`, so a prover can back the whole tree with pooled memory.

```rust
-pub struct BinaryMerkleTree<D> {
-    pub inner_nodes: Vec<D>,
+pub struct BinaryMerkleTree<D: Send, A: Allocator = GlobalAllocator> {
+    pub inner_nodes: A::Vec<D>,
```

**This PR changes no allocation.** The default type parameter is `GlobalAllocator`, whose `alloc` is `Vec::with_capacity`, so every existing caller gets exactly the buffer it got before. Threading a real `&BufferPool` down to `commit_iterated` is BINIUS-490.

### The layer-filling body is untouched

`VecLike` already exposes the two things `from_leaves` needs — `spare_capacity_mut` and `set_len` — so the unsafe code that writes each layer into uninitialized capacity and then claims the length is unchanged, line for line. Only the one allocation at the top moved:

```rust
-let mut inner_nodes = Vec::with_capacity(total_length);
+let mut inner_nodes = alloc.alloc::<Array<u8, N>>(total_length);
```

Both give a buffer of capacity *at least* `total_length`, which is what the existing code already assumed: it slices `spare_capacity_mut()` down to each layer's width and leaves any surplus untouched.

### Scope

- **changed:** `BinaryMerkleTree` gains the parameter; `new` and `from_leaves` gain an `alloc` argument
- **call sites:** one, `merkle_tree/prover.rs`, which passes `&GlobalAllocator`
- **untouched:** `MerkleTreeProver`, the Merkle channel, and every verifier path

Only two places outside `binius-hash` name the struct, both prover-side associated types, and the default parameter keeps both compiling unchanged.

`binius-hash` gains a dependency on `binius-compute`. That crate has an **empty** `[dependencies]` table, so this adds no external dependency to any crate that reaches the tree, verifier included, and there is no cycle.

### Two derives could not survive

`#[derive(Debug, Clone)]` on a struct whose field is `A::Vec<D>` bounds the *parameter* `A`, not the field, so neither derive applies.

- **`Debug` is reimplemented by hand**, formatting through the node slice rather than the buffer:

  ```rust
  .field("inner_nodes", &&*self.inner_nodes)
  ```

  `A::Vec<D>: Deref<Target = [D]>` holds for every allocator, so the impl needs no `where A::Vec<D>: Debug` clause — a bound that would otherwise propagate into every downstream signature that wants to print a tree. The crate's own tests need it: they call `.unwrap_err()` on `Result<BinaryMerkleTree, _>`.

- **`Clone` is dropped.** It cannot be provided unconditionally — cloning through the deref would need an allocator handle, which the tree does not hold. `cargo check --workspace --all-targets` is clean without it, so nothing used it. `PoolVec` and `Vec` are both `Clone`, so BINIUS-490 can add a bounded impl if a caller ever needs one.

### Performance: no change, and the bench cannot say better than that

`crates/iop-prover/benches/binary_merkle_tree.rs` covers this path directly. Interleaved paired rounds, alternating the two pre-built bench binaries so slow drift in machine load cancels — Blake3, 2^17 leaves, 16×B128 per leaf, `-C target-cpu=native`, medians in ms:

| round | before | after |
|---|--:|--:|
| 1 | 70.3 | 105.8 |
| 2 | 101.1 | 95.6 |
| 3 | 110.7 | 98.7 |
| 4 | 72.0 | 96.2 |
| 5 | 114.9 | 101.6 |

**The `before` column swings 70 → 115 ms on identical code**, a 64% spread. That is the measurement's own noise floor, and it is far wider than any effect this change could have: the median moves −2% and the mean +6%, opposite signs, which is the signature of no effect. The box is 4 cores under load average 6–8 with 14 other `rustc` processes, so a criterion `--save-baseline` run (all *before*, then all *after*) reported nonsense — −35% on one case and +69% on another. I would not trust a number off this machine finer than about ±25%, and this change should produce none: `GlobalAllocator::alloc` monomorphizes to the `Vec::with_capacity` that was already there.

The real measurement belongs on BINIUS-490, where the allocation strategy actually changes.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-hash -p binius-iop-prover --all-targets -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `cargo test -p binius-hash -p binius-iop-prover` — 70 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
