### PR TITLE
Encode Reed-Solomon codewords through an Allocator

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -4,7 +4,7 @@
 
 use std::ops::Deref;
 
-use binius_compute::Allocator;
+use binius_compute::{Allocator, GlobalAllocator};
 use binius_field::{BinaryField, Field, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_ip_prover::{
@@ -610,10 +610,20 @@ where
 				self.ntt,
 				buffer.to_ref(),
 				&mut self.rng,
+				&GlobalAllocator,
 			);
 			(codeword, Some(mask))
 		} else {
-			(fri::encode_interleaved(&self.fri_params, index, self.ntt, buffer.to_ref()), None)
+			(
+				fri::encode_interleaved(
+					&self.fri_params,
+					index,
+					self.ntt,
+					buffer.to_ref(),
+					&GlobalAllocator,
+				),
+				None,
+			)
 		};
 
 		// Commit the codeword over the Merkle channel, with one interleaved coset per leaf.

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -175,8 +175,14 @@ mod test {
 		// Encode the interleaved (witness ‖ mask), generating the mask internally, and commit the
 		// codeword over the Merkle channel.
 		let mut commit_rng = StdRng::seed_from_u64(7);
-		let MaskedCodeword { codeword, mask } =
-			fri::encode_masked(&fri_params, 0, &ntt, witness.to_ref(), &mut commit_rng);
+		let MaskedCodeword { codeword, mask } = fri::encode_masked(
+			&fri_params,
+			0,
+			&ntt,
+			witness.to_ref(),
+			&mut commit_rng,
+			&GlobalAllocator,
+		);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover_channel =

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -1,8 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::iter;
+use std::{iter, ops::Deref};
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{BinaryField, PackedField};
 use binius_iop::fri::FRIParams;
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT, reed_solomon::ReedSolomonCode};
@@ -26,21 +27,24 @@ use rand::{CryptoRng, rngs::StdRng};
 /// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being encoded.
 /// * `ntt` - the additive NTT for Reed-Solomon encoding.
 /// * `message` - the interleaved message to encode.
+/// * `alloc` - the allocator the codeword is drawn from.
 ///
 /// ## Preconditions
 ///
 /// * `message.log_len()` must equal the oracle's committed message length,
 ///   `params.rs_code().log_dim() - log_lift + log_batch_size`.
-pub fn encode_interleaved<F, P, NTT>(
+pub fn encode_interleaved<F, P, NTT, A>(
 	params: &FRIParams<F>,
 	oracle_index: usize,
 	ntt: &NTT,
 	message: FieldSlice<P>,
-) -> FieldBuffer<P>
+	alloc: &A,
+) -> FieldBuffer<P, A::Vec<P>>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
+	A: Allocator,
 {
 	let oracle_spec = &params.input_oracles()[oracle_index];
 	let log_batch_size = oracle_spec.log_batch_size();
@@ -69,16 +73,19 @@ where
 	)
 	.entered();
 
-	rs_code.encode_batch(ntt, message.to_ref(), log_batch_size)
+	rs_code.encode_batch(ntt, message.to_ref(), log_batch_size, alloc)
 }
 
 /// Output of [`encode_masked`]: the interleaved (message ‖ mask) codeword and the generated mask.
+///
+/// Both buffers come from the allocator the encode was given, so a pooled prover holds neither on
+/// the global heap.
 #[derive(Debug)]
