### PR TITLE
Make building a circuit consume the builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 tracing-profile = "0.10.11"
 tracing-forest = { version = "0.3.1", features = ["ansi", "env-filter"] }
 trait-set = "0.3.0"
+trybuild = "1.0"
 uninit = "0.6.2"
 ureq = "3.1"
 

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -200,7 +200,7 @@ mod tests {
 	/// Run a success-case test: pack `input_data` and `expected_slice_data` into the test setup,
 	/// run the circuit, and verify constraints.
 	fn run_slice_success(
-		setup: &SliceTestSetup,
+		setup: SliceTestSetup,
 		len_input_val: u64,
 		len_slice_val: u64,
 		offset_val: u64,
@@ -222,7 +222,7 @@ mod tests {
 
 	/// Run a failure-case test: expect `populate_wire_witness` to error.
 	fn run_slice_failure(
-		setup: &SliceTestSetup,
+		setup: SliceTestSetup,
 		len_input_val: u64,
 		len_slice_val: u64,
 		offset_val: u64,
@@ -248,7 +248,7 @@ mod tests {
 			0x0e, 0x0f,
 		];
 		let slice_data = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		run_slice_success(&setup, 16, 8, 0, &input_data, &slice_data);
+		run_slice_success(setup, 16, 8, 0, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -260,7 +260,7 @@ mod tests {
 			0x0e, 0x0f,
 		];
 		let slice_data = [0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a];
-		run_slice_success(&setup, 16, 8, 3, &input_data, &slice_data);
+		run_slice_success(setup, 16, 8, 3, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -269,7 +269,7 @@ mod tests {
 		let setup = build_slice_check(2, 1);
 		let dummy_input = vec![0u8; 10];
 		let dummy_slice = vec![0u8; 8];
-		run_slice_failure(&setup, 10, 8, 5, &dummy_input, &dummy_slice);
+		run_slice_failure(setup, 10, 8, 5, &dummy_input, &dummy_slice);
 	}
 
 	#[test]
@@ -278,7 +278,7 @@ mod tests {
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let slice_data = vec![5, 6, 7, 8, 9];
-		run_slice_success(&setup, 10, 5, 5, &input_data, &slice_data);
+		run_slice_success(setup, 10, 5, 5, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -286,7 +286,7 @@ mod tests {
 		// len_slice = 0 — output is all zeros.
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(&setup, 10, 0, 5, &input_data, &[]);
+		run_slice_success(setup, 10, 0, 5, &input_data, &[]);
 	}
 
 	#[test]
@@ -297,7 +297,7 @@ mod tests {
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		// Actual extracted slice at offset 2 with len 5 is [2,3,4,5,6]; we claim [0,1,2,3,4].
 		let wrong_slice_data = vec![0, 1, 2, 3, 4];
-		run_slice_failure(&setup, 10, 5, 2, &input_data, &wrong_slice_data);
+		run_slice_failure(setup, 10, 5, 2, &input_data, &wrong_slice_data);
 	}
 
 	#[test]
@@ -305,7 +305,7 @@ mod tests {
 		// Empty slice at offset 10, where len_input = 10.
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(&setup, 10, 0, 10, &input_data, &[]);
+		run_slice_success(setup, 10, 0, 10, &input_data, &[]);
 	}
 
 	#[test]
@@ -321,7 +321,7 @@ mod tests {
 				let setup = build_slice_check(3, 1);
 				let input_data: Vec<u8> = (0..24).map(|i| i as u8).collect();
 				let slice_data: Vec<u8> = input_data[offset_val..offset_val + 8].to_vec();
-				run_slice_success(&setup, 24, 8, offset_val as u64, &input_data, &slice_data);
+				run_slice_success(setup, 24, 8, offset_val as u64, &input_data, &slice_data);
 			}
 		}
 	}
@@ -341,7 +341,7 @@ mod tests {
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
 			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 padded to 16 bytes
 		];
-		run_slice_success(&setup, 20, 12, 0, &input_data, &correct_slice);
+		run_slice_success(setup, 20, 12, 0, &input_data, &correct_slice);
 	}
 
 	#[test]
@@ -419,14 +419,14 @@ mod tests {
 	fn test_edge_case_len_input_zero() {
 		// Empty input + empty slice at offset 0.
 		let setup = build_slice_check(2, 1);
-		run_slice_success(&setup, 0, 0, 0, &[], &[]);
+		run_slice_success(setup, 0, 0, 0, &[], &[]);
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero_with_nonzero_slice() {
 		// Empty input + non-empty slice → bounds check fails.
 		let setup = build_slice_check(2, 1);
-		run_slice_failure(&setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
+		run_slice_failure(setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
 	}
 
 	#[test]
@@ -436,7 +436,7 @@ mod tests {
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 		// Slice is 8 bytes, so word 1 is fully zero-padded.
 		let slice_data = vec![2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(&setup, 12, 8, 2, &input_data, &slice_data);
+		run_slice_success(setup, 12, 8, 2, &input_data, &slice_data);
 	}
 
 	#[test]

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -24,3 +24,4 @@ rustc-hash.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }
 proptest = { workspace = true }
 insta = { workspace = true }
+trybuild = { workspace = true }

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -216,7 +216,7 @@ pub(crate) struct Shared {
 pub struct CircuitBuilder {
 	/// Current path at which this circuit builder is positioned.
 	current_path: PathSpec,
-	shared: Rc<RefCell<Option<Shared>>>,
+	shared: Rc<RefCell<Shared>>,
 }
 
 impl Default for CircuitBuilder {
@@ -238,7 +238,7 @@ impl CircuitBuilder {
 		let root = graph.path_spec_tree.root();
 		CircuitBuilder {
 			current_path: root,
-			shared: Rc::new(RefCell::new(Some(Shared {
+			shared: Rc::new(RefCell::new(Shared {
 				graph,
 				opts,
 				force_committed: EntitySet::new(),
@@ -246,7 +246,7 @@ impl CircuitBuilder {
 				chips: Vec::new(),
 				chip_calls: Vec::new(),
 				chip_gadgets: HashMap::new(),
-			}))),
+			})),
 		}
 	}
 
@@ -267,10 +267,7 @@ impl CircuitBuilder {
 	/// carrying any.
 	pub fn add_chip(&self, chip: CircuitM4) -> ChipRef {
 		let mut shared = self.shared.borrow_mut();
-		let chips = &mut shared
-			.as_mut()
-			.expect("CircuitBuilder used after build")
-			.chips;
+		let chips = &mut shared.chips;
 
 		let chip_id = chips.len();
 		// The system's main takes the next slot and its own chips follow it, so an ID naming its
@@ -319,7 +316,6 @@ impl CircuitBuilder {
 	/// Panics if the wire count differs from the callee's inout word count.
 	pub fn call_chip(&self, chip: ChipRef, inout: &[Wire]) {
 		let mut shared = self.shared.borrow_mut();
-		let shared = shared.as_mut().expect("CircuitBuilder used after build");
 
 		let n_inout = shared.chips[chip.chip_id()].circuit.inout().len();
 		assert_eq!(inout.len(), n_inout, "chip #{} takes {n_inout} inout words", chip.chip_id());
@@ -386,8 +382,6 @@ impl CircuitBuilder {
 
 		let mut shared = self.shared.borrow_mut();
 		let previous = shared
-			.as_mut()
-			.expect("CircuitBuilder used after build")
 			.chip_gadgets
 			.insert((G::NAME, dimensions.to_vec()), RegisteredGadget { chip, inout_order });
 		assert!(
@@ -461,8 +455,6 @@ impl CircuitBuilder {
 	) -> Option<RegisteredGadget> {
 		self.shared
 			.borrow()
-			.as_ref()
-			.expect("CircuitBuilder used after build")
 			.chip_gadgets
 			.get(&(name, dimensions.to_vec()))
 			.cloned()
@@ -470,14 +462,18 @@ impl CircuitBuilder {
 
 	/// Returns the circuit built by this builder.
 	///
-	/// Note that cloning the circuit builder only clones the reference and as such is treated
-	/// as a shallow copy.
+	/// Consumes the builder, so building is a one-shot operation.
+	/// There is no builder left afterward for the type system to reject a second call on.
 	///
-	/// # Preconditions
+	/// # Panics
 	///
-	/// Must be called only once, on a builder with no chip registered by [`Self::add_chip`].
-	pub fn build(&self) -> Circuit {
-		let shared = self.take_shared();
+	/// Panics if a clone or a subcircuit of this builder is still alive elsewhere.
+	/// Reclaiming the state needs sole ownership of it.
+	///
+	/// Panics if the builder carries a chip registered by [`Self::add_chip`].
+	/// Build that one with [`Self::build_m4`] instead.
+	pub fn build(self) -> Circuit {
+		let shared = self.into_shared();
 		assert!(
 			shared.chips.is_empty(),
 			"a builder carrying chips builds with CircuitBuilder::build_m4"
@@ -492,11 +488,15 @@ impl CircuitBuilder {
 	/// indices the build assigned them, and each chip's active-instance count is counted off the
 	/// resulting call graph.
 	///
-	/// # Preconditions
+	/// Consumes the builder, so building is a one-shot operation.
+	/// There is no builder left afterward for the type system to reject a second call on.
 	///
-	/// Must be called only once.
-	pub fn build_m4(&self) -> CircuitM4 {
-		let mut shared = self.take_shared();
+	/// # Panics
+	///
+	/// Panics if a clone or a subcircuit of this builder is still alive elsewhere.
+	/// Reclaiming the state needs sole ownership of it.
+	pub fn build_m4(self) -> CircuitM4 {
+		let mut shared = self.into_shared();
 		let chips = mem::take(&mut shared.chips);
 		let pending = mem::take(&mut shared.chip_calls);
 		let circuit = Self::compile(shared, &pending);
@@ -527,17 +527,16 @@ impl CircuitBuilder {
 		circuit
 	}
 
-	/// Takes the builder's state, leaving it spent.
+	/// Reclaims the state behind the shared handle, requiring sole ownership of it.
 	///
 	/// # Panics
 	///
-	/// Panics if the state was already taken, which is what makes building a one-shot operation.
-	fn take_shared(&self) -> Shared {
-		let shared = self.shared.borrow_mut().take();
-		let Some(shared) = shared else {
-			panic!("CircuitBuilder::build called twice");
-		};
-		shared
+	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state.
+	/// Only sole ownership can be unwrapped out of a reference count.
+	fn into_shared(self) -> Shared {
+		Rc::into_inner(self.shared)
+			.expect("a clone or subcircuit of this builder is still alive")
+			.into_inner()
 	}
 
 	/// Compiles the builder's state into a circuit, running every optimization pass it enables.
@@ -761,12 +760,7 @@ impl CircuitBuilder {
 	/// This annotate the wire to be forcefully committed. This instructs optimization passes
 	/// (ATOW only gate fusion) to forcibly materialize wire.
 	pub fn force_commit(&self, wire: Wire) {
-		self.shared
-			.borrow_mut()
-			.as_mut()
-			.unwrap()
-			.force_committed
-			.insert(wire);
+		self.shared.borrow_mut().force_committed.insert(wire);
 	}
 
 	/// Promotes a gate-created wire to a public output.
@@ -813,21 +807,7 @@ impl CircuitBuilder {
 	}
 
 	fn graph_mut(&self) -> RefMut<'_, GateGraph> {
-		RefMut::map(self.shared.borrow_mut(), |shared| &mut shared.as_mut().unwrap().graph)
-	}
-
-	/// The compile-time value of a wire, when it is a constant.
-	///
-	/// Returns `None` for inputs, witnesses, and gate outputs whose value is only known at
-	/// proving time.
-	/// Used by the builder to fold trivial gate identities at construction.
-	fn const_of(&self, wire: Wire) -> Option<Word> {
-		let shared = self.shared.borrow();
-		let shared = shared.as_ref().expect("CircuitBuilder used after build");
-		match shared.graph.wires[wire] {
-			WireKind::Constant(word) => Some(word),
-			_ => None,
-		}
+		RefMut::map(self.shared.borrow_mut(), |shared| &mut shared.graph)
 	}
 
 	/// Creates a wire from a 64-bit word.
@@ -902,22 +882,6 @@ impl CircuitBuilder {
 		self.graph_mut().add_witness()
 	}
 
-	/// Adds a wire similar to [`Self::add_witness`]. Internal wires are meant to designate wires
-	/// that are prunable.
-	fn add_internal(&self) -> Wire {
-		self.graph_mut().add_internal()
-	}
-
-	/// Whether build-time algebraic identity folding is enabled.
-	fn algebraic_folding(&self) -> bool {
-		self.shared
-			.borrow()
-			.as_ref()
-			.expect("CircuitBuilder used after build")
-			.opts
-			.enable_algebraic_folding
-	}
-
 	/// Bitwise AND.
 	///
 	/// Returns z = x & y
@@ -926,23 +890,25 @@ impl CircuitBuilder {
 	///
 	/// 1 AND constraint, or none when both operands are the same wire.
 	pub fn band(&self, x: Wire, y: Wire) -> Wire {
+		let mut shared = self.shared.borrow_mut();
 		// Idempotent: x & x = x, bit for bit, so return x and emit no gate.
-		if self.algebraic_folding() && x == y {
+		if shared.opts.enable_algebraic_folding && x == y {
 			return x;
 		}
 		// Identities that hold bit for bit, so they need no AND constraint:
 		//   c & d  -> fold        0 & y -> 0        all-1 & y -> y
-		match (self.const_of(x), self.const_of(y)) {
-			(Some(a), Some(b)) => return self.add_constant(Word(a.0 & b.0)),
+		match (const_of(&shared.graph, x), const_of(&shared.graph, y)) {
+			(Some(a), Some(b)) => return shared.graph.add_constant(Word(a.0 & b.0)),
 			(Some(a), _) if a == Word::ZERO => return x,
 			(Some(a), _) if a == Word::ALL_ONE => return y,
 			(_, Some(b)) if b == Word::ZERO => return y,
 			(_, Some(b)) if b == Word::ALL_ONE => return x,
 			_ => {}
 		}
-		let z = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Band, [x, y], [z]);
+		let z = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Band, [x, y], [z]);
 		z
 	}
 
@@ -954,21 +920,23 @@ impl CircuitBuilder {
 	///
 	/// 1 linear constraint, or none when both operands are the same wire.
 	pub fn bxor(&self, a: Wire, b: Wire) -> Wire {
+		let mut shared = self.shared.borrow_mut();
 		// Self-inverse: x ^ x = 0, so return the zero constant and emit no gate.
-		if self.algebraic_folding() && a == b {
-			return self.add_constant(Word::ZERO);
+		if shared.opts.enable_algebraic_folding && a == b {
+			return shared.graph.add_constant(Word::ZERO);
 		}
 		// Identities that hold bit for bit, so they need no linear constraint:
 		//   c ^ d  -> fold        0 ^ b -> b        a ^ 0 -> a
-		match (self.const_of(a), self.const_of(b)) {
-			(Some(x), Some(y)) => return self.add_constant(Word(x.0 ^ y.0)),
+		match (const_of(&shared.graph, a), const_of(&shared.graph, b)) {
+			(Some(x), Some(y)) => return shared.graph.add_constant(Word(x.0 ^ y.0)),
 			(Some(x), _) if x == Word::ZERO => return b,
 			(_, Some(y)) if y == Word::ZERO => return a,
 			_ => {}
 		}
-		let z = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Bxor, [a, b], [z]);
+		let z = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Bxor, [a, b], [z]);
 		z
 	}
 
@@ -992,9 +960,9 @@ impl CircuitBuilder {
 			return self.bxor(wires[0], wires[1]);
 		}
 
-		let z = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate_generic(
+		let mut shared = self.shared.borrow_mut();
+		let z = shared.graph.add_internal();
+		shared.graph.emit_gate_generic(
 			self.current_path,
 			Opcode::BxorMulti,
 			wires.iter().copied(),
@@ -1025,23 +993,25 @@ impl CircuitBuilder {
 	///
 	/// 1 AND constraint, or none when both operands are the same wire.
 	pub fn bor(&self, a: Wire, b: Wire) -> Wire {
+		let mut shared = self.shared.borrow_mut();
 		// Idempotent: x | x = x, bit for bit, so return x and emit no gate.
-		if self.algebraic_folding() && a == b {
+		if shared.opts.enable_algebraic_folding && a == b {
 			return a;
 		}
 		// Identities that hold bit for bit, so they need no AND constraint:
 		//   c | d  -> fold        0 | b -> b        all-1 | b -> all-1
-		match (self.const_of(a), self.const_of(b)) {
-			(Some(x), Some(y)) => return self.add_constant(Word(x.0 | y.0)),
+		match (const_of(&shared.graph, a), const_of(&shared.graph, b)) {
+			(Some(x), Some(y)) => return shared.graph.add_constant(Word(x.0 | y.0)),
 			(Some(x), _) if x == Word::ZERO => return b,
 			(Some(x), _) if x == Word::ALL_ONE => return a,
 			(_, Some(y)) if y == Word::ZERO => return a,
 			(_, Some(y)) if y == Word::ALL_ONE => return b,
 			_ => {}
 		}
-		let z = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Bor, [a, b], [z]);
+		let z = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Bor, [a, b], [z]);
 		z
 	}
 
@@ -1055,9 +1025,11 @@ impl CircuitBuilder {
 	///
 	/// 1 AND constraint.
 	pub fn fax(&self, x: Wire, y: Wire, w: Wire) -> Wire {
-		let z = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Fax, [x, y, w], [z]);
+		let mut shared = self.shared.borrow_mut();
+		let z = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Fax, [x, y, w], [z]);
 		z
 	}
 
@@ -1070,10 +1042,12 @@ impl CircuitBuilder {
 	///
 	/// 1 AND constraint, 1 linear constraint.
 	pub fn iadd_32(&self, a: Wire, b: Wire) -> Wire {
-		let sum = self.add_internal();
-		let cout = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Iadd32, [a, b], [sum, cout]);
+		let mut shared = self.shared.borrow_mut();
+		let sum = shared.graph.add_internal();
+		let cout = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Iadd32, [a, b], [sum, cout]);
 		sum
 	}
 
@@ -1091,10 +1065,12 @@ impl CircuitBuilder {
 	///
 	/// 1 AND constraint, 1 linear constraint.
 	pub fn iadd32_cin_cout(&self, a: Wire, b: Wire, cin: Wire) -> (Wire, Wire) {
-		let sum = self.add_internal();
-		let cout = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Iadd32CinCout, [a, b, cin], [sum, cout]);
+		let mut shared = self.shared.borrow_mut();
+		let sum = shared.graph.add_internal();
+		let cout = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Iadd32CinCout, [a, b, cin], [sum, cout]);
 		(sum, cout)
 	}
 
@@ -1112,10 +1088,12 @@ impl CircuitBuilder {
 	/// - 1 AND constraint,
 	/// - 1 linear constraint.
 	pub fn iadd_cin_cout(&self, a: Wire, b: Wire, cin: Wire) -> (Wire, Wire) {
-		let sum = self.add_internal();
-		let cout = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::IaddCinCout, [a, b, cin], [sum, cout]);
+		let mut shared = self.shared.borrow_mut();
+		let sum = shared.graph.add_internal();
+		let cout = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::IaddCinCout, [a, b, cin], [sum, cout]);
 		(sum, cout)
 	}
 
@@ -1133,10 +1111,12 @@ impl CircuitBuilder {
 	/// - 1 AND constraint,
 	/// - 1 linear constraint.
 	pub fn isub_bin_bout(&self, a: Wire, b: Wire, bin: Wire) -> (Wire, Wire) {
-		let diff = self.add_internal();
-		let bout = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::IsubBinBout, [a, b, bin], [diff, bout]);
+		let mut shared = self.shared.borrow_mut();
+		let diff = shared.graph.add_internal();
+		let bout = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::IsubBinBout, [a, b, bin], [diff, bout]);
 		(diff, bout)
 	}
 
@@ -1145,9 +1125,9 @@ impl CircuitBuilder {
 	/// The variant and amount are carried as the gate's two immediates.
 	/// The caller enforces the amount range and any identity fast-paths.
 	fn emit_shift(&self, variant: ShiftVariant, x: Wire, n: u32) -> Wire {
-		let z = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate_generic(
+		let mut shared = self.shared.borrow_mut();
+		let z = shared.graph.add_internal();
+		shared.graph.emit_gate_generic(
 			self.current_path,
 			Opcode::Shift,
 			[x],
@@ -1456,10 +1436,12 @@ impl CircuitBuilder {
 	///
 	/// 1 IMUL constraint.
 	pub fn imul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
-		let hi = self.add_internal();
-		let lo = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Imul, [a, b], [hi, lo]);
+		let mut shared = self.shared.borrow_mut();
+		let hi = shared.graph.add_internal();
+		let lo = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Imul, [a, b], [hi, lo]);
 		(hi, lo)
 	}
 
@@ -1475,10 +1457,15 @@ impl CircuitBuilder {
 	///
 	/// - 1 BMUL constraint.
 	pub fn bmul(&self, a_lo: Wire, a_hi: Wire, b_lo: Wire, b_hi: Wire) -> (Wire, Wire) {
-		let c_lo = self.add_internal();
-		let c_hi = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Bmul, [a_lo, a_hi, b_lo, b_hi], [c_lo, c_hi]);
+		let mut shared = self.shared.borrow_mut();
+		let c_lo = shared.graph.add_internal();
+		let c_hi = shared.graph.add_internal();
+		shared.graph.emit_gate(
+			self.current_path,
+			Opcode::Bmul,
+			[a_lo, a_hi, b_lo, b_hi],
+			[c_lo, c_hi],
+		);
 		(c_lo, c_hi)
 	}
 
@@ -1512,9 +1499,11 @@ impl CircuitBuilder {
 	/// - 1 AND constraint,
 	/// - 1 linear constraint.
 	pub fn icmp_ult(&self, x: Wire, y: Wire) -> Wire {
-		let out_wire = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::IcmpUlt, [x, y], [out_wire]);
+		let mut shared = self.shared.borrow_mut();
+		let out_wire = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::IcmpUlt, [x, y], [out_wire]);
 		out_wire
 	}
 
@@ -1590,9 +1579,11 @@ impl CircuitBuilder {
 	///
 	/// 1 AND constraint.
 	pub fn icmp_eq(&self, x: Wire, y: Wire) -> Wire {
-		let out_wire = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::IcmpEq, [x, y], [out_wire]);
+		let mut shared = self.shared.borrow_mut();
+		let out_wire = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::IcmpEq, [x, y], [out_wire]);
 		out_wire
 	}
 
@@ -1649,19 +1640,21 @@ impl CircuitBuilder {
 	///
 	/// 1 BMUL constraint, or none when both arms are the same wire.
 	pub fn select(&self, cond: Wire, t: Wire, f: Wire) -> Wire {
+		let mut shared = self.shared.borrow_mut();
 		// Both arms identical: the result is that wire regardless of the condition.
 		// This reads no bit of `cond`, so it is independent of the MSB-boolean convention.
-		if self.algebraic_folding() && t == f {
+		if shared.opts.enable_algebraic_folding && t == f {
 			return t;
 		}
 		// A constant condition resolves the branch at compile time.
 		// The selector reads only the most significant bit (bit 63), the MSB-bool.
-		if let Some(c) = self.const_of(cond) {
+		if let Some(c) = const_of(&shared.graph, cond) {
 			return if (c.0 >> 63) == 1 { t } else { f };
 		}
-		let out = self.add_internal();
-		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Select, [cond, t, f], [out]);
+		let out = shared.graph.add_internal();
+		shared
+			.graph
+			.emit_gate(self.current_path, Opcode::Select, [cond, t, f], [out]);
 		out
 	}
 
@@ -1688,18 +1681,10 @@ impl CircuitBuilder {
 			inputs.len(),
 		);
 
-		let hint_id = self
-			.shared
-			.borrow_mut()
-			.as_mut()
-			.expect("CircuitBuilder used after build")
-			.hint_registry
-			.register(hint);
-
-		let outputs: Vec<Wire> = (0..n_out).map(|_| self.add_internal()).collect();
-
-		let mut graph = self.graph_mut();
-		graph.emit_hint_gate(
+		let mut shared = self.shared.borrow_mut();
+		let hint_id = shared.hint_registry.register(hint);
+		let outputs: Vec<Wire> = (0..n_out).map(|_| shared.graph.add_internal()).collect();
+		shared.graph.emit_hint_gate(
 			self.current_path,
 			hint_id,
 			dimensions,
@@ -1739,5 +1724,16 @@ impl CircuitBuilder {
 	/// The high word is the sign extension of the product.
 	pub fn smul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
 		smul64(self, a, b)
+	}
+}
+
+/// The compile-time value of a wire, when it is a constant.
+///
+/// Returns `None` for a wire whose value is only known at proving time.
+/// Takes the graph by reference, so a caller already holding a borrow can call this directly.
+fn const_of(graph: &GateGraph, wire: Wire) -> Option<Word> {
+	match graph.wires[wire] {
+		WireKind::Constant(word) => Some(word),
+		_ => None,
 	}
 }

--- a/crates/frontend/src/pass/fusion/tests/awhole.rs
+++ b/crates/frontend/src/pass/fusion/tests/awhole.rs
@@ -180,7 +180,7 @@ fn mk_circuit_builder() -> CircuitBuilder {
 	CircuitBuilder::with_opts(opts)
 }
 
-fn compile(circuit_builder: &CircuitBuilder) -> ConstraintSystem {
+fn compile(circuit_builder: CircuitBuilder) -> ConstraintSystem {
 	let circuit = circuit_builder.build();
 	circuit.constraint_system().clone()
 }
@@ -200,7 +200,7 @@ fn test_mul_inlining_duplicate_linear_in_mul() {
 
 	let (_hi, _lo) = b.imul(y, y);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"IMUL[0]: (v[0] ⊕ v[1]) * (v[0] ⊕ v[1]) = (HI: v[2], LO: v[3])");
 }
@@ -223,7 +223,7 @@ fn test_mul_and_and_shared_linear_uses() {
 	let z = b.add_witness();
 	let (_hi, _lo) = b.imul(y, z);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"
 	AND[0]: (v[0] ⊕ v[1]) ∧ (v[2]) = (v[4])
 	IMUL[0]: (v[0] ⊕ v[1]) * (v[3]) = (HI: v[5], LO: v[6])
@@ -252,7 +252,7 @@ fn test_mul_inlining_into_hi_lo() {
 	// We cannot directly modify outputs, but using them later in ANDs will keep them alive
 	// The important check is that IMUL constraint references should inline hi_src and lo_src
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"
 	ZERO[0]: (v[0] ⊕ v[1] ⊕ v[6]) = 0
 	ZERO[1]: (v[2] ⊕ v[3] ⊕ v[7]) = 0
@@ -279,7 +279,7 @@ fn test_mul_inlining_distinct_linears() {
 
 	let (_hi, _lo) = b.imul(y1, y2);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"IMUL[0]: (v[0] ⊕ v[1]) * (v[2]≪3 ⊕ v[3]) = (HI: v[4], LO: v[5])");
 }
 
@@ -290,7 +290,7 @@ fn test_xor_unused_preserved() {
 	let v0 = b.add_constant_64(0xe4);
 	let v1 = b.add_witness();
 	let _v2 = b.bxor(v0, v1);
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"ZERO[0]: (0xe4 ⊕ v[0] ⊕ v[1]) = 0");
 }
 
@@ -301,7 +301,7 @@ fn test_xor_into_assert() {
 	let v1 = b.add_witness();
 	let v2 = b.bxor(v0, v1);
 	b.assert_zero("derp", v2);
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
 		@"ZERO[0]: (0xe4 ⊕ v[0]) = 0",
@@ -322,7 +322,7 @@ fn test_xor_into_and_single_use() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
 		@"AND[0]: (v[2]) ∧ (v[0] ⊕ v[1]) = (v[3])",
@@ -346,7 +346,7 @@ fn test_xor_used_on_both_sides() {
 	let rhs = b.bxor(v4, v2); // v4 ^ v2
 	let _v6 = b.band(lhs, rhs);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// v2 is preserved since it's still referenced after lhs and rhs are inlined
 	// Expected: v[6] (which is v2 = v0^v1) should be fully inlined as (v[2] ⊕ v[3])
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0] ⊕ v[1] ⊕ v[2]) ∧ (v[3] ⊕ v[0] ⊕ v[1]) = (v[4])");
@@ -365,7 +365,7 @@ fn test_shifted_base_into_and() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v2, v1);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[1]) ∧ (v[0]≪33) = (v[2])");
 }
 
@@ -385,7 +385,7 @@ fn test_mixed_xor_of_shifts_into_and() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]) ∧ (v[0]≫7 ⊕ v[1]≪3) = (v[3])");
 }
 
@@ -408,7 +408,7 @@ fn test_deep_xor_in_both_a_and_c() {
 	let mask = b.add_witness();
 	let _v7 = b.band(lhs, mask);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0] ⊕ v[1] ⊕ v[2]a≫1 ⊕ v[3]) ∧ (v[4]) = (v[5])");
 }
 
@@ -431,7 +431,7 @@ fn test_fuse_across_parens() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(lhs, v5);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0]≪33 ⊕ v[1] ⊕ v[2] ⊕ v[3]) ∧ (v[4]) = (v[5])");
 }
 
@@ -459,7 +459,7 @@ fn test_multiple_producers_into_one_consumer() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0] ⊕ v[1] ⊕ v[2]≫5) ∧ (v[3]) = (v[4])");
 }
 
@@ -480,7 +480,7 @@ fn test_xor_producer_used_twice_inside_one_side() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// When used twice, the XOR terms should be inlined twice
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0] ⊕ v[1] ⊕ v[0] ⊕ v[1] ⊕ v[2]) ∧ (v[3]) = (v[4])");
 }
@@ -503,7 +503,7 @@ fn test_chain_two_level_fusion() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[0] ⊕ v[1] ⊕ v[2]) = (v[4])");
 }
 
@@ -528,7 +528,7 @@ fn test_chain_with_shifts_inside_producers() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[0]≫2 ⊕ v[1]a≫7 ⊕ v[2]≪11) = (v[4])");
 }
 
@@ -554,7 +554,7 @@ fn test_fuse_into_both_a_and_b() {
 
 	let _v6 = b.band(lhs, rhs);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0] ⊕ v[1]≫3 ⊕ v[2]) ∧ (v[3] ⊕ v[0] ⊕ v[1]≫3 ⊕ v[4]) = (v[5])");
 }
 
@@ -577,7 +577,7 @@ fn test_xor_feeding_xor_via_all_one() {
 	let mask = b.add_witness();
 	let _v5 = b.band(lhs, mask);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0] ⊕ v[1]≪2 ⊕ v[2] ⊕ v[3]) ∧ (v[4]) = (v[5])");
 }
 
@@ -595,7 +595,7 @@ fn test_not_pattern_via_xor_with_all_one() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v2, v1);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[1]) ∧ (v[0] ⊕ all-1) = (v[2])");
 }
 
@@ -614,7 +614,7 @@ fn test_dont_inline_xor_into_shifted_use() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v2_sll, v3);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// The optimization successfully inlines despite the shift at the use site
 	// This shows gate fusion can handle shifts in the consuming constraint
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0]≪5 ⊕ v[1]≪5) ∧ (v[2]) = (v[3])");
@@ -634,7 +634,7 @@ fn test_dont_inline_shifted_producer_into_shifted_use() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v1_sll, v2);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// Cannot compose different shift types (srl then sll), so it commits the intermediate
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
@@ -660,7 +660,7 @@ fn test_dont_inline_xor_into_shifted_xor_use() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// The optimization can actually compose shifts of the same type (shr)
 	// So it inlines despite the shift at use site
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[0]≫9 ⊕ v[1]≫11 ⊕ v[2]) ∧ (v[3]) = (v[4])");
@@ -685,7 +685,7 @@ fn test_mixed_one_unshifted_use_one_shifted_use() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v2_srl, v5);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// The optimization can inline into both uses since shifts distribute over XOR
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"
 	AND[0]: (v[2]) ∧ (v[0] ⊕ v[1]) = (v[4])
