### PR TITLE
Keep PathSpec a type across the bytecode boundary

### DIFF
--- a/crates/frontend/src/eval_form/builder.rs
+++ b/crates/frontend/src/eval_form/builder.rs
@@ -5,6 +5,7 @@
 use binius_core::constraint_system::ShiftVariant;
 
 use super::opcode::EvalOpcode;
+use crate::ir::path::PathSpec;
 
 /// Builder for constructing bytecode during circuit compilation
 pub struct BytecodeBuilder {
@@ -197,49 +198,49 @@ impl BytecodeBuilder {
 	}
 
 	// Assertions
-	pub fn emit_assert_eq(&mut self, src1: u32, src2: u32, error_id: u32) {
+	pub fn emit_assert_eq(&mut self, src1: u32, src2: u32, path_spec: PathSpec) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::AssertEq);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
-		self.emit_u32(error_id);
+		self.emit_path_spec(path_spec);
 	}
 
-	pub fn emit_assert_eq_cond(&mut self, cond: u32, src1: u32, src2: u32, error_id: u32) {
+	pub fn emit_assert_eq_cond(&mut self, cond: u32, src1: u32, src2: u32, path_spec: PathSpec) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::AssertEqCond);
 		self.emit_reg(cond);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
-		self.emit_u32(error_id);
+		self.emit_path_spec(path_spec);
 	}
 
-	pub fn emit_assert_zero(&mut self, src: u32, error_id: u32) {
+	pub fn emit_assert_zero(&mut self, src: u32, path_spec: PathSpec) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::AssertZero);
 		self.emit_reg(src);
-		self.emit_u32(error_id);
+		self.emit_path_spec(path_spec);
 	}
 
-	pub fn emit_assert_non_zero(&mut self, src: u32, error_id: u32) {
+	pub fn emit_assert_non_zero(&mut self, src: u32, path_spec: PathSpec) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::AssertNonZero);
 		self.emit_reg(src);
-		self.emit_u32(error_id);
+		self.emit_path_spec(path_spec);
 	}
 
-	pub fn emit_assert_false(&mut self, src: u32, error_id: u32) {
+	pub fn emit_assert_false(&mut self, src: u32, path_spec: PathSpec) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::AssertFalse);
 		self.emit_reg(src);
-		self.emit_u32(error_id);
+		self.emit_path_spec(path_spec);
 	}
 
-	pub fn emit_assert_true(&mut self, src: u32, error_id: u32) {
+	pub fn emit_assert_true(&mut self, src: u32, path_spec: PathSpec) {
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::AssertTrue);
 		self.emit_reg(src);
-		self.emit_u32(error_id);
+		self.emit_path_spec(path_spec);
 	}
 
 	// Hint calls
