### PR TITLE
Draw BaseFold Merkle tree nodes from the prover's BufferPool

### DIFF
--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::BufferPool;
 use binius_field::{BinaryField128bGhash as B128, PackedField, arch::OptimalPackedB128};
 use binius_hash::{
 	binary_merkle_tree::HashSuite, blake3::Blake3HashSuite, sha256::Sha256HashSuite,
@@ -44,16 +45,23 @@ where
 		((1 << (LOG_LEAVES + LOG_ELEMS_IN_LEAF)) * std::mem::size_of::<B128>()) as u64,
 	));
 	group.sample_size(10);
-	group.bench_function(
-		format!(
-			"{LOG_LEAVES} log leaves size {}xB128 leaf {}",
-			1 << LOG_ELEMS_IN_LEAF,
-			packing_name.as_ref()
-		),
-		|b| {
-			b.iter(|| merkle_prover.commit_field_buffer(buffer.to_ref(), LOG_ELEMS_IN_LEAF));
-		},
+	let case = format!(
+		"{LOG_LEAVES} log leaves size {}xB128 leaf {}",
+		1 << LOG_ELEMS_IN_LEAF,
+		packing_name.as_ref()
 	);
+	group.bench_function(&case, |b| {
+		b.iter(|| merkle_prover.commit_field_buffer(buffer.to_ref(), LOG_ELEMS_IN_LEAF));
+	});
+
+	// The same commitment out of a pool the prover holds across iterations, which is how a real
+	// prover uses one. Benching both here rather than against a baseline build keeps the
+	// comparison inside a single binary, where the two arms meet identical machine conditions.
+	let pool = BufferPool::new();
+	let pooled_prover = BinaryMerkleTreeProver::<B128, H, _>::with_allocator(&pool);
+	group.bench_function(format!("{case} pooled"), |b| {
+		b.iter(|| pooled_prover.commit_field_buffer(buffer.to_ref(), LOG_ELEMS_IN_LEAF));
+	});
 	group.finish()
 }
 

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -764,6 +764,7 @@ mod tests {
 			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
+				GlobalAllocator,
 			);
 
 		let oracle = prover_channel.send_oracle(buffer.to_ref());
@@ -832,6 +833,7 @@ mod tests {
 			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
+				GlobalAllocator,
 			);
 
 		let oracle_1 = prover_channel.send_oracle(buffer_1.to_ref());
@@ -917,6 +919,7 @@ mod tests {
 			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
+				GlobalAllocator,
 			);
 
 		let oracles: Vec<_> = data
@@ -1005,6 +1008,7 @@ mod tests {
 			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
+				GlobalAllocator,
 			);
 
 		let oracles: Vec<_> = data
@@ -1256,6 +1260,7 @@ mod tests {
 			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
+				GlobalAllocator,
 			);
 
 		let oracles = data

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -20,7 +20,15 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 use crate::{
 	basefold::channel::BaseFoldProverChannel,
 	merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel},
+	merkle_tree::prover::BinaryMerkleTreeProver,
 };
+
+/// The channel the `*_from_transcript` constructors return.
+///
+/// A BaseFold channel over a transcript-backed Merkle channel, where `A` backs both the BaseFold
+/// working buffers and the nodes of every Merkle tree committed through it.
+pub type TranscriptBaseFoldProverChannel<'a, F, P, NTT, T, Challenger_, H, A> =
+	BaseFoldProverChannel<'a, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>, A>;
 
 /// A compiler that creates BaseFold ZK prover channels with precomputed parameters.
 ///
@@ -172,11 +180,14 @@ where
 	/// The transcript may be owned or mutably borrowed.
 	/// It is wrapped in a [`ProverMerkleTranscriptChannel`] for the given hash suite.
 	/// That channel is then passed to [`Self::create_channel`].
+	/// `alloc` backs both the channel's working buffers and the nodes of every Merkle tree it
+	/// commits, so one pool serves the whole opening.
 	pub fn create_channel_from_transcript<H, Challenger_, T, A>(
 		&self,
 		transcript: T,
 		rng: impl Rng,
-	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>, A>
+		alloc: A,
+	) -> TranscriptBaseFoldProverChannel<'_, F, P, NTT, T, Challenger_, H, A>
 	where
 		H: HashSuite,
 		Challenger_: Challenger,
