### PR TITLE
BINIUS-500: M4 proving benchmark for secp256k1 incomplete point addition

### DIFF
--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -27,6 +27,7 @@ binius-verifier = { path = "../verifier" }
 bytemuck.workspace = true
 digest.workspace = true
 # Enabled by the `test-circuits` feature only.
+k256 = { workspace = true, features = ["arithmetic"], optional = true }
 rand = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
@@ -46,8 +47,8 @@ tracing-subscriber = { workspace = true }
 [features]
 default = []
 rayon = ["binius-utils/rayon"]
-# Circuits over hash primitives, shared by this crate's proving benchmarks and timing tests.
-test-circuits = ["dep:binius-circuits", "dep:rand"]
+# Circuits over primitives, shared by this crate's proving benchmarks and timing tests.
+test-circuits = ["dep:binius-circuits", "dep:k256", "dep:rand"]
 
 [[bench]]
 name = "keccak_witness_gen"

--- a/crates/m4-prover/benches/prove_hash_primitives.rs
+++ b/crates/m4-prover/benches/prove_hash_primitives.rs
@@ -1,12 +1,13 @@
 // Copyright 2026 The Binius Developers
-//! End-to-end M4 proving throughput for batches of independent hash primitives.
+//! End-to-end M4 proving throughput for batches of independent primitives.
 //!
 //! One benchmark runs per primitive, each proving a batch of instances of a single-instance circuit
 //! from [`binius_m4_prover::test_circuits`], which the `prove_hash_primitives` timing tests share.
 //! The `_3x` variants pack three primitives into one instance instead of one, filling the value
 //! vector more densely, so a smaller share of the committed trace is padding. Throughput is
 //! reported in primitives, not instances: the BLAKE3 and SHA-256 cores each compute two
-//! independent compressions from the two 32-bit lanes of a 64-bit word.
+//! independent compressions from the two 32-bit lanes of a 64-bit word, while one instance of the
+//! secp256k1 circuit is one point addition.
 //!
 //! Witness generation is inside the timed unit. Published Flock figures include it in the proof
 //! path, so the measured unit matches.
@@ -21,7 +22,9 @@ use binius_frontend::BatchWitnessFiller;
 use binius_hash::StdHashSuite;
 use binius_m4_prover::{
 	Prover,
-	test_circuits::{Blake3Circuit, KeccakCircuit, Sha256Circuit, TestCircuit},
+	test_circuits::{
+		Blake3Circuit, KeccakCircuit, Secp256k1AddIncompleteCircuit, Sha256Circuit, TestCircuit,
+	},
 };
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
@@ -118,6 +121,12 @@ fn bench_prove_hash_primitives(c: &mut Criterion) {
 	bench_primitive::<Sha256Circuit<3>>(&mut group, "sha256_3x", log_instances, log_inv_rate);
 	bench_primitive::<KeccakCircuit<1>>(&mut group, "keccak", log_instances, log_inv_rate);
 	bench_primitive::<KeccakCircuit<3>>(&mut group, "keccak_3x", log_instances, log_inv_rate);
+	bench_primitive::<Secp256k1AddIncompleteCircuit>(
+		&mut group,
+		"secp256k1_add",
+		log_instances,
+		log_inv_rate,
+	);
 
 	group.finish();
 }

--- a/crates/m4-prover/src/test_circuits.rs
+++ b/crates/m4-prover/src/test_circuits.rs
@@ -1,20 +1,24 @@
 // Copyright 2026 The Binius Developers
-//! Single-instance circuits over hash primitives and integer multiplication.
+//! Single-instance circuits over hash primitives, integer multiplication, and elliptic-curve
+//! point addition.
 //!
 //! The proving benchmarks and the proving timing tests both prove batches of these, so the circuits
-//! live here rather than in either. Each is generic over the number `N` of independent primitives
-//! one instance computes: a larger `N` fills the value vector more densely, so a smaller share of
-//! the committed trace is padding.
+//! live here rather than in either. The hash circuits are generic over the number `N` of
+//! independent primitives one instance computes: a larger `N` fills the value vector more densely,
+//! so a smaller share of the committed trace is padding.
 
-use std::array;
+use std::{array, iter};
 
 use binius_circuits::{
+	bignum::BigUint,
 	blake3::blake3_compress_2x,
 	keccak::permutation::keccak_f1600,
+	secp256k1::{N_LIMBS, Secp256k1, Secp256k1Affine},
 	sha256::{State, sha256_compress_2x},
 };
 use binius_core::word::Word;
 use binius_frontend::{BatchWitnessFiller, Circuit, CircuitBuilder, Wire};
