### PR TITLE
fix(spartan-verifier): pack the statement into wires, not circuit constants

### DIFF
--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -186,6 +186,14 @@ pub trait WordIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 	fn pack_words(&mut self, words: &[Self::Word]) -> Vec<Self::Elem>;
 }
 
+/// The number of elements [`WordIPVerifierChannel::pack_words`] returns for `n_words` words.
+///
+/// A channel that packs the words into wires rather than computing them needs the count on its
+/// own, so the layout stays in one place.
+pub fn n_packed_elems<F: BinaryField>(n_words: usize) -> usize {
+	n_words.div_ceil(F::N_BITS / Word::BITS)
+}
+
 /// [`WordIPVerifierChannel::pack_words`] over concrete words, for channels carrying [`Word`].
 ///
 /// A set bit contributes the basis element at its position in the packed layout, which is what

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -190,7 +190,7 @@ pub trait WordIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 ///
 /// A channel that packs the words into wires rather than computing them needs the count on its
 /// own, so the layout stays in one place.
-pub fn n_packed_elems<F: BinaryField>(n_words: usize) -> usize {
+pub const fn n_packed_elems<F: BinaryField>(n_words: usize) -> usize {
 	n_words.div_ceil(F::N_BITS / Word::BITS)
 }
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -671,24 +671,37 @@ fn xmss_aggregate_circuit(num_signers: usize, n_pad: usize) -> (ConstraintSystem
 	(cs, witness)
 }
 
+/// The padding that takes a `num_signers` circuit's public segment to exactly `n_public` words.
+///
+/// The unpadded width is whatever the XMSS circuit currently needs, and it moves whenever that
+/// circuit does, so the tests below state the width they mean to exercise and derive the padding
+/// from it rather than hard-coding a count that drifts out from under them. The probe pads by one
+/// rather than none so that the zero constant the padding introduces is already inside the
+/// measured base.
+fn pad_for_public_words(num_signers: usize, n_public: usize) -> usize {
+	let (cs, _) = xmss_aggregate_circuit(num_signers, 1);
+	let base = cs.n_public_words(InoutSegment::Public) - 1;
+	n_public - base
+}
+
 /// A public segment of exactly 2^9 words proves and verifies, plain and ZK.
 #[test]
 fn test_zk_prove_verify_aggregate_public_segment_at_power_of_two() {
-	let (cs, witness) = xmss_aggregate_circuit(1, 151);
+	let (cs, witness) = xmss_aggregate_circuit(1, pad_for_public_words(1, 512));
 	assert_eq!(cs.n_public_words(InoutSegment::Public), 512);
 	prove_verify(cs.clone(), &witness);
 	prove_verify_zk(cs, &witness);
 }
 
-/// One public word more, and the ZK wrapper rejects an honest proof.
+/// One public word past the power of two proves and verifies too.
 ///
-/// The plain prover accepts the same circuit and witness, so this is the ZK composition alone:
-/// verification fails in the outer Spartan check with `IPChannel(InvalidAssert)`. The only
-/// difference from the test above is one inert padding word, which takes the public segment from
-/// 512 words to 513.
+/// This is the case the packed statement broke: the wrapper circuit read the statement back as
+/// constants, so a public segment that crossed 2^9 words disagreed with the one the concrete
+/// channels packed, and the outer Spartan check rejected an honest proof with
+/// `IPChannel(InvalidAssert)`. The only difference from the test above is one inert padding word.
 #[test]
 fn test_zk_prove_verify_aggregate_public_segment_over_power_of_two() {
-	let (cs, witness) = xmss_aggregate_circuit(1, 152);
+	let (cs, witness) = xmss_aggregate_circuit(1, pad_for_public_words(1, 513));
 	assert_eq!(cs.n_public_words(InoutSegment::Public), 513);
 	prove_verify(cs.clone(), &witness);
 	prove_verify_zk(cs, &witness);

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -3,7 +3,14 @@
 
 use std::collections::HashSet;
 
-use binius_circuits::sha256::{State, populate_message_block, sha256_compress};
+use binius_circuits::{
+	hash_based_sig::{
+		MESSAGE_LEN, Message,
+		aggregate::{MultiSigWires, circuit_xmss_multisig},
+		xmss::{XmssPublicKey, XmssSignature, generate_signature},
+	},
+	sha256::{State, populate_message_block, sha256_compress},
+};
 use binius_core::{
 	constraint_system::{
 		AndConstraint, BmulConstraint, ConstraintSystem, ImulConstraint, InoutSegment,
@@ -18,7 +25,7 @@ use binius_prover::{Prover, zk_config::ZKProver};
 use binius_transcript::ProverTranscript;
 use binius_utils::{DeserializeBytes, SerializeBytes};
 use binius_verifier::{Verifier, config::StdChallenger, zk_config::ZKVerifier};
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 fn prove_verify(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
@@ -624,4 +631,65 @@ fn test_plain_proof_rejects_message() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A plain proof of knowledge must not verify when a message is supplied.
 	assert!(!sign_verify(cs, &witness, None, Some(b"hello world")));
+}
+
+/// An aggregate XMSS verification, with `n_pad` extra public words pinned to zero.
+///
+/// The padding is inert: every padded word is a constant-zero assertion, and nothing else about
+/// the circuit depends on `n_pad`. It exists only to move the public segment's width.
+fn xmss_aggregate_circuit(num_signers: usize, n_pad: usize) -> (ConstraintSystem, ValueVec) {
+	const EPOCH: u32 = 42;
+
+	let mut rng = StdRng::seed_from_u64(1);
+	let mut message: Message = [0u8; MESSAGE_LEN];
+	rng.fill_bytes(&mut message);
+	let signatures: Vec<(XmssPublicKey, XmssSignature)> = (0..num_signers)
+		.map(|_| generate_signature(&mut rng, &message, EPOCH))
+		.collect();
+
+	let builder = CircuitBuilder::new();
+	let wires = MultiSigWires::new(&builder, num_signers);
+	circuit_xmss_multisig(&builder, &wires);
+
+	let zero = builder.add_constant(Word::ZERO);
+	let pad = (0..n_pad).map(|_| builder.add_inout()).collect::<Vec<_>>();
+	for &wire in &pad {
+		builder.assert_eq("pad_is_zero", wire, zero);
+	}
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	wires.populate(&mut w, &message, EPOCH, &signatures);
+	for &wire in &pad {
+		w[wire] = Word::ZERO;
+	}
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	let cs = circuit.constraint_system().clone();
+	let witness = w.into_value_vec();
+	cs.verify(&witness).unwrap();
+	(cs, witness)
+}
+
+/// A public segment of exactly 2^9 words proves and verifies, plain and ZK.
+#[test]
+fn test_zk_prove_verify_aggregate_public_segment_at_power_of_two() {
+	let (cs, witness) = xmss_aggregate_circuit(1, 151);
+	assert_eq!(cs.n_public_words(InoutSegment::Public), 512);
+	prove_verify(cs.clone(), &witness);
+	prove_verify_zk(cs, &witness);
+}
+
+/// One public word more, and the ZK wrapper rejects an honest proof.
+///
+/// The plain prover accepts the same circuit and witness, so this is the ZK composition alone:
+/// verification fails in the outer Spartan check with `IPChannel(InvalidAssert)`. The only
+/// difference from the test above is one inert padding word, which takes the public segment from
+/// 512 words to 513.
+#[test]
+fn test_zk_prove_verify_aggregate_public_segment_over_power_of_two() {
+	let (cs, witness) = xmss_aggregate_circuit(1, 152);
+	assert_eq!(cs.n_public_words(InoutSegment::Public), 513);
+	prove_verify(cs.clone(), &witness);
+	prove_verify_zk(cs, &witness);
 }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -68,6 +68,15 @@ impl<F: Field> ReplayChannel<F> {
 			.next()
 			.unwrap_or_else(|| panic!("replay exhausted: no more events"));
 
+		self.alloc_inout_elem(value)
+	}
+
+	/// Allocates the next inout wire around a value the replay computes rather than reads back.
+	///
+	/// Most inout wires carry a recorded value, since they stand for what crossed the channel. The
+	/// packed statement does not cross it: both sides hold the words and pack them, so the value
+	/// comes from the caller.
+	fn alloc_inout_elem(&mut self, value: F) -> CircuitElem<F, WitnessGenerator<F>> {
 		let wire = self.inout_alloc.alloc();
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
 		CircuitElem::wire(&self.witness_gen, witness_wire)
@@ -167,7 +176,12 @@ impl<F: BinaryField> WordIPVerifierChannel<F> for ReplayChannel<F> {
 	}
 
 	fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
-		pack_words_concrete::<F, Self::Elem>(words)
+		// One inout wire per packed element, matching the symbolic phase; the prover holds the same
+		// words the verifier does, so it packs them itself rather than replaying them.
+		pack_words_concrete::<F, F>(words)
+			.into_iter()
+			.map(|value| self.alloc_inout_elem(value))
+			.collect()
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -12,7 +12,7 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 use binius_ip::channel::{
-	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
+	IPVerifierChannel, WordIPVerifierChannel, n_packed_elems, select_word, subset_sum_word,
 };
 use binius_spartan_frontend::circuit_builder::{CircuitBuilder, ConstraintBuilder};
 
@@ -149,8 +149,13 @@ impl<F: BinaryField> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	}
 
 	fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
-		// The words are concrete, so the packed elements are settled while building.
-		pack_words_concrete::<F, Self::Elem>(words)
+		// The words are the statement, and this circuit is built once to be reused across every
+		// statement, so the packed elements cannot be settled here: a constant would fix the
+		// statement it was built against into the circuit. They enter as inout wires instead, which
+		// `ZKWrappedVerifierChannel` and `ReplayChannel` fill with the concrete packing.
+		(0..n_packed_elems::<F>(words.len()))
+			.map(|_| self.alloc_inout_elem())
+			.collect()
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -21,11 +21,12 @@ pub use zk_wrapped_channel::ZKWrappedVerifierChannel;
 mod tests {
 	use std::rc::Rc;
 
+	use binius_core::word::Word;
 	use binius_field::{
 		BinaryField1b as B1, BinaryField128bGhash as B128, ExtensionField, Field, Random,
 		arithmetic_traits::InvertOrZero, field::FieldOps,
 	};
-	use binius_ip::channel::IPVerifierChannel;
+	use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 	use binius_spartan_frontend::circuit_builder::ConstraintBuilder;
 	use rand::{SeedableRng, rngs::StdRng};
 
@@ -142,6 +143,28 @@ mod tests {
 		for elem in &c {
 			assert!(matches!(elem, BuildElem::Wire { .. }));
 		}
+	}
+
+	/// The packed statement enters the circuit as inout wires, not as constants.
+	///
+	/// The wrapper circuit is built once, against whatever statement the symbolic run was handed,
+	/// and reused for every other one. Packing the words into constants would fix that first
+	/// statement into the circuit, so the words become wires the concrete channels fill in.
+	#[test]
+	fn test_pack_words_allocates_inout_wires() {
+		let mut channel = IronSpartanBuilderChannel::<B128>::new();
+
+		// Two words to a `B128`, so three words span two elements. The zero word is deliberate:
+		// nothing about the packing may turn on the values.
+		let words = [Word::from_u64(7), Word::ZERO, Word::from_u64(9)];
+		let elems = channel.pack_words(&words);
+
+		assert_eq!(elems.len(), 2);
+		assert!(
+			elems
+				.iter()
+				.all(|elem| matches!(elem, BuildElem::Wire { .. }))
+		);
 	}
 
 	#[test]

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -256,8 +256,13 @@ where
 	}
 
 	fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
-		// The words are concrete, so the packed elements are constants of the wrapper circuit.
-		pack_words_concrete::<F, Self::Elem>(words)
+		// The symbolic phase allocated an inout wire per packed element, since the statement is not
+		// the circuit's to fix. Fill them here: the words are concrete, so the verifier packs them
+		// itself and writes the result into the public segment.
+		pack_words_concrete::<F, F>(words)
+			.into_iter()
+			.map(|value| self.alloc_inout_elem(value))
+			.collect()
 	}
 }
 


### PR DESCRIPTION
An honest ZK proof fails verification once the constraint system's public segment passes a
power of two. For a circuit built from `hash_based_sig::aggregate::circuit_xmss_multisig`, a
statement of **512** public words verifies and one of **513** does not, the two circuits
differing only by one inert padding word — an inout constrained to the constant zero that
nothing else reads.

```
ZKVerifier::verify → Err(OuterVerification(IPChannel(InvalidAssert)))
```

`Prover`/`Verifier` (non-ZK) accept both, so this is the ZK composition, not the core IOP.

The first commit adds the two tests, the second fixes the bug, the third pins the rule it turned
on. Bisected to `156b0bd6` ("BINIUS-466: ring-switch the public segment's evaluation", #2114).

## The bug

`IronSpartanBuilderChannel::pack_words` packed the words it was handed into *constants*:

```rust
fn pack_words(&mut self, words: &[Word]) -> Vec<Self::Elem> {
    // The words are concrete, so the packed elements are settled while building.
    pack_words_concrete::<F, Self::Elem>(words)
}
```

But those words are the statement, and the circuit they are being packed into is built once —
`ZKVerifier::setup` symbolically executes the inner verifier against a placeholder of all-zero
inout words — and then reused for every real statement. So the circuit was built around zeros
that no real statement shares.

Zeros are not inert in that circuit. `CircuitElem`'s multiplication folds `x * 0` to a constant,
so wherever a placeholder zero made a product vanish that a real statement does not, the
symbolic run allocated one wire fewer than verification then did. Nothing catches that:
`InstanceGenerator::write_public` drops wires the layout has no slot for, which is also how
pruned intermediates are handled, so the run continues with every later derived value written
into the previous one's slot, and the outer proof fails.

Crossing a power of two is what exposes it. `verify_public_eval` pads the packed public segment
up to `1 << log_public_elems` with zeros, so at 513 words the fold that evaluates it pairs each
of the statement's own elements against a padding zero: `delta = 0 - w`, which is zero for the
placeholder and non-zero for a real statement. At exactly 512 words there is no padding, every
element is paired with another real element, and the deltas are non-zero either way — which is
why that case passes, and why the threshold moves with the circuit rather than sitting at a
fixed word count.

Two probes confirm the path, both on the 513-word circuit:

- seeding `setup`'s symbolic run with the real statement instead of zeros makes the unfixed
  prover and verifier agree — the proof verifies;
- the circuits the zero statement and the real one induce differ, by exactly the wires the
  vanished products would have allocated.

## The fix

The packed elements enter as inout wires. `ZKWrappedVerifierChannel` and `ReplayChannel` fill
them with the concrete packing, which both sides compute from words they already hold, so
nothing is added to the transcript and no new value has to be agreed on.

The point is not that the zeros are gone but that the statement is: the wrapper circuit no
longer holds any of it, so it is now *identical* whatever statement the symbolic run was handed.
Building it against an all-zero statement and against a real one gives the same constants, the
same mul constraints and the same wire counts, which was not true before — and is what makes the
placeholder in `setup` sound rather than lucky.

It costs nothing. On the aggregate circuit above:

| | constants | inout | derived | mul constraints | `log_public` |
|---|---|---|---|---|---|
| before | 431 | 1,019 | 594,499 | 396,630 | 20 |
| after | 255 | 1,276 | 594,499 | 396,630 | 20 |

176 constants traded for 257 inout wires — the packed segment has to live somewhere — with the
derived wires, the constraints and the padded public size all unchanged, so the outer proof is
the same size.

One nearby hazard of the same kind, left alone here since nothing wrapped today reaches it:
`subset_sum` and `select` shape the circuit from a concrete word, and the builder channel's
`sample_bits` returns `Word::ZERO`. A verifier that reached either of those with sampled bits
would build its circuit around that zero and run it against another word.

## Testing

- The two tests in `crates/prover/tests/prove_verify.rs` fail (513) / pass (512) on the first
  commit, and both pass on the second.
- `test_pack_words_allocates_inout_wires`, in the third commit, states the rule where the
  packing is: the elements come back as wires, for words that include a zero.
- `cargo test --release -p binius-spartan-verifier -p binius-spartan-prover -p binius-verifier
  -p binius-prover -p binius-ip` — the crates that depend on the changed code, plus the
  end-to-end tests: 122 passed, 0 failed.
- `cargo +nightly-2026-07-01 fmt`: clean.
- Full workspace suite and clippy: <!-- FILL IN -->

## Bisect

Bisected over `eaa3b6d0..029b44d8` with a different circuit (a blind-signature aggregate of our
own, which crosses **256** public words at 22 signers):

| rev | 22-signer circuit |
|---|---|
| `eaa3b6d0` — "Bind the shift indicator bit index with a sumcheck" (#2113) | verifies |
| `156b0bd6` — "BINIUS-466: ring-switch the public segment's evaluation" (#2114) | `OuterVerification(IPChannel(InvalidAssert))` |

Every later rev tested (`1c8a1e68`, `029b44d8`, `7d457ae1`, `a7ef8201`) fails. #2114 did not
introduce the packing into constants — it introduced the zero-padded public fold that reaches
the statement's own words with a multiplication.

## Why it went unnoticed

`test_prove_verify_public_wider_than_hidden` covers a wide-public circuit at 301 public words
and passes: with no ZK wrapper in that test, nothing is built against a placeholder. The
aggregate tests in `hash_based_sig::aggregate` check only `ConstraintSystem::verify`, never a
prove/verify round trip.

Circuits whose public segment happens to land on a power of two, or whose statement words are
paired only with other statement words, verify fine — which is most of what the suite covers.
