### PR TITLE
BINIUS-494: carry a shift sequence through gate fusion

### DIFF
--- a/crates/frontend/src/lower/expr.rs
+++ b/crates/frontend/src/lower/expr.rs
@@ -47,11 +47,8 @@ pub enum WireExprTerm {
 impl WireExprTerm {
 	const fn to_shifted_wire(self) -> ShiftedWire {
 		match self {
-			WireExprTerm::Wire(wire) => ShiftedWire {
-				wire,
-				shift: Shift::IDENTITY,
-			},
-			WireExprTerm::Shifted(wire, shift) => ShiftedWire { wire, shift },
+			WireExprTerm::Wire(wire) => ShiftedWire::single(wire, Shift::IDENTITY),
+			WireExprTerm::Shifted(wire, shift) => ShiftedWire::single(wire, shift),
 		}
 	}
 }

--- a/crates/frontend/src/lower/mod.rs
+++ b/crates/frontend/src/lower/mod.rs
@@ -17,7 +17,7 @@ pub use constraint::{
 use cranelift_entity::{EntitySet, SecondaryMap};
 use expr::WireExpr;
 pub use expr::WireExprTerm;
-pub use operand::{ShiftedWire, WireOperand};
+pub use operand::{PushInner, ShiftedWire, WireOperand, push_inner};
 
 use crate::ir::Wire;
 

--- a/crates/frontend/src/lower/operand.rs
+++ b/crates/frontend/src/lower/operand.rs
@@ -5,28 +5,131 @@
 
 use std::ops::Index;
 
-use binius_core::constraint_system::{Shift, ShiftedValueIndex, ValueIndex};
+use binius_core::constraint_system::{Composition, Shift, ShiftedValueIndex, ValueIndex};
 use cranelift_entity::{EntitySet, SecondaryMap};
 
 use crate::ir::Wire;
 
-/// A single wire term of an operand, tagged with the shift to apply to it.
-#[derive(Copy, Clone, Debug)]
+/// A single wire term of an operand, tagged with the shifts to apply to it.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ShiftedWire {
-	/// The wire the shift applies to.
+	/// The wire the shifts apply to.
 	pub wire: Wire,
-	/// The shift folded into this term.
-	pub shift: Shift,
+	/// The shifts folded into this term, innermost first, matching
+	/// [`ShiftedValueIndex::shift_seq`].
+	///
+	/// A term the builder produces carries one shift, in the inner slot. The second slot is filled
+	/// only by gate fusion, and only for a chain that [`Shift::compose`] cannot collapse — see
+	/// [`push_inner`].
+	pub shift_seq: [Shift; 2],
 }
 
 impl ShiftedWire {
+	/// A term carrying one shift, which the canonical form places in the inner slot.
+	pub const fn single(wire: Wire, shift: Shift) -> Self {
+		Self {
+			wire,
+			shift_seq: [shift, Shift::IDENTITY],
+		}
+	}
+
+	/// The one shift this term carries.
+	///
+	/// ## Preconditions
+	///
+	/// * the term is singly shifted, which every term the builder produces is — a second slot is
+	///   only ever filled by gate fusion, over its own output
+	pub fn sole_shift(&self) -> Shift {
+		let [inner, outer] = self.shift_seq;
+		assert!(outer.is_identity(), "precondition: the term carries one shift");
+		inner
+	}
+
 	/// Lowers this term to a core [`ShiftedValueIndex`] via the wire mapping.
 	pub(super) fn to_shifted_value_index(
 		self,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> ShiftedValueIndex {
-		// The builder carries one shift per term, which the canonical form places inner.
-		ShiftedValueIndex::single(wire_mapping[self.wire], self.shift)
+		ShiftedValueIndex::new(wire_mapping[self.wire], self.shift_seq)
+	}
+}
+
+/// What folding one more shift inside a shift sequence comes to.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PushInner {
+	/// The sequence with the shift folded in, filling no more slots than the two a term has.
+	Seq([Shift; 2]),
+	/// The shifts clear every bit between them, so the term they apply to is identically zero.
+	///
+	/// An operand is an XOR, so such a term contributes nothing and is dropped rather than spelled.
+	Zero,
+	/// The shift would need a third slot, which no term can carry.
+	///
+	/// Gate fusion's commit set refuses to inline a path that would reach here, so a caller that
+	/// respects its decision never sees this.
+	OverBudget,
+}
+
+/// The canonical sequence carrying one shift: the shift inner, and an identity spelled one way.
+///
+/// [`Shift::compose`] reports a cancellation with whichever variant produced it, so an identity
+/// can arrive spelled `rotr(0)` or `srl(0)`. Letting that through would give one transformation
+/// several spellings, and the prover keys a row of its shift tables on the spelling — so equal
+/// transformations spelled differently cost it a row each instead of sharing one.
+const fn lone(shift: Shift) -> [Shift; 2] {
+	if shift.is_identity() {
+		[Shift::IDENTITY, Shift::IDENTITY]
+	} else {
+		[shift, Shift::IDENTITY]
+	}
+}
+
+/// Folds `shift` into `seq` as the new innermost shift, as greedily as the shifts compose.
+///
+/// Inlining a definition applies the consumer's accumulated shifts to a term that already carries
+/// one of its own, and that term's shift lands innermost:
+///
+/// ```text
+///     definition:  y = sll(x, 4)
+///     consumer:    ... ^ sll(y, 3) ^ ...        seq = [sll(3), id]
+///     substituted: ... ^ sll(x, 7) ^ ...        push_inner(seq, sll(4), _) -> [sll(7), id]
+/// ```
+///
+/// A slot is spent only where [`Shift::compose`] genuinely cannot collapse two shifts, so a
+/// sequence reaches its second slot only where one shift could not have done the job. Keeping to
+/// that matters beyond tidiness: the prover carries one row of its shift tables per distinct
+/// sequence, so a pair left unmerged is a row it did not need.
+///
+/// # Arguments
+///
+/// - `slots`: how many shifts a term may carry. A sequence needing more is refused rather than
+///   truncated, since dropping a shift would change what the term denotes.
+pub fn push_inner(seq: [Shift; 2], shift: Shift, slots: usize) -> PushInner {
+	let [inner, outer] = seq;
+
+	// Fold the new shift into the inner slot first, which is where it applies.
+	let inner = match Shift::compose(shift, inner) {
+		Composition::Single(merged) => merged,
+		// Clearing the inner word leaves the outer shift nothing to carry.
+		Composition::Zero => return PushInner::Zero,
+		// The two need a slot each. That is three shifts for two slots unless the outer slot is
+		// still free, and both halves are non-identity here or one would have absorbed the other.
+		Composition::Pair if slots >= 2 && outer.is_identity() => {
+			return PushInner::Seq([shift, inner]);
+		}
+		Composition::Pair => return PushInner::OverBudget,
+	};
+
+	// Merging inward can bring the two slots within reach of each other, so try again outward.
+	// A full-width shift past the halfway point is the case that does it: it carries every bit
+	// clear of its own half, after which a half-word shift continues it as if it were full-width.
+	//
+	//     [sll(1), sll32(11)]  is a genuine pair — 1 is not past the halfway point
+	//     fold sll(31) inside  -> [sll(32), sll32(11)], whose halves now chain into sll(43)
+	match Shift::compose(inner, outer) {
+		Composition::Single(collapsed) => PushInner::Seq(lone(collapsed)),
+		Composition::Zero => PushInner::Zero,
+		Composition::Pair => PushInner::Seq([inner, outer]),
 	}
 }
 
@@ -115,10 +218,8 @@ mod tests {
 	use binius_core::constraint_system::{ShiftVariant, ValueIndex};
 	use cranelift_entity::{EntityRef, SecondaryMap};
 
-	use crate::{
-		ir::Wire,
-		lower::{ConstraintBuilder, expr},
-	};
+	use super::*;
+	use crate::lower::{ConstraintBuilder, expr};
 
 	#[test]
 	fn rotr_zero_folds_to_plain_via_linear() {
@@ -242,6 +343,149 @@ mod tests {
 					&& svi.inner().amount == 8
 					&& matches!(svi.inner().variant, ShiftVariant::Rotr)
 			}));
+		}
+	}
+
+	/// The identity is what an unshifted term's sequence holds in both slots.
+	const NONE: [Shift; 2] = [Shift::IDENTITY, Shift::IDENTITY];
+
+	/// The budget the flip will run at, which is what these cases are about.
+	const TWO: usize = 2;
+
+	#[test]
+	fn push_inner_merges_as_greedily_as_the_shifts_compose() {
+		// Two shifts of one variant chain into one, so the sequence keeps its second slot free.
+		// Spending a slot here would cost the prover a second shift-table row for a
+		// transformation one shift already spells.
+		assert_eq!(
+			push_inner([Shift::sll(3), Shift::IDENTITY], Shift::sll(5), TWO),
+			PushInner::Seq([Shift::sll(8), Shift::IDENTITY])
+		);
+		// The identity folds into anything, from either side.
+		assert_eq!(
+			push_inner(NONE, Shift::rotr(7), TWO),
+			PushInner::Seq([Shift::rotr(7), Shift::IDENTITY])
+		);
+		assert_eq!(
+			push_inner([Shift::rotr(7), Shift::IDENTITY], Shift::IDENTITY, TWO),
+			PushInner::Seq([Shift::rotr(7), Shift::IDENTITY])
+		);
+	}
+
+	#[test]
+	fn push_inner_fills_the_second_slot_in_application_order() {
+		// A genuine pair: shifting a field up and arithmetically back down sign-extends it, and no
+		// single shift does that. The one that applies first lands in the inner slot.
+		let (inner, outer) = (Shift::sll(40), Shift::sar(40));
+		assert_eq!(
+			push_inner([outer, Shift::IDENTITY], inner, TWO),
+			PushInner::Seq([inner, outer])
+		);
+	}
+
+	#[test]
+	fn push_inner_drops_a_term_the_shifts_clear() {
+		// Shifting a word 126 places off one end leaves nothing, so the term is identically zero.
+		assert_eq!(
+			push_inner([Shift::sll(63), Shift::IDENTITY], Shift::sll(63), TWO),
+			PushInner::Zero
+		);
+		// The outer slot cannot bring it back: a shift of nothing is nothing.
+		assert_eq!(
+			push_inner([Shift::sll(63), Shift::rotr(9)], Shift::sll(63), TWO),
+			PushInner::Zero
+		);
+	}
+
+	#[test]
+	fn push_inner_returns_a_cancelled_pair_to_a_lone_shift() {
+		// Rotating one way and back cancels, leaving the outer shift standing alone — which
+		// belongs in the inner slot, since that is where the canonical form puts a lone shift.
+		assert_eq!(
+			push_inner([Shift::rotr(1), Shift::sar(7)], Shift::rotr(63), TWO),
+			PushInner::Seq([Shift::sar(7), Shift::IDENTITY])
+		);
+		// With nothing outside either, the term is left unshifted, spelled the canonical way
+		// rather than as the rotate that cancelled.
+		assert_eq!(
+			push_inner([Shift::rotr(1), Shift::IDENTITY], Shift::rotr(63), TWO),
+			PushInner::Seq(NONE)
+		);
+	}
+
+	#[test]
+	fn push_inner_refuses_a_third_slot() {
+		// Both slots hold shifts that do not chain, so a third non-composing shift has nowhere to
+		// go. Reporting that is what lets the caller trust the commit set rather than silently
+		// dropping the shift, which would change what the term denotes.
+		let full = [Shift::sll(40), Shift::sar(40)];
+		assert_eq!(push_inner(full, Shift::rotr(9), TWO), PushInner::OverBudget);
+		// A shift that *does* chain with the inner slot still fits, full sequence or not.
+		assert_eq!(
+			push_inner(full, Shift::sll(5), TWO),
+			PushInner::Seq([Shift::sll(45), Shift::sar(40)])
+		);
+	}
+
+	#[test]
+	fn every_reachable_sequence_is_one_the_constraint_system_accepts() {
+		// Emitting a sequence core would reject is the compiler's failure, not core's, so the
+		// property is that *no reachable sequence* is rejectable. Reachable means: start from what
+		// the builder emits — one shift, inner slot — and fold in shifts until nothing new appears.
+		// That closure is exactly the set inlining can produce, however deep a chain it walks.
+		//
+		// The two faults being ruled out are the ones `ConstraintSystem::operand_fault` names:
+		// a lone shift sitting in the outer slot, and a "pair" whose halves collapse — the latter
+		// being what a naive "didn't compose, so append" would emit.
+		let alphabet = [
+			Shift::IDENTITY,
+			Shift::sll(1),
+			Shift::sll(40),
+			Shift::srl(8),
+			Shift::srl(63),
+			Shift::sar(7),
+			Shift::sar(40),
+			Shift::rotr(1),
+			Shift::rotr(63),
+			Shift::sll32(11),
+			Shift::sra32(11),
+			Shift::rotr32(5),
+		];
+
+		let mut reachable: std::collections::BTreeSet<[Shift; 2]> = alphabet
+			.iter()
+			.map(|&shift| [shift, Shift::IDENTITY])
+			.collect();
+		loop {
+			let mut next = reachable.clone();
+			for &seq in &reachable {
+				for &shift in &alphabet {
+					if let PushInner::Seq(folded) = push_inner(seq, shift, TWO) {
+						next.insert(folded);
+					}
+				}
+			}
+			if next.len() == reachable.len() {
+				break;
+			}
+			reachable = next;
+		}
+
+		// A doubly shifted sequence was reached, or this proves nothing about the second slot.
+		assert!(reachable.iter().any(|[_, outer]| !outer.is_identity()));
+
+		for seq in reachable {
+			let [inner, outer] = seq;
+			if outer.is_identity() {
+				assert!(inner.is_canonical(), "one transformation, two spellings: {seq:?}");
+			} else {
+				assert!(!inner.is_identity(), "a lone shift belongs in the inner slot: {seq:?}");
+				assert_eq!(
+					Shift::compose(inner, outer),
+					Composition::Pair,
+					"a pair that collapses should have been merged: {seq:?}"
+				);
+			}
 		}
 	}
 }