@@ -184,7 +195,13 @@ where
 		Output<H::LeafHash>: SerializeBytes,
 		A: Allocator,
 	{
-		self.create_channel(ProverMerkleTranscriptChannel::new(transcript), rng)
+		self.create_channel(
+			ProverMerkleTranscriptChannel::with_merkle_prover(
+				transcript,
+				BinaryMerkleTreeProver::with_allocator(alloc),
+			),
+			rng,
+		)
 	}
 
 	/// Creates a non-ZK prover channel over a transcript, for the common case.
@@ -194,7 +211,8 @@ where
 	pub fn create_channel_without_zk_from_transcript<H, Challenger_, T, A>(
 		&self,
 		transcript: T,
-	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>, A>
+		alloc: A,
+	) -> TranscriptBaseFoldProverChannel<'_, F, P, NTT, T, Challenger_, H, A>
 	where
 		H: HashSuite,
 		Challenger_: Challenger,
@@ -202,6 +220,9 @@ where
 		Output<H::LeafHash>: SerializeBytes,
 		A: Allocator,
 	{
-		self.create_channel_without_zk(ProverMerkleTranscriptChannel::new(transcript))
+		self.create_channel_without_zk(ProverMerkleTranscriptChannel::with_merkle_prover(
+			transcript,
+			BinaryMerkleTreeProver::with_allocator(alloc),
+		))
 	}
 }

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -466,6 +466,7 @@ mod tests {
 			.create_channel_from_transcript::<StdHashSuite, Chal, _, _>(
 				&mut prover_transcript,
 				prover_channel_rng,
+				GlobalAllocator,
 			);
 
 		let alloc = GlobalAllocator;

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -13,6 +13,7 @@
 
 use std::{borrow::BorrowMut, marker::PhantomData};
 
+use binius_compute::{Allocator, GlobalAllocator};
 use binius_core::word::Word;
 use binius_field::{Field, PackedField};
 use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
@@ -80,9 +81,15 @@ pub trait MerkleIPProverChannel<F: Field>: WordIPProverChannel<F> {
 ///
 /// The transcript is held through a [`BorrowMut`] bound, so the channel can own the transcript or
 /// mutably borrow one.
-pub struct ProverMerkleTranscriptChannel<T, Challenger_, F, H: HashSuite> {
+pub struct ProverMerkleTranscriptChannel<
+	T,
+	Challenger_,
+	F,
+	H: HashSuite,
+	A: Allocator = GlobalAllocator,
+> {
 	transcript: T,
-	merkle_prover: BinaryMerkleTreeProver<F, H>,
+	merkle_prover: BinaryMerkleTreeProver<F, H, A>,
 	_challenger_marker: PhantomData<Challenger_>,
 }
 
@@ -91,11 +98,17 @@ impl<T, Challenger_, F, H: HashSuite> ProverMerkleTranscriptChannel<T, Challenge
 	pub fn new(transcript: T) -> Self {
 		Self::with_merkle_prover(transcript, BinaryMerkleTreeProver::new())
 	}
+}
 
+impl<T, Challenger_, F, H: HashSuite, A: Allocator>
+	ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>
+{
 	/// Constructs a channel over the transcript with the given Merkle tree prover.
+	///
+	/// The prover carries the allocator every committed tree draws its nodes from.
 	pub const fn with_merkle_prover(
 		transcript: T,
-		merkle_prover: BinaryMerkleTreeProver<F, H>,
+		merkle_prover: BinaryMerkleTreeProver<F, H, A>,
 	) -> Self {
 		Self {
 			transcript,
@@ -118,13 +131,14 @@ pub struct ProverMerkleCommitment<Committed> {
 	log_leaf_size: usize,
 }
 
-impl<F, T, Challenger_, H> IPProverChannel<F>
-	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
+impl<F, T, Challenger_, H, A> IPProverChannel<F>
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>
 where
 	F: Field,
 	T: BorrowMut<ProverTranscript<Challenger_>>,
 	Challenger_: Challenger,
 	H: HashSuite,
+	A: Allocator,
 {
 	fn send_one(&mut self, elem: F) {
 		self.transcript.borrow_mut().send_one(elem)
@@ -147,13 +161,14 @@ where
 	}
 }
 
-impl<F, T, Challenger_, H> WordIPProverChannel<F>
-	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
+impl<F, T, Challenger_, H, A> WordIPProverChannel<F>
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>
 where
 	F: Field,
 	T: BorrowMut<ProverTranscript<Challenger_>>,
 	Challenger_: Challenger,
 	H: HashSuite,
+	A: Allocator,
 {
 	type Word = Word;
 
@@ -166,16 +181,17 @@ where
 	}
 }
 
-impl<F, T, Challenger_, H> MerkleIPProverChannel<F>
-	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
+impl<F, T, Challenger_, H, A> MerkleIPProverChannel<F>
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>
 where
 	F: Field,
 	T: BorrowMut<ProverTranscript<Challenger_>>,
 	Challenger_: Challenger,
 	H: HashSuite,
+	A: Allocator,
 	Output<H::LeafHash>: SerializeBytes,
 {
-	type Commitment = ProverMerkleCommitment<BinaryMerkleTree<Output<H::LeafHash>>>;
+	type Commitment = ProverMerkleCommitment<BinaryMerkleTree<Output<H::LeafHash>, A>>;
 
 	fn send_merkle_commitment<P: PackedField<Scalar = F>>(
 		&mut self,

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::GlobalAllocator;
+use binius_compute::{Allocator, GlobalAllocator};
 use binius_field::Field;
 use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment};
@@ -12,33 +12,50 @@ use getset::Getters;
 
 use super::{MerkleTreeProver, ProverDigest};
 
+/// Builds Merkle trees over an allocator, which every tree it commits draws its nodes from.
+///
+/// The allocator is state rather than a per-call argument because [`MerkleTreeProver::Committed`]
+/// names the tree, and an associated type cannot depend on a method's generic parameter.
 #[derive(Getters)]
-pub struct BinaryMerkleTreeProver<T, H: HashSuite> {
+pub struct BinaryMerkleTreeProver<T, H: HashSuite, A: Allocator = GlobalAllocator> {
 	#[getset(get = "pub")]
 	scheme: BinaryMerkleTreeScheme<T, H>,
+	alloc: A,
 }
 
-impl<T, H: HashSuite> BinaryMerkleTreeProver<T, H> {
+impl<T, H: HashSuite> BinaryMerkleTreeProver<T, H, GlobalAllocator> {
+	/// Commits trees on the global heap.
 	pub fn new() -> Self {
+		Self::with_allocator(GlobalAllocator)
+	}
+}
+
+impl<T, H: HashSuite, A: Allocator> BinaryMerkleTreeProver<T, H, A> {
+	/// Commits trees whose nodes are drawn from `alloc`.
+	///
+	/// Pass `&BufferPool` to recycle node buffers across the proofs one prover runs.
+	pub fn with_allocator(alloc: A) -> Self {
 		Self {
 			scheme: BinaryMerkleTreeScheme::new(),
+			alloc,
 		}
 	}
 }
 
-impl<T, H: HashSuite> Default for BinaryMerkleTreeProver<T, H> {
+impl<T, H: HashSuite> Default for BinaryMerkleTreeProver<T, H, GlobalAllocator> {
 	fn default() -> Self {
 		Self::new()
 	}
 }
 
-impl<F, H> MerkleTreeProver<F> for BinaryMerkleTreeProver<F, H>
+impl<F, H, A> MerkleTreeProver<F> for BinaryMerkleTreeProver<F, H, A>
 where
 	F: Field,
 	H: HashSuite,
+	A: Allocator,
 {
 	type Scheme = BinaryMerkleTreeScheme<F, H>;
-	type Committed = BinaryMerkleTree<Output<H::LeafHash>>;
+	type Committed = BinaryMerkleTree<Output<H::LeafHash>, A>;
 
 	fn scheme(&self) -> &Self::Scheme {
 		&self.scheme
@@ -71,9 +88,7 @@ where
 	where
 		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 	{
-		// The global heap for now; BINIUS-490 threads a pool allocator down to here.
-		let tree =
-			BinaryMerkleTree::from_leaves::<F, H, _>(leaves, n_items_per_input, &GlobalAllocator);
+		let tree = BinaryMerkleTree::from_leaves::<F, H, _>(leaves, n_items_per_input, &self.alloc);
 
 		let commitment = Commitment {
 			root: tree.root(),

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -3,6 +3,7 @@
 
 use core::slice;
 
+use binius_compute::BufferPool;
 use binius_field::{
 	BinaryField128bGhash as B128, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
 };
@@ -169,4 +170,33 @@ fn test_commit_field_buffer_rejects_oversized_leaf() {
 		&mut rng, 4,
 	));
 	let _ = prover.commit_field_buffer(buffer.to_ref(), 3);
+}
+
+#[test]
+fn a_pooled_prover_commits_the_same_tree_as_the_global_one() {
+	// Invariant: the allocator backing the nodes is not observable in what gets committed.
+	// Pooling is a memory strategy, so every digest the two provers produce must agree.
+	//
+	// Fixture state: 64 scalars in leaves of 2, committed twice — once on the global heap, once
+	// out of a `BufferPool`.
+	let mut rng = StdRng::seed_from_u64(0);
+	let data = random_scalars::<B128>(&mut rng, 64);
+
+	let global = BinaryMerkleTreeProver::<B128, StdHashSuite>::new();
+	let (global_commitment, global_tree) = global.commit(&data, 2);
+
+	let pool = BufferPool::new();
+	let pooled = BinaryMerkleTreeProver::<B128, StdHashSuite, _>::with_allocator(&pool);
+	let (pooled_commitment, pooled_tree) = pooled.commit(&data, 2);
+
+	assert_eq!(pooled_commitment.root, global_commitment.root);
+	assert_eq!(pooled_commitment.depth, global_commitment.depth);
+	// Every node, not just the root: a layer or branch read off the pooled tree must match too.
+	assert_eq!(&*pooled_tree.inner_nodes, &*global_tree.inner_nodes);
+
+	// The pool is reused across commitments, which is the whole point of holding one.
+	// A second commitment through the same pool draws recycled blocks and must still agree.
+	drop(pooled_tree);
+	let (again, _) = pooled.commit(&data, 2);
+	assert_eq!(again.root, global_commitment.root);
 }

--- a/crates/iop-prover/tests/merkle_pool_allocations.rs
+++ b/crates/iop-prover/tests/merkle_pool_allocations.rs
@@ -1,0 +1,108 @@
+// Copyright 2026 The Binius Developers
+
+//! That a pooled Merkle tree prover stops going to the global allocator for its nodes.
+//!
+//! Wall-clock is the wrong instrument for this change: the saving is one large allocation per
+//! committed tree, which is a few percent of a commitment dominated by hashing, and well inside
+//! the run-to-run spread of a loaded machine. The count of large global allocations is the same
+//! fact measured exactly, and it does not depend on how busy the box is.
+//!
+//! This is an integration test rather than a unit test because it installs a
+//! `#[global_allocator]`, which is a whole-binary choice.
+
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use binius_compute::BufferPool;
+use binius_field::BinaryField128bGhash as B128;
+use binius_hash::StdHashSuite;
+use binius_iop_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use binius_math::test_utils::random_scalars;
+use rand::{SeedableRng, rngs::StdRng};
+
+/// Allocations at or above this size are counted.
+///
+/// The tree below is about 1 MiB of nodes, so its buffer is far above the threshold, while the
+/// small incidental allocations a commitment makes are far below it.
+const LARGE: usize = 256 * 1024;
+
+static LARGE_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicBool = AtomicBool::new(false);
+
+/// Counts large allocations while armed, and otherwise just forwards to the system allocator.
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		if layout.size() >= LARGE && COUNTING.load(Ordering::Relaxed) {
+			LARGE_ALLOCS.fetch_add(1, Ordering::Relaxed);
+		}
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Runs `f` with counting armed, and returns how many large allocations it made.
+fn count_large_allocs(f: impl FnOnce()) -> usize {
+	LARGE_ALLOCS.store(0, Ordering::Relaxed);
+	COUNTING.store(true, Ordering::Relaxed);
+	f();
+	COUNTING.store(false, Ordering::Relaxed);
+	LARGE_ALLOCS.load(Ordering::Relaxed)
+}
+
+/// Base-2 logarithm of the number of leaves; 2^15 nodes of 32 bytes is about 1 MiB of tree.
+const LOG_LEAVES: usize = 14;
+const COMMITS: usize = 4;
+
+#[test]
+fn a_pooled_prover_stops_allocating_tree_nodes_globally() {
+	// Invariant: a prover holding a pool reuses one block of node memory across the trees it
+	// commits, where a global prover asks the OS for a fresh block every time.
+	//
+	// Fixture state: the same data committed four times through each prover, in leaves of 2.
+	let mut rng = StdRng::seed_from_u64(0);
+	let data = random_scalars::<B128>(&mut rng, 1 << (LOG_LEAVES + 1));
+
+	// Warm both paths first, so neither count includes one-off setup — rayon spinning up its
+	// thread pool, say — that has nothing to do with the allocator under test.
+	let global = BinaryMerkleTreeProver::<B128, StdHashSuite>::new();
+	let pool = BufferPool::new();
+	let pooled = BinaryMerkleTreeProver::<B128, StdHashSuite, _>::with_allocator(&pool);
+	drop(global.commit(&data, 2));
+	drop(pooled.commit(&data, 2));
+
+	let global_allocs = count_large_allocs(|| {
+		for _ in 0..COMMITS {
+			drop(global.commit(&data, 2));
+		}
+	});
+	let pooled_allocs = count_large_allocs(|| {
+		for _ in 0..COMMITS {
+			drop(pooled.commit(&data, 2));
+		}
+	});
+
+	// The global prover cannot do better than one large block per tree.
+	assert!(
+		global_allocs >= COMMITS,
+		"expected at least one large allocation per tree, got {global_allocs} for {COMMITS} trees"
+	);
+	// The pool was warmed above, so every tree here is served from a recycled block.
+	assert!(
+		pooled_allocs < global_allocs,
+		"pooling must remove large allocations: {pooled_allocs} pooled against {global_allocs} global"
+	);
+
+	println!(
+		"large allocations over {COMMITS} commitments: {global_allocs} global, {pooled_allocs} pooled"
+	);
+}

--- a/crates/m4-prover/src/composite.rs
+++ b/crates/m4-prover/src/composite.rs
@@ -194,15 +194,14 @@ where
 	where
 		Challenger_: Challenger,
 	{
+		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
+		// by earlier proofs. The channel commits its Merkle trees out of the same pool.
+		let alloc = &self.pool;
 		// A composite proof is transparent: every oracle is committed without a mask, so the
 		// channel draws no randomness.
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript);
-
-		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
-		// by earlier proofs.
-		let alloc = &self.pool;
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript, alloc);
 		self.iop_prover
 			.prove::<P, _, _>(witness, &mut channel, &alloc)?;
 

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -426,13 +426,12 @@ where
 	) where
 		Challenger_: Challenger,
 	{
+		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
+		// by earlier proofs. The channel commits its Merkle trees out of the same pool.
+		let alloc = &self.pool;
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript);
-
-		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
-		// by earlier proofs.
-		let alloc = &self.pool;
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript, alloc);
 		self.iop_prover
 			.prove_chip::<P, _, _>(table, &mut channel, &alloc);
 

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -124,6 +124,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 					let channel = compiler
 						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 							ProverTranscript::default(),
+							alloc,
 						);
 					(Some(witness.clone()), channel)
 				},
@@ -146,6 +147,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 					compiler
 						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 							ProverTranscript::default(),
+							alloc,
 						)
 				},
 				|channel| {
@@ -295,6 +297,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 				compiler
 					.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 						ProverTranscript::default(),
+						alloc,
 					)
 			},
 			|channel| {

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -462,12 +462,13 @@ where
 		// Create channel, delegate to IOPProver::prove, then finish it. The unified channel takes
 		// an rng to mask ZK oracles, but a plain `Prover` produces a transparent proof whose only
 		// oracle is non-ZK, so no masks are drawn and the rng is never consumed.
+		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
+		// by earlier proofs. The pool is passed as an `&BufferPool` allocator, and the channel
+		// commits its Merkle trees out of the same pool.
+		let alloc = &self.pool;
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript);
-		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
-		// by earlier proofs. The pool is passed as an `&BufferPool` allocator.
-		let alloc = &self.pool;
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript, alloc);
 		self.iop_prover
 			.prove::<_, P, _>(witness, &mut channel, &alloc)?;
 		channel.finish(&alloc);

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -147,7 +147,7 @@ where
 		// Create BaseFold prover channel and wrap with outer prover.
 		let basefold_channel = self
 			.basefold_compiler
-			.create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng);
+			.create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng, alloc);
 		let mut wrapped_channel = ZKWrappedProverChannel::new(
 			basefold_channel,
 			&self.outer_iop_prover,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -399,14 +399,15 @@ where
 		let public = witness.public();
 		transcript.observe().write_slice(public);
 
+		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
+		// by earlier proofs. The channel gets the same pool, so the Merkle trees it commits draw
+		// their nodes from it too.
+		let alloc = &self.pool;
 		// Create ZK channel (owns the RNG for mask generation), commit the precommit oracle,
 		// and delegate to the IOP prover.
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng);
-		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
-		// by earlier proofs.
-		let alloc = &self.pool;
+			.create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng, alloc);
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
 				.commit_precommit::<P, _, _>(witness, &mut rng, &mut channel, &alloc);

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -144,6 +144,7 @@ fn test_zk_wrapped_prove_verify() {
 		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 			&mut prover_transcript,
 			&mut rng,
+			GlobalAllocator,
 		);
 	let mut wrapped_prover_channel = ZKWrappedProverChannel::new(
 		basefold_channel,


### PR DESCRIPTION
Closes [BINIUS-490](https://linear.app/jimpo/issue/BINIUS-490/use-bufferpool-to-allocate-basefold-merkle-tree-nodes). Builds on #2156, which made `BinaryMerkleTree` generic over an `Allocator`; this hands it the pool the prover already owns.

Every prover in the workspace already holds a `BufferPool` for its lifetime and already draws its BaseFold working buffers from it. The Merkle trees were the one large allocation still going to the global heap on every commitment. Now they come from the same pool.

**Measured: 4 large global allocations become 0**, over 4 commitments. See below — that number, not a timing, is the deliverable.

### Where the allocator goes

It becomes *state* on the two prover-side structs, not a new argument:

```rust
-pub struct BinaryMerkleTreeProver<T, H: HashSuite> { scheme: ... }
+pub struct BinaryMerkleTreeProver<T, H: HashSuite, A: Allocator = GlobalAllocator> { scheme: ..., alloc: A }
```

with `ProverMerkleTranscriptChannel` gaining the same parameter and passing it down.

It has to be state rather than an `alloc` argument on `send_merkle_commitment`, because `MerkleTreeProver::Committed` and `MerkleIPProverChannel::Commitment` *name the tree*, and an associated type cannot depend on a method's generic parameter.

**Neither trait changes.** `type Commitment` is already abstract, so only the impls mention `A`. That is what keeps this from spreading: `FRIFoldProver`, the FRI fold loop, and everything generic over `Channel` are untouched.

### Wiring at the top

`create_channel_from_transcript` and its non-ZK twin already had an `A: Allocator` parameter for the BaseFold channel's own buffers — it was simply never constrained by an argument. They now take the allocator, so **one pool serves the whole opening**:

```rust
 let alloc = &self.pool;
 let mut channel = self.basefold_compiler
-    .create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng);
+    .create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng, alloc);
```

All four production provers — `binius-prover` (both the plain and ZK paths), `binius-spartan-prover`, and `binius-m4-prover` (plain and composite) — already had `let alloc = &self.pool` a few lines below. They each needed the binding moved above the channel construction and passed in. Test and bench call sites pass `GlobalAllocator`, except the `intmul` benches, which already had a pool in scope and now use it.

### Verification

Wall-clock is the wrong instrument here and I want to be explicit about why. The saving is one large allocation per committed tree, against a commitment dominated by hashing. On this box — 4 cores, load average 6–8 — the same commitment varies 66→89 ms run to run. Eight paired rounds, both allocators benched **inside one binary** so they meet identical conditions (medians, ms):

| round | global | pooled |
|---|--:|--:|
| 1 | 81.9 | 68.3 |
| 2 | 74.7 | 65.1 |
| 3 | 71.1 | 72.9 |
| 4 | 82.1 | 102.6 |
| 5 | 89.3 | 73.9 |
| 6 | 66.3 | 71.5 |
| 7 | 80.0 | 77.3 |
| 8 | 79.0 | 65.8 |

Pooled wins 5 of 8 (sign test p ≈ 0.36 — not significant), median delta ≈ −8%, and round 4 swings +25% the other way. **I would not claim a speedup from this.**

So the change is verified by counting instead, which is exact and machine-independent. `crates/iop-prover/tests/merkle_pool_allocations.rs` installs a counting `#[global_allocator]`, warms both paths, then commits four trees through each:

```
large allocations over 4 commitments: 4 global, 0 pooled
```

One large block per tree becomes none. That is the whole mechanism, stated as a fact rather than a measurement.

Correctness is pinned separately: `a_pooled_prover_commits_the_same_tree_as_the_global_one` asserts the two provers agree on **every node**, not just the root, and that a second commitment drawn from recycled blocks still matches.

### Gates

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-iop-prover -p binius-prover -p binius-spartan-prover -p binius-m4-prover --all-targets -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `cargo test -p binius-iop-prover -p binius-prover -p binius-spartan-prover -p binius-m4-prover` — 172 passed, 0 failed

The one clippy fix worth noting: the `*_from_transcript` return types tripped `type_complexity` with the extra parameter, so they are now a `TranscriptBaseFoldProverChannel` alias, which reads better anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
