### PR TITLE
Return an error from constant propagation instead of panicking

### DIFF
--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 	},
 	lower::ConstraintBuilder,
 	pass::{
-		BuiltGates, const_prop, cse, dce, fusion,
+		AlwaysFailingGateError, BuiltGates, const_prop, cse, dce, fusion,
 		layout::{
 			scratch_alloc::{ScratchAlloc, ScratchPolicy},
 			value_vec_alloc,
@@ -468,12 +468,34 @@ impl CircuitBuilder {
 	///
 	/// # Panics
 	///
-	/// Panics if a clone or a subcircuit of this builder is still alive elsewhere.
-	/// Reclaiming the state needs sole ownership of it.
+	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state.
+	/// Only sole ownership can be unwrapped out of a reference count.
 	///
 	/// Panics if the builder carries a chip registered by [`Self::add_chip`].
 	/// Build that one with [`Self::build_m4`] instead.
+	///
+	/// Panics if constant propagation is enabled and finds a gate whose constant inputs can
+	/// never satisfy it.
 	pub fn build(self) -> Circuit {
+		self.try_build().unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Returns the circuit built by this builder, or an error instead of panicking on an
+	/// unsatisfiable constant gate.
+	///
+	/// # Panics
+	///
+	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state.
+	/// Only sole ownership can be unwrapped out of a reference count.
+	///
+	/// Panics if the builder carries a chip registered by [`Self::add_chip`].
+	/// Build that one with [`Self::build_m4`] instead.
+	///
+	/// # Errors
+	///
+	/// Returns an error when constant propagation is enabled and finds a gate whose constant
+	/// inputs can never satisfy it.
+	pub fn try_build(self) -> Result<Circuit, AlwaysFailingGateError> {
 		let shared = self.into_shared();
 		assert!(
 			shared.chips.is_empty(),
@@ -494,13 +516,32 @@ impl CircuitBuilder {
 	///
 	/// # Panics
 	///
-	/// Panics if a clone or a subcircuit of this builder is still alive elsewhere.
-	/// Reclaiming the state needs sole ownership of it.
+	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state.
+	/// Only sole ownership can be unwrapped out of a reference count.
+	///
+	/// Panics if constant propagation is enabled and finds a gate whose constant inputs can
+	/// never satisfy it.
 	pub fn build_m4(self) -> CircuitM4 {
+		self.try_build_m4().unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Returns the chip-composed circuit built by this builder, or an error instead of
+	/// panicking on an unsatisfiable constant gate.
+	///
+	/// # Panics
+	///
+	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state.
+	/// Only sole ownership can be unwrapped out of a reference count.
+	///
+	/// # Errors
+	///
+	/// Returns an error when constant propagation is enabled and finds a gate whose constant
+	/// inputs can never satisfy it.
+	pub fn try_build_m4(self) -> Result<CircuitM4, AlwaysFailingGateError> {
 		let mut shared = self.into_shared();
 		let chips = mem::take(&mut shared.chips);
 		let pending = mem::take(&mut shared.chip_calls);
-		let circuit = Self::compile(shared, &pending);
+		let circuit = Self::compile(shared, &pending)?;
 
 		// The instances and the active-instance counts are the whole call graph's to settle, so
 		// both are left to `recompute_instances` below.
@@ -525,7 +566,7 @@ impl CircuitBuilder {
 			chips: chips.into_iter().map(|chip| (chip, 0)).collect(),
 		};
 		circuit.recompute_instances();
-		circuit
+		Ok(circuit)
 	}
 
 	/// Reclaims the state behind the shared handle, requiring sole ownership of it.
@@ -541,7 +582,15 @@ impl CircuitBuilder {
 	}
 
 	/// Compiles the builder's state into a circuit, running every optimization pass it enables.
-	fn compile(shared: Shared, chip_calls: &[PendingCall]) -> Circuit {
+	///
+	/// # Errors
+	///
+	/// Returns an error when constant propagation is enabled and finds a gate whose constant
+	/// inputs can never satisfy it.
+	fn compile(
+		shared: Shared,
+		chip_calls: &[PendingCall],
+	) -> Result<Circuit, AlwaysFailingGateError> {
 		let mut graph = shared.graph;
 
 		// A chip call is a constraint on the words its wires hold, but the compiler passes have
@@ -561,7 +610,7 @@ impl CircuitBuilder {
 
 		// Run constant propagation optimization
 		if shared.opts.enable_constant_propagation {
-			const_prop::constant_propagation(&mut graph, &shared.hint_registry);
+			const_prop::constant_propagation(&mut graph, &shared.hint_registry)?;
 		}
 
 		// Zero propagation: drop the gates a zero operand turns into the identity.
@@ -731,7 +780,7 @@ impl CircuitBuilder {
 		// A circuit only reads back path names and a per-gate record, so the rest drops now.
 		let built_gates = BuiltGates::from_graph(graph);
 
-		Circuit::new(
+		Ok(Circuit::new(
 			built_gates,
 			cs,
 			value_vec_layout,
@@ -739,7 +788,7 @@ impl CircuitBuilder {
 			inout,
 			eval_form,
 			scratch_alloc.peak_live(),
-		)
+		))
 	}
 
 	/// Creates a reference to the same underlying circuit builder that is namespaced to the

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -474,14 +474,13 @@ impl CircuitBuilder {
 	/// Panics if the builder carries a chip registered by [`Self::add_chip`].
 	/// Build that one with [`Self::build_m4`] instead.
 	///
-	/// Panics if constant propagation is enabled and finds a gate whose constant inputs can
-	/// never satisfy it.
+	/// Panics if an enabled constant-propagation pass finds an unsatisfiable gate.
 	pub fn build(self) -> Circuit {
 		self.try_build().unwrap_or_else(|err| panic!("{err}"))
 	}
 
-	/// Returns the circuit built by this builder, or an error instead of panicking on an
-	/// unsatisfiable constant gate.
+	/// Returns the circuit built by this builder.
+	/// Returns an error instead of panicking on an unsatisfiable constant gate.
 	///
 	/// # Panics
 	///
@@ -493,8 +492,7 @@ impl CircuitBuilder {
 	///
 	/// # Errors
 	///
-	/// Returns an error when constant propagation is enabled and finds a gate whose constant
-	/// inputs can never satisfy it.
+	/// Returns an error when an enabled constant-propagation pass finds an unsatisfiable gate.
 	pub fn try_build(self) -> Result<Circuit, AlwaysFailingGateError> {
 		let shared = self.into_shared();
 		assert!(
@@ -519,14 +517,13 @@ impl CircuitBuilder {
 	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state.
 	/// Only sole ownership can be unwrapped out of a reference count.
 	///
-	/// Panics if constant propagation is enabled and finds a gate whose constant inputs can
-	/// never satisfy it.
+	/// Panics if an enabled constant-propagation pass finds an unsatisfiable gate.
 	pub fn build_m4(self) -> CircuitM4 {
 		self.try_build_m4().unwrap_or_else(|err| panic!("{err}"))
 	}
 
-	/// Returns the chip-composed circuit built by this builder, or an error instead of
-	/// panicking on an unsatisfiable constant gate.
+	/// Returns the chip-composed circuit built by this builder.
+	/// Returns an error instead of panicking on an unsatisfiable constant gate.
 	///
 	/// # Panics
 	///
@@ -535,8 +532,7 @@ impl CircuitBuilder {
 	///
 	/// # Errors
 	///
-	/// Returns an error when constant propagation is enabled and finds a gate whose constant
-	/// inputs can never satisfy it.
+	/// Returns an error when an enabled constant-propagation pass finds an unsatisfiable gate.
 	pub fn try_build_m4(self) -> Result<CircuitM4, AlwaysFailingGateError> {
 		let mut shared = self.into_shared();
 		let chips = mem::take(&mut shared.chips);
@@ -585,8 +581,7 @@ impl CircuitBuilder {
 	///
 	/// # Errors
 	///
-	/// Returns an error when constant propagation is enabled and finds a gate whose constant
-	/// inputs can never satisfy it.
+	/// Returns an error when an enabled constant-propagation pass finds an unsatisfiable gate.
 	fn compile(
 		shared: Shared,
 		chip_calls: &[PendingCall],

--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -282,6 +282,28 @@ fn test_call_hint_user_registered() {
 	assert_eq!(w[out2[0]], expected);
 }
 
+#[test]
+fn test_try_build_reports_an_always_failing_constant_gate() {
+	// Constant propagation evaluates a gate once every one of its inputs is a constant.
+	//
+	// An assert-zero gate fed the constant 1 fails that evaluation.
+	// So no witness for the rest of the circuit can ever satisfy it.
+	let builder = CircuitBuilder::with_opts(Options {
+		enable_constant_propagation: true,
+		..Options::default()
+	});
+
+	let non_zero = builder.add_constant_64(1);
+	builder.assert_zero("always_fails", non_zero);
+
+	// The build reports the unsatisfiable gate as an error instead of panicking.
+	// `Circuit` has no `Debug` impl, so match instead of `unwrap_err`.
+	match builder.try_build() {
+		Ok(_) => panic!("an assert-zero gate fed the constant 1 can never be satisfied"),
+		Err(err) => assert!(!err.reason.is_empty()),
+	}
+}
+
 fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {
 	let builder = CircuitBuilder::new();
 	let a_wire = builder.add_constant_64(a);

--- a/crates/frontend/src/pass/const_prop.rs
+++ b/crates/frontend/src/pass/const_prop.rs
@@ -9,6 +9,7 @@ use std::collections::VecDeque;
 
 use rustc_hash::FxHashSet;
 
+use super::AlwaysFailingGateError;
 use crate::{
 	eval_form::evaluate_gate_constants,
 	ir::{Gate, GateGraph, WireKind, hints::HintRegistry},
@@ -20,8 +21,18 @@ use crate::{
 /// and replaces their outputs with constant wires. The process iterates until no more constants
 /// can be propagated.
 ///
-/// Returns the number of wires that were replaced with constants.
-pub fn constant_propagation(graph: &mut GateGraph, hint_registry: &HintRegistry) -> usize {
+/// # Errors
+///
+/// Returns an error when a gate with all-constant inputs fails to evaluate.
+/// That means the circuit can never be satisfied.
+///
+/// # Returns
+///
+/// The number of wires that were replaced with constants.
+pub fn constant_propagation(
+	graph: &mut GateGraph,
+	hint_registry: &HintRegistry,
+) -> Result<usize, AlwaysFailingGateError> {
 	// This pass reads both halves: readers to seed the worklist, definitions to follow the graph.
 	graph.rebuild_use_def_chains(hint_registry);
 
@@ -79,15 +90,14 @@ pub fn constant_propagation(graph: &mut GateGraph, hint_registry: &HintRegistry)
 						}
 					}
 				}
-				Err(err) => {
-					// TODO: bubble up the error. For now we just panic.
-					panic!("Constant propagation detected an always-failing gate: {err}");
+				Err(reason) => {
+					return Err(AlwaysFailingGateError { gate, reason });
 				}
 			}
 		}
 	}
 
-	total_replaced
+	Ok(total_replaced)
 }
 
 /// Tries to evaluate a gate with constant inputs.
@@ -151,7 +161,7 @@ mod tests {
 		assert!(!matches!(graph.wires[and_out], WireKind::Constant(_)));
 
 		// Run constant propagation
-		let replaced = constant_propagation(&mut graph, &HintRegistry::new());
+		let replaced = constant_propagation(&mut graph, &HintRegistry::new()).unwrap();
 
 		// We replace: xor_out in and_gate, and_out in test_gate (twice, since both inputs)
 		assert_eq!(replaced, 3);
@@ -215,7 +225,7 @@ mod tests {
 		let test_gate = graph.emit_gate(root, Opcode::Bxor, vec![shl_out, shl_out], vec![test_out]);
 
 		// Run constant propagation
-		let replaced = constant_propagation(&mut graph, &HintRegistry::new());
+		let replaced = constant_propagation(&mut graph, &HintRegistry::new()).unwrap();
 		// We replace: shr_out in shl_gate, shl_out in test_gate (twice)
 		assert_eq!(replaced, 3);
 
@@ -292,7 +302,7 @@ mod tests {
 		let test_r_gate =
 			graph.emit_gate(root, Opcode::Bxor, vec![remainder, remainder], vec![test_r]);
 
-		let replaced = constant_propagation(&mut graph, &hint_registry);
+		let replaced = constant_propagation(&mut graph, &hint_registry).unwrap();
 		// quotient used twice in test_q_gate, remainder used twice in test_r_gate.
 		assert_eq!(replaced, 4);
 
@@ -317,18 +327,20 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "Constant propagation detected an always-failing gate")]
 	fn test_constant_propagation_with_failing_gate() {
 		let mut graph = GateGraph::new();
 		let root = graph.path_spec_tree.root();
 
-		// Create an Assert0 gate with a non-zero constant input
-		// This should fail evaluation because Assert0 expects the input to be zero
-		let non_zero_const = graph.add_constant(Word(42)); // Non-zero value
-		let _assert_gate = graph.emit_gate(root, Opcode::AssertZero, vec![non_zero_const], vec![]);
+		// AssertZero requires its input to equal zero.
+		// A non-zero constant input can never satisfy it.
+		let non_zero_const = graph.add_constant(Word(42));
+		let assert_gate = graph.emit_gate(root, Opcode::AssertZero, vec![non_zero_const], vec![]);
 
-		// This should panic when the Assert0 gate fails during evaluation
-		// because the constant input (42) is not zero
-		constant_propagation(&mut graph, &HintRegistry::new());
+		// Constant evaluation runs the gate and finds it fails.
+		// So the pass reports the error instead of panicking.
+		let err = constant_propagation(&mut graph, &HintRegistry::new())
+			.expect_err("an AssertZero gate fed a non-zero constant can never be satisfied");
+		assert_eq!(err.gate, assert_gate);
+		assert!(!err.reason.is_empty());
 	}
 }

--- a/crates/frontend/src/pass/mod.rs
+++ b/crates/frontend/src/pass/mod.rs
@@ -2,6 +2,8 @@
 
 //! Transformations over the gate graph, each rewriting it in place or reporting what it found.
 
+use crate::ir::Gate;
+
 pub mod const_prop;
 pub mod cse;
 pub mod dce;
@@ -45,4 +47,19 @@ impl BuiltGates {
 			gate_records,
 		}
 	}
+}
+
+/// A gate whose constant inputs can never satisfy it.
+///
+/// Constant propagation evaluates a gate once every one of its inputs is a constant.
+/// If that evaluation fails, no assignment elsewhere in the circuit can make the gate hold.
+/// So the circuit is unsatisfiable regardless of the witness.
+#[derive(Debug, thiserror::Error)]
+#[error("gate {gate:?} always fails when evaluated with constant inputs: {reason}")]
+#[non_exhaustive]
+pub struct AlwaysFailingGateError {
+	/// The gate whose constant evaluation failed.
+	pub gate: Gate,
+	/// The message the failing evaluation reported.
+	pub reason: String,
 }


### PR DESCRIPTION
Makes constant propagation report an unsatisfiable gate instead of panicking.

### The problem

Constant propagation folds a gate once every one of its inputs is a constant.
When that fold itself fails — the gate can never be satisfied, whatever the rest of the circuit
does — the pass panicked:

```rust
Err(err) => {
    // TODO: bubble up the error. For now we just panic.
    panic!("Constant propagation detected an always-failing gate: {err}");
}
```

The pass only runs when `enable_constant_propagation` is set, and that defaults to `false`, so this
was latent: turning the pass on converted a normal circuit-construction error into a hard panic.

### The idea

The `Result`-returning plumbing this needs already existed one layer down — the pass's own
constant-evaluation call already returned a `Result` it only matched in order to panic on `Err`.

Add an error type naming the gate and the reason, and return it instead:

```rust
#[derive(Debug, thiserror::Error)]
#[error("gate {gate:?} always fails when evaluated with constant inputs: {reason}")]
#[non_exhaustive]
pub struct AlwaysFailingGateError {
    pub gate: Gate,
    pub reason: String,
}
```

`constant_propagation` now returns `Result<usize, AlwaysFailingGateError>`, threaded up through
`compile`.

### The change

`build`/`build_m4` keep their existing infallible signatures — changing those would have forced
edits across every crate that calls `.build()` (`circuits`, `examples`, `m4-prover`, `m4-verifier`,
`prover`, `recursion`), for a pass that is off by default.
Instead, two new fallible entry points do the real work, and the existing ones delegate:

```rust
pub fn build(self) -> Circuit {
    self.try_build().unwrap_or_else(|err| panic!("{err}"))
}

pub fn try_build(self) -> Result<Circuit, AlwaysFailingGateError> {
    ...
}
```

`try_build`/`try_build_m4` are the only new public surface; `build`/`build_m4`'s panicking behavior
is unchanged for every existing caller.

### Verification — checked both directions, not just the new one

Reproduced the old panic first: an `assert_zero` gate fed a non-zero constant, with constant
propagation on, panicked on the pre-change code with exactly the message above.
The same construction, through `try_build()` on the new code, returns `Err` cleanly.

- `cargo test -p binius-frontend` — 250 passed (249 existing + 1 new).
- `cargo check -p binius-circuits -p binius-examples -p binius-m4-prover -p binius-recursion --all-targets` — clean, confirming `build`/`build_m4`'s unchanged signature means zero downstream edits.
- `cargo clippy -p binius-frontend --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

### Scope

- **changed:** `pass/const_prop.rs`, `pass/mod.rs` (new error type), `builder/mod.rs` (`try_build`/`try_build_m4`).
- **new:** one test building an always-failing constant gate and asserting `try_build()` returns `Err`.
- **note:** this overlaps textually with two other open PRs against `builder/mod.rs` / `pass/mod.rs` (#2172, #2174) — all three are independent changes, so whichever lands first, the others will need a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