+use k256::{ProjectivePoint, elliptic_curve::sec1::ToSec1Point};
 use rand::prelude::*;
 
 /// The number of 64-bit lanes in a Keccak-f1600 state.
@@ -311,4 +315,134 @@ impl TestCircuit for ImulCircuit {
 			w[wire] = Word(rng.next_u64());
 		}
 	}
+}
+
+/// The number of on-curve summand pairs the point-addition circuit precomputes.
+///
+/// Instances cycle through the pool. The circuit's shape, and so its proving cost, does not depend
+/// on the coordinate values, so reusing pairs across a larger batch does not bias the measurement.
+/// Precomputing keeps witness filling — which the benchmark times — free of the host-side curve
+/// arithmetic that generating a fresh pair per instance would cost.
+const N_SUMMAND_PAIRS: usize = 1 << 10;
+
+/// The affine coordinates of a curve point, each as little-endian 64-bit limbs.
+struct AffineLimbs {
+	x: [u64; N_LIMBS],
+	y: [u64; N_LIMBS],
+}
+
+/// A circuit of one incomplete secp256k1 affine point addition.
+///
+/// The two summands are public inputs, their point-at-infinity flags included. Those flags are
+/// wires rather than constants because the scalar-multiplication circuits call
+/// [`Secp256k1::add_incomplete`] with flags computed in-circuit; folding a constant flag would
+/// drop the point-at-infinity handling from the measured circuit.
+///
+/// Unlike the hash primitives, this circuit is built from 256-bit modular arithmetic — three
+/// 4-limb multiplications and a modular-division hint — so its proof exercises the IntMul
+/// reduction, which the purely bitwise hash circuits do not.
+pub struct Secp256k1AddIncompleteCircuit {
+	circuit: Circuit,
+	summands: [Secp256k1Affine; 2],
+	/// Pairs of distinct on-curve points, cycled over the batch's instances.
+	summand_pairs: Vec<[AffineLimbs; 2]>,
+}
+
+impl TestCircuit for Secp256k1AddIncompleteCircuit {
+	const PRIMITIVES_PER_INSTANCE: u64 = 1;
+
+	fn new() -> Self {
+		let builder = CircuitBuilder::new();
+		let curve = Secp256k1::new(&builder);
+
+		// Both summands are public, filled per instance.
+		let summands: [Secp256k1Affine; 2] = array::from_fn(|_| Secp256k1Affine {
+			x: BigUint::new_inout(&builder, N_LIMBS),
+			y: BigUint::new_inout(&builder, N_LIMBS),
+			is_point_at_infinity: builder.add_inout(),
+		});
+
+		// Promote the sum to public outputs.
+		// That promotion keeps the addition alive under dead-code elimination.
+		let sum = curve.add_incomplete(&builder, &summands[0], &summands[1]);
+		for &wire in sum
+			.x
+			.limbs
+			.iter()
+			.chain(&sum.y.limbs)
+			.chain(iter::once(&sum.is_point_at_infinity))
+		{
+			builder.mark_inout(wire);
+		}
+
+		Self {
+			circuit: builder.build(),
+			summands,
+			summand_pairs: summand_pairs(),
+		}
+	}
+
+	fn circuit(&self) -> &Circuit {
+		&self.circuit
+	}
+
+	/// Assigns one instance's summands from the precomputed pool, cycling over it.
+	fn fill(&self, instance: usize, w: &mut BatchWitnessFiller<'_, '_>) {
+		let pair = &self.summand_pairs[instance % self.summand_pairs.len()];
+
+		for (point, limbs) in iter::zip(&self.summands, pair) {
+			for (&wire, &limb) in iter::zip(&point.x.limbs, &limbs.x) {
+				w[wire] = Word(limb);
+			}
+			for (&wire, &limb) in iter::zip(&point.y.limbs, &limbs.y) {
+				w[wire] = Word(limb);
+			}
+			// Every summand is a genuine curve point, never the identity.
+			w[point.is_point_at_infinity] = Word::ZERO;
+		}
+	}
+}
+
+/// Precomputes [`N_SUMMAND_PAIRS`] pairs of on-curve points that are valid incomplete-addition
+/// summands.
+///
+/// Pair `j` is `((2j + 1)·G, (2j + 2)·G)`. Consecutive multiples of the generator are neither equal
+/// — [`Secp256k1::add_incomplete`] asserts against doubling — nor negatives of each other, which
+/// would make their sum the point at infinity.
+fn summand_pairs() -> Vec<[AffineLimbs; 2]> {
+	let generator = ProjectivePoint::GENERATOR;
+	let step = generator + generator;
+
+	iter::successors(Some(generator), |&first| Some(first + step))
+		.take(N_SUMMAND_PAIRS)
+		.map(|first| [affine_limbs(&first), affine_limbs(&(first + generator))])
+		.collect()
+}
+
+/// The affine coordinates of `point`, each as little-endian 64-bit limbs.
+///
+/// # Panics
+///
+/// Panics if `point` is the identity, which has no affine coordinates.
+fn affine_limbs(point: &ProjectivePoint) -> AffineLimbs {
+	// Uncompressed SEC1 encoding: `0x04 || x (32 bytes) || y (32 bytes)`, coordinates big-endian.
+	let bytes = point.to_affine().to_sec1_point(false).to_bytes();
+	assert_eq!(bytes.len(), 65, "the identity has no affine coordinates");
+
+	AffineLimbs {
+		x: le_limbs(&bytes[1..33]),
+		y: le_limbs(&bytes[33..65]),
+	}
+}
+
+/// Converts a big-endian 256-bit integer into little-endian 64-bit limbs.
+fn le_limbs(be_bytes: &[u8]) -> [u64; N_LIMBS] {
+	array::from_fn(|i| {
+		let end = be_bytes.len() - i * 8;
+		u64::from_be_bytes(
+			be_bytes[end - 8..end]
+				.try_into()
+				.expect("the slice is 8 bytes"),
+		)
+	})
 }

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -29,7 +29,10 @@ use binius_frontend::CircuitStat;
 use binius_hash::StdHashSuite;
 use binius_m4_prover::{
 	Prover,
-	test_circuits::{Blake3Circuit, ImulCircuit, KeccakCircuit, Sha256Circuit, TestCircuit},
+	test_circuits::{
+		Blake3Circuit, ImulCircuit, KeccakCircuit, Secp256k1AddIncompleteCircuit, Sha256Circuit,
+		TestCircuit,
+	},
 };
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
@@ -219,6 +222,18 @@ fn prove_keccak_permutation_3x() {
 fn prove_integer_multiplication() {
 	let log_instances = log_size_from_env("LOG_IMUL_INSTANCES", 13);
 	prove_once::<ImulCircuit>("imul", log_instances);
+}
+
+// Proves incomplete secp256k1 point additions through M4 and verifies them.
+//
+// The heaviest primitive here: one addition is three 256-bit modular multiplications plus a
+// modular-division hint, so its circuit dwarfs a hash compression. Overridable via
+// `LOG_SECP256K1_ADDITIONS`.
+#[test]
+#[ignore = "proving run for its timing tree; use --ignored --release"]
+fn prove_secp256k1_add_incomplete() {
+	let log_additions = log_size_from_env("LOG_SECP256K1_ADDITIONS", 10);
+	prove_once::<Secp256k1AddIncompleteCircuit>("secp256k1_add", log_additions);
 }
 
 // A batch of one instance, with IMUL constraints.


### PR DESCRIPTION
Adds a `Secp256k1::add_incomplete` chip to the M4 test circuits and benchmarks and profiles it, alongside the hash primitives.

Linear: [BINIUS-500](https://linear.app/jimpo/issue/BINIUS-500/m4-prove-hash-primitives-circuit-for-secp256k1add-incomplete)

### Commits

1. **Add a secp256k1 incomplete point-addition circuit to the M4 test circuits.** `Secp256k1AddIncompleteCircuit` in `crates/m4-prover/src/test_circuits.rs`: one instance computes one incomplete affine addition. Both summands are public inputs, their point-at-infinity flags included — those are wires rather than constants because the scalar-multiplication circuits call `add_incomplete` with flags computed in-circuit, and folding a constant flag would drop the point-at-infinity handling from the measured circuit. Witness inputs come from a precomputed pool of consecutive generator multiples, so witness filling — which the benchmark times — carries no host-side curve arithmetic. `k256` joins the crate's optional deps behind the existing `test-circuits` feature; it is already a workspace dependency.

2. **Wire it into the benchmark and the timing test.** A `secp256k1_add` entry in `benches/prove_hash_primitives.rs` and a `prove_secp256k1_add_incomplete` timing test.

### Notes

This is the first entry in the group that is not a hash primitive — unlike BLAKE3/SHA-256/Keccak it is built from 256-bit modular arithmetic, so its proof exercises the IntMul reduction. It is also the heaviest entry: at the default `LOG_INSTANCES=13` a criterion sample is tens of seconds, so `LOG_INSTANCES` is worth turning down for a quick sweep.

Measurements and the phase profile are in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)