-pub struct MaskedCodeword<P: PackedField> {
+pub struct MaskedCodeword<P: PackedField, Data: Deref<Target = [P]> = Vec<P>> {
 	/// The Reed-Solomon encoding of the interleaved (message ‖ mask) buffer.
-	pub codeword: FieldBuffer<P>,
+	pub codeword: FieldBuffer<P, Data>,
 	/// The generated random mask, of equal length to the message.
-	pub mask: FieldBuffer<P>,
+	pub mask: FieldBuffer<P, Data>,
 }
 
 /// Generates a random mask, interleaves it with the message, and Reed-Solomon encodes.
@@ -96,17 +103,20 @@ pub struct MaskedCodeword<P: PackedField> {
 /// * `ntt` - the additive NTT for Reed-Solomon encoding
 /// * `message` - the raw message to encode (not doubled)
 /// * `rng` - cryptographic RNG for mask generation
-pub fn encode_masked<F, P, NTT>(
+/// * `alloc` - the allocator the mask, the codeword, and the concatenation temporary are drawn from
+pub fn encode_masked<F, P, NTT, A>(
 	params: &FRIParams<F>,
 	oracle_index: usize,
 	ntt: &NTT,
 	message: FieldSlice<P>,
 	mut rng: impl CryptoRng,
-) -> MaskedCodeword<P>
+	alloc: &A,
+) -> MaskedCodeword<P, A::Vec<P>>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
+	A: Allocator,
 {
 	let oracle_spec = &params.input_oracles()[oracle_index];
 	assert_eq!(oracle_spec.log_batch_size(), 1, "encode_masked requires log_batch_size == 1");
@@ -124,33 +134,47 @@ where
 	let packed_len = 1usize << log_len.saturating_sub(P::LOG_WIDTH);
 
 	let gen_mask_scope = tracing::debug_span!("Generate random mask").entered();
-	let mask = FieldBuffer::<P>::new(
-		log_len,
-		par_rand::<StdRng, _, _>(packed_len, &mut rng, P::random).collect(),
-	);
+	// `par_rand` is a parallel iterator, so the buffer is filled by writing into its uninitialized
+	// capacity rather than collected — an allocator's buffer has no rayon `collect` to target.
+	let mut mask_values = alloc.alloc::<P>(packed_len);
+	(
+		mask_values.spare_capacity_mut()[..packed_len].par_iter_mut(),
+		par_rand::<StdRng, _, _>(packed_len, &mut rng, P::random),
+	)
+		.into_par_iter()
+		.for_each(|(slot, value)| {
+			slot.write(value);
+		});
+	// SAFETY: the loop above wrote every one of the leading `packed_len` words.
+	unsafe { mask_values.set_len(packed_len) };
+	let mask = FieldBuffer::new(log_len, mask_values);
 	drop(gen_mask_scope);
 
 	let combined_values = if log_len < P::LOG_WIDTH {
 		let combined_value =
 			P::from_scalars(iter::chain(message.iter_scalars(), mask.iter_scalars()));
-		vec![combined_value]
+		let mut values = alloc.alloc::<P>(1);
+		values.push(combined_value);
+		values
 	} else {
 		let _scope = tracing::debug_span!("Concatenate message and mask").entered();
 		// TODO: Ideally, encoding should not allocate and copy the memory into a temp buffer.
-		let mut combined_values: Vec<P> = Vec::with_capacity(2 * packed_len);
+		// Until then the temporary at least comes from the pool rather than the global heap.
+		let mut combined_values = alloc.alloc::<P>(2 * packed_len);
 		combined_values.extend_from_slice(message.as_ref());
 		combined_values.extend_from_slice(mask.as_ref());
 		combined_values
 	};
 	let combined = FieldBuffer::new(log_len + 1, combined_values);
 
-	let codeword = encode_interleaved(params, oracle_index, ntt, combined.to_ref());
+	let codeword = encode_interleaved(params, oracle_index, ntt, combined.to_ref(), alloc);
 
 	MaskedCodeword { codeword, mask }
 }
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash1x128b};
 	use binius_hash::StdHashSuite;
 	use binius_iop::fri::FRIParams;
@@ -194,7 +218,8 @@ mod tests {
 
 		let message = random_field_buffer::<P>(&mut rng, log_dim);
 
-		let output: MaskedCodeword<P> = encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng);
+		let output: MaskedCodeword<P> =
+			encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng, &GlobalAllocator);
 
 		// Verify mask has correct dimensions.
 		assert_eq!(output.mask.log_len(), log_dim);

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -3,6 +3,7 @@
 
 use std::{iter, vec};
 
+use binius_compute::GlobalAllocator;
 use binius_field::{
 	BinaryField, BinaryField128bGhash as B128, Field, PackedBinaryGhash1x128b, PackedField,
 };
@@ -54,7 +55,7 @@ fn test_commit_prove_verify_success<F, P>(
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());
 
 	// Prover encodes the message and commits the codeword over a Merkle channel.
-	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref());
+	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
 
 	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
 	let mut prover_channel =
@@ -257,7 +258,7 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 		let oracle_params =
 			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
 		let commitment =
 			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 		messages.push(msg);
@@ -392,7 +393,7 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 		let oracle_params =
 			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
 		let commitment =
 			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 		messages.push(msg);
@@ -547,7 +548,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
 		let oracle_params = FRIParams::new(rs_code, log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
 		let commitment =
 			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 		messages.push(msg);
@@ -667,7 +668,7 @@ where
 
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());
 
-	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref());
+	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	let mut prover_channel =

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -7,6 +7,7 @@
 
 use std::{marker::PhantomData, ptr};
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{BinaryField, PackedField};
 use binius_utils::rayon::{prelude::*, task_size::task_chunk_len};
 use getset::CopyGetters;
