### PR TITLE
BINIUS-495: spend the second shift slot when the terms do not multiply out

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 47,238
 
 Constraints
-├─ ZERO constraints: 4,744 used (57.9% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,448
+├─ ZERO constraints: 3,912 used (95.5% of 2^12)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 184
 ├─ AND constraints: 15,104 used (92.2% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,280
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 110 used (85.9% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 18
-└─ Distinct value indices: 47,323
-   ├─ Distinct shifted value indices: 27,162
-   └─ Distinct unshifted value indices: 20,161
+└─ Distinct value indices: 46,699
+   ├─ Distinct shifted value indices: 27,370
+   └─ Distinct unshifted value indices: 19,329
 
 Value Vector
 ├─ Public Section: 156 (not committed)
 │  ├─ Constants: 156
 │  └─ Inout: 0
-├─ Private Section: 20,012
+├─ Private Section: 19,180
 │  ├─ Witness: 104
-│  └─ Internal: 19,908
-├─ Committed Trace: 20,012 used (61.1% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,756
-└─ Scratch (uncommitted): 39,280 (peak live: 53)
+│  └─ Internal: 19,076
+├─ Committed Trace: 19,180 used (58.5% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 13,588
+└─ Scratch (uncommitted): 40,112 (peak live: 65)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 176,783
 
 Constraints
-├─ ZERO constraints: 16,585 used (50.6% of 2^15)
-│  [▓▓▓▓▓░░░░░] spare: 16,183
+├─ ZERO constraints: 16,137 used (98.5% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 247
 ├─ AND constraints: 84,229 used (64.3% of 2^17)
 │  [▓▓▓▓▓▓░░░░] spare: 46,843
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 3,718
-└─ Distinct value indices: 275,066
-   ├─ Distinct shifted value indices: 139,192
-   └─ Distinct unshifted value indices: 135,874
+└─ Distinct value indices: 275,334
+   ├─ Distinct shifted value indices: 139,908
+   └─ Distinct unshifted value indices: 135,426
 
 Value Vector
 ├─ Public Section: 134 (not committed)
 │  ├─ Constants: 134
 │  └─ Inout: 0
-├─ Private Section: 135,751
+├─ Private Section: 135,303
 │  ├─ Witness: 9
-│  └─ Internal: 135,742
-├─ Committed Trace: 135,751 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,393
-└─ Scratch (uncommitted): 108,461 (peak live: 109)
+│  └─ Internal: 135,294
+├─ Committed Trace: 135,303 used (51.6% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,841
+└─ Scratch (uncommitted): 108,909 (peak live: 109)
 

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -13,9 +13,9 @@ Constraints
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 19,332
-   ├─ Distinct shifted value indices: 11,486
-   └─ Distinct unshifted value indices: 7,846
+└─ Distinct value indices: 19,651
+   ├─ Distinct shifted value indices: 11,810
+   └─ Distinct unshifted value indices: 7,841
 
 Value Vector
 ├─ Public Section: 28 (not committed)
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 7,696
 ├─ Committed Trace: 7,832 used (95.6% of 2^13)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 360
-└─ Scratch (uncommitted): 7,728 (peak live: 21)
+└─ Scratch (uncommitted): 7,728 (peak live: 25)
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 18,568
 
 Constraints
-├─ ZERO constraints: 5,300 used (64.7% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,892
+├─ ZERO constraints: 3,460 used (84.5% of 2^12)
+│  [▓▓▓▓▓▓▓▓░░] spare: 636
 ├─ AND constraints: 7,680 used (93.8% of 2^13)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 512
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 32,508
-   ├─ Distinct shifted value indices: 19,510
-   └─ Distinct unshifted value indices: 12,998
+└─ Distinct value indices: 41,628
+   ├─ Distinct shifted value indices: 30,479
+   └─ Distinct unshifted value indices: 11,149
 
 Value Vector
 ├─ Public Section: 45 (not committed)
 │  ├─ Constants: 45
 │  └─ Inout: 0
-├─ Private Section: 13,108
+├─ Private Section: 11,268
 │  ├─ Witness: 136
-│  └─ Internal: 12,972
-├─ Committed Trace: 13,108 used (80.0% of 2^14)
-│  [▓▓▓▓▓▓▓▓░░] spare: 3,276
-└─ Scratch (uncommitted): 13,268 (peak live: 37)
+│  └─ Internal: 11,132
+├─ Committed Trace: 11,268 used (68.8% of 2^14)
+│  [▓▓▓▓▓▓░░░░] spare: 5,116
+└─ Scratch (uncommitted): 15,108 (peak live: 41)
 

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 7,256
 
 Constraints
-├─ ZERO constraints: 2,069 used (50.5% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 2,027
+├─ ZERO constraints: 1,389 used (67.8% of 2^11)
+│  [▓▓▓▓▓▓░░░░] spare: 659
 ├─ AND constraints: 2,688 used (65.6% of 2^12)
 │  [▓▓▓▓▓▓░░░░] spare: 1,408
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 12,378
-   ├─ Distinct shifted value indices: 7,617
-   └─ Distinct unshifted value indices: 4,761
+└─ Distinct value indices: 14,868
+   ├─ Distinct shifted value indices: 10,787
+   └─ Distinct unshifted value indices: 4,081
 
 Value Vector
 ├─ Public Section: 281 (not committed)
 │  ├─ Constants: 17
 │  └─ Inout: 264
-├─ Private Section: 4,749
+├─ Private Section: 4,069
 │  ├─ Witness: 0
-│  └─ Internal: 4,749
-├─ Committed Trace: 4,749 used (58.0% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,443
-└─ Scratch (uncommitted): 5,179 (peak live: 42)
+│  └─ Internal: 4,069
+├─ Committed Trace: 4,069 used (99.3% of 2^12)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 27
+└─ Scratch (uncommitted): 5,859 (peak live: 30)
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 244,030
 
 Constraints
-├─ ZERO constraints: 21,878 used (66.8% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 10,890
+├─ ZERO constraints: 21,366 used (65.2% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 11,402
 ├─ AND constraints: 112,581 used (85.9% of 2^17)
 │  [▓▓▓▓▓▓▓▓░░] spare: 18,491
 ├─ IMUL constraints: 20,524 used (62.6% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,244
 ├─ BMUL constraints: 23,632 used (72.1% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 9,136
-└─ Distinct value indices: 374,601
-   ├─ Distinct shifted value indices: 186,465
-   └─ Distinct unshifted value indices: 188,136
+└─ Distinct value indices: 373,577
+   ├─ Distinct shifted value indices: 185,953
+   └─ Distinct unshifted value indices: 187,624
 
 Value Vector
 ├─ Public Section: 52 (not committed)
 │  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 188,089
+├─ Private Section: 187,577
 │  ├─ Witness: 0
-│  └─ Internal: 188,089
-├─ Committed Trace: 188,089 used (71.8% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 74,055
-└─ Scratch (uncommitted): 145,575 (peak live: 254)
+│  └─ Internal: 187,577
+├─ Committed Trace: 187,577 used (71.6% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 74,567
+└─ Scratch (uncommitted): 146,087 (peak live: 254)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 250,294
 
 Constraints
-├─ ZERO constraints: 21,889 used (66.8% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 10,879
+├─ ZERO constraints: 21,342 used (65.1% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 11,426
 ├─ AND constraints: 113,992 used (87.0% of 2^17)
 │  [▓▓▓▓▓▓▓▓░░] spare: 17,080
 ├─ IMUL constraints: 20,538 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,230
 ├─ BMUL constraints: 23,874 used (72.9% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 8,894
-└─ Distinct value indices: 388,977
-   ├─ Distinct shifted value indices: 199,089
-   └─ Distinct unshifted value indices: 189,888
+└─ Distinct value indices: 387,895
+   ├─ Distinct shifted value indices: 198,554
+   └─ Distinct unshifted value indices: 189,341
 
 Value Vector
 ├─ Public Section: 114 (not committed)
 │  ├─ Constants: 85
 │  └─ Inout: 29
-├─ Private Section: 189,783
+├─ Private Section: 189,236
 │  ├─ Witness: 0
-│  └─ Internal: 189,783
-├─ Committed Trace: 189,783 used (72.4% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,361
-└─ Scratch (uncommitted): 150,128 (peak live: 256)
+│  └─ Internal: 189,236
+├─ Committed Trace: 189,236 used (72.2% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,908
+└─ Scratch (uncommitted): 150,675 (peak live: 256)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 276,525
 
 Constraints
-├─ ZERO constraints: 66,908 used (51.0% of 2^17)
-│  [▓▓▓▓▓░░░░░] spare: 64,164
+├─ ZERO constraints: 42,501 used (64.9% of 2^16)
+│  [▓▓▓▓▓▓░░░░] spare: 23,035
 ├─ AND constraints: 61,743 used (94.2% of 2^16)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 3,793
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 44,694 used (68.2% of 2^16)
 │  [▓▓▓▓▓▓░░░░] spare: 20,842
-└─ Distinct value indices: 368,986
-   ├─ Distinct shifted value indices: 195,685
-   └─ Distinct unshifted value indices: 173,301
+└─ Distinct value indices: 419,016
+   ├─ Distinct shifted value indices: 270,123
+   └─ Distinct unshifted value indices: 148,893
 
 Value Vector
 ├─ Public Section: 81 (not committed)
 │  ├─ Constants: 64
 │  └─ Inout: 17
-├─ Private Section: 173,248
+├─ Private Section: 148,841
 │  ├─ Witness: 453
-│  └─ Internal: 172,795
-├─ Committed Trace: 173,248 used (66.1% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 88,896
-└─ Scratch (uncommitted): 178,616 (peak live: 487)
+│  └─ Internal: 148,388
+├─ Committed Trace: 148,841 used (56.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 113,303
+└─ Scratch (uncommitted): 203,023 (peak live: 729)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 20,312
 
 Constraints
-├─ ZERO constraints: 2,077 used (50.7% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 2,019
+├─ ZERO constraints: 1,759 used (85.9% of 2^11)
+│  [▓▓▓▓▓▓▓▓░░] spare: 289
 ├─ AND constraints: 6,503 used (79.4% of 2^13)
 │  [▓▓▓▓▓▓▓░░░] spare: 1,689
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,060
-   ├─ Distinct shifted value indices: 12,350
-   └─ Distinct unshifted value indices: 8,710
+└─ Distinct value indices: 21,021
+   ├─ Distinct shifted value indices: 12,629
+   └─ Distinct unshifted value indices: 8,392
 
 Value Vector
 ├─ Public Section: 404 (not committed)
 │  ├─ Constants: 140
 │  └─ Inout: 264
-├─ Private Section: 8,572
+├─ Private Section: 8,254
 │  ├─ Witness: 0
-│  └─ Internal: 8,572
-├─ Committed Trace: 8,572 used (52.3% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,812
-└─ Scratch (uncommitted): 17,124 (peak live: 22)
+│  └─ Internal: 8,254
+├─ Committed Trace: 8,254 used (50.4% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 8,130
+└─ Scratch (uncommitted): 17,442 (peak live: 30)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 459,115
 
 Constraints
-├─ ZERO constraints: 38,358 used (58.5% of 2^16)
-│  [▓▓▓▓▓░░░░░] spare: 27,178
+├─ ZERO constraints: 33,654 used (51.4% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 31,882
 ├─ AND constraints: 187,912 used (71.7% of 2^18)
 │  [▓▓▓▓▓▓▓░░░] spare: 74,232
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 31,716 used (96.8% of 2^15)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,052
-└─ Distinct value indices: 546,132
-   ├─ Distinct shifted value indices: 285,527
-   └─ Distinct unshifted value indices: 260,605
+└─ Distinct value indices: 537,603
+   ├─ Distinct shifted value indices: 281,702
+   └─ Distinct unshifted value indices: 255,901
 
 Value Vector
 ├─ Public Section: 1,031 (not committed)
 │  ├─ Constants: 729
 │  └─ Inout: 302
-├─ Private Section: 259,584
+├─ Private Section: 254,880
 │  ├─ Witness: 1,381
-│  └─ Internal: 258,203
-├─ Committed Trace: 259,584 used (99.0% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 2,560
-└─ Scratch (uncommitted): 320,445 (peak live: 1,542)
+│  └─ Internal: 253,499
+├─ Committed Trace: 254,880 used (97.2% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7,264
+└─ Scratch (uncommitted): 325,149 (peak live: 1,547)
 

--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -129,18 +129,22 @@ fn test_linear_constraints_lower_to_zero_constraints() {
 	cs.verify(&filler.value_vec).unwrap();
 }
 
-/// Builds `((x << 32) >> 32) & y == z` with gate fusion left on.
+/// Builds `sar(rotr(x << 3, 5), 7) & y == z` with gate fusion left on.
 ///
-/// A left-then-right shift pair is not expressible as one shifted operand, so fusion cannot
-/// inline the intermediate into the `band` and has to commit it. That committed definition lowers
-/// to a ZERO constraint like any other linear constraint.
+/// A term carries two shifts, and none of these three collapse into another, so the chain does not
+/// fit however it is grouped. Fusion therefore cannot inline the intermediate into the `band` and
+/// has to commit it. That committed definition lowers to a ZERO constraint like any other linear
+/// constraint.
+///
+/// Two shifts would not do it: `(x << 32) >> 32` is one term now, which is the point of carrying a
+/// sequence.
 fn build_committed_lin_def_circuit() -> (Circuit, Wire, Wire, Wire) {
 	let builder = CircuitBuilder::new();
 	let x = builder.add_inout();
 	let y = builder.add_inout();
 	let z = builder.add_inout();
-	let low = builder.shr(builder.shl(x, 32), 32);
-	builder.assert_eq("and", builder.band(low, y), z);
+	let chained = builder.sar(builder.rotr(builder.shl(x, 3), 5), 7);
+	builder.assert_eq("and", builder.band(chained, y), z);
 	(builder.build(), x, y, z)
 }
 
@@ -161,9 +165,10 @@ fn test_zero_constraints_reach_a_fused_committed_lin_def() {
 	);
 
 	let mut filler = zero_circuit.new_witness_filler();
-	filler[x] = Word(0x1234_5678_9abc_def0);
-	filler[y] = Word(0x0fed_cba9_8765_4321);
-	filler[z] = Word(0x9abc_def0 & 0x0fed_cba9_8765_4321);
+	let (x_val, y_val) = (0x1234_5678_9abc_def0u64, 0x0fed_cba9_8765_4321u64);
+	filler[x] = Word(x_val);
+	filler[y] = Word(y_val);
+	filler[z] = Word(((x_val << 3).rotate_right(5) as i64 >> 7) as u64 & y_val);
 	zero_circuit.populate_wire_witness(&mut filler).unwrap();
 	zero_cs.verify(&filler.value_vec).unwrap();
 }

--- a/crates/frontend/src/pass/fusion/commit_set.rs
+++ b/crates/frontend/src/pass/fusion/commit_set.rs
@@ -23,6 +23,21 @@ use super::{LeGraph, Stat};
 /// It trades committed words against operand size, and both costs are prover-side.
 pub const MAX_DEPTH: usize = 6;
 
+/// How many terms inlining a definition may add before the pass commits it instead.
+///
+/// This gates the paths that need a second shift slot, and only those: a path a single slot can
+/// spell is inlined on the same terms as it always was. Inlining such a definition adds
+/// `(k - 1)(c - 1) - 2` terms over committing it, so the bound is on that product.
+///
+/// # Why this value
+///
+/// Empirical, like [`MAX_DEPTH`]. Across the example circuits the product is concentrated at 4 —
+/// the shape of a three-term definition read from three places, which is what the σ-functions of
+/// the SHA and BLAKE families look like — and 4 admits 84% of the definitions a second slot could
+/// dissolve while adding at most two terms to each. Above it the distribution thins out and the
+/// terms per definition climb quickly.
+pub(super) const MAX_TERM_GROWTH: usize = 4;
+
 /// The largest shift budget any caller of this pass asks for.
 ///
 /// A shifted term carries a sequence of shifts, and the pass is told how many slots of that
@@ -326,6 +341,10 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat, shift_slots: us
 			let outcoming = leg.pg.edges_directed(node, Direction::Outgoing);
 
 			let mut composable = true;
+			// Whether every path spells this definition's shifts without reaching for a second
+			// slot. Such a path is one today's single-slot pass would have inlined too, so it is
+			// held to today's rules and to no more.
+			let mut fits_one_slot = true;
 			let mut depth = 0;
 
 			'out: for out_edge in outcoming.clone() {
@@ -335,9 +354,12 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat, shift_slots: us
 				depth = out_edge_cx.depth.max(depth);
 				for in_edge in incoming.clone() {
 					let in_shift = in_edge.weight().shift;
-					if !out_edge_cx.composable(in_shift, shift_slots) {
-						composable = false;
-						break 'out;
+					if !out_edge_cx.composable(in_shift, 1) {
+						fits_one_slot = false;
+						if !out_edge_cx.composable(in_shift, shift_slots) {
+							composable = false;
+							break 'out;
+						}
 					}
 				}
 			}
@@ -351,10 +373,31 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat, shift_slots: us
 			//
 			// The operand keeps its size, so no operand can grow out of a chain of these.
 			// The depth cap guards against operands growing, so it has nothing to guard here.
-			let single_term = incoming.clone().count() == 1;
+			let term_count = incoming.clone().count();
+			let single_term = term_count == 1;
 			let too_deep = depth > MAX_DEPTH && !single_term;
 
-			if too_deep || !composable {
+			// A path that has to spend the second shift slot is one a single-slot pass refuses
+			// outright, and refusing it is usually right: inlining substitutes the definition's
+			// `k` terms into each of its `c` consumers, where committing costs `k + 1 + c` terms
+			// and one word. So the second slot is spent only where the terms it multiplies out
+			// are worth the word they save.
+			//
+			//     inlined:    k * c terms
+			//     committed:  (k + 1) + c terms, one committed word, one Zero constraint
+			//     growth:     k*c - (k + c + 1) = (k - 1)(c - 1) - 2
+			//
+			// `MAX_DEPTH` does not cover this: it counts how long a chain is, not how many terms
+			// fan out across it.
+			//
+			// The counts are read before inlining, so a definition whose own cone is inlined into
+			// it later can grow past what was weighed here. This is a brake rather than an
+			// optimizer, and that direction only makes it more conservative than the true cost.
+			let consumer_count = outcoming.clone().count();
+			let growth = term_count.saturating_sub(1) * consumer_count.saturating_sub(1);
+			let multiplies_out = !fits_one_slot && growth > MAX_TERM_GROWTH;
+
+			if too_deep || !composable || multiplies_out {
 				// Decision: commit.
 				//
 				// Every incoming edge context is going to be a brand new one seeded with the

--- a/crates/frontend/src/pass/fusion/mod.rs
+++ b/crates/frontend/src/pass/fusion/mod.rs
@@ -40,12 +40,16 @@ use stat::Stat;
 /// How many shifts a term of the lowered constraint system may carry.
 ///
 /// A [`ShiftedValueIndex`](binius_core::constraint_system::ShiftedValueIndex) names two, and the
-/// shift reduction proves both. The pass keeps to one for now: spending the second slot changes
-/// which definitions are worth inlining, which wants a cost rule this pass does not yet have.
+/// shift reduction proves both, so the pass may spend either.
+///
+/// Spending the second is what lets a definition be inlined where its consumers' shifts do not
+/// compose — the reason two thirds of all committed definitions are committed today. It is not
+/// free: the terms multiply out across the consumers, which
+/// [`MAX_TERM_GROWTH`](commit_set::MAX_TERM_GROWTH) is what bounds.
 ///
 /// Both halves of the pass read this — the commit set to decide what it may inline, and the patch
 /// builder to decide what it may spell — so they cannot disagree about the budget.
-pub(super) const LOWERED_SHIFT_SLOTS: usize = 1;
+pub(super) const LOWERED_SHIFT_SLOTS: usize = 2;
 
 pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>) {
 	let mut stat = Stat::new(cb);

--- a/crates/frontend/src/pass/fusion/tests/awhole.rs
+++ b/crates/frontend/src/pass/fusion/tests/awhole.rs
@@ -122,10 +122,14 @@ fn format_operand(
 
 		let value_name = format_value_name(term.value_index, cs);
 
-		if term.is_unshifted() {
-			write!(output, "{}", value_name).unwrap();
-		} else {
-			let shift_op = match term.inner().variant {
+		// Both slots are spelled, innermost first, or a doubly shifted term would render
+		// indistinguishably from the singly shifted one it was inlined from.
+		write!(output, "{value_name}").unwrap();
+		for shift in term.shift_seq {
+			if shift.is_identity() {
+				continue;
+			}
+			let shift_op = match shift.variant {
 				ShiftVariant::Sll => "≪",
 				ShiftVariant::Slr => "≫",
 				ShiftVariant::Sar => "a≫",
@@ -135,7 +139,7 @@ fn format_operand(
 				ShiftVariant::Sra32 => "a≫32",
 				ShiftVariant::Rotr32 => "≫≫32",
 			};
-			write!(output, "{}{}{}", value_name, shift_op, term.inner().amount).unwrap();
+			write!(output, "{}{}", shift_op, shift.amount).unwrap();
 		}
 	}
 }
@@ -632,10 +636,10 @@ fn test_dont_inline_shifted_producer_into_shifted_use() {
 
 	let cs = compile(&b);
 	// Cannot compose different shift types (srl then sll), so it commits the intermediate
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @"
-	ZERO[0]: (v[0]≫7 ⊕ v[2]) = 0
-	AND[0]: (v[2]≪3) ∧ (v[1]) = (v[3])
-	");
+	insta::assert_snapshot!(
+		stringify_constraint_system(&cs),
+		@"AND[0]: (v[0]≫7≪3) ∧ (v[1]) = (v[2])"
+	);
 }
 
 #[test]
@@ -930,10 +934,7 @@ fn test_chained_shifts_beyond_the_word_width_compile() {
 
 	// The break lands on the topmost link, which is committed as v[4].
 	// The three links below it merge into the single shift of 60 in the AND operand.
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @"
-	ZERO[0]: (v[0]≪20 ⊕ v[2]) = 0
-	AND[0]: (v[2]≪60) ∧ (v[1]) = (v[3])
-	");
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (0) ∧ (v[1]) = (v[2])");
 }
 
 #[test]

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -244,13 +244,15 @@ mod tests {
 		univariate::lagrange_evals_scalars,
 	};
 	use binius_prover::protocols::shift::{
-		DenseShiftEncoding, OperatorData, build_key_collection, monster::shift_operator_table,
+		DenseShiftEncoding, OperatorData, build_key_collection, monster::shift_operator_row,
+		outer::decode_shift,
 	};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
 		protocols::shift::{
-			OperatorData as VerifierOperatorData, check_eval, evaluate_words_mle, verify,
+			LOG_SHIFT_COUNT, OperatorData as VerifierOperatorData, SHIFT_COUNT, check_eval,
+			evaluate_words_mle, verify,
 		},
 	};
 	use rand::prelude::*;
@@ -460,9 +462,9 @@ mod tests {
 	// lambda-batched operand evaluation claim.
 	//
 	// The g multilinear comes from the batched build_g on the full folded witness; h comes from
-	// the shift operator table over the oblong weights at the same univariate challenge r_z. Their
-	// inner product must equal the lambda-powers scaling of the batched AND-check operand evals
-	// (the intmul claim is empty, contributing nothing).
+	// pushing the oblong weights at the same univariate challenge r_z through each term's two shift
+	// slots. Their inner product must equal the lambda-powers scaling of the batched AND-check
+	// operand evals (the intmul claim is empty, contributing nothing).
 	#[test]
 	fn phase_1_g_h_inner_product_matches_batched_evals() {
 		type P = PackedBinaryGhash1x128b;
@@ -532,19 +534,24 @@ mod tests {
 		// from the single-instance prover.
 		let public = build_g::<B128, B128>(public_words, &key_collection.public, &prepared);
 		let hidden = build_g_from_folded_words(&hidden_folded, &key_collection.hidden, &prepared);
-		let h = shift_operator_table::<B128, B128, _>(
-			&GlobalAllocator,
-			lagrange_evals(&domain_subspace, r_z).as_ref(),
-		);
+		let psi = lagrange_evals(&domain_subspace, r_z);
 
 		// `g` is zero outside the rows the segments name, so the inner product is those rows
-		// alone — each sitting at `shift_index * Word::BITS` in the phase-1 layout.
+		// alone. A term names a shift *pair*, and its `h` row is the operator applied twice: the
+		// oblong weights push through the outer slot, and that row pushes through the inner. The
+		// composed table the two slots span holds `2^24` entries and is never formed — this walks
+		// the one row per term instead, which is all the inner product reads.
 		let segment_inner_product = |rows: &[B128], enc: &DenseShiftEncoding| {
 			iter::zip(enc.shift_indices(), rows.chunks_exact(Word::BITS))
-				.map(|(shift_index, row)| {
-					let base = shift_index * Word::BITS;
-					iter::zip(row, base..)
-						.map(|(&value, index)| value * h.get(index))
+				.map(|(quadruple, row)| {
+					let (outer_variant, outer_amount) = decode_shift(quadruple >> LOG_SHIFT_COUNT);
+					let (inner_variant, inner_amount) = decode_shift(quadruple % SHIFT_COUNT);
+					let mut eta_row = [B128::ZERO; Word::BITS];
+					let mut h_row = [B128::ZERO; Word::BITS];
+					shift_operator_row(outer_variant, outer_amount, &mut eta_row, psi.as_ref());
+					shift_operator_row(inner_variant, inner_amount, &mut h_row, &eta_row);
+					iter::zip(row, h_row)
+						.map(|(&value, h)| value * h)
 						.sum::<B128>()
 				})
 				.sum::<B128>()

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -169,7 +169,7 @@ mod tests {
 		test_utils::random_scalars,
 	};
 	use binius_prover::fold_word::fold_words;
-	use binius_utils::checked_arithmetics::checked_log_2;
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use binius_verifier::config::B128;
 	use rand::prelude::*;
 
@@ -220,18 +220,31 @@ mod tests {
 		}
 	}
 
-	// A batch of 2^3 instances of a circuit whose committed word count is `3 * n_gates`: each gate
-	// commits two inputs and the conjunction it promotes to a public output.
+	// A batch of 2^3 instances of a circuit committing `3 * n_gates + n_filler` words: three per
+	// gate — two inputs and the conjunction it promotes to a public output — plus one per filler
+	// wire, which is committed because it is a witness value and kept alive by being XORed into
+	// the first gate.
 	//
-	// A multiple of three is a power of two only for a hand-picked gate count.
-	// That is what lets a caller choose whether the word axis needs padding.
-	fn and_chain_table(n_gates: usize) -> ValueTable {
+	// A multiple of three is never a power of two, so the filler is what lets a caller land on one
+	// and choose whether the word axis needs padding. Reaching that regime through a fixture the
+	// test sizes itself, rather than through whatever a real circuit happens to commit, is what
+	// keeps the coverage from lapsing when the compiler's word counts move.
+	fn and_chain_table(n_gates: usize, n_filler: usize) -> ValueTable {
 		// Each gate consumes two fresh input words and promotes its result to a public output.
 		// That promotion is what keeps the gate alive under dead-code elimination.
 		let builder = CircuitBuilder::new();
 		let inputs: Vec<Wire> = (0..2 * n_gates).map(|_| builder.add_inout()).collect();
-		for pair in inputs.chunks_exact(2) {
-			builder.mark_inout(builder.band(pair[0], pair[1]));
+		let filler: Vec<Wire> = (0..n_filler).map(|_| builder.add_witness()).collect();
+		for (gate, pair) in inputs.chunks_exact(2).enumerate() {
+			// The filler rides on the first gate's left operand, so every filler wire is read.
+			let lhs = if gate == 0 {
+				filler
+					.iter()
+					.fold(pair[0], |acc, &wire| builder.bxor(acc, wire))
+			} else {
+				pair[0]
+			};
+			builder.mark_inout(builder.band(lhs, pair[1]));
 		}
 		let circuit = builder.build();
 
@@ -239,7 +252,7 @@ mod tests {
 		circuit
 			.populate_batch(3, |i, w| {
 				let mut rng = StdRng::seed_from_u64(i as u64);
-				for &wire in &inputs {
+				for &wire in inputs.iter().chain(&filler) {
 					w[wire] = Word(rng.random());
 				}
 			})
@@ -272,11 +285,13 @@ mod tests {
 			let constants = &c.circuit.constraint_system().constants;
 
 			// The committed segment runs from the inout offset to the end of the value vector.
-			// Its length fixes the width of the word axis.
+			// Its length, rounded up, fixes the width of the word axis: a circuit commits whatever
+			// it commits, and the axis spans the power of two above it. The padding words are zero
+			// on both routes, so they cancel out of the identity rather than needing to be absent.
 			let offset = table.layout().offset_inout();
 			let n_committed = table.n_hidden_words();
 			assert_eq!(n_committed, table.layout().combined_len() - offset);
-			let log_committed = checked_log_2(n_committed);
+			let log_committed = log2_ceil_usize(n_committed);
 
 			// The instance-fold point, and a fresh point over the (bit, word) axes.
 			// This point is unrelated to the reduction's own challenges.
@@ -292,15 +307,21 @@ mod tests {
 			// Route B: collapse each word's bits against the bit coordinates first.
 			let bit_tensor = eq_ind_partial_eval_scalars::<B128>(r_bit);
 
-			// Gather every instance's committed words, instance-major:
+			// Gather every instance's committed words, instance-major, each run zero-padded to the
+			// width of the word axis:
 			//
-			//     index = rho * n_committed + w
+			//     index = rho * 2^log_committed + w
+			//
+			// Route A pads, so route B has to stride by the same width or the two read different
+			// words for the same coordinate.
 			//
 			// Each instance is reconstructed on its own, independently of the fold under test.
-			let mut committed = Vec::with_capacity(n_instances * n_committed);
+			let padded_words = 1 << log_committed;
+			let mut committed = Vec::with_capacity(n_instances * padded_words);
 			for rho in 0..n_instances {
 				let vv = table.instance_value_vec(rho, constants);
 				committed.extend_from_slice(&vv.combined_witness()[offset..]);
+				committed.resize(committed.len() + padded_words - n_committed, Word::ZERO);
 			}
 			let folded_words = fold_words::<B128, P, _>(&GlobalAllocator, &committed, &bit_tensor);
 
@@ -324,12 +345,10 @@ mod tests {
 		//
 		//     CRC-64:    1024 committed words  -> already a power of two, no padding
 		//     AND chain:    6 committed words  -> zero-padded up to 8
-		let c = crc64_circuit();
-		let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..8)
-			.map(|_| std::array::from_fn(|_| rng.random()))
-			.collect();
-		let unpadded = populate_crc64_witness(&c, &inputs);
-		let padded = and_chain_table(2);
+		// 3 words per gate plus one per filler, so the two regimes are picked rather than found:
+		// 3*2 + 2 = 8 lands on the power of two, 3*2 + 0 = 6 pads up to it.
+		let unpadded = and_chain_table(2, 2);
+		let padded = and_chain_table(2, 0);
 
 		// Pin which fixture is which, so neither regime can silently stop being covered.
 		assert!(unpadded.n_hidden_words().is_power_of_two(), "fixture must skip the padding");

--- a/crates/prover/src/protocols/shift/outer.rs
+++ b/crates/prover/src/protocols/shift/outer.rs
@@ -30,7 +30,7 @@ use super::{
 /// # Panics
 ///
 /// Panics unless the index is below [`SHIFT_COUNT`].
-fn decode_shift(index: usize) -> (ShiftVariant, usize) {
+pub fn decode_shift(index: usize) -> (ShiftVariant, usize) {
 	assert!(index < SHIFT_COUNT, "a shift index names one slot's spelling");
 	let variant = ShiftVariant::from_u8((index >> Word::LOG_BITS) as u8)
 		.expect("an index below SHIFT_COUNT has a variant field below the variant count");


### PR DESCRIPTION
Gate fusion may now spend both shift slots ([BINIUS-495](https://linear.app/jimpo/issue/BINIUS-495)). This is the change whose output the double-shift backend (#2145, #2146, #2152) finally consumes — until now nothing in the compiler emitted a doubly shifted term, and the backend's cost was paid for nothing.

`LOWERED_SHIFT_SLOTS` goes to 2, behind a growth gate. jimpo picked `T = 4` from the measurement below; **that choice is a tradeoff, not a clean win, and the numbers are here so a reviewer sees it.**

## Why a gate

`run_decide_commit_set` makes a legality decision: inline when the path's shifts fit the budget. At one slot that doubles as a decent cost heuristic — non-composing paths get committed, which is usually right. At two slots it almost never refuses, and `patch::process_term` distributes the consumer's shift over every term it inlines. A `k`-term definition with `c` consumers becomes `k·c` terms where committing costs `k + 1 + c` terms and one word:

```
growth = k*c - (k + c + 1) = (k - 1)(c - 1) - 2
```

`MAX_DEPTH` does not cover this — it counts how long a chain is, not how many terms fan out across it. So paths needing the second slot inline only when `(k - 1)(c - 1) <= MAX_TERM_GROWTH`. **Paths that fit one slot are untouched**, which keeps the single-shift behaviour exactly as it was; at `LOWERED_SHIFT_SLOTS = 1` the gate cannot fire at all.

## What it costs and buys

Committed words, against main:

| circuit | main | now | |
|---|---:|---:|---|
| blake3 | 4,749 /2^13 | **4,069 /2^12** | crosses, halving the commitment |
| hashsign | 173,248 /2^18 | 148,841 /2^18 | −14%, same bucket — but its ZERO constraints cross 2^17 → 2^16 |
| blake2s | 13,108 /2^14 | 11,268 /2^14 | −14%, same bucket |
| sha256 | 8,572 /2^14 | 8,254 /2^14 | −4%, misses 2^13 by 62 words |

ZERO constraints drop broadly — hashsign −36%, blake2s −35%, blake3 −33%, sha256 −15%. AND constraints are unchanged everywhere; inlining trades ZERO constraints and words, never ANDs.

Prove spans, single-slot baseline vs this:

| | blake3 (crosses a bucket) | hashsign (did not, when measured) |
|---|---|---|
| **Prove** | 11.5 → **11.0 ms** (−4%) | 207 → **276 ms** (+33%) |
| Commit witness | 2.45 → **1.20 ms** (−51%) | 42.1 → 50.0 ms |
| Assemble columns | 316 → 493 µs | 12.3 → 22.4 ms (+82%) |
| Distinct shifted value indices | +42% | +41% |

**The honest summary**: term growth is a steady cost, and the word savings only pay where they cross a power of two. blake3 crosses and comes out ahead; hashsign shed fifty times more words, got nothing for them because both counts pad to 2^18, and paid +33%. A global threshold cannot tell those apart, since proximity to a boundary is a property of the circuit. Making the gate boundary-aware is the follow-up that would fix it, and it wants its own issue.

⚠️ **The hashsign timings above predate #2165**, which shrank that circuit; on the rebase its ZERO constraints now do cross a bucket, so the +33% is likely an overstatement of what it costs today. I have not re-run the span measurement. The blake3 column and the shape of the tradeoff are unaffected.

Swept `T ∈ {0, 2, 4, 8, 16, 32, ∞}`. `T = 0` and `T = 2` are neutral on prove time and cross no boundaries; `T = 4` is the knee where 84% of the eligible definitions dissolve, and the only setting where blake3 crosses.

## Test fallout, which is the feature showing through

Three tests asserted the limitation being removed:

- `test_dont_inline_shifted_producer_into_shifted_use` — `srl(7)` then `sll(3)` was a committed word plus a ZERO constraint, and is now one term: `AND[0]: (v[0]≫7≪3) ∧ (v[1]) = (v[2])`.
- `test_chained_shifts_beyond_the_word_width_compile` — `sll(20)` then `sll(60)` clears the word, so the term is dropped outright and the operand becomes `(0)`.
- `build_committed_lin_def_circuit` was built on `(x << 32) >> 32` precisely because it "is not expressible as one shifted operand". It is now, so the fixture needs a three-shift chain to still force a commit.

**`stringify_constraint_system` printed only a term's inner shift**, so a doubly shifted term rendered identically to the singly shifted one it was inlined from — every fusion snapshot would have passed while hiding the change. It now spells both slots.

### And in `binius-m4-prover`, which the smaller circuits reach

Its fixtures are built on crc64, whose committed words fall 1,024 → 768 here. Two of them were resting on that count without saying so:

- `fold_instances_commutes_with_evaluation` sized the word axis with `checked_log_2`, so a non-power-of-two count panicked. The axis is the padded width, and route B was striding instances by the *unpadded* one while route A padded — the two read different words for the same coordinate. Both now use `log2_ceil_usize` and stride alike.
- `fold_bits_matches_the_scalar_contraction` needed one padded and one unpadded table, and got them from crc64 plus a comment that was wrong about `and_chain_table` ever landing on a power of two (it yields exactly `3n`). `and_chain_table` now takes a filler count, so `(2, 2)` = 8 and `(2, 0)` = 6 pick both regimes by construction.
- `phase_1_g_h_inner_product_matches_batched_evals` modelled `h` as one lookup into the single-slot operator table at `shift_index * 64`. Terms now carry 18-bit pair indices, which walk off the end of it. It pushes the oblong weights through both of a term's slots instead — which is what the reduction proves, and what avoids forming the 2^24 table a pair would span. `decode_shift` becomes `pub` for it.

## Verification

All 13 circuit snapshots re-blessed (9 moved, 4 unchanged — keccak among them, which commits nothing and is a useful control). `binius-frontend` 249, `binius-circuits` 334, `binius-prover` 60 + 15 — the last being end-to-end prove/verify over compiler-produced double shifts, which nothing had exercised before — plus `binius-m4-prover` and `binius-m4-verifier`. Workspace clippy and `cargo doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)