### PR TITLE
Verify a batch of XMSS signatures through an M4 chip

### DIFF
--- a/crates/circuits/src/hash_based_sig/aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/aggregate.rs
@@ -4,16 +4,21 @@
 //! Each signer has an independent tree, so a public key is a `(root, public parameter)` pair and
 //! both are per-signer. All signers sign the same message at the same epoch, and one proof stands
 //! for every signature.
+//!
+//! The same aggregate is built two ways over one set of wires: [`circuit_xmss_multisig`] emits
+//! every signer's verification inline, and [`circuit_xmss_multisig_chip`] states it once as an M4
+//! chip and calls that chip per signer.
 
 use std::iter;
 
 use binius_core::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, CircuitM4, Wire, WitnessFiller};
 
 use super::{
 	DIGEST_WIRES, MESSAGE_WIRES, Message, PUBLIC_PARAM_WIRES,
 	xmss::{XmssPublicKey, XmssSignature, XmssSignatureWires, circuit_xmss_verify},
 };
+use crate::blake3::Blake3Compress2x;
 
 /// One signer's public key and signature wires.
 #[derive(Debug, Clone)]
@@ -98,6 +103,99 @@ pub fn circuit_xmss_multisig(builder: &CircuitBuilder, wires: &MultiSigWires) {
 	}
 }
 