@@ -104,15 +105,17 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 	/// ## Postconditions
 	///
 	/// * All elements in the output buffer are initialized with the encoded codeword.
-	pub fn encode_batch<P, NTT>(
+	pub fn encode_batch<P, NTT, A>(
 		&self,
 		ntt: &NTT,
 		data: FieldSlice<P>,
 		log_batch_size: usize,
-	) -> FieldBuffer<P>
+		alloc: &A,
+	) -> FieldBuffer<P, A::Vec<P>>
 	where
 		P: PackedField<Scalar = F>,
 		NTT: AdditiveNTT<Field = F> + Sync,
+		A: Allocator,
 	{
 		assert_eq!(
 			ntt.subspace(self.log_len()),
@@ -139,7 +142,10 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 			let mut scalars = data.iter_scalars().collect::<Vec<_>>();
 			bit_reverse_indices(&mut scalars);
 			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
-			vec![elem_0; 1 << log_output_len.saturating_sub(P::LOG_WIDTH)]
+			let len = 1 << log_output_len.saturating_sub(P::LOG_WIDTH);
+			let mut output = alloc.alloc::<P>(len);
+			output.resize(len, elem_0);
+			output
 		} else {
 			// The forward transform below skips its first `log_inv_rate` layers.
 			// Each skipped layer would butterfly a coefficient with a zero pad:
@@ -156,7 +162,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 				.len()
 				.min(task_chunk_len::<P>().next_power_of_two());
 
-			repeated_message_buffer(data, output_packed_len, run)
+			repeated_message_buffer(data, output_packed_len, run, alloc)
 		};
 		let mut output = FieldBuffer::new(log_output_len, output_data);
 
@@ -187,13 +193,18 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 ///
 /// * `msg` holds at least one whole word, and `total` is a multiple of its word count
 /// * `run` is a power of two, and at most the message's word count
-fn repeated_message_buffer<P: PackedField>(msg: FieldSlice<P>, total: usize, run: usize) -> Vec<P> {
+fn repeated_message_buffer<P: PackedField, A: Allocator>(
+	msg: FieldSlice<P>,
+	total: usize,
+	run: usize,
+	alloc: &A,
+) -> A::Vec<P> {
 	let msg_len = msg.as_ref().len();
 	debug_assert!(msg_len.is_power_of_two());
 	debug_assert!(run.is_power_of_two() && run <= msg_len);
 	debug_assert_eq!(total % msg_len, 0);
 
-	let mut output = Vec::<P>::with_capacity(total);
+	let mut output = alloc.alloc::<P>(total);
 
 	// Copy the message into the leading copy.
 	let head = &mut output.spare_capacity_mut()[..msg_len];
@@ -211,7 +222,7 @@ fn repeated_message_buffer<P: PackedField>(msg: FieldSlice<P>, total: usize, run
 	unsafe { output.set_len(msg_len) };
 
 	// Permute the leading copy, so the copies below inherit it.
-	bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()));
+	bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), &mut output));
 
 	// The source is read through an address rather than a borrow.
 	// That is what lets the workers read the leading copy while the rest is held mutably.
@@ -241,6 +252,7 @@ fn repeated_message_buffer<P: PackedField>(msg: FieldSlice<P>, total: usize, run
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField, PackedBinaryGhash1x128b, PackedBinaryGhash4x128b, PackedField,
 	};
