### PR TITLE
Stop a built circuit from retaining the whole gate graph

### DIFF
--- a/crates/frontend/src/artifact/circuit.rs
+++ b/crates/frontend/src/artifact/circuit.rs
@@ -17,7 +17,11 @@ use crate::{
 		witness::{BatchWitnessFiller, PopulateError, WitnessFiller},
 	},
 	eval_form::{BatchPopulateError, EvalForm},
-	ir::{GateGraph, Wire},
+	ir::{
+		GateBody, Wire,
+		path::{PathSpec, PathSpecTree},
+	},
+	pass::BuiltGates,
 };
 
 /// Default number of instance columns evaluated by one parallel witness-generation task.
@@ -28,7 +32,8 @@ const DEFAULT_PARALLEL_STRIPE_WIDTH: usize = 1024;
 /// The difference from [`ConstraintSystem`] is that a circuit retains enough information to
 /// perform circuit evaluation to generate internal witness values.
 pub struct Circuit {
-	gate_graph: GateGraph,
+	path_spec_tree: PathSpecTree,
+	gate_records: Vec<(PathSpec, GateBody)>,
 	constraint_system: ConstraintSystem,
 	value_vec_layout: ValueVecLayout,
 	wire_mapping: SecondaryMap<Wire, ValueIndex>,
@@ -40,8 +45,8 @@ pub struct Circuit {
 impl Circuit {
 	/// Creates a new circuit with the given shared data and wire mapping. Only used during building
 	/// by the circuit builder.
-	pub(crate) const fn new(
-		gate_graph: GateGraph,
+	pub(crate) fn new(
+		built_gates: BuiltGates,
 		constraint_system: ConstraintSystem,
 		value_vec_layout: ValueVecLayout,
 		wire_mapping: SecondaryMap<Wire, ValueIndex>,
@@ -49,8 +54,13 @@ impl Circuit {
 		eval_form: EvalForm,
 		scratch_peak_live: usize,
 	) -> Self {
+		let BuiltGates {
+			path_spec_tree,
+			gate_records,
+		} = built_gates;
 		Self {
-			gate_graph,
+			path_spec_tree,
+			gate_records,
 			constraint_system,
 			value_vec_layout,
 			wire_mapping,
@@ -140,7 +150,7 @@ impl Circuit {
 		// Execute the evaluation form - it modifies the ValueVec in place
 		// Pass the PathSpecTree for assertion error symbolication
 		self.eval_form
-			.evaluate(&mut w.value_vec, Some(&self.gate_graph.path_spec_tree))?;
+			.evaluate(&mut w.value_vec, Some(&self.path_spec_tree))?;
 
 		Ok(())
 	}
@@ -178,7 +188,7 @@ impl Circuit {
 
 		// Evaluate the bytecode across all instances, symbolicating assertion failures.
 		self.eval_form
-			.evaluate_batched(values, Some(&self.gate_graph.path_spec_tree))
+			.evaluate_batched(values, Some(&self.path_spec_tree))
 	}
 
 	/// Populates non-input values for a batch of instances split into vertical stripes.
@@ -209,11 +219,8 @@ impl Circuit {
 		}
 
 		// Evaluate independent instance stripes in parallel, symbolicating assertion failures.
-		self.eval_form.evaluate_batched_parallel(
-			values,
-			stripe_width,
-			Some(&self.gate_graph.path_spec_tree),
-		)
+		self.eval_form
+			.evaluate_batched_parallel(values, stripe_width, Some(&self.path_spec_tree))
 	}
 
 	/// Returns the constraint system for this circuit.
@@ -230,8 +237,8 @@ impl Circuit {
 	///
 	/// Depending on what type of gates this circuit uses, the number of constraints might be
 	/// significantly larger.
-	pub fn n_gates(&self) -> usize {
-		self.gate_graph.gates.len()
+	pub const fn n_gates(&self) -> usize {
+		self.gate_records.len()
 	}
 
 	/// Returns the number of evaluation instructions in this circuit.
@@ -241,7 +248,7 @@ impl Circuit {
 
 	/// Returns a string with a JSON dump that is useful to profile the circuit.
 	pub fn simple_json_dump(&self) -> String {
-		dump_composition(&self.gate_graph)
+		dump_composition(&self.path_spec_tree, &self.gate_records)
 	}
 
 	/// Builds the batch witness in wire-major order, populating all `2^log_instances` instances.

--- a/crates/frontend/src/artifact/dump.rs
+++ b/crates/frontend/src/artifact/dump.rs
@@ -3,11 +3,14 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::ser::SerializeStruct;
 
-use crate::ir::{Gate, GateBody, GateGraph, path::PathSpec};
+use crate::ir::{
+	GateBody,
+	path::{PathSpec, PathSpecTree},
+};
 
 struct PathSpecData {
 	name: String,
-	gates: Vec<Gate>,
+	gates: Vec<GateBody>,
 	parent: Option<PathSpec>,
 	children: Vec<PathSpec>,
 	breakdown: Option<GateBreakdown>,
@@ -34,12 +37,12 @@ struct GateBreakdown {
 }
 
 impl GateBreakdown {
-	fn count(gg: &GateGraph, gates: &[Gate]) -> GateBreakdown {
+	fn count(gates: &[GateBody]) -> GateBreakdown {
 		let mut breakdown = GateBreakdown {
 			by_kind: BTreeMap::new(),
 		};
-		for gate in gates {
-			*breakdown.by_kind.entry(gg.gates[*gate].body).or_insert(0) += 1;
+		for &kind in gates {
+			*breakdown.by_kind.entry(kind).or_insert(0) += 1;
 		}
 		breakdown
 	}
@@ -87,14 +90,17 @@ impl Cx {
 		}
 	}
 
-	fn bucket_gates(&mut self, gg: &GateGraph) {
-		self.data
-			.insert(gg.path_spec_tree.root(), PathSpecData::new());
+	fn bucket_gates(
+		&mut self,
+		path_spec_tree: &PathSpecTree,
+		gate_records: &[(PathSpec, GateBody)],
+	) {
+		self.data.insert(path_spec_tree.root(), PathSpecData::new());
 
 		// First, collect all PathSpecs that have gates
 		let mut path_specs_with_gates = BTreeSet::new();
-		for gate in gg.gates.keys() {
-			path_specs_with_gates.insert(gg.gate_origin[gate]);
+		for &(path, _) in gate_records {
+			path_specs_with_gates.insert(path);
 		}
 
 		// Add all ancestors of PathSpecs with gates to ensure complete hierarchy
@@ -103,7 +109,7 @@ impl Cx {
 			let mut current = path_spec;
 			loop {
 				all_needed_paths.insert(current);
-				if let Some(parent) = gg.path_spec_tree.parent(current) {
+				if let Some(parent) = path_spec_tree.parent(current) {
 					current = parent;
 				} else {
 					break;
@@ -117,34 +123,30 @@ impl Cx {
 		}
 
 		// Now add gates to their respective PathSpecs
-		for gate in gg.gates.keys() {
-			self.data
-				.get_mut(&gg.gate_origin[gate])
-				.unwrap()
-				.gates
-				.push(gate);
+		for &(path, body) in gate_records {
+			self.data.get_mut(&path).unwrap().gates.push(body);
 		}
 	}
 
-	fn recover_hierarchy(&mut self, gg: &GateGraph) {
+	fn recover_hierarchy(&mut self, path_spec_tree: &PathSpecTree) {
 		let paths = self.data.keys().cloned().collect::<Vec<_>>();
 		for current in paths {
-			if let Some(parent) = gg.path_spec_tree.parent(current) {
+			if let Some(parent) = path_spec_tree.parent(current) {
 				self.data.get_mut(&current).unwrap().parent = Some(parent);
 				self.data.get_mut(&parent).unwrap().children.push(current);
 			}
 		}
 	}
 
-	fn symbolicate_paths(&mut self, gg: &GateGraph) {
+	fn symbolicate_paths(&mut self, path_spec_tree: &PathSpecTree) {
 		for (path, data) in &mut self.data {
-			gg.path_spec_tree.stringify(*path, &mut data.name);
+			path_spec_tree.stringify(*path, &mut data.name);
 		}
 	}
 
-	fn compute_breakdowns(&mut self, gg: &GateGraph) {
+	fn compute_breakdowns(&mut self) {
 		for data in self.data.values_mut() {
-			data.breakdown = Some(GateBreakdown::count(gg, &data.gates));
+			data.breakdown = Some(GateBreakdown::count(&data.gates));
 		}
 	}
 
@@ -152,7 +154,7 @@ impl Cx {
 	/// then the parent.
 	///
 	/// Requires to be called after recovering the hierarchy.
-	fn compute_postorder(&mut self, gg: &GateGraph) {
+	fn compute_postorder(&mut self, path_spec_tree: &PathSpecTree) {
 		fn collect_postorder(
 			data: &BTreeMap<PathSpec, PathSpecData>,
 			visited: &mut BTreeSet<PathSpec>,
@@ -176,7 +178,7 @@ impl Cx {
 		let mut visited = BTreeSet::new();
 
 		// Start from root to ensure proper traversal
-		let root = gg.path_spec_tree.root();
+		let root = path_spec_tree.root();
 		collect_postorder(&self.data, &mut visited, &mut self.post_order, root);
 	}
 
@@ -203,8 +205,8 @@ impl Cx {
 	}
 
 	/// Builds the hierarchical SubcircuitInfo structure starting from root
-	fn build_subcircuit_info(&self, gg: &GateGraph) -> SubcircuitInfo {
-		let root = gg.path_spec_tree.root();
+	fn build_subcircuit_info(&self, path_spec_tree: &PathSpecTree) -> SubcircuitInfo {
+		let root = path_spec_tree.root();
 		self.build_subcircuit_info_recursive(root)
 	}
 
@@ -239,23 +241,30 @@ struct SubcircuitInfo {
 }
 
 /// Dumps a hierarchical JSON representation of the given circuit.
-pub(crate) fn dump_composition(gg: &GateGraph) -> String {
+pub(crate) fn dump_composition(
+	path_spec_tree: &PathSpecTree,
+	gate_records: &[(PathSpec, GateBody)],
+) -> String {
 	let mut cx = Cx::new();
-	cx.bucket_gates(gg);
-	cx.recover_hierarchy(gg);
-	cx.compute_postorder(gg);
-	cx.compute_breakdowns(gg);
+	cx.bucket_gates(path_spec_tree, gate_records);
+	cx.recover_hierarchy(path_spec_tree);
+	cx.compute_postorder(path_spec_tree);
+	cx.compute_breakdowns();
 	cx.compute_cum_breakdowns();
-	cx.symbolicate_paths(gg);
+	cx.symbolicate_paths(path_spec_tree);
 
-	let subcircuit_info = cx.build_subcircuit_info(gg);
+	let subcircuit_info = cx.build_subcircuit_info(path_spec_tree);
 	serde_json::to_string_pretty(&subcircuit_info).unwrap()
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{gates::Opcode, ir::hints::hint_id_of};
+	use crate::{
+		gates::Opcode,
+		ir::{GateGraph, hints::hint_id_of},
+		pass::BuiltGates,
+	};
 
 	#[test]
 	fn every_hint_is_counted_under_one_name() {
@@ -273,7 +282,8 @@ mod tests {
 		let o3 = graph.add_internal();
 		graph.emit_gate(root, Opcode::Band, vec![x, y], vec![o3]);
 
-		let dump = dump_composition(&graph);
+		let built = BuiltGates::from_graph(graph);
+		let dump = dump_composition(&built.path_spec_tree, &built.gate_records);
 
 		assert!(dump.contains("\"Hint\": 2"), "{dump}");
 		assert!(dump.contains("\"Band\": 1"), "{dump}");

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 	},
 	lower::ConstraintBuilder,
 	pass::{
-		const_prop, cse, dce, fusion,
+		BuiltGates, const_prop, cse, dce, fusion,
 		layout::{
 			scratch_alloc::{ScratchAlloc, ScratchPolicy},
 			value_vec_alloc,
@@ -727,8 +727,12 @@ impl CircuitBuilder {
 			shared.hint_registry,
 		);
 
+		// Passes above needed the whole graph.
+		// A circuit only reads back path names and a per-gate record, so the rest drops now.
+		let built_gates = BuiltGates::from_graph(graph);
+
 		Circuit::new(
-			graph,
+			built_gates,
 			cs,
 			value_vec_layout,
 			wire_mapping,

--- a/crates/frontend/src/pass/mod.rs
+++ b/crates/frontend/src/pass/mod.rs
@@ -8,3 +8,41 @@ pub mod dce;
 pub mod fusion;
 pub mod layout;
 pub mod zero_fold;
+
+use crate::ir::{
+	GateBody, GateGraph,
+	path::{PathSpec, PathSpecTree},
+};
+
+/// What a built circuit keeps once the gate graph has done its job.
+///
+/// Building walks the full graph to compile the constraint system and the evaluation form.
+/// That walk touches every wire and every gate's inputs, outputs and immediates.
+/// None of it is needed again once building finishes.
+///
+/// A circuit only reads back the path names for assertions and dumps afterwards.
+/// It also reads one path-and-kind pair per gate, for the composition breakdown.
+/// This holds exactly that, so the rest of the graph can be dropped.
+pub struct BuiltGates {
+	/// The tree of circuit paths, named at build time and read back for assertions and dumps.
+	pub path_spec_tree: PathSpecTree,
+	/// One entry per gate, in construction order.
+	///
+	/// Dead and duplicate gates are included, exactly as the source graph counted them.
+	pub gate_records: Vec<(PathSpec, GateBody)>,
+}
+
+impl BuiltGates {
+	/// Extracts what a built circuit keeps, dropping the rest of the graph.
+	pub fn from_graph(graph: GateGraph) -> Self {
+		let gate_records = graph
+			.gates
+			.iter()
+			.map(|(gate, data)| (graph.gate_origin[gate], data.body))
+			.collect();
+		Self {
+			path_spec_tree: graph.path_spec_tree,
+			gate_records,
+		}
+	}
+}


### PR DESCRIPTION
Stops a built `Circuit` from retaining the whole mid-compile gate graph.

### The problem

Building a circuit walks the full gate graph once, to compile the constraint system and the
evaluation form.
That walk touches every wire and every gate's inputs, outputs, and immediates.

`Circuit` kept the whole graph anyway, for the rest of the prover's lifetime — hundreds of
megabytes on a large circuit — even though it only ever reads three things back out of it
afterward:

- path names, for assertion messages and dumps
- a gate count
- one path-and-kind pair per gate, for the JSON composition breakdown

### The idea

Extract exactly those three, and drop the rest of the graph when `compile()` returns.

```rust
pub struct BuiltGates {
    pub path_spec_tree: PathSpecTree,
    pub gate_records: Vec<(PathSpec, GateBody)>,
}
```

One entry per gate at 2 words, against the ~96 bytes a full `GateData` costs — every wire, every
operand, the use-def index, the constant pool, none of it survives past this point.

### The change

```rust
- Circuit::new(graph, cs, value_vec_layout, wire_mapping, inout, eval_form, scratch_peak_live)
+ let built_gates = BuiltGates::from_graph(graph);
+ Circuit::new(built_gates, cs, value_vec_layout, wire_mapping, inout, eval_form, scratch_peak_live)
```

`dump_composition` (the JSON dump behind `simple_json_dump`, genuinely used by the `examples` CLI's
`composition` subcommand, not just tests) now threads `&PathSpecTree` and
`&[(PathSpec, GateBody)]` through instead of `&GateGraph`.

### Per circuit — measured, not estimated

Measured on the `hashsign` example (3 signers, 275,391 gates), with a throwaway custom allocator
tracking live heap bytes right after `build()` returns:

| | `Circuit` struct | total heap footprint |
|---|---|---|
| before | 584 bytes | 105.7 MiB |
| after | 376 bytes | 46.4 MiB |

→ **≈62.2 MB less, ≈56% of the total footprint on this circuit.**

### Soundness

Retaining less must not change what the dump reports.
Ran `hashsign -- composition` before and after this change and compared the raw JSON output —
identical, MD5 `59b847bb54f22c26a430dec0290f9f1a` both times.

### Scope

- **changed:** `artifact/circuit.rs`, `artifact/dump.rs`, `pass/mod.rs` (new `BuiltGates`), one call site in `builder/mod.rs`.
- **left untouched:** every other reader of a built circuit — `n_gates()` still returns the same number, now from `gate_records.len()` instead of `gate_graph.gates.len()`, and became `const fn` since a `Vec::len()` read allows it.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo test -p binius-frontend -p binius-examples` — 249 + 1 + 2 (frontend) + 22 + 3 (examples), all passed.
- `cargo clippy -p binius-frontend -p binius-examples --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