--- a/crates/frontend/src/pass/fusion/legraph.rs
+++ b/crates/frontend/src/pass/fusion/legraph.rs
@@ -312,7 +312,7 @@ fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
 	for lin in &cb.linear_constraints {
 		let consumer = lin.dst;
 		for term in &lin.rhs {
-			leg.note_lin_use(term.wire, term.shift, consumer);
+			leg.note_lin_use(term.wire, term.sole_shift(), consumer);
 		}
 	}
 
@@ -346,7 +346,7 @@ fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
 fn harvest_root_uses(operand: &WireOperand, leg: &mut LeGraph, constraint: ConstraintRef) {
 	for term in operand {
 		if leg.is_lin_def(term.wire) {
-			leg.note_root_use(term.wire, term.shift, constraint);
+			leg.note_root_use(term.wire, term.sole_shift(), constraint);
 		}
 	}
 }

--- a/crates/frontend/src/pass/fusion/mod.rs
+++ b/crates/frontend/src/pass/fusion/mod.rs
@@ -39,9 +39,13 @@ use stat::Stat;
 
 /// How many shifts a term of the lowered constraint system may carry.
 ///
-/// A [`ShiftedValueIndex`](binius_core::constraint_system::ShiftedValueIndex) names one shift, so
-/// the pass has to collapse every inlined path down to one.
-const LOWERED_SHIFT_SLOTS: usize = 1;
+/// A [`ShiftedValueIndex`](binius_core::constraint_system::ShiftedValueIndex) names two, and the
+/// shift reduction proves both. The pass keeps to one for now: spending the second slot changes
+/// which definitions are worth inlining, which wants a cost rule this pass does not yet have.
+///
+/// Both halves of the pass read this — the commit set to decide what it may inline, and the patch
+/// builder to decide what it may spell — so they cannot disagree about the budget.
+pub(super) const LOWERED_SHIFT_SLOTS: usize = 1;
 
 pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>) {
 	let mut stat = Stat::new(cb);

--- a/crates/frontend/src/pass/fusion/patch.rs
+++ b/crates/frontend/src/pass/fusion/patch.rs
@@ -1,14 +1,14 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 
-use binius_core::constraint_system::{Composition, Shift};
+use binius_core::constraint_system::Shift;
 
-use super::legraph::LeGraph;
+use super::{LOWERED_SHIFT_SLOTS, legraph::LeGraph};
 use crate::{
 	ir::Wire,
 	lower::{
-		ConstraintBuilder, ShiftedWire, WireAndConstraint, WireBmulConstraint, WireImulConstraint,
-		WireLinearConstraint, WireOperand, WireZeroConstraint,
+		ConstraintBuilder, PushInner, ShiftedWire, WireAndConstraint, WireBmulConstraint,
+		WireImulConstraint, WireLinearConstraint, WireOperand, WireZeroConstraint, push_inner,
 	},
 	pass::fusion::legraph::ConstraintRef,
 };
@@ -218,49 +218,55 @@ fn process_operand(
 ) -> WireOperand {
 	let mut new_operand = WireOperand::new();
 	for term in old_operand {
-		process_term(cb, leg, &mut new_operand, subsumes, term.wire, term.shift);
+		process_term(cb, leg, &mut new_operand, subsumes, term.wire, term.shift_seq);
 	}
 	new_operand
 }
 
 /// Recursively process a term, inlining non-committed linear definitions.
+///
+/// `shift_seq` is what the consumers above have accumulated, to be applied to `wire`. Inlining
+/// folds the definition's own shift inside it, greedily, so a slot is spent only where the two
+/// genuinely do not collapse.
 fn process_term(
 	cb: &ConstraintBuilder,
 	leg: &LeGraph,
 	new_operand: &mut WireOperand,
 	subsumes: &mut Vec<ConstraintRef>,
 	wire: Wire,
-	shift: Shift,
+	shift_seq: [Shift; 2],
 ) {
 	// Check if this wire is committed or not a linear def (i.e., opaque)
 	if leg.commit_set().contains(wire) || !leg.is_lin_def(wire) {
-		// This is a terminal or committed wire - add it to the result with the accumulated shift
-		new_operand.push(ShiftedWire { wire, shift });
+		// This is a terminal or committed wire - add it to the result with the accumulated shifts
+		new_operand.push(ShiftedWire { wire, shift_seq });
 	} else {
 		// This is a non-committed linear def - we need to inline it!
 		let inner_operand = leg.lin_def_operand(cb, wire);
 		let constraint_ref = leg.lin_def_constraint_ref(wire);
 		subsumes.push(constraint_ref);
 
-		// Distribute the current shift over all terms in the inner operand
+		// Distribute the accumulated shifts over all terms in the inner operand
 		// This is crucial for correctness: shift(a ^ b) = shift(a) ^ shift(b)
 		for inner_term in inner_operand {
-			// Compose shifts: we're applying 'shift' to 'inner_term'
-			// So we need Shift::compose(inner_term.shift, shift)
-			match Shift::compose(inner_term.shift, shift) {
-				Composition::Single(composed_shift) => {
-					// Recursively process this term with the composed shift
-					process_term(cb, leg, new_operand, subsumes, inner_term.wire, composed_shift);
+			// The definition's own shift is applied before anything accumulated above it, so it
+			// folds into the sequence from the inside.
+			let inner_shift = inner_term.sole_shift();
+			match push_inner(shift_seq, inner_shift, LOWERED_SHIFT_SLOTS) {
+				PushInner::Seq(composed) => {
+					// Recursively process this term with the composed sequence
+					process_term(cb, leg, new_operand, subsumes, inner_term.wire, composed);
 				}
-				// The two shifts clear the word, so the term is identically zero. An operand is
+				// The shifts clear the word, so the term is identically zero. An operand is
 				// an XOR, so a zero term contributes nothing and the inlining simply drops it.
-				Composition::Zero => {}
-				// Needing both slots means the commit set inlined a definition it should have
+				PushInner::Zero => {}
+				// Needing a third slot means the commit set inlined a definition it should have
 				// committed: the two passes disagree about what is inlinable.
-				Composition::Pair => {
+				PushInner::OverBudget => {
 					panic!(
-						"Incompatible shifts during inlining: {:?} followed by {:?} for wire {:?}",
-						inner_term.shift, shift, inner_term.wire
+						"Incompatible shifts during inlining: {inner_shift:?} followed by \
+						 {shift_seq:?} for wire {:?}",
+						inner_term.wire
 					);
 				}
 			}
@@ -308,17 +314,17 @@ mod tests {
 			let actual = expand_expression(&cb, &leg, wire);
 
 			// Convert to BTreeMap for easier comparison (order-independent)
-			let expected_map: BTreeMap<(Wire, Shift), usize> =
+			let expected_map: BTreeMap<(Wire, [Shift; 2]), usize> =
 				expected_expansion
 					.iter()
 					.fold(BTreeMap::new(), |mut map, term| {
-						*map.entry((term.wire, term.shift)).or_insert(0) += 1;
+						*map.entry((term.wire, term.shift_seq)).or_insert(0) += 1;
 						map
 					});
 
-			let actual_map: BTreeMap<(Wire, Shift), usize> =
+			let actual_map: BTreeMap<(Wire, [Shift; 2]), usize> =
 				actual.iter().fold(BTreeMap::new(), |mut map, term| {
-					*map.entry((term.wire, term.shift)).or_insert(0) += 1;
+					*map.entry((term.wire, term.shift_seq)).or_insert(0) += 1;
 					map
 				});
 
@@ -347,14 +353,8 @@ mod tests {
 			&[(
 				w(4),
 				vec![
-					ShiftedWire {
-						wire: w(0),
-						shift: Shift::IDENTITY,
-					},
-					ShiftedWire {
-						wire: w(1),
-						shift: Shift::IDENTITY,
-					},
+					ShiftedWire::single(w(0), Shift::IDENTITY),
+					ShiftedWire::single(w(1), Shift::IDENTITY),
 				],
 			)],
 		);
@@ -525,16 +525,13 @@ mod tests {
 
 		if !leg.is_lin_def(wire) {
 			// Not a linear def - return as is
-			result.push(ShiftedWire {
-				wire,
-				shift: Shift::IDENTITY,
-			});
+			result.push(ShiftedWire::single(wire, Shift::IDENTITY));
 			return result;
 		}
 
 		let operand = leg.lin_def_operand(cb, wire);
 		for term in operand {
-			expand_term_recursive(cb, leg, &mut result, term.wire, term.shift);
+			expand_term_recursive(cb, leg, &mut result, term.wire, term.shift_seq);
 		}
 		result
 	}
@@ -544,23 +541,23 @@ mod tests {
 		leg: &LeGraph,
 		result: &mut Vec<ShiftedWire>,
 		wire: Wire,
-		shift: Shift,
+		shift_seq: [Shift; 2],
 	) {
 		// Check if this wire is committed OR not a linear def (terminal)
 		if !leg.is_lin_def(wire) || leg.commit_set().contains(wire) {
 			// Terminal or committed - add it as is
-			result.push(ShiftedWire { wire, shift });
+			result.push(ShiftedWire { wire, shift_seq });
 		} else {
 			// This is a non-committed linear def - expand recursively
 			let inner = leg.lin_def_operand(cb, wire);
 			for term in inner {
-				match Shift::compose(term.shift, shift) {
-					Composition::Single(composed) => {
+				match push_inner(shift_seq, term.sole_shift(), LOWERED_SHIFT_SLOTS) {
+					PushInner::Seq(composed) => {
 						expand_term_recursive(cb, leg, result, term.wire, composed)
 					}
-					// A term the two shifts clear contributes nothing to the XOR.
-					Composition::Zero => {}
-					Composition::Pair => {
+					// A term the shifts clear contributes nothing to the XOR.
+					PushInner::Zero => {}
+					PushInner::OverBudget => {
 						panic!("the commit set only inlines definitions whose shifts compose")
 					}
 				}
@@ -569,10 +566,12 @@ mod tests {
 	}
 
 	/// Build a frequency map for an operand for order-independent comparison.
-	fn operand_count_map(ops: &[ShiftedWire]) -> std::collections::BTreeMap<(Wire, Shift), usize> {
+	fn operand_count_map(
+		ops: &[ShiftedWire],
+	) -> std::collections::BTreeMap<(Wire, [Shift; 2]), usize> {
 		let mut map = std::collections::BTreeMap::new();
 		for t in ops {
-			*map.entry((t.wire, t.shift)).or_insert(0) += 1;
+			*map.entry((t.wire, t.shift_seq)).or_insert(0) += 1;
 		}
 		map
 	}
@@ -608,32 +607,17 @@ mod tests {
 				(
 					w(4),
 					vec![
-						ShiftedWire {
-							wire: w(0),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(1),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(3),
-							shift: Shift::IDENTITY,
-						},
+						ShiftedWire::single(w(0), Shift::IDENTITY),
+						ShiftedWire::single(w(1), Shift::IDENTITY),
+						ShiftedWire::single(w(3), Shift::IDENTITY),
 					],
 				),
 				// y should expand to: x ^ a
 				(
 					w(2),
 					vec![
-						ShiftedWire {
-							wire: w(0),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(1),
-							shift: Shift::IDENTITY,
-						},
+						ShiftedWire::single(w(0), Shift::IDENTITY),
+						ShiftedWire::single(w(1), Shift::IDENTITY),
 					],
 				),
 			],
@@ -656,21 +640,9 @@ mod tests {
 			&[],
 			&[
 				// z should expand to: x << 30
-				(
-					w(2),
-					vec![ShiftedWire {
-						wire: w(0),
-						shift: Shift::sll(30),
-					}],
-				),
+				(w(2), vec![ShiftedWire::single(w(0), Shift::sll(30))]),
 				// y should expand to: x << 10
-				(
-					w(1),
-					vec![ShiftedWire {
-						wire: w(0),
-						shift: Shift::sll(10),
-					}],
-				),
+				(w(1), vec![ShiftedWire::single(w(0), Shift::sll(10))]),
 			],
 		);
 	}
@@ -694,14 +666,8 @@ mod tests {
 				(
 					w(3),
 					vec![
-						ShiftedWire {
-							wire: w(0),
-							shift: Shift::rotr(5),
-						},
-						ShiftedWire {
-							wire: w(1),
-							shift: Shift::rotr(5),
-						},
+						ShiftedWire::single(w(0), Shift::rotr(5)),
+						ShiftedWire::single(w(1), Shift::rotr(5)),
 					],
 				),
 			],
@@ -724,13 +690,7 @@ mod tests {
 			&[w(1)], // y must be committed (incompatible shifts)
 			&[
 				// z should expand to: y >> 20 (y is committed, not inlined)
-				(
-					w(2),
-					vec![ShiftedWire {
-						wire: w(1),
-						shift: Shift::srl(20),
-					}],
-				),
+				(w(2), vec![ShiftedWire::single(w(1), Shift::srl(20))]),
 			],
 		);
 	}
@@ -754,26 +714,11 @@ mod tests {
 				(
 					w(6),
 					vec![
-						ShiftedWire {
-							wire: w(0),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(1),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(2),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(4),
-							shift: Shift::IDENTITY,
-						},
-						ShiftedWire {
-							wire: w(5),
-							shift: Shift::IDENTITY,
-						},
+						ShiftedWire::single(w(0), Shift::IDENTITY),
+						ShiftedWire::single(w(1), Shift::IDENTITY),
+						ShiftedWire::single(w(2), Shift::IDENTITY),
+						ShiftedWire::single(w(4), Shift::IDENTITY),
+						ShiftedWire::single(w(5), Shift::IDENTITY),
 					],
 				),
 			],
@@ -808,66 +753,26 @@ mod tests {
 			Patch {
 				subsumes: vec![ConstraintRef::And { index: 1 }],
 				added: AddedConstraint::And(WireAndConstraint {
-					a: vec![ShiftedWire {
-						wire: w(30),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					b: vec![ShiftedWire {
-						wire: w(31),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					c: vec![ShiftedWire {
-						wire: w(32),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
+					a: vec![ShiftedWire::single(w(30), Shift::IDENTITY)].into(),
+					b: vec![ShiftedWire::single(w(31), Shift::IDENTITY)].into(),
+					c: vec![ShiftedWire::single(w(32), Shift::IDENTITY)].into(),
 				}),
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Linear { index: 0 }],
 				added: AddedConstraint::And(WireAndConstraint {
-					a: vec![ShiftedWire {
-						wire: w(33),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					b: vec![ShiftedWire {
-						wire: w(34),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					c: vec![ShiftedWire {
-						wire: w(35),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
+					a: vec![ShiftedWire::single(w(33), Shift::IDENTITY)].into(),
+					b: vec![ShiftedWire::single(w(34), Shift::IDENTITY)].into(),
+					c: vec![ShiftedWire::single(w(35), Shift::IDENTITY)].into(),
 				}),
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Imul { index: 0 }],
 				added: AddedConstraint::Imul(WireImulConstraint {
-					a: vec![ShiftedWire {
-						wire: w(36),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					b: vec![ShiftedWire {
-						wire: w(37),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					lo: vec![ShiftedWire {
-						wire: w(38),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
-					hi: vec![ShiftedWire {
-						wire: w(39),
-						shift: Shift::IDENTITY,
-					}]
-					.into(),
+					a: vec![ShiftedWire::single(w(36), Shift::IDENTITY)].into(),
+					b: vec![ShiftedWire::single(w(37), Shift::IDENTITY)].into(),
+					lo: vec![ShiftedWire::single(w(38), Shift::IDENTITY)].into(),
+					hi: vec![ShiftedWire::single(w(39), Shift::IDENTITY)].into(),
 				}),
 			},
 		];
@@ -979,26 +884,11 @@ mod tests {
 		assert_operand_eq(
 			a,
 			&[
-				ShiftedWire {
-					wire: w(0),
-					shift: Shift::IDENTITY,
-				},
-				ShiftedWire {
-					wire: w(1),
-					shift: Shift::IDENTITY,
-				},
-				ShiftedWire {
-					wire: w(0),
-					shift: Shift::IDENTITY,
-				},
-				ShiftedWire {
-					wire: w(1),
-					shift: Shift::IDENTITY,
-				},
-				ShiftedWire {
-					wire: w(3),
-					shift: Shift::IDENTITY,
-				},
+				ShiftedWire::single(w(0), Shift::IDENTITY),
+				ShiftedWire::single(w(1), Shift::IDENTITY),
+				ShiftedWire::single(w(0), Shift::IDENTITY),
+				ShiftedWire::single(w(1), Shift::IDENTITY),
+				ShiftedWire::single(w(3), Shift::IDENTITY),
 			],
 			"mul.a",
 		);
@@ -1032,25 +922,12 @@ mod tests {
 
 		assert_eq!(cb2.imul_constraints.len(), 1);
 		let m = &cb2.imul_constraints[0];
-		assert_operand_eq(
-			&m.a,
-			&[ShiftedWire {
-				wire: w(1),
-				shift: Shift::sll(30),
-			}],
-			"mul.a (committed)",
-		);
+		assert_operand_eq(&m.a, &[ShiftedWire::single(w(1), Shift::sll(30))], "mul.a (committed)");
 		assert_operand_eq(
 			&m.b,
 			&[
-				ShiftedWire {
-					wire: w(3),
-					shift: Shift::IDENTITY,
-				},
-				ShiftedWire {
-					wire: w(4),
-					shift: Shift::IDENTITY,
-				},
+				ShiftedWire::single(w(3), Shift::IDENTITY),
+				ShiftedWire::single(w(4), Shift::IDENTITY),
 			],
 			"mul.b (inlinable)",
 		);
@@ -1085,23 +962,14 @@ mod tests {
 		let m = &cb2.imul_constraints[0];
 		assert_operand_eq(
 			&m.hi,
-			&[ShiftedWire {
-				wire: w(1),
-				shift: Shift::sll(20),
-			}],
+			&[ShiftedWire::single(w(1), Shift::sll(20))],
 			"mul.hi (committed)",
 		);
 		assert_operand_eq(
 			&m.lo,
 			&[
-				ShiftedWire {
-					wire: w(3),
-					shift: Shift::IDENTITY,
-				},
-				ShiftedWire {
-					wire: w(4),
-					shift: Shift::IDENTITY,
-				},
+				ShiftedWire::single(w(3), Shift::IDENTITY),
+				ShiftedWire::single(w(4), Shift::IDENTITY),
 			],
 			"mul.lo (inlinable)",
 		);


### PR DESCRIPTION
Gate fusion's terms carry a sequence of two shifts instead of one ([BINIUS-494](https://linear.app/jimpo/issue/BINIUS-494)), composed **greedily** — a slot is spent only where `Shift::compose` genuinely cannot collapse two shifts. `LOWERED_SHIFT_SLOTS` stays at 1, so nothing can reach the second slot yet and **every circuit snapshot is unchanged**. The flip is BINIUS-495.

BINIUS-493 measured the reason to bother: 68% of all committed definitions across the example suite (112,140 of 165,891) are committed purely because their consumers' shifts don't compose, which is what a second slot dissolves.

## The change

`ShiftedWire` carries `shift_seq: [Shift; 2]` matching core's `ShiftedValueIndex`, and `patch::process_term` accumulates one through `push_inner`:

```rust
pub fn push_inner(seq: [Shift; 2], shift: Shift, slots: usize) -> PushInner
```

`Seq` folded in, `Zero` when the shifts clear the word between them (the term is dropped from the XOR), `OverBudget` when it needs more slots than a term has. The two `panic!`s on `Composition::Pair` become the append path, and the panic now fires on `OverBudget` — which at one slot is exactly the case that panicked before, so the safety net that the commit set and the patch builder agree is preserved rather than lost.

Threading `slots` through is what preserves it: `LOWERED_SHIFT_SLOTS` is now read by both halves of the pass, so they cannot disagree about the budget.

**The blast radius is smaller than the issue assumed.** `pass/fusion/legraph.rs` keeps single-shift edge weights and `lower/expr.rs` is untouched: `WireExprTerm::Shifted(Wire, Shift)` takes a wire rather than a nested expression, and fusion runs once, last, after every graph pass — so a chain can only arise through inlining and can never sit on an edge. `sole_shift()` states that as a precondition where those two read a term. `cse`, `dce`, `zero_fold` and `const_prop` don't touch shifts at all.

## Two bugs the tests found

Both were in my first draft of `push_inner`, and both would have produced sequences the constraint system rejects — the compiler's job, since core validates but doesn't canonicalize.

**Merging inward can bring the slots newly within reach of each other.** A full-width shift past the halfway point carries every bit clear of its own half, after which a half-word shift continues it as if it were full-width:

```
[sll(1), sll32(11)]   a genuine pair — 1 is not past the halfway point
fold sll(31) inside   -> [sll(32), sll32(11)], whose halves now chain into sll(43)
```

So the fold retries outward after merging, rather than assuming a pair stays a pair.

**A cancellation arrives spelled by whichever variant produced it.** `compose(rotr(63), rotr(1))` reports `Single(rotr(0))`, not `Single(sll(0))`. Left alone that gives one transformation several spellings — and the prover keys a row of its shift tables on the spelling, so equal transformations spelled differently cost it a row each instead of sharing one. `lone()` puts a surviving lone shift back in the inner slot with the identity spelled one way.

## Testing

- **The circuits-snapshot check is the real assertion**: all 13 snapshots unchanged, run directly rather than trusting CI.
- `every_reachable_sequence_is_one_the_constraint_system_accepts` is the test that found both bugs. Rather than sweeping an arbitrary input domain — my first attempt did, and mostly tested inputs that can't occur — it computes the **closure** of what's reachable: start from what the builder emits (one shift, inner slot), fold in shifts until nothing new appears, and check every sequence in that set against the two faults `ConstraintSystem::operand_fault` names — a lone shift in the outer slot, and a "pair" whose halves collapse.
- Four focused cases: greedy merging, `Zero` dropping, a genuine pair landing in application order, a cancelled pair returning to a lone shift, and a third non-composing shift reporting `OverBudget` rather than silently truncating.
- `binius-frontend` 245 + 1 + 2, `binius-circuits` 355, workspace clippy and `cargo doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)