### PR TITLE
Make sha256_compress_2x a gadget, so a circuit can compress in a chip

### DIFF
--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -2,7 +2,7 @@
 use std::{array, iter};
 
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Hint, Wire, WitnessFiller};
+use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire, WitnessFiller};
 
 use crate::util::clear_high_bits;
 
@@ -108,7 +108,61 @@ pub fn sha256_compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16])
 /// # Returns
 ///
 /// The updated 8-word state, with each wire packing both lanes' results.
+///
+/// # Chips
+///
+/// This is a [`ChipGadget`]. A circuit that calls
+/// [`register_chip`](CircuitBuilder::register_chip) with [`Sha256Compress2x`] before building
+/// turns every paired compression under it into a chip call, including the ones
+/// [`sha256_compress_2x_seq`] and the fixed and variable length hashers reach.
 pub fn sha256_compress_2x(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> State {
+	let inputs = state_in.0.into_iter().chain(m).collect::<Vec<_>>();
+
+	let outputs = builder.build_gadget(Sha256Compress2x, &[], &inputs);
+	State(array::from_fn(|i| outputs[i]))
+}
+
+/// [`sha256_compress_2x`] as a gadget, so that a circuit can make it a chip.
+///
+/// Its interface is the flat 24 input words `state[0..8]`, `m[0..16]`, and the 8 output state
+/// words, all packing two lanes as [`sha256_compress_2x`] documents.
+pub struct Sha256Compress2x;
+
+impl Hint for Sha256Compress2x {
+	const NAME: &'static str = "binius.sha256_compress_2x";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(24, 8)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		// Each lane is a 32-bit half of every input word, and the halves never interact: the
+		// core's adds, rotates and shifts are 32-bit and its ch/maj are bitwise. So a lane is
+		// the reference compression of its own halves.
+		let compress_lane = |i: usize| {
+			let lane = |word: Word| (word.as_u64() >> (32 * i)) as u32;
+			let state: [u32; 8] = array::from_fn(|j| lane(inputs[j]));
+			let m: [u32; 16] = array::from_fn(|j| lane(inputs[8 + j]));
+			ref_compress(state, m)
+		};
+
+		let (lane_0, lane_1) = (compress_lane(0), compress_lane(1));
+		for (slot, (low, high)) in iter::zip(outputs, iter::zip(lane_0, lane_1)) {
+			*slot = Word(low as u64 | ((high as u64) << 32));
+		}
+	}
+}
+
+impl ChipGadget for Sha256Compress2x {
+	fn build(&self, builder: &CircuitBuilder, _dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+		let state_in = State(array::from_fn(|i| inputs[i]));
+		let m: [Wire; 16] = array::from_fn(|i| inputs[8 + i]);
+		compress_2x_gates(builder, state_in, m).0.to_vec()
+	}
+}
+
+/// [`sha256_compress_2x`] in gates, whatever the building circuit does with the gadget.
+fn compress_2x_gates(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> State {
 	// Round constants replicated into both 32-bit halves, so each lane adds the same K[t].
 	let k: [Wire; 64] = std::array::from_fn(|t| {
 		let kt = K[t] as u64;
@@ -439,11 +493,12 @@ fn small_sigma_1(b: &CircuitBuilder, x: Wire) -> Wire {
 #[cfg(test)]
 mod tests {
 	use binius_core::word::Word;
-	use binius_frontend::{CircuitBuilder, Wire};
+	use binius_frontend::{CircuitBuilder, Hint, Wire};
+	use proptest::prelude::*;
 
 	use super::{
-		IV, State, populate_message_block, ref_compress, sha256_compress, sha256_compress_2x,
-		sha256_compress_2x_seq,
+		IV, Sha256Compress2x, State, compress_2x_gates, populate_message_block, ref_compress,
+		sha256_compress, sha256_compress_2x, sha256_compress_2x_seq,
 	};
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
@@ -790,5 +845,44 @@ mod tests {
 		let block1: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0xdead_beef));
 		let block2: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0x0101_0101));
 		run_2x_seq(state_in, block1, block2);
+	}
+
+	/// Runs `sha256_compress_2x` in gates over its flat packed-word interface.
+	fn run_compress_2x_words(inputs: [u64; 24]) -> [u64; 8] {
+		let builder = CircuitBuilder::new();
+		let wires: [Wire; 24] = std::array::from_fn(|_| builder.add_witness());
+		let out = compress_2x_gates(
+			&builder,
+			State(std::array::from_fn(|i| wires[i])),
+			std::array::from_fn(|i| wires[8 + i]),
+		);
+		for wire in out.0 {
+			builder.mark_inout(wire);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for (wire, word) in std::iter::zip(wires, inputs) {
+			w[wire] = Word(word);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		std::array::from_fn(|i| w[out.0[i]].as_u64())
+	}
+
+	proptest! {
+		// The chip path takes the outputs from `Sha256Compress2x::execute` and the chip recomputes
+		// them from its gates, so the two have to agree on every word a circuit can reach them
+		// with. Any 64-bit word is a valid lane pair here, so random words cover the whole
+		// interface.
+		#[test]
+		fn compress_2x_hint_matches_its_gates(words in prop::collection::vec(any::<u64>(), 24)) {
+			let inputs: [u64; 24] = std::array::from_fn(|i| words[i]);
+
+			let mut hinted = [Word::ZERO; 8];
+			Sha256Compress2x.execute(&[], &inputs.map(Word), &mut hinted);
+
+			prop_assert_eq!(hinted.map(|word| word.as_u64()), run_compress_2x_words(inputs));
+		}
 	}
 }

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -5,8 +5,8 @@ pub mod compress;
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 pub use compress::{
-	State, populate_message_block, ref_compress, sha256_compress, sha256_compress_2x,
-	sha256_compress_2x_seq,
+	Sha256Compress2x, State, populate_message_block, ref_compress, sha256_compress,
+	sha256_compress_2x, sha256_compress_2x_seq,
 };
 
 use crate::{
@@ -567,5 +567,80 @@ mod tests {
 			// Test with our circuit
 			test_sha256_fixed_with_input(&message, expected_bytes);
 		}
+	}
+
+	/// Hashes `message` with [`Sha256Compress2x`] as a chip, and checks the digest and the system.
+	///
+	/// The digest wires are public and filled with the reference digest, so a disagreement fails
+	/// to populate. What the chip adds is checked after: the paired compressions have to be
+	/// served by an instance that recomputes the same words.
+	fn check_fixed_with_compress_chip(message: &[u8]) {
+		let b = CircuitBuilder::new();
+		b.register_chip(Sha256Compress2x, &[]);
+
+		let n_words = message.len().div_ceil(4);
+		let message_wires: Vec<Wire> = (0..n_words).map(|_| b.add_witness()).collect();
+		let computed_digest = sha256_fixed(&b, &message_wires, message.len());
+		let digest_out: [Wire; 8] = array::from_fn(|_| b.add_inout());
+		for i in 0..8 {
+			b.assert_eq(format!("digest[{i}]"), computed_digest[i], digest_out[i]);
+		}
+
+		let circuit = b.build_m4();
+		circuit.validate().unwrap();
+		let cs = circuit.to_constraint_system();
+		cs.validate().unwrap();
+
+		let expected: [u8; 32] = sha2::Sha256::digest(message).into();
+
+		let witness = circuit
+			.generate_witness(|w| {
+				for (word_idx, wire) in message_wires.iter().enumerate() {
+					let mut packed = 0u32;
+					for i in 0..4 {
+						let byte_idx = word_idx * 4 + i;
+						if byte_idx < message.len() {
+							packed |= (message[byte_idx] as u32) << (24 - i * 8);
+						}
+					}
+					w[*wire] = Word(packed as u64);
+				}
+				for i in 0..8 {
+					let mut word = 0u32;
+					for j in 0..4 {
+						word |= (expected[i * 4 + j] as u32) << (24 - j * 8);
+					}
+					w[digest_out[i]] = Word(word as u64);
+				}
+			})
+			.unwrap_or_else(|e| {
+				panic!("sha256_fixed failed for len_bytes={}: {e:?}", message.len())
+			});
+
+		witness.verify(&cs).unwrap();
+	}
+
+	// The layers between `sha256_fixed` and `sha256_compress_2x` are untouched by the chip: block
+	// pairs land as calls because the builder holds the chip, not because anything in between was
+	// told. Lengths cover one pair, a pair plus a trailing single-lane block, two pairs, and two
+	// pairs plus a trailing single.
+	#[test]
+	fn a_registered_chip_serves_every_paired_compression() {
+		for &len in &[64usize, 128, 192, 300] {
+			let message: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+			check_fixed_with_compress_chip(&message);
+		}
+	}
+
+	// A single-block message compresses single-lane only and never reaches the paired gadget, so
+	// its chip goes uncalled and the system it leaves is not one that can be populated.
+	#[test]
+	fn a_chip_no_paired_compression_reaches_leaves_an_uncalled_chip() {
+		let b = CircuitBuilder::new();
+		b.register_chip(Sha256Compress2x, &[]);
+		sha256_fixed(&b, &[b.add_witness()], 4);
+
+		let error = b.build_m4().validate().unwrap_err();
+		assert!(matches!(error, binius_frontend::CircuitM4Error::NeverCalled { .. }), "{error:?}");
 	}
 }


### PR DESCRIPTION
## What

Follows #2141, which made `blake3_compress_2x` a `ChipGadget`. SHA-256 is the next gadget with the same shape: `sha256_fixed` and `sha256_varlen` reach the paired core through `sha256_compress_2x_seq`, and none of the layers in between should have to know whether a compression is gates or a chip call.

`sha256_compress_2x` becomes a `ChipGadget` and everything above it is left alone. Its gates move to a private `compress_2x_gates`; the public function flattens its arguments and calls `build_gadget`, which is where the choice is made. `Sha256Compress2x` supplies the hint the chip path needs, running the existing `ref_compress` once per lane: the paired core's adds, rotates and shifts are 32-bit and its ch/maj are bitwise, so a lane is the reference compression of its own halves.

`sha256_compress_2x_seq`, `sha256_fixed`, `sha256_varlen` and every circuit built on them (`double_sha256`, the bitcoin gadgets, `rs256`) are unchanged and all compress through a chip when the circuit registers one:

```rust
let builder = CircuitBuilder::new();
builder.register_chip(Sha256Compress2x, &[]);
let digest = sha256_fixed(&builder, &message, len_bytes);
let circuit = builder.build_m4();
```

## Numbers

Apple M3, rate 1/2, `ProverM4`, `sha256_fixed`, median of 5 after a warmup, proof verified in every configuration. Committed counts are words used.

| message | main AND | main committed | prove |
|---|---|---|---|
| 300 B (2 calls) | 2,171 -> 715 | 2,973 -> 1,118 | 1.18 -> 1.74 ms |
| 1 KiB (8 calls) | 6,503 -> 679 | 8,658 -> 1,451 | 2.20 -> 1.92 ms |
| 4 KiB (32 calls) | 23,975 -> 679 | 31,602 -> 2,987 | 5.97 -> 3.11 ms |
| 16 KiB (128 calls) | 93,863 -> 679 | 123,378 -> 9,131 | 21.40 -> 8.55 ms |

The chip system stays at 728 AND and 999 committed words whatever the instance count. The 679 is the one trailing single-lane compression an odd block count keeps inline; with an even count the whole load leaves main (16,375 B: main lands at 1 AND constraint, 21.15 -> 8.01 ms). The chip pays for itself from about eight paired calls up; below that the second table's fixed cost wins, the same trade that leaves single-lane compressions inline.

## Testing

- `a_registered_chip_serves_every_paired_compression` hashes at four lengths (one pair, a pair plus a trailing single-lane block, two pairs, two pairs plus a trailing single), each building the M4 system, validating, generating a witness against the sha2 reference digest, and passing `WitnessM4::verify`.
- `compress_2x_hint_matches_its_gates` holds `Sha256Compress2x::execute` to `compress_2x_gates` over random words. Any 64-bit word is a valid lane pair for this interface, so random words cover it whole.
- `a_chip_no_paired_compression_reaches_leaves_an_uncalled_chip` pins the sharp edge: a single-block message compresses single-lane only, so a registered chip goes uncalled and `validate()` rejects the system.

## Costs

A call commits 32 words per instance (24 in, 8 out). The lane-packing expressions in `sha256_compress_2x_seq` hand the gadget words that a constraint operand would have fused in for free, the same cost #2141 notes. The gates path is unchanged: all 13 example snapshots pass untouched.

Single-lane `sha256_compress` is left inline, as `blake3_compress` was.