@@ -709,7 +709,7 @@ fn test_rotr_overflow_to_zero() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// rotr(v0, 64) should be simplified to v0 (no rotation)
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[1]) ∧ (v[0]) = (v[2])");
 }
@@ -730,7 +730,7 @@ fn test_rotr_wrap_around() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[1]) ∧ (v[0]≫≫16) = (v[2])");
 }
 
@@ -754,7 +754,7 @@ fn test_rotr_in_xor_overflow() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	// rotr(v0 ^ v1, 64) should be just v0 ^ v1
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]) ∧ (v[0] ⊕ v[1]) = (v[3])");
 }
@@ -776,7 +776,7 @@ fn test_rotr_chain_with_wrap() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(v4, v3);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[1]) ∧ (v[0]≫≫11) = (v[2])");
 }
 
@@ -797,7 +797,7 @@ fn test_rotr_distributes_over_xor_expanded() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(v4, v3);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]) ∧ (v[0]≫≫6 ⊕ v[1]≫≫6) = (v[3])");
 }
 
@@ -847,7 +847,7 @@ fn test_depth_limit_deep_chain() {
 	let w9 = b.add_witness();
 	let _result = b.band(v8, w9);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 
 	// The deep chain should cause intermediate commitments due to depth limit
 	// We expect the optimizer to commit some intermediate value and create multiple AND constraints
@@ -901,7 +901,7 @@ fn test_depth_limit_with_shifts() {
 	let w9 = b.add_witness();
 	let _result = b.band(v8, w9);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 
 	// With shifts in the chain, the depth limit should still apply
 	// The optimizer should handle the complexity and commit when needed
@@ -930,7 +930,7 @@ fn test_chained_shifts_beyond_the_word_width_compile() {
 	let y = b.add_witness();
 	let _out = b.band(v, y);
 
-	let cs = compile(&b);
+	let cs = compile(b);
 
 	// The break lands on the topmost link, which is committed as v[4].
 	// The three links below it merge into the single shift of 60 in the AND operand.

--- a/crates/frontend/tests/compile-fail/build_twice.rs
+++ b/crates/frontend/tests/compile-fail/build_twice.rs
@@ -1,3 +1,5 @@
+// Copyright 2026 The Binius Developers
+
 use binius_frontend::CircuitBuilder;
 
 fn main() {

--- a/crates/frontend/tests/compile-fail/build_twice.rs
+++ b/crates/frontend/tests/compile-fail/build_twice.rs
@@ -1,0 +1,9 @@
+use binius_frontend::CircuitBuilder;
+
+fn main() {
+	let builder = CircuitBuilder::new();
+	let _circuit = builder.build();
+	// The first call above moved `builder`.
+	// There is no builder left for the second call to type-check against.
+	let _circuit_again = builder.build();
+}

--- a/crates/frontend/tests/compile-fail/build_twice.stderr
+++ b/crates/frontend/tests/compile-fail/build_twice.stderr
@@ -1,20 +1,20 @@
 error[E0382]: use of moved value: `builder`
- --> tests/compile-fail/build_twice.rs:8:23
-  |
-4 |     let builder = CircuitBuilder::new();
-  |         ------- move occurs because `builder` has type `CircuitBuilder`, which does not implement the `Copy` trait
-5 |     let _circuit = builder.build();
-  |                            ------- `builder` moved due to this method call
+  --> tests/compile-fail/build_twice.rs:10:23
+   |
+ 6 |     let builder = CircuitBuilder::new();
+   |         ------- move occurs because `builder` has type `CircuitBuilder`, which does not implement the `Copy` trait
+ 7 |     let _circuit = builder.build();
+   |                            ------- `builder` moved due to this method call
 ...
-8 |     let _circuit_again = builder.build();
-  |                          ^^^^^^^ value used here after move
-  |
+10 |     let _circuit_again = builder.build();
+   |                          ^^^^^^^ value used here after move
+   |
 note: `CircuitBuilder::build` takes ownership of the receiver `self`, which moves `builder`
- --> src/builder/mod.rs
-  |
-  |     pub fn build(self) -> Circuit {
-  |                  ^^^^
+  --> src/builder/mod.rs
+   |
+   |     pub fn build(self) -> Circuit {
+   |                  ^^^^
 help: you can `clone` the value and consume it, but this might not be your desired behavior
-  |
-5 |     let _circuit = builder.clone().build();
-  |                           ++++++++
+   |
+ 7 |     let _circuit = builder.clone().build();
+   |                           ++++++++

--- a/crates/frontend/tests/compile-fail/build_twice.stderr
+++ b/crates/frontend/tests/compile-fail/build_twice.stderr
@@ -1,0 +1,20 @@
+error[E0382]: use of moved value: `builder`
+ --> tests/compile-fail/build_twice.rs:8:23
+  |
+4 |     let builder = CircuitBuilder::new();
+  |         ------- move occurs because `builder` has type `CircuitBuilder`, which does not implement the `Copy` trait
+5 |     let _circuit = builder.build();
+  |                            ------- `builder` moved due to this method call
+...
+8 |     let _circuit_again = builder.build();
+  |                          ^^^^^^^ value used here after move
+  |
+note: `CircuitBuilder::build` takes ownership of the receiver `self`, which moves `builder`
+ --> src/builder/mod.rs
+  |
+  |     pub fn build(self) -> Circuit {
+  |                  ^^^^
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+  |
+5 |     let _circuit = builder.clone().build();
+  |                           ++++++++

--- a/crates/frontend/tests/compile_fail.rs
+++ b/crates/frontend/tests/compile_fail.rs
@@ -1,0 +1,12 @@
+// Copyright 2026 The Binius Developers
+
+//! Pins the ownership contract on building a circuit.
+//!
+//! A builder is consumed by the call.
+//! So the compiler rejects reuse at compile time, instead of a panic surfacing at run time.
+
+#[test]
+fn build_consumes_the_builder() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/compile-fail/*.rs");
+}

--- a/crates/frontend/tests/test_assertion_paths.rs
+++ b/crates/frontend/tests/test_assertion_paths.rs
@@ -18,6 +18,11 @@ fn test_assertion_failure_shows_path() {
 	// Add an assertion that will fail
 	submodule.assert_eq("test_assertion", x, y);
 
+	// Building reclaims sole ownership of the shared builder state.
+	// So every subcircuit handle must be dropped first.
+	drop(submodule);
+	drop(module_a);
+
 	// Build the circuit
 	let circuit = builder.build();
 
@@ -65,6 +70,10 @@ fn test_multiple_assertion_failures() {
 
 	module.assert_eq("check_a_equals_b", a, b);
 	module.assert_eq("check_b_equals_c", b, c);
+
+	// Building reclaims sole ownership of the shared builder state.
+	// So the subcircuit handle must be dropped first.
+	drop(module);
 
 	let circuit = builder.build();
 	let mut filler = circuit.new_witness_filler();

--- a/crates/recursion/src/challenger.rs
+++ b/crates/recursion/src/challenger.rs
@@ -588,6 +588,9 @@ mod tests {
 			})
 			.collect();
 
+		// The gadget holds its own clone of the builder.
+		// It must be dropped before building can reclaim sole ownership of the shared state.
+		drop(gadget);
 		let circuit = builder.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
@@ -733,6 +736,9 @@ mod tests {
 		builder.assert_eq("low", low, builder.add_inout());
 		builder.assert_eq("high", high, builder.add_inout());
 
+		// The gadget holds its own clone of the builder.
+		// It must be dropped before building can reclaim sole ownership of the shared state.
+		drop(gadget);
 		CircuitStat::collect(&builder.build())
 	}
 

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -118,12 +118,20 @@ impl Binius64BuilderChannel {
 	/// Every [`SymbolicElem`] and [`SymbolicWord`] derived from this channel must be dropped first:
 	/// they hold weak handles to the builder, and using one afterwards panics.
 	pub fn build(self) -> Recorded {
-		let shared = Rc::try_unwrap(self.shared).unwrap_or_else(|_| {
+		// The challenger keeps its own clone of the builder alive to absorb or sample from.
+		// Dropping it here is what leaves exactly one handle to the shared state below.
+		let Self {
+			shared, challenger, ..
+		} = self;
+		drop(challenger);
+
+		let shared = Rc::try_unwrap(shared).unwrap_or_else(|_| {
 			panic!("SymbolicElem and SymbolicWord values hold only weak handles")
 		});
+		let inputs = shared.inputs();
 		Recorded {
-			inputs: shared.inputs(),
-			circuit: shared.builder().build(),
+			inputs,
+			circuit: shared.into_builder().build(),
 		}
 	}
 

--- a/crates/recursion/src/shared.rs
+++ b/crates/recursion/src/shared.rs
@@ -44,6 +44,14 @@ impl Shared {
 		&self.builder
 	}
 
+	/// Consumes the shared state, returning the builder alone.
+	///
+	/// Building needs to own the builder outright.
+	/// So a caller reaches for this only once every wire allocation is done.
+	pub fn into_builder(self) -> CircuitBuilder {
+		self.builder
+	}
+
 	/// Allocates a wire the witness must supply, recording which operation asked for it.
 	pub fn input_wire(&self, kind: &'static str) -> Wire {
 		let wire = self.builder.add_witness();

--- a/crates/recursion/src/symbolic/elem.rs
+++ b/crates/recursion/src/symbolic/elem.rs
@@ -459,7 +459,10 @@ mod tests {
 		let inv_wires = [builder.add_inout(), builder.add_inout()];
 		constrain_inverse(builder, (x_wires[0], x_wires[1]), (inv_wires[0], inv_wires[1]));
 
-		let circuit = builder.build();
+		let circuit = Rc::try_unwrap(shared)
+			.unwrap_or_else(|_| panic!("no SymbolicElem or SymbolicWord should still be alive"))
+			.into_builder()
+			.build();
 		let mut w = circuit.new_witness_filler();
 		for (wires, value) in [(x_wires, x), (inv_wires, inv)] {
 			for (wire, word) in wires.iter().zip(element_words(u128::from(value))) {
@@ -529,7 +532,10 @@ mod tests {
 			fill.push((claimed, want));
 		}
 
-		let circuit = builder.build();
+		let circuit = Rc::try_unwrap(shared)
+			.unwrap_or_else(|_| panic!("no SymbolicElem or SymbolicWord should still be alive"))
+			.into_builder()
+			.build();
 		let stat = CircuitStat::collect(&circuit);
 		let mut w = circuit.new_witness_filler();
 		for (wires, value) in fill {


### PR DESCRIPTION
Makes building a circuit consume the builder, and collapses one borrow per gate.

### The problem

`CircuitBuilder::build` took `&self`.
That is not what building actually is — a builder is meant to be used exactly once — so the
one-shot rule had to be enforced by hand, at run time.

The state lived behind `Rc<RefCell<Option<Shared>>>`, and `build` emptied that `Option`.
Every other method then had to re-check it wasn't already empty:

```rust
let chips = &mut shared
    .as_mut()
    .expect("CircuitBuilder used after build")
    .chips;
```

Nine call sites carried that same `.expect("CircuitBuilder used after build")`, one invariant
checked nine separate times.

### The idea

Move the state to `Rc<RefCell<Shared>>`, drop the `Option`, and make `build`/`build_m4` take `self`.

Reclaiming the state is now one call:

```rust
fn into_shared(self) -> Shared {
    Rc::into_inner(self.shared)
        .expect("a clone or subcircuit still holds a live handle to the same shared state")
        .into_inner()
}
```

`Rc::into_inner` only returns `Some` under sole ownership.
So the one real failure mode left — a clone or a subcircuit still alive elsewhere — collapses onto
one panic site, instead of nine scattered re-checks of the same thing.

The type system now rejects a second `build()` outright, since there is no builder left to call it
on.
Pinned with a `trybuild` fixture (`tests/compile-fail/build_twice.rs`) — none existed in the crate
before, so the harness is new too.

### One borrow per gate

Separately, in the same file, for the same reason: each gate-emission method — `band`, `bxor`,
`imul`, `select`, and about a dozen more — took 2 to 5 separate short-lived borrows of the same
`RefCell` per call. `band(x, y)` alone touched it once each for `algebraic_folding()`, `const_of(x)`,
`const_of(y)`, `add_constant`, and `graph_mut()`. Each now takes one borrow, held across the whole
operation.

### The change

```rust
pub fn build(&self) -> Circuit {
    let shared = self.take_shared();
    ...
}
```
becomes
```rust
pub fn build(self) -> Circuit {
    let shared = self.into_shared();
    ...
}
```

### Scope

- **changed:** `crates/frontend/src/builder/mod.rs` — the `build`/`build_m4` signatures, `into_shared`, and every gate-emission method's borrow count.
- **new:** `crates/frontend/tests/compile-fail/build_twice.rs` + `.stderr`, `crates/frontend/tests/compile_fail.rs`, and a `trybuild` dev-dependency.
- **fixed at the call sites `cargo check --workspace --all-targets` found:** a local test helper in `pass/fusion/tests/awhole.rs` that took `&CircuitBuilder` and its 31 call sites, one test helper in `crates/circuits/src/slice.rs` and its 13 call sites, and `crates/recursion` (see below).
- **left untouched:** every gate's constraint semantics, the six assertion-emission methods (already single-borrow).

### A real bug this surfaced

`&self` → `self` only catches *compile-time* breaks.
It also introduces a new *runtime* one: anything holding its own clone of a `CircuitBuilder` now
keeps `Rc::into_inner` from ever succeeding.

`Sha256Challenger` (`crates/recursion/src/challenger.rs`) is exactly that — it clones the builder to
absorb into. `Binius64BuilderChannel::build()` never dropped the challenger before reclaiming the
shared state, so under the new contract every real call to build a recorded circuit through that
channel would have panicked:

```rust
- let shared = Rc::try_unwrap(self.shared).unwrap_or_else(|_| { panic!(...) });
+ let Self { shared, challenger, .. } = self;
+ drop(challenger);
+ let shared = Rc::try_unwrap(shared).unwrap_or_else(|_| { panic!(...) });
```

This was latent before this change too — nothing dropped the challenger early — but `&self`
`build()` never needed sole ownership, so it never surfaced.
Two test helpers in `challenger.rs` had the same shape and needed the same one-line `drop`.

### Verification

- `cargo check --workspace --all-targets` — clean; this is what found every call site above.
- `cargo test -p binius-frontend` — 249 + 1 (`trybuild`) + 1 (`crc64_chip`) + 2 (`test_assertion_paths`) + 2 (doctests), all passed.
- `cargo test -p binius-recursion` — 30 + 8 + 2 + 4, all passed.
- `cargo test -p binius-circuits --lib slice` — 29 passed.
- `cargo clippy -p binius-frontend -p binius-recursion -p binius-circuits --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