+/// The words one call to the XMSS chip passes, in the chip's inout order.
+///
+/// [`xmss_verify_chip`] allocates its interface in this same order, so a call's operands line up
+/// with the chip's inout segment position by position.
+fn chip_call_words(
+	signer: &SignerWires,
+	message: &[Wire; MESSAGE_WIRES],
+	epoch: Wire,
+) -> Vec<Wire> {
+	let XmssSignatureWires {
+		randomness,
+		chain_tips,
+		merkle_path,
+	} = &signer.signature;
+	signer
+		.public_param
+		.iter()
+		.chain(&signer.merkle_root)
+		.chain(message)
+		.chain(iter::once(&epoch))
+		.chain(randomness)
+		.chain(chain_tips.iter().flatten())
+		.chain(merkle_path.iter().flatten())
+		.copied()
+		.collect()
+}
+
+/// One XMSS verification, as a system of its own for a caller to embed as a chip.
+///
+/// Every word the check relates is an inout word, so a call supplies the signer's public key, the
+/// message, the epoch and the whole signature, and the chip derives the rest. There is nothing for
+/// the caller to compute on the chip's behalf: the chip has no outputs, only the constraints that
+/// make its operands a valid signature.
+///
+/// The system registers [`Blake3Compress2x`] for itself, so the paired chain compressions inside it
+/// are calls to a chip of its own. Embedding this system therefore brings in two chips: this one,
+/// and the compression it calls.
+fn xmss_verify_chip() -> CircuitM4 {
+	let builder = CircuitBuilder::new();
+	builder.register_chip(Blake3Compress2x, &[]);
+
+	// The inout segment is ordered by wire creation, so allocating in `chip_call_words` order is
+	// what makes the interface that order. The assertion below holds the two together.
+	let public_param = std::array::from_fn(|_| builder.add_inout());
+	let merkle_root = std::array::from_fn(|_| builder.add_inout());
+	let message: [Wire; MESSAGE_WIRES] = std::array::from_fn(|_| builder.add_inout());
+	let epoch = builder.add_inout();
+	let signature = XmssSignatureWires {
+		randomness: std::array::from_fn(|_| builder.add_inout()),
+		chain_tips: std::array::from_fn(|_| std::array::from_fn(|_| builder.add_inout())),
+		merkle_path: std::array::from_fn(|_| std::array::from_fn(|_| builder.add_inout())),
+	};
+	let signer = SignerWires {
+		public_param,
+		merkle_root,
+		signature,
+	};
+
+	circuit_xmss_verify(
+		&builder,
+		&signer.public_param,
+		&signer.merkle_root,
+		&message,
+		epoch,
+		&signer.signature,
+	);
+
+	let system = builder.build_m4();
+	assert_eq!(
+		system.main.circuit.inout(),
+		chip_call_words(&signer, &message, epoch),
+		"the chip's inout segment must be the order its call sites pass"
+	);
+	system
+}
+
+/// [`circuit_xmss_multisig`] with each signer's verification dispatched to a chip.
+///
+/// The main circuit is left holding no hash gates at all: it declares the statement, witnesses the
+/// signatures, and passes both to one chip call per signer. Every signer's verification is the same
+/// relation over different words, which is what a chip is for — the constraints are stated once and
+/// the trace pays for them once per instance.
+///
+/// The wires are [`MultiSigWires`] unchanged, so [`MultiSigWires::populate`] fills this circuit as
+/// it does the inline one. The built circuit carries chips, though, so it builds with
+/// [`CircuitBuilder::build_m4`] rather than [`CircuitBuilder::build`].
+pub fn circuit_xmss_multisig_chip(builder: &CircuitBuilder, wires: &MultiSigWires) {
+	let chip = builder.add_chip(xmss_verify_chip());
+	for signer in &wires.signers {
+		builder.call_chip(chip, &chip_call_words(signer, &wires.message, wires.epoch));
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -142,6 +240,31 @@ mod tests {
 			.map_err(|e| format!("verify: {e:?}"))
 	}
 
+	/// [`run`] over the chip-dispatching circuit, checking the chips as well as the main circuit.
+	///
+	/// The main circuit populating is only half of it: a call whose operands its chip's instance
+	/// does not reproduce shows up in [`WitnessM4::verify`](binius_core::m4::WitnessM4::verify)
+	/// alone, which is what the final check here covers.
+	fn run_chip(
+		message: &Message,
+		epoch: u32,
+		signatures: &[(XmssPublicKey, XmssSignature)],
+	) -> Result<(), String> {
+		let b = CircuitBuilder::new();
+		let wires = MultiSigWires::new(&b, signatures.len());
+		circuit_xmss_multisig_chip(&b, &wires);
+
+		let circuit = b.build_m4();
+		circuit.validate().map_err(|e| format!("validate: {e:?}"))?;
+		let cs = circuit.to_constraint_system();
+		cs.validate().map_err(|e| format!("validate cs: {e:?}"))?;
+
+		let witness = circuit
+			.generate_witness(|w| wires.populate(w, message, epoch, signatures))
+			.map_err(|e| format!("populate: {e:?}"))?;
+		witness.verify(&cs).map_err(|e| format!("verify: {e:?}"))
+	}
+
 	#[test]
 	fn independent_signers_verify_together() {
 		let (message, signatures) = generate(1, 3, 42);
@@ -164,5 +287,18 @@ mod tests {
 		rng.fill_bytes(&mut other);
 		signatures[0] = generate_signature(&mut rng, &other, 42);
 		assert!(run(&message, 42, &signatures).is_err());
+	}
+
+	#[test]
+	fn independent_signers_verify_together_through_the_chip() {
+		let (message, signatures) = generate(1, 2, 42);
+		run_chip(&message, 42, &signatures).unwrap();
+	}
+
+	#[test]
+	fn one_bad_signature_fails_the_chip_aggregate() {
+		let (message, mut signatures) = generate(2, 2, 42);
+		signatures[1].1.chain_tips[0][0] ^= 0xFF;
+		assert!(run_chip(&message, 42, &signatures).is_err());
 	}
 }

--- a/crates/m4-prover/tests/prove_hash_based_sig.rs
+++ b/crates/m4-prover/tests/prove_hash_based_sig.rs
@@ -1,14 +1,15 @@
 // Copyright 2026 The Binius Developers
-//! M4 proof of one XMSS verification, compressing through a BLAKE3 chip.
+//! M4 proof of a batch of XMSS verifications, each dispatched to a chip.
 //!
 //! The companion to `prove_hash_primitives`, one level up: that file proves a batch of bare
-//! primitives, this one proves a whole signature verification — the encoding, the 42 Winternitz
-//! chains, the leaf and the 32-level authentication path.
+//! primitives, this one proves whole signature verifications — the encoding, the 42 Winternitz
+//! chains, the leaf and the 32-level authentication path, once per signer.
 //!
-//! Registering the chip is the whole opt-in: `circuit_xmss_verify` reaches `blake3_compress_2x`
-//! through the paired chain steps without knowing whether it lands in gates or a chip call. The
-//! lone compressions the encoding, the leaf and the path use stay inline, so the chip serves the
-//! chain steps alone.
+//! The circuit is two chips deep. The main circuit holds no hash gates at all: it declares the
+//! statement — the message, the epoch and every signer's public key — witnesses the signatures, and
+//! dispatches one call per signer to the XMSS chip. That chip in turn reaches `blake3_compress_2x`
+//! through the paired chain steps as a chip of its own. So each verification's constraints are
+//! stated once and the trace pays for them once per instance, at both levels.
 //!
 //! The proof runs inside a timing span. With tracing enabled, the prover's internal spans nest
 //! beneath that span, so the per-phase breakdown of proving is visible.
@@ -24,15 +25,12 @@
 //!     -- --ignored --nocapture
 //! ```
 
-use binius_circuits::{
-	blake3::Blake3Compress2x,
-	hash_based_sig::{
-		DIGEST_WIRES, MESSAGE_LEN, MESSAGE_WIRES, Message, PUBLIC_PARAM_WIRES,
-		xmss::{XmssSignatureWires, circuit_xmss_verify, generate_signature},
-	},
+use binius_circuits::hash_based_sig::{
+	MESSAGE_LEN, Message,
+	aggregate::{MultiSigWires, circuit_xmss_multisig_chip},
+	xmss::generate_signature,
 };
-use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, CircuitM4, CircuitStat, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, CircuitM4, CircuitStat, WitnessFiller};
 use binius_hash::StdHashSuite;
 use binius_m4_prover::ProverM4;
 use binius_m4_verifier::VerifierM4;
@@ -46,6 +44,15 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 
 /// Base-2 logarithm of the inverse Reed-Solomon rate: rate 1/2, matching `prove_hash_primitives`.
 const LOG_INV_RATE: usize = 1;
+
+/// The number of signatures the batch verifies.
+///
+/// A power of two fills the XMSS chip's instances exactly. The BLAKE3 chip beneath it takes a
+/// number of calls per signature that is not a power of two, so its own count pads whatever this
+/// is set to — filling both at once is not on offer. The count is what makes the run a batch
+/// rather than a single verification; it trades proving time for a timing tree whose per-phase
+/// costs are legible.
+const NUM_SIGNERS: usize = 8;
 
 /// Installs a timing-tree tracing subscriber, once per test binary.
 ///
@@ -64,51 +71,19 @@ fn init_tracing() {
 		.try_init();
 }
 
-/// The public wires of one XMSS verification.
-struct XmssWires {
-	public_param: [Wire; PUBLIC_PARAM_WIRES],
-	message: [Wire; MESSAGE_WIRES],
-	merkle_root: [Wire; DIGEST_WIRES],
-	epoch: Wire,
-	signature: XmssSignatureWires,
-}
-
-/// Builds a circuit verifying one XMSS signature, with the paired BLAKE3 compression as a chip.
-fn build_xmss_circuit() -> (CircuitM4, XmssWires) {
+/// Builds a circuit verifying `NUM_SIGNERS` XMSS signatures on one message, each through the chip.
+fn build_multisig_circuit() -> (CircuitM4, MultiSigWires) {
 	let builder = CircuitBuilder::new();
-	builder.register_chip(Blake3Compress2x, &[]);
-
-	// Everything the verifier is given is public: the statement is the signature and what it
-	// signs. Nothing here is a witness, so the committed trace holds only derived values.
-	let public_param: [Wire; PUBLIC_PARAM_WIRES] = std::array::from_fn(|_| builder.add_inout());
-	let message: [Wire; MESSAGE_WIRES] = std::array::from_fn(|_| builder.add_inout());
-	let merkle_root: [Wire; DIGEST_WIRES] = std::array::from_fn(|_| builder.add_inout());
-	let epoch = builder.add_inout();
-	let signature = XmssSignatureWires {
-		randomness: std::array::from_fn(|_| builder.add_inout()),
-		chain_tips: std::array::from_fn(|_| std::array::from_fn(|_| builder.add_inout())),
-		merkle_path: std::array::from_fn(|_| std::array::from_fn(|_| builder.add_inout())),
-	};
-
-	circuit_xmss_verify(&builder, &public_param, &merkle_root, &message, epoch, &signature);
-
-	let circuit = builder.build_m4();
-	(
-		circuit,
-		XmssWires {
-			public_param,
-			message,
-			merkle_root,
-			epoch,
-			signature,
-		},
-	)
+	let wires = MultiSigWires::new(&builder, NUM_SIGNERS);
+	circuit_xmss_multisig_chip(&builder, &wires);
+	(builder.build_m4(), wires)
 }
 
-/// Generates a valid signature and writes it into the circuit's public wires.
+/// Generates a valid signature per signer and writes the statement and the signatures into the
+/// main circuit's wires.
 ///
-/// Every digest the circuit checks is derived from these inputs, so the evaluator fills the rest.
-fn fill_xmss(wires: &XmssWires, w: &mut WitnessFiller<'_>) {
+/// Every digest the chips check is derived from these words, so the evaluator fills the rest.
+fn fill_multisig(wires: &MultiSigWires, w: &mut WitnessFiller<'_>) {
 	let mut rng = StdRng::seed_from_u64(0);
 
 	let mut message: Message = [0u8; MESSAGE_LEN];
@@ -117,30 +92,29 @@ fn fill_xmss(wires: &XmssWires, w: &mut WitnessFiller<'_>) {
 	rng.fill_bytes(&mut epoch_bytes);
 	let epoch = u32::from_le_bytes(epoch_bytes);
 
-	// Grinding the randomness and walking the chains out of circuit is what makes the assignment
-	// a signature the circuit accepts rather than arbitrary words.
-	let (public_key, signature) = generate_signature(&mut rng, &message, epoch);
+	// Grinding the randomness and walking the chains out of circuit is what makes each assignment
+	// a signature the chip accepts rather than arbitrary words. The signers are independent, so
+	// each gets its own key; only the message and the epoch are shared.
+	let signatures = (0..NUM_SIGNERS)
+		.map(|_| generate_signature(&mut rng, &message, epoch))
+		.collect::<Vec<_>>();
 
-	w.pack_bytes_le(&wires.public_param, &public_key.public_param);
-	w.pack_bytes_le(&wires.message, &message);
-	w.pack_bytes_le(&wires.merkle_root, &public_key.merkle_root);
-	w[wires.epoch] = Word::from_u64(epoch as u64);
-	wires.signature.populate(w, &signature);
+	wires.populate(w, &message, epoch, &signatures);
 }
 
-// Proves one XMSS verification through M4 and verifies it.
+// Proves a batch of XMSS verifications through M4 and verifies it.
 #[test]
 #[ignore = "proving run for its timing tree; use --ignored --release"]
 fn prove_hash_based_sig() {
 	init_tracing();
 
-	let (circuit, wires) = build_xmss_circuit();
+	let (circuit, wires) = build_multisig_circuit();
 	circuit
 		.validate()
 		.expect("the system can be populated in one pass");
 
-	// Report what each sub-system costs. The chip's instance count is what the chain steps
-	// produced, and the spare-capacity lines show how much of each padded section is wasted.
+	// Report what each sub-system costs. Each chip's instance count is what its callers produced,
+	// and the spare-capacity lines show how much of each padded section is wasted.
 	debug!("xmss main circuit stats:\n{}", CircuitStat::collect(&circuit.main.circuit));
 	for (id, (chip, instances)) in circuit.chips.iter().enumerate() {
 		debug!(
@@ -152,8 +126,8 @@ fn prove_hash_based_sig() {
 	// Generate the witness in its own span: for this circuit that is every BLAKE3 compression,
 	// which is the bulk of it.
 	let witness = info_span!("witness_generation", primitive = "xmss")
-		.in_scope(|| circuit.generate_witness(|w| fill_xmss(&wires, w)))
-		.expect("the generated signature satisfies the circuit");
+		.in_scope(|| circuit.generate_witness(|w| fill_multisig(&wires, w)))
+		.expect("the generated signatures satisfy the circuit");
 
 	let cs = circuit.to_constraint_system();
 	cs.validate().unwrap();
@@ -161,7 +135,7 @@ fn prove_hash_based_sig() {
 	// The witness satisfying the system is what says the timing below is of a real proof.
 	witness
 		.verify(&cs)
-		.expect("the signature verifies in circuit");
+		.expect("the signatures verify in circuit");
 
 	let verifier = VerifierM4::<StdHashSuite>::setup(&cs, LOG_INV_RATE).unwrap();
 	let prover = ProverM4::<OptimalPackedB128, StdHashSuite>::setup(&verifier);


### PR DESCRIPTION
Closes [BINIUS-498](https://linear.app/jimpo/issue/BINIUS-498/m4-prove-hash-based-sig-should-make-a-chip-for-xmss).

`prove_hash_based_sig` proved one XMSS verification, with the paired BLAKE3 compression as its only chip. It now proves a batch of them, each dispatched to an XMSS chip that reaches BLAKE3 through a chip of its own.

### Commits

**Verify an XMSS signature through an M4 chip** (`binius-circuits`)

Adds `circuit_xmss_multisig_chip`: the same aggregate relation `circuit_xmss_multisig` states inline, dispatched instead to one chip call per signer. The wires are `MultiSigWires` unchanged, so `populate` fills either circuit.

The chip is one XMSS verification as a system of its own, embedded with `add_chip`. Its whole interface is inout words — the signer's public key, the message, the epoch and the signature — so it has no outputs, and a call site computes nothing on its behalf; the chip is purely the constraints relating its operands. It registers `Blake3Compress2x` for itself, so the paired chain compressions inside it land in a chip of their own and embedding it brings in both.

A call matches its operands positionally against the callee's inout segment, and that segment is ordered by wire creation. The chip therefore allocates its interface in the order `chip_call_words` hands it back, and asserts the two agree once it is built — a reordered field fails loudly at build rather than producing a trace whose calls no instance serves.

**Prove a batch of XMSS verifications through the chip** (`binius-m4-prover`)

Rewrites the timing test over `NUM_SIGNERS = 8` signatures on a shared message.

### Effect on the circuit

The main circuit is left holding **no gates and no constraints at all** — it declares the statement, witnesses the signatures, and makes one chip call per signer:

| | gates | AND constraints | inout | witness | instances |
|---|---|---|---|---|---|
| main | 0 | 0 | 37 | 1,208 | 1 |
| chip[0] — XMSS | 43,585 | 6,600 | 160 | 0 | 8 |
| chip[1] — `blake3_compress_2x` | 792 | 336 | 28 | 0 | 1,216 |

A power of two fills the XMSS chip's instances exactly. The BLAKE3 chip takes a non-power-of-two number of calls per signature, so filling both at once is not on offer.

### Testing

- Two new unit tests in `binius-circuits` cover the chip path in CI (the M4 timing test is `#[ignore]`d, so it is not CI coverage): one that independent signers verify together through the chip, one that a tampered chain tip fails. Both run the full `validate` → `generate_witness` → `WitnessM4::verify` path, which is where a mis-ordered call operand would show up.
- `cargo test -p binius-circuits --lib hash_based_sig`: 28 passed.
- The `#[ignore]`d proving run passes end to end in release (~9 s to prove, 455 KB proof), and both commits are independently clippy-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)