### PR TITLE
Cap batched assertion failures per reported instance, not globally

### DIFF
--- a/crates/frontend/src/eval_form/batch.rs
+++ b/crates/frontend/src/eval_form/batch.rs
@@ -31,9 +31,8 @@ use crate::{
 	ir::path::{PathSpec, PathSpecTree},
 };
 
-/// A single assertion failure, tagged with the instance whose values violated it.
+/// A single assertion failure recorded for the current lowest-failing instance.
 struct InstanceAssertionFailure {
-	instance: usize,
 	path_spec: PathSpec,
 	message: String,
 }
@@ -61,11 +60,16 @@ pub struct BatchExecutionContext<'a, 'v> {
 	values: &'a mut StridedArray2DViewMut<'v, Word>,
 	/// The global instance index represented by local column 0.
 	instance_offset: usize,
-	/// Assertion failures recorded during evaluation, capped by [`MAX_ASSERTION_FAILURES`].
+	/// Failures recorded for [`Self::min_failing_instance`], capped by [`MAX_ASSERTION_FAILURES`].
+	///
+	/// Cleared whenever a strictly lower failing instance is found.
+	/// So a higher-numbered instance's failures never survive to be reported.
 	failures: Vec<InstanceAssertionFailure>,
-	/// The total number of assertion violations recorded, across all instances.
-	total_count: usize,
-	/// The lowest-indexed instance that has failed an assertion, tracked even past the cap.
+	/// Every violation recorded for [`Self::min_failing_instance`], capped or not.
+	///
+	/// Reset alongside `failures` whenever a strictly lower failing instance is discovered.
+	min_failure_count: usize,
+	/// The lowest-indexed instance that has failed an assertion so far.
 	min_failing_instance: Option<usize>,
 }
 
@@ -78,7 +82,7 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 			values,
 			instance_offset,
 			failures: Vec::new(),
-			total_count: 0,
+			min_failure_count: 0,
 			min_failing_instance: None,
 		}
 	}
@@ -92,11 +96,11 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 			return Ok(());
 		};
 
-		// Keep just the reported instance's failures, resolving each path against the tree.
+		// `failures` already holds only records for the reported instance.
+		// Resolve each one's path against the tree.
 		let failures: Vec<AssertionFailure> = self
 			.failures
 			.into_iter()