@@ -286,6 +287,11 @@ impl BytecodeBuilder {
 
 	fn emit_reg(&mut self, reg: u32) {
 		self.emit_u32(reg);
+	}
+
+	/// Encodes a path spec as the `u32` an assertion instruction carries on the wire.
+	fn emit_path_spec(&mut self, path_spec: PathSpec) {
+		self.emit_u32(path_spec.as_u32());
 	}
 
 	pub fn finalize(self) -> (Vec<u8>, usize) {

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -346,8 +346,7 @@ impl<'a> Executor<'a> {
 	fn exec_assert_eq<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
+		let path_spec = self.read_path_spec();
 
 		for i in 0..ctx.n_instances() {
 			let val1 = ctx.load(src1, i);
@@ -362,8 +361,7 @@ impl<'a> Executor<'a> {
 		let cond = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
+		let path_spec = self.read_path_spec();
 
 		for i in 0..ctx.n_instances() {
 			if ctx.load(cond, i).is_msb_true() {
@@ -382,8 +380,7 @@ impl<'a> Executor<'a> {
 
 	fn exec_assert_zero<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
+		let path_spec = self.read_path_spec();
 
 		for i in 0..ctx.n_instances() {
 			let val = ctx.load(src, i);
@@ -395,8 +392,7 @@ impl<'a> Executor<'a> {
 
 	fn exec_assert_non_zero<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
+		let path_spec = self.read_path_spec();
 
 		for i in 0..ctx.n_instances() {
 			let val = ctx.load(src, i);
@@ -408,8 +404,7 @@ impl<'a> Executor<'a> {
 
 	fn exec_assert_false<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
+		let path_spec = self.read_path_spec();
 
 		for i in 0..ctx.n_instances() {
 			let val = ctx.load(src, i);
@@ -421,8 +416,7 @@ impl<'a> Executor<'a> {
 
 	fn exec_assert_true<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
+		let path_spec = self.read_path_spec();
 
 		for i in 0..ctx.n_instances() {
 			let val = ctx.load(src, i);
@@ -500,5 +494,10 @@ impl<'a> Executor<'a> {
 
 	fn read_reg(&mut self) -> u32 {
 		self.read_u32()
+	}
+
+	/// Decodes the `u32` an assertion instruction carries on the wire back into a path spec.
+	fn read_path_spec(&mut self) -> PathSpec {
+		PathSpec::from_u32(self.read_u32())
 	}
 }

--- a/crates/frontend/src/eval_form/tests.rs
+++ b/crates/frontend/src/eval_form/tests.rs
@@ -5,7 +5,7 @@ use binius_core::{ValueVec, ValueVecLayout, word::Word};
 
 use crate::{
 	eval_form::{BytecodeBuilder, exec::Executor, scalar::ExecutionContext},
-	ir::hints::HintRegistry,
+	ir::{hints::HintRegistry, path::PathSpec},
 };
 
 /// Test harness for interpreter tests that makes them much more concise
@@ -30,7 +30,8 @@ impl InterpreterTest {
 
 	/// Emit an assert_eq_cond instruction
 	fn assert_eq_cond(mut self, cond: u32, x: u32, y: u32) -> Self {
-		self.builder.emit_assert_eq_cond(cond, x, y, 1);
+		self.builder
+			.emit_assert_eq_cond(cond, x, y, PathSpec::from_u32(1));
 		self
 	}
 

--- a/crates/frontend/src/gates/assert_eq.rs
+++ b/crates/frontend/src/gates/assert_eq.rs
@@ -36,6 +36,6 @@ impl GateKind for AssertEq {
 	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
 		let [x, y] = gate.in_wires();
 
-		bc.emit_assert_eq(ctx.reg(x), ctx.reg(y), ctx.path().as_u32());
+		bc.emit_assert_eq(ctx.reg(x), ctx.reg(y), ctx.path());
 	}
 }

--- a/crates/frontend/src/gates/assert_eq_cond.rs
+++ b/crates/frontend/src/gates/assert_eq_cond.rs
@@ -40,6 +40,6 @@ impl GateKind for AssertEqCond {
 
 		// The condition is read as an MSB-bool, and broadcasting the sign bit preserves it.
 		// So the condition is passed as it stands, with no mask to compute or hold.
-		bc.emit_assert_eq_cond(ctx.reg(cond), ctx.reg(x), ctx.reg(y), ctx.path().as_u32());
+		bc.emit_assert_eq_cond(ctx.reg(cond), ctx.reg(x), ctx.reg(y), ctx.path());
 	}
 }

--- a/crates/frontend/src/gates/assert_false.rs
+++ b/crates/frontend/src/gates/assert_false.rs
@@ -38,6 +38,6 @@ impl GateKind for AssertFalse {
 	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
 		let [x] = gate.in_wires();
 
-		bc.emit_assert_false(ctx.reg(x), ctx.path().as_u32());
+		bc.emit_assert_false(ctx.reg(x), ctx.path());
 	}
 }

--- a/crates/frontend/src/gates/assert_non_zero.rs
+++ b/crates/frontend/src/gates/assert_non_zero.rs
@@ -71,7 +71,7 @@ impl GateKind for AssertNonZero {
 		// Carry bits of all-1 + x. Only the carries matter, so the sum is not stored.
 		bc.emit_iadd_carry(ctx.reg(cout), ctx.reg(all_one), ctx.reg(x));
 
-		bc.emit_assert_non_zero(ctx.reg(cout), ctx.path().as_u32());
+		bc.emit_assert_non_zero(ctx.reg(cout), ctx.path());
 	}
 }
 

--- a/crates/frontend/src/gates/assert_true.rs
+++ b/crates/frontend/src/gates/assert_true.rs
@@ -41,6 +41,6 @@ impl GateKind for AssertTrue {
 	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
 		let [x] = gate.in_wires();
 
-		bc.emit_assert_true(ctx.reg(x), ctx.path().as_u32());
+		bc.emit_assert_true(ctx.reg(x), ctx.path());
 	}
 }

--- a/crates/frontend/src/gates/assert_zero.rs
+++ b/crates/frontend/src/gates/assert_zero.rs
@@ -32,6 +32,6 @@ impl GateKind for AssertZero {
 	fn emit(gate: GateParam<'_>, ctx: EmitCtx<'_>, bc: &mut BytecodeBuilder) {
 		let [x] = gate.in_wires();
 
-		bc.emit_assert_zero(ctx.reg(x), ctx.path().as_u32());
+		bc.emit_assert_zero(ctx.reg(x), ctx.path());
 	}
 }


### PR DESCRIPTION
Keeps `PathSpec` a real type across the boundary between emitting bytecode and running it.

### The problem

An assertion gate's path identifier crossed from the emitter to the executor by convention, not by
type.
The emitting side converted it away:

```rust
bc.emit_assert_eq(ctx.reg(x), ctx.reg(y), ctx.path().as_u32());
```

and the executing side converted it back:

```rust
let error_id = self.read_u32();
let path_spec = PathSpec::from_u32(error_id);
```

Nothing between those two lines said the `u32` passing through six emitter functions and six
executor functions was ever anything but an arbitrary integer.

### The idea

Thread `PathSpec` itself through every signature in between, and push the only remaining
`u32` conversion into one method on each side of the boundary:

```rust
fn emit_path_spec(&mut self, path_spec: PathSpec) {
    self.emit_u32(path_spec.as_u32());
}

fn read_path_spec(&mut self) -> PathSpec {
    PathSpec::from_u32(self.read_u32())
}
```

### The change

```rust
- pub fn emit_assert_eq(&mut self, src1: u32, src2: u32, error_id: u32) {
-     ...
-     self.emit_u32(error_id);
+ pub fn emit_assert_eq(&mut self, src1: u32, src2: u32, path_spec: PathSpec) {
+     ...
+     self.emit_path_spec(path_spec);
```

Every call site in `gates/assert_*.rs` drops the `.as_u32()`, since `EmitCtx::path()` already
returns `PathSpec` — the conversion was pure loss, not something those call sites needed.

### Soundness

The on-the-wire encoding is unchanged: still a `u32`, same 4 bytes, same position in the
instruction stream.
Only the function signatures around it change, from carrying a raw integer to carrying the typed
value the integer always meant.

### Scope

- **changed:** `eval_form/builder.rs`, `eval_form/exec.rs`, all six `gates/assert_*.rs` files.
- **incidental:** `eval_form/tests.rs` passed a bare `1u32` literal to `emit_assert_eq_cond`; changed to `PathSpec::from_u32(1)` to keep the same encoded value under the new signature.
- **left untouched:** every other opcode's bytecode encoding.

### Verification

- `cargo test -p binius-frontend` — 254 passed (249 lib + 5 new since a sibling PR merged) + 1 + 2 + 2, no test needed changing beyond the one literal above.
- `cargo clippy -p binius-frontend --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