@@ -275,7 +287,8 @@ mod tests {
 		let message = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
 
 		// Test the new encode_batch interface
-		let encoded_buffer = rs_code.encode_batch(&ntt, message.to_ref(), log_batch_size);
+		let encoded_buffer =
+			rs_code.encode_batch(&ntt, message.to_ref(), log_batch_size, &GlobalAllocator);
 
 		// Method 2: Reference implementation - apply NTT with zero-padded coefficients to the
 		// bit-reversal permuted message.
@@ -357,8 +370,8 @@ mod tests {
 			msg_large.set(i, val);
 		}
 
-		let enc_small = rs_small.encode_batch(&ntt, msg_small.to_ref(), 0);
-		let enc_large = rs_large.encode_batch(&ntt, msg_large.to_ref(), 0);
+		let enc_small = rs_small.encode_batch(&ntt, msg_small.to_ref(), 0, &GlobalAllocator);
+		let enc_large = rs_large.encode_batch(&ntt, msg_large.to_ref(), 0, &GlobalAllocator);
 
 		let small_scalars = enc_small.iter_scalars().collect::<Vec<_>>();
 		let large_scalars = enc_large.iter_scalars().collect::<Vec<_>>();
@@ -418,7 +431,12 @@ mod tests {
 				// A run under the message length is what splits a fill across workers.
 				// The encoder only reaches that on a message above one mebibyte.
 				for log_run in 0..=log_msg {
-					let built = repeated_message_buffer(msg.to_ref(), total, 1 << log_run);
+					let built = repeated_message_buffer(
+						msg.to_ref(),
+						total,
+						1 << log_run,
+						&GlobalAllocator,
+					);
 					assert_eq!(built, expected, "log_msg={log_msg} log_run={log_run}");
 				}
 			}

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -193,8 +193,14 @@ fn prove(shape: &Shape, setup: &Setup, seed: u64) -> Opening {
 	// A masked encoding interleaves the polynomial with a random mask of the same size.
 	// That is what stops the opened cosets leaking the polynomial.
 	let merkle_prover = BinaryMerkleTreeProver::<B128, StdHashSuite>::new();
-	let MaskedCodeword { codeword, mask } =
-		fri::encode_masked(&setup.fri_params, 0, &setup.ntt, witness.to_ref(), &mut rng);
+	let MaskedCodeword { codeword, mask } = fri::encode_masked(
+		&setup.fri_params,
+		0,
+		&setup.ntt,
+		witness.to_ref(),
+		&mut rng,
+		&GlobalAllocator,
+	);
 
 	let mut transcript = ProverTranscript::new(StdChallenger::default());
 	let mut channel =


### PR DESCRIPTION
Part of [BINIUS-492](https://linear.app/jimpo/issue/BINIUS-492/basefold-use-bufferpool-to-allocate-codeword-buffer). **This is the enabling half only — it changes no allocation.** Every caller passes `GlobalAllocator`, so behaviour is identical. The second half needs a decision from you, which I've written up on the issue; see "Why this stops here".

`encode_batch`, `encode_interleaved` and `encode_masked` allocated their buffers as plain `Vec`s. They now take an `A: Allocator` and hand back `A::Vec<P>`-backed buffers, the same shape #2156 gave `BinaryMerkleTree`.

### What moved

| buffer | was | now |
|---|---|---|
| the codeword, in `encode_batch` | `Vec::with_capacity` inside `repeated_message_buffer` | `alloc.alloc::<P>(total)` |
| the small-message codeword | `vec![elem_0; n]` | allocated, then `resize` |
| the mask, in `encode_masked` | `par_rand(..).collect()` | written into the buffer's spare capacity |
| the `message ‖ mask` temporary | `Vec::with_capacity(2 * packed_len)` | from the allocator |

That last one is the `// TODO: encoding should not allocate and copy into a temp buffer` already in the code — it still copies, but at least the copy no longer comes off the global heap once a pool is threaded in.

The mask is the one place the code shape changed. `par_rand` is a *parallel* iterator, and an allocator's buffer has no rayon `collect` to target, so the values are written into the uninitialized capacity through an indexed zip and the length claimed after — the same pattern `repeated_message_buffer` and the Merkle tree already use. The order is positional in both versions, so the mask is bit-for-bit what it was.

`binius-math` already depends on `binius-compute`, and `binius-compute` has an empty `[dependencies]`, so this adds nothing to anyone's dependency tree.

### Why this stops here

The issue asks for the codeword to come from the prover's pool. It cannot, yet — and the reason is worth stating because it isn't visible from the issue.

`BaseFoldProverChannel::send_oracle` hands the codeword straight to `FRIFoldProver::new_batch`, which stores it in `ProxTestFolder` → `BatchBrakedownFolder` → `FRIFolderState`, and after the first fold it moves into `BatchBrakedownOracleProver` and is **held for the whole proof** so the query phase can open it. So a pooled codeword has to be pooled everywhere along that chain: `ProxTestFolder`, `BatchBrakedownFolder`, `FRIFolderState`, `FRIFoldProver`, `BrakedownOracleProver`, `BatchBrakedownOracleProver`, plus `prove_mlecheck_basefold`'s signature. `FRIFoldProver` alone is named in 18 places across 5 files.

That is the FRI prover core, and it is a bigger change than the issue's estimate of 3 suggests, so I'd rather you pick the shape than guess. Options and trade-offs are on the Linear issue. This PR is a prerequisite for every one of them and is safe on its own.

### Gates

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-math -p binius-iop-prover --all-targets -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `cargo test -p binius-math -p binius-iop-prover` — 192 passed, 0 failed

The FRI round-trip tests in `fri/tests.rs` are what pin the encode rewrite: they prove and verify real proofs, so any divergence in the codeword or the mask fails them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