-			.filter(|f| f.instance == instance)
 			.map(|f| AssertionFailure {
 				path: render_path(path_spec_tree, f.path_spec),
 				detail: f.message,
@@ -106,7 +110,7 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 		Err(BatchPopulateError {
 			instance,
 			source: PopulateError {
-				total: failures.len(),
+				total: self.min_failure_count,
 				failures,
 			},
 		})
@@ -130,23 +134,29 @@ impl EvalContext for BatchExecutionContext<'_, '_> {
 
 	/// Record an assertion failure for one local instance.
 	///
-	/// The failure may be dropped from the stored list once the cap is reached.
-	/// It always updates the count and the lowest-failing-instance tracker.
+	/// A failure for a higher instance than the current lowest-failing one is dropped.
+	/// It can never become the reported instance.
+	/// A failure for a new, strictly lower instance clears every record kept so far.
+	/// Those records belonged to an instance that turned out not to be the one reported.
 	/// The stripe offset remaps the local index to a global instance index.
 	#[cold]
 	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String) {
 		let instance = self.instance_offset + instance;
-		self.total_count += 1;
-		self.min_failing_instance = Some(
-			self.min_failing_instance
-				.map_or(instance, |m| m.min(instance)),
-		);
+		match self.min_failing_instance {
+			Some(min) if instance > min => return,
+			Some(min) if instance < min => {
+				self.min_failing_instance = Some(instance);
+				self.failures.clear();
+				self.min_failure_count = 0;
+			}
+			// Either the first failure ever seen, or another failure of the current minimum.
+			_ => self.min_failing_instance = Some(instance),
+		}
+
+		self.min_failure_count += 1;
 		if self.failures.len() < MAX_ASSERTION_FAILURES {
-			self.failures.push(InstanceAssertionFailure {
-				instance,
-				path_spec,
-				message,
-			});
+			self.failures
+				.push(InstanceAssertionFailure { path_spec, message });
 		}
 	}
 }
@@ -156,7 +166,9 @@ mod tests {
 	use binius_core::Word;
 	use binius_utils::strided_array::StridedArray2DViewMut;
 
-	use crate::{artifact::witness::AssertionFailure, builder::CircuitBuilder};
+	use crate::{
+		MAX_ASSERTION_FAILURES, Wire, artifact::witness::AssertionFailure, builder::CircuitBuilder,
+	};
 
 	// The batched interpreter must reproduce, for every instance, exactly what the single-instance
 	// interpreter produces for the same inputs. This is the core equivalence guarantee.
@@ -272,5 +284,118 @@ mod tests {
 		// An error message must not carry its own trailing newline.
 		assert!(!rendered.ends_with('\n'), "{rendered}");
 		assert!(std::error::Error::source(&err).is_some(), "the inner error must be the source");
+	}
+
+	// Invariant: the lowest-failing instance is reported, however full the cap got beforehand.
+	//
+	// Fixture state, two assertions in program order:
+	//   assertion one fails for every instance from 50 up, 150 instances in total.
+	//   assertion two fails only for instance 10.
+	//
+	// The cap on retained failures is 100.
+	// Assertion one alone fills it, with records for instances 50..149, before assertion two runs.
+	// Instance 10 is the true minimum, so it must still be the reported instance.
+	// Its own record must survive, unevicted by the unrelated higher-numbered records.
+	#[test]
+	fn batch_min_failing_instance_survives_a_full_cap_of_higher_instances() {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		let c = builder.add_witness();
+		let d = builder.add_witness();
+		// Assertion 1: fails for instance >= 50 when the inputs are driven that way below.
+		builder.assert_eq("assertion_one", a, b);
+		// Assertion 2, recorded after assertion 1 for every instance: fails only for instance 10.
+		builder.assert_eq("assertion_two", c, d);
+		let circuit = builder.build();
+
+		let layout = circuit.value_vec_layout().clone();
+		let full_len = layout.combined_len() + layout.n_scratch;
+		// 150 instances fail assertion 1 (50..199).
+		// That overflows the cap of 100 well before assertion 2 ever runs.
+		let n = 200usize;
+
+		let a_row = circuit.witness_row(a);
+		let b_row = circuit.witness_row(b);
+		let c_row = circuit.witness_row(c);
+		let d_row = circuit.witness_row(d);
+		let mut data = vec![Word::ZERO; full_len * n];
+		let mut view = StridedArray2DViewMut::without_stride(&mut data, full_len, n).unwrap();
+		for instance in 0..n {
+			// a == b everywhere except instance >= 50, where assertion 1 fails.
+			let a_val = Word(1);
+			let b_val = Word(if instance >= 50 { 2 } else { 1 });
+			// c == d everywhere except instance 10, where assertion 2 fails.
+			let c_val = Word(3);
+			let d_val = Word(if instance == 10 { 4 } else { 3 });
+			view[(a_row, instance)] = a_val;
+			view[(b_row, instance)] = b_val;
+			view[(c_row, instance)] = c_val;
+			view[(d_row, instance)] = d_val;
+		}
+
+		let err = circuit
+			.populate_wire_witness_batched(&mut view)
+			.expect_err("instance 10 and instances 50..199 all violate an assertion");
+
+		// Instance 10 is the true minimum: 10 < 50.
+		assert_eq!(err.instance, 10);
+		// Exactly one assertion fails for instance 10: assertion 2.
+		assert_eq!(err.source.total, 1);
+		assert_eq!(
+			err.source.failures,
+			vec![AssertionFailure {
+				path: ".assertion_two".to_string(),
+				detail: "Word(0x0000000000000003) != Word(0x0000000000000004)".to_string(),
+			}]
+		);
+	}
+
+	// Invariant: `total` counts every violation the reported instance racked up.
+	// So it can exceed `failures.len()` once the cap kicks in.
+	#[test]
+	fn batch_total_counts_every_violation_past_the_cap_for_the_reported_instance() {
+		// Half again the cap, so the cap alone cannot retain them all.
+		const N: usize = MAX_ASSERTION_FAILURES + 50;
+
+		let builder = CircuitBuilder::new();
+		let x: [Wire; N] = core::array::from_fn(|_| builder.add_witness());
+		let y: [Wire; N] = core::array::from_fn(|_| builder.add_witness());
+		builder.assert_eq_v("pairs", x, y);
+		let circuit = builder.build();
+
+		let layout = circuit.value_vec_layout().clone();
+		let full_len = layout.combined_len() + layout.n_scratch;
+		let n_instances = 4usize;
+
+		let x_rows: Vec<usize> = x.iter().map(|&w| circuit.witness_row(w)).collect();
+		let y_rows: Vec<usize> = y.iter().map(|&w| circuit.witness_row(w)).collect();
+		let mut data = vec![Word::ZERO; full_len * n_instances];
+		let mut view =
+			StridedArray2DViewMut::without_stride(&mut data, full_len, n_instances).unwrap();
+		for instance in 0..n_instances {
+			for i in 0..N {
+				// x == y everywhere except instance 0, where every one of the N pairs disagrees.
+				let x_val = Word(i as u64);
+				let y_val = if instance == 0 {
+					Word(i as u64 + 1)
+				} else {
+					x_val
+				};
+				view[(x_rows[i], instance)] = x_val;
+				view[(y_rows[i], instance)] = y_val;
+			}
+		}
+
+		let err = circuit
+			.populate_wire_witness_batched(&mut view)
+			.expect_err("instance 0 violates every one of the N pairwise assertions");
+
+		assert_eq!(err.instance, 0);
+		// Every one of the N assertions failed for instance 0.
+		assert_eq!(err.source.total, N);
+		// Only the cap's worth of records survives, so `total` exceeds `failures.len()`.
+		assert_eq!(err.source.failures.len(), MAX_ASSERTION_FAILURES);
+		assert!(err.source.total > err.source.failures.len());
 	}
 }


### PR DESCRIPTION
Fixes a real bug: a batch's reported assertion failure can come back with zero detail.

### The problem

`MAX_ASSERTION_FAILURES` caps how many failure records a batch evaluation keeps — but the cap was
applied **globally** across every instance, while the instance actually reported is always the
lowest-numbered one that failed, found only afterward.

If the cap fills up with records from high-numbered instances before the true minimum's own
failure is ever recorded, the reported instance has nothing left by the time anyone asks:

```
instance 10 is not satisfied: circuit not satisfied: 0 assertion(s) failed
```

Instance 10 is correctly named as the failing one, and simultaneously claimed to have zero failed
assertions — self-contradictory, and exactly this bug.

### Reproducing it first

Built the exact shape that triggers it: two assertions, in program order.

- assertion one fails for every instance from 50 up — 150 instances, `50..199`.
- assertion two fails only for instance 10.

The cap is 100.
Assertion one alone fills it with records for instances `50..149`, before assertion two — and
instance 10's own failure — ever runs.
Confirmed this reproduces the exact broken output on the pre-change code before writing the fix.

### The idea

Track the lowest failing instance as failures arrive, not after the fact.
Clear the list whenever a strictly lower instance is newly found, so it only ever holds records
for the current minimum:

```rust
match self.min_failing_instance {
    Some(min) if instance > min => return,           // can never be the reported instance
    Some(min) if instance < min => {                  // new minimum: old records are stale
        self.min_failing_instance = Some(instance);
        self.failures.clear();
        self.min_failure_count = 0;
    }
    _ => self.min_failing_instance = Some(instance),  // first failure, or another of the minimum
}
```

A failure for a higher instance than the current minimum is dropped immediately — it can never
become the reported one, so there's no reason to spend a cap slot on it.

### A second bug this uncovered

`PopulateError::total`'s own doc comment says it "counts every violation, capped or not" — the two
fields are meant to be able to disagree once the cap is reached.
The code computed `total: failures.len()`, which by construction can never exceed the capped
list's own length.
The two fields could never legitimately disagree; the doc's contract was unreachable.

Fixed by tracking `min_failure_count` independently of the capped `failures` list — this also
repurposes `total_count` (incremented on every failure, read nowhere) rather than just deleting
dead code, since it's the same counter the fix already needs.

### Scope

- **changed:** `eval_form/batch.rs` only.
- **new:** two tests — one reproducing the exact bug above end to end, one confirming `total` can exceed `failures.len()` once the cap kicks in (`150` violations for one instance, cap `100`).

### Verification

- `cargo test -p binius-frontend --lib eval_form` — 26 passed, including both new tests.
- `cargo clippy -p binius-frontend --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
