### PR TITLE
Give the gate-fusion graph three typed node id spaces

### DIFF
--- a/crates/frontend/src/pass/fusion/commit_set.rs
+++ b/crates/frontend/src/pass/fusion/commit_set.rs
@@ -7,7 +7,7 @@ use petgraph::{
 	visit::{DfsPostOrder, EdgeRef},
 };
 
-use super::{LeGraph, Stat};
+use super::{LeGraph, Stat, legraph::NodeKind};
 
 /// Longest inline chain a definition of two or more terms may sit at the top of.
 ///
@@ -315,28 +315,27 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat, shift_slots: us
 	// every user's shifts compose with the current node shifts which are stored in the incoming
 	// edges and additionally the node does not lie too deep in the graph for any of the users.
 	let mut postorder = DfsPostOrder::empty(&leg.pg);
-	for source in &leg.opaque {
-		postorder.move_to(*source);
+	for &source in leg.opaque.values() {
+		postorder.move_to(source);
 		while let Some(node) = postorder.next(&leg.pg) {
-			if leg.is_root(node) {
-				// Special handling for the root nodes.
-				//
-				// Just create a new context for each root node with the seed shift.
-				for in_edge in leg.pg.edges_directed(node, Direction::Incoming) {
-					let shift = in_edge.weight().shift;
-					per_edge[in_edge.id().index()] = Some(CommitSetCx::new(shift));
+			// Classify the node once.
+			// Only a linear definition carries edges that need composing.
+			// The other two kinds are handled and skipped right here.
+			let lin_def_id = match leg.node_kind(node) {
+				NodeKind::Root => {
+					// Just create a new context for each root node with the seed shift.
+					for in_edge in leg.pg.edges_directed(node, Direction::Incoming) {
+						let shift = in_edge.weight().shift;
+						per_edge[in_edge.id().index()] = Some(CommitSetCx::new(shift));
+					}
+					continue;
 				}
-				continue;
-			}
-			if leg.is_opaque(node) {
-				// Special handling for opaque nodes, or lack of there of.
-				continue;
-			}
+				NodeKind::Opaque => continue,
+				NodeKind::LinDef(id) => id,
+			};
 
-			// Must be a linear definition then.
-			//
 			// Check whether the incoming edges are composing with every outcoming edges.
-			let lin_def_wire = leg.lin_dst(node);
+			let lin_def_wire = leg.lin_dst(lin_def_id);
 			let incoming = leg.pg.edges_directed(node, Direction::Incoming);
 			let outcoming = leg.pg.edges_directed(node, Direction::Outgoing);
 

--- a/crates/frontend/src/pass/fusion/legraph.rs
+++ b/crates/frontend/src/pass/fusion/legraph.rs
@@ -3,7 +3,7 @@
 //! linear expression graph.
 
 use binius_core::constraint_system::Shift;
-use cranelift_entity::{EntitySet, SecondaryMap};
+use cranelift_entity::{EntityRef, EntitySet, PrimaryMap, SecondaryMap, entity_impl};
 use petgraph::graph::{DiGraph, NodeIndex};
 
 use crate::{
@@ -20,66 +20,51 @@ pub enum ConstraintRef {
 	Linear { index: usize },
 }
 
-/// Represents the different types of nodes in the Linear Expression Graph.
-#[derive(Debug)]
-pub enum NodeData {
-	/// Root node - represents a use site in a constraint that defines no wire.
-	///
-	/// These nodes are the "sinks" of the graph where linear expressions flow into
-	/// AND/IMUL/BMUL/ZERO constraints. They have no outgoing edges and represent
-	/// the termination points for inlining decisions.
-	///
-	/// # Example
-	/// ```text
-	/// y = x ^ a       // Linear definition
-	/// z = y & b       // AND constraint creates a Root node for y's use
-	/// ```
-	Root {
-		/// Reference to the non-linear constraint using the linear definition.
-		constraint: ConstraintRef,
-	},
+/// Identifies a linear-definition node: a linear constraint that assigns a wire.
+///
+/// Its position matches the constraint's own position in the constraint builder's linear list.
+/// So an id's index doubles as that list's index.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LinDefId(u32);
+entity_impl!(LinDefId);
 
-	/// Linear definition node - represents a linear constraint.
-	///
-	/// These nodes define a wire as an XOR combination of shifted values.
-	/// They are candidates for inlining into their consumers.
-	///
-	/// # Example
-	/// ```text
-	/// y = x ^ (a << 5) ^ (b >> 3)  // Creates a LinDef node for y
-	/// ```
-	LinDef {
-		/// The wire being defined by this linear constraint.
-		dst: Wire,
-		/// Index in the linear constraint list.
-		///
-		/// The operand itself stays in the constraint builder rather than being copied here.
-		/// Copying it would allocate once per linear constraint, and there is one per fused wire.
-		index: usize,
-	},
+/// Identifies a root node: a use site in a constraint that defines no wire.
+///
+/// A root is a sink of the graph.
+/// A linear definition flows into it as an AND, IMUL, BMUL, or Zero constraint.
+/// A root has no consumer of its own.
+/// Inlining always terminates here.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RootId(u32);
+entity_impl!(RootId);
 
-	/// Opaque node - represents a wire not defined by a linear constraint.
+/// Identifies an opaque node: a wire that is not defined by a linear constraint.
+///
+/// Inputs, constants, and the outputs of non-linear operations are opaque.
+/// Inlining cannot reach past one.
+/// So an opaque node is a source of the graph.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OpaqueId(u32);
+entity_impl!(OpaqueId);
+
+/// Which of the three node kinds a graph node holds.
+///
+/// A traversal walks the graph through petgraph's own untyped node index.
+/// This is the one place all three kinds still meet.
+/// Everywhere else a node is named by its own specific kind of id.
+/// So the compiler rejects handing one kind's id to code that expects another.
+#[derive(Debug, Copy, Clone)]
+pub(super) enum NodeKind {
+	/// A linear definition, named by its id.
+	LinDef(LinDefId),
+	/// A root use.
 	///
-	/// These are wires that come from inputs, constants, or outputs of non-linear
-	/// operations. They cannot be inlined and serve as terminal nodes in the
-	/// inlining traversal.
-	///
-	/// # Example
-	/// ```text
-	/// x = input()     // Creates an Opaque node for x
-	/// y = a * b       // Creates Opaque nodes for y (IMUL output)
-	/// ```
+	/// Its constraint lives in a separate collection, addressed by discovery order.
+	/// That is not by this node.
+	/// So the variant itself carries no id.
+	Root,
+	/// A wire that is not defined by a linear constraint.
 	Opaque,
-}
-
-impl NodeData {
-	const fn is_root(&self) -> bool {
-		matches!(self, NodeData::Root { .. })
-	}
-
-	const fn is_opaque(&self) -> bool {
-		matches!(self, NodeData::Opaque)
-	}
 }
 
 /// Data associated with edges in the Linear Expression Graph.
@@ -139,15 +124,21 @@ pub struct EdgeData {
 /// In this example, both `y` and `z` can potentially be inlined into the AND constraint,
 /// resulting in `w = ((a ^ b) >> 5) & c` without intermediate wire commitments.
 pub struct LeGraph {
-	pub pg: DiGraph<NodeData, EdgeData>,
+	pub pg: DiGraph<NodeKind, EdgeData>,
 	/// Node holding each wire, for the wires that have one.
 	///
 	/// Wire identifiers are dense, so this indexes directly instead of hashing.
 	pub wire_to_node: SecondaryMap<Wire, Option<NodeIndex>>,
 	pub lin_def: EntitySet<Wire>,
 	pub lin_committed: EntitySet<Wire>,
-	pub roots: Vec<NodeIndex>,
-	pub opaque: Vec<NodeIndex>,
+	/// The linear-definition id that assigns each wire, for wires that have one.
+	wire_to_lin_def: SecondaryMap<Wire, Option<LinDefId>>,
+	/// The wire each linear-definition id assigns.
+	lin_defs: PrimaryMap<LinDefId, Wire>,
+	/// The constraint each root id names, in the order the roots were discovered.
+	pub roots: PrimaryMap<RootId, ConstraintRef>,
+	/// The graph node each opaque id names, in the order the wires were discovered.
+	pub opaque: PrimaryMap<OpaqueId, NodeIndex>,
 }
 
 impl LeGraph {
@@ -168,19 +159,18 @@ impl LeGraph {
 			wire_to_node: SecondaryMap::new(),
 			lin_committed: EntitySet::new(),
 			lin_def: EntitySet::new(),
-			roots: Vec::new(),
-			opaque: Vec::new(),
+			wire_to_lin_def: SecondaryMap::new(),
+			lin_defs: PrimaryMap::new(),
+			roots: PrimaryMap::new(),
+			opaque: PrimaryMap::new(),
 		};
 		build_use_def(cb, &mut leg);
 		leg
 	}
 
-	pub(super) fn is_root(&self, node: NodeIndex) -> bool {
-		self.pg.node_weight(node).unwrap().is_root()
-	}
-
-	pub(super) fn is_opaque(&self, node: NodeIndex) -> bool {
-		self.pg.node_weight(node).unwrap().is_opaque()
+	/// Classifies a graph node as a linear definition, a root, or an opaque wire.
+	pub(super) fn node_kind(&self, node: NodeIndex) -> NodeKind {
+		self.pg[node]
 	}
 
 	/// Returns the set of wires that must be committed (converted to AND constraints).
@@ -198,20 +188,17 @@ impl LeGraph {
 	///
 	/// Panics if `wire` is not assigned by a linear definition.
 	pub fn lin_def_operand<'a>(&self, cb: &'a ConstraintBuilder, wire: Wire) -> &'a WireOperand {
-		&cb.linear_constraints[self.lin_def_index(wire)].rhs
+		&cb.linear_constraints[self.lin_def_id(wire).index()].rhs
 	}
 
-	/// The position of the linear definition that assigns `wire`.
+	/// The id of the linear definition that assigns `wire`.
 	///
 	/// # Panics
 	///
 	/// Panics if `wire` is not assigned by a linear definition.
-	fn lin_def_index(&self, wire: Wire) -> usize {
-		let node = self.node_of(wire);
-		match self.pg.node_weight(node).unwrap() {
-			NodeData::LinDef { index, .. } => *index,
-			_ => panic!("{wire:?} is not assigned by a linear definition"),
-		}
+	fn lin_def_id(&self, wire: Wire) -> LinDefId {
+		self.wire_to_lin_def[wire]
+			.unwrap_or_else(|| panic!("{wire:?} is not assigned by a linear definition"))
 	}
 
 	/// Returns the node holding the given wire.
@@ -223,23 +210,14 @@ impl LeGraph {
 		self.wire_to_node[wire].unwrap_or_else(|| panic!("{wire:?} has no node in the graph"))
 	}
 
-	pub fn lin_dst(&self, node: NodeIndex) -> Wire {
-		match self.pg.node_weight(node).unwrap() {
-			NodeData::LinDef { dst, .. } => *dst,
-			_ => panic!("supposed to be a linear assignment"),
-		}
+	/// The wire a linear-definition id assigns.
+	pub fn lin_dst(&self, id: LinDefId) -> Wire {
+		self.lin_defs[id]
 	}
 
 	pub fn lin_def_constraint_ref(&self, wire: Wire) -> ConstraintRef {
 		ConstraintRef::Linear {
-			index: self.lin_def_index(wire),
-		}
-	}
-
-	pub fn root_constraint_ref(&self, node: NodeIndex) -> ConstraintRef {
-		match self.pg.node_weight(node).unwrap() {
-			NodeData::Root { constraint } => *constraint,
-			_ => panic!("supposed to be a root"),
+			index: self.lin_def_id(wire).index(),
 		}
 	}
 
@@ -251,15 +229,17 @@ impl LeGraph {
 		self.lin_def.contains(wire)
 	}
 
-	/// Add a linear definition node to the graph.
+	/// Adds a linear-definition node to the graph for the constraint that assigns `dst`.
 	///
-	/// Creates a new node representing a linear constraint that defines `dst` as
-	/// the XOR combination specified by `operand`.
-	fn add_lin_def(&mut self, dst: Wire, index: usize) {
-		let lin_node = self.pg.add_node(NodeData::LinDef { dst, index });
+	/// Returns the id the new node is addressed by.
+	fn add_lin_def(&mut self, dst: Wire) -> LinDefId {
+		let lin_def_id = self.lin_defs.push(dst);
+		let lin_node = self.pg.add_node(NodeKind::LinDef(lin_def_id));
 		let prev = self.wire_to_node[dst].replace(lin_node);
 		assert!(prev.is_none(), "wire already has a node");
+		self.wire_to_lin_def[dst] = Some(lin_def_id);
 		self.lin_def.insert(dst);
+		lin_def_id
 	}
 
 	/// Notes a use of a wire by a linear user.
@@ -281,7 +261,7 @@ impl LeGraph {
 			let opaque_node = match self.wire_to_node[producer] {
 				Some(node) => node,
 				None => {
-					let node = self.pg.add_node(NodeData::Opaque);
+					let node = self.pg.add_node(NodeKind::Opaque);
 					self.opaque.push(node);
 					self.wire_to_node[producer] = Some(node);
 					node
@@ -294,8 +274,8 @@ impl LeGraph {
 	/// Notes a use of a wire of a linear producer by a user that defines no wire.
 	fn note_root_use(&mut self, producer: Wire, shift: Shift, constraint: ConstraintRef) {
 		let node_p = self.node_of(producer);
-		let root_node = self.pg.add_node(NodeData::Root { constraint });
-		self.roots.push(root_node);
+		self.roots.push(constraint);
+		let root_node = self.pg.add_node(NodeKind::Root);
 		self.pg.add_edge(node_p, root_node, EdgeData { shift });
 	}
 }
@@ -305,8 +285,8 @@ fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
 	//
 	// Linear constraints are simple definitions. We assert that this is the case here.
 	// In future we should actually define `linear_constraints`.
-	for (index, lin) in cb.linear_constraints.iter().enumerate() {
-		leg.add_lin_def(lin.dst, index);
+	for lin in &cb.linear_constraints {
+		leg.add_lin_def(lin.dst);
 	}
 
 	for lin in &cb.linear_constraints {

--- a/crates/frontend/src/pass/fusion/patch.rs
+++ b/crates/frontend/src/pass/fusion/patch.rs
@@ -117,11 +117,9 @@ pub fn build(cb: &ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
 
 /// Collect patches for the root constraints that inline linear definitions.
 fn build_root_patches(cb: &ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<Patch>) {
-	// Collect *distinct* constraint references for each root constraint.
-	let mut constraints = Vec::with_capacity(leg.roots.len());
-	for root in leg.roots.iter() {
-		constraints.push(leg.root_constraint_ref(*root));
-	}
+	// Collect *distinct* constraint references.
+	// Several roots may name the same constraint, e.g. two operands of one AND both inlined.
+	let mut constraints: Vec<ConstraintRef> = leg.roots.values().copied().collect();
 	constraints.sort_unstable();
 	constraints.dedup();
 


### PR DESCRIPTION
Gives the gate-fusion graph three typed node id spaces instead of one runtime-tagged enum.

### The problem

`LeGraph`'s node data was one enum with three variants for three logically distinct kinds of
node — a linear definition, a root use, and an opaque wire.
Reading one back out meant asking "is this the right variant?" at run time:

```rust
pub fn lin_dst(&self, node: NodeIndex) -> Wire {
    match self.pg.node_weight(node).unwrap() {
        NodeData::LinDef { dst, .. } => *dst,
        _ => panic!("supposed to be a linear assignment"),
    }
}
```

5 sites called `.node_weight(node).unwrap()`; 3 of those had a `_ => panic!("supposed to be a ...")`
arm right behind it.
Nothing in the type of `NodeIndex` said which of the three kinds it actually named.

### The idea

Split the enum into three newtype id spaces — `LinDefId`, `RootId`, `OpaqueId` — the same shape as
the crate's existing `Gate`/`Wire`/`PathSpec` ids.

```rust
- pub fn lin_dst(&self, node: NodeIndex) -> Wire {
-     match self.pg.node_weight(node).unwrap() {
-         NodeData::LinDef { dst, .. } => *dst,
-         _ => panic!("supposed to be a linear assignment"),
-     }
- }
+ pub fn lin_dst(&self, id: LinDefId) -> Wire {
+     self.lin_defs[id]
+ }
```

A caller holding a `LinDefId` can no longer hand it to code expecting a `RootId` — the compiler
rejects that, instead of a panic firing when the wrong variant shows up at run time.

### The change

Payload moves out of the petgraph node weight into three dedicated maps: `lin_defs` and `roots`
are `PrimaryMap`s keyed by their own id type, `opaque` is a plain map from id to graph node.
The petgraph node weight itself shrinks to a bare classifier:

```rust
pub(super) enum NodeKind {
    LinDef(LinDefId),
    Root,
    Opaque,
}
```

Only `LinDef` carries an id in the node weight — a traversal is the one place that still needs to
read a `LinDefId` back out of a raw graph node.
`Root` and `Opaque` are unit variants: nothing downstream ever needs "which root" or "which
opaque" from the node itself, only "which kind."

All 5 `.node_weight(node).unwrap()` sites and all 3 `panic!("supposed to be a ...")` arms are gone.

### What's left, deliberately

Two panics remain: `node_of`'s `"{wire:?} has no node in the graph"` and `lin_def_id`'s
`"{wire:?} is not assigned by a linear definition"`.
Neither is a wrong-variant bug a type split can fix — at both sites, the caller only ever has a
bare `Wire` in hand, not a typed id, so there is no narrower type to hand it instead.
Both are guarded by an `is_lin_def(wire)` check at every real call site, same as before.

### Soundness

Pure representation change, no behavior change.
Every `insta` snapshot in `pass/fusion/tests/` — the rendered constraint system after fusion runs,
pinned byte for byte — still matches without re-blessing.

### Scope

- **changed:** `pass/fusion/legraph.rs`, `commit_set.rs`, `patch.rs`.
- **left untouched:** the fusion algorithm itself; this only changes how a node's kind and payload are named and stored.

### Verification

- `cargo check -p binius-frontend --all-targets` — clean.
- `cargo test -p binius-frontend --lib pass::fusion` — 95 passed, 0 snapshot changes.
- `cargo clippy -p binius-frontend --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
