### PR TITLE
Give the compiler pass options one construction path

### DIFF
--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -53,11 +53,12 @@ use gadget::smul64;
 /// ```
 /// use binius_frontend::{CircuitBuilder, Options};
 ///
-/// let builder = CircuitBuilder::with_opts(Options {
-///     enable_gate_fusion: false,
-///     ..Options::default()
-/// });
+/// let mut opts = Options::default();
+/// opts.enable_gate_fusion = false;
+/// let builder = CircuitBuilder::with_opts(opts);
 /// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Options {
 	/// Inline linear definitions into the non-linear gates that consume them.
 	pub enable_gate_fusion: bool,

--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -882,6 +882,146 @@ fn test_scratch_pooling_rejects_a_bad_assignment() {
 	assert!(!err.failures[0].detail.is_empty());
 }
 
+/// Compiles one fixture under one option, returning the resulting statistics.
+///
+/// `opts` names the flag under test; every other flag stays at its default.
+fn stat_with(opts: Options, build: impl FnOnce(&CircuitBuilder)) -> crate::CircuitStat {
+	let builder = CircuitBuilder::with_opts(opts);
+	build(&builder);
+	let circuit = builder.build();
+	crate::CircuitStat::collect(&circuit)
+}
+
+#[test]
+fn constant_propagation_flag_is_honoured() {
+	// Invariant: the flag decides whether an all-constant gate folds away or stays a gate.
+	//
+	// A comparison never folds at build time the way `band`/`bxor` do, so the flag is the
+	// only thing standing between two constants and a real AND constraint.
+	let and_count = |enable| {
+		stat_with(
+			Options {
+				enable_constant_propagation: enable,
+				..Options::default()
+			},
+			|b| {
+				let a = b.add_constant(Word(3));
+				let c = b.add_constant(Word(5));
+				let lt = b.icmp_ult(a, c);
+				let out = b.add_inout();
+				b.assert_eq("lt", lt, out);
+			},
+		)
+		.n_and_constraints
+	};
+	assert_eq!(and_count(true), 0, "folded away, so no AND constraint remains");
+	assert_eq!(and_count(false), 1, "left as a gate, so its AND constraint stands");
+}
+
+#[test]
+fn algebraic_folding_flag_is_honoured() {
+	// Invariant: `x & x = x` bit for bit, so the flag decides whether that identity is applied
+	// at build time instead of spending an AND constraint on it.
+	let and_count = |enable| {
+		stat_with(
+			Options {
+				enable_algebraic_folding: enable,
+				..Options::default()
+			},
+			|b| {
+				let x = b.add_inout();
+				let z = b.band(x, x);
+				let out = b.add_inout();
+				b.assert_eq("self_and", z, out);
+			},
+		)
+		.n_and_constraints
+	};
+	assert_eq!(and_count(true), 0, "the identity fires, so no gate is emitted");
+	assert_eq!(and_count(false), 1, "the identity is skipped, so a real AND gate remains");
+}
+
+#[test]
+fn gate_fusion_flag_is_honoured() {
+	// Invariant: fusion inlines a linear definition into the AND constraint that consumes it,
+	// dropping the linear constraint that would otherwise commit it on its own.
+	//
+	//     x --xor-- y --> lin --and-- z --> out
+	//
+	// With fusion, `lin`'s definition is folded into the AND's operand, leaving one constraint.
+	// Without it, `lin` is committed by its own linear constraint, and the AND references it.
+	let zero_count = |enable| {
+		stat_with(
+			Options {
+				enable_gate_fusion: enable,
+				..Options::default()
+			},
+			|b| {
+				let x = b.add_inout();
+				let y = b.add_inout();
+				let z = b.add_inout();
+				let lin = b.bxor(x, y);
+				let out = b.band(lin, z);
+				b.mark_inout(out);
+			},
+		)
+		.n_zero_constraints
+	};
+	assert_eq!(zero_count(true), 0, "the linear step is inlined into the AND operand");
+	assert_eq!(zero_count(false), 1, "the linear step is committed on its own");
+}
+
+#[test]
+fn common_subexpression_elimination_flag_is_honoured() {
+	// Invariant: two gates over the same operation and operands compute the same value, so one
+	// of them is redundant. The flag decides whether the pass notices.
+	//
+	// Dead-code elimination is turned off so its own removal cannot be mistaken for this one.
+	let and_count = |enable| {
+		stat_with(
+			Options {
+				enable_common_subexpression_elimination: enable,
+				enable_dead_code_elimination: false,
+				..Options::default()
+			},
+			|b| {
+				let x = b.add_inout();
+				let y = b.add_inout();
+				let z1 = b.band(x, y);
+				let z2 = b.band(x, y);
+				let out1 = b.add_inout();
+				let out2 = b.add_inout();
+				b.assert_eq("z1", z1, out1);
+				b.assert_eq("z2", z2, out2);
+			},
+		)
+		.n_and_constraints
+	};
+	assert_eq!(and_count(true), 1, "the duplicate collapses onto the first gate");
+	assert_eq!(and_count(false), 2, "both gates keep their own AND constraint");
+}
+
+#[test]
+fn dead_code_elimination_flag_is_honoured() {
+	// Invariant: a gate nothing reads contributes no constraint, but only once the pass says so.
+	let and_count = |enable| {
+		stat_with(
+			Options {
+				enable_dead_code_elimination: enable,
+				..Options::default()
+			},
+			|b| {
+				let x = b.add_inout();
+				let y = b.add_inout();
+				let _unread = b.band(x, y);
+			},
+		)
+		.n_and_constraints
+	};
+	assert_eq!(and_count(true), 0, "the unread gate is dropped before constraining");
+	assert_eq!(and_count(false), 1, "the unread gate still constrains, unread or not");
+}
+
 #[test]
 fn test_scratch_pooling_matches_scalar_per_instance_batched() {
 	// Invariant: the batched fill and the one-at-a-time fill must agree for every instance.

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -807,10 +807,9 @@ mod tests {
 		//
 		// Gate fusion is off: it inlines a linear definition into the gate that consumes it, which
 		// would leave no linear constraint to lower.
-		let builder = CircuitBuilder::with_opts(Options {
-			enable_gate_fusion: false,
-			..Options::default()
-		});
+		let mut opts = Options::default();
+		opts.enable_gate_fusion = false;
+		let builder = CircuitBuilder::with_opts(opts);
 		let inputs: [Wire; 4] = array::from_fn(|_| builder.add_inout());
 		let x = builder.bxor(inputs[0], inputs[1]);
 		let y = builder.bxor(x, inputs[2]);
@@ -866,10 +865,9 @@ mod tests {
 		use binius_frontend::{Options, Wire};
 
 		// Gate fusion off, so the `bxor` survives as a linear constraint to lower.
-		let builder = CircuitBuilder::with_opts(Options {
-			enable_gate_fusion: false,
-			..Options::default()
-		});
+		let mut opts = Options::default();
+		opts.enable_gate_fusion = false;
+		let builder = CircuitBuilder::with_opts(opts);
 		let inputs: [Wire; 3] = array::from_fn(|_| builder.add_inout());
 		builder.mark_inout(builder.bxor(inputs[0], inputs[1]));
 		let circuit = builder.build();

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -353,13 +353,12 @@ fn zero_constraint_circuit(
 	n_rotr: usize,
 	n_and: usize,
 ) -> (ConstraintSystem, ValueVec) {
-	let builder = CircuitBuilder::with_opts(Options {
-		enable_gate_fusion: false,
-		enable_common_subexpression_elimination: false,
-		enable_dead_code_elimination: false,
-		enable_algebraic_folding: false,
-		..Options::default()
-	});
+	let mut opts = Options::default();
+	opts.enable_gate_fusion = false;
+	opts.enable_common_subexpression_elimination = false;
+	opts.enable_dead_code_elimination = false;
+	opts.enable_algebraic_folding = false;
+	let builder = CircuitBuilder::with_opts(opts);
 	let a = builder.add_witness();
 	let b = builder.add_witness();
 
@@ -436,13 +435,12 @@ fn test_prove_verify_fewer_zero_than_and_constraints() {
 /// values the circuit declares. The optimization passes are off so that the repeated assertions
 /// survive as distinct constraints.
 fn public_heavy_circuit(n_inout: usize) -> (ConstraintSystem, ValueVec) {
-	let builder = CircuitBuilder::with_opts(Options {
-		enable_gate_fusion: false,
-		enable_common_subexpression_elimination: false,
-		enable_dead_code_elimination: false,
-		enable_algebraic_folding: false,
-		..Options::default()
-	});
+	let mut opts = Options::default();
+	opts.enable_gate_fusion = false;
+	opts.enable_common_subexpression_elimination = false;
+	opts.enable_dead_code_elimination = false;
+	opts.enable_algebraic_folding = false;
+	let builder = CircuitBuilder::with_opts(opts);
 	let a = builder.add_witness();
 	let b = builder.add_witness();
 	let and_out = builder.band(a, b);


### PR DESCRIPTION
Makes `Options` construct one way, and proves every flag on it actually does something.

### The problem

`Options` is seven `bool`s controlling which compiler passes run, and it derived nothing.
Writing a benchmark that flips one flag meant hand-cloning the struct field by field, since there
was no `Clone` to reach for.

Its own doc comment already told callers to construct through `..Options::default()`:

```rust
let builder = CircuitBuilder::with_opts(Options {
    enable_gate_fusion: false,
    ..Options::default()
});
```

Nothing enforced that.
A caller could just as easily write out all seven fields by hand, and a new flag added later would
silently compile against every such call site without forcing a decision about its default.

### The idea

Derive `Clone, Copy, Debug, PartialEq, Eq`, and mark the struct `#[non_exhaustive]`.

`#[non_exhaustive]` blocks struct-literal construction from another crate outright, even with
`..Options::default()` filling the rest.
So `..Options::default()` construction — the one path the doc already pointed at — becomes the only
path the compiler accepts.

### The change

Three call sites outside the frontend crate built an `Options` by struct literal.
Each becomes a default plus field mutation:

```rust
- let builder = CircuitBuilder::with_opts(Options {
-     enable_gate_fusion: false,
-     ..Options::default()
- });
+ let mut opts = Options::default();
+ opts.enable_gate_fusion = false;
+ let builder = CircuitBuilder::with_opts(opts);
```

The type's own doctest hit the same rule and got the same treatment.

### Tests: does the flag actually do anything

Two of the seven flags already had a test proving the builder consults them — zero propagation and
scratch pooling.
The other five did not: constant propagation, algebraic folding, gate fusion, common-subexpression
elimination, and dead-code elimination were each exercised only through the pass's own internal
unit tests, never through `CircuitBuilder::with_opts` end to end.

Added one test per missing flag, each toggling it and asserting a real observable difference:

| flag | fixture | with flag | without |
|---|---|---|---|
| `enable_constant_propagation` | `icmp_ult` over two constants | 0 AND constraints | 1 |
| `enable_algebraic_folding` | `band(x, x)` | 0 AND constraints | 1 |
| `enable_gate_fusion` | a linear `bxor` feeding an AND | 0 ZERO constraints | 1 |
| `enable_common_subexpression_elimination` | two identical `band(x, y)` gates | 1 AND constraint | 2 |
| `enable_dead_code_elimination` | an unread `band(x, y)` | 0 AND constraints | 1 |

`icmp_ult` was picked for the constant-propagation fixture specifically because `band`/`bxor`
already fold two constant operands at build time on their own — that fixture would exercise the
build-time fold, not the pass under test.

### Scope

- **changed:** `Options`'s derives and attribute, its doctest, and the three external construction sites in `binius-m4-prover` and `binius-prover`.
- **new:** 5 flag tests in `builder/tests.rs`.
- **left untouched:** every field's name, type, and default value.

### Verification

- `cargo check --workspace --all-targets` — clean (this is the gate that actually matters here: `#[non_exhaustive]` breaks any external struct-literal site, and this is how all three got found).
- `cargo test -p binius-frontend` — 254 passed (249 existing + 5 new).
- `cargo clippy -p binius-frontend --all-targets -D warnings` — clean.
- `cargo check -p binius-m4-prover -p binius-prover --all-targets` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
