### PR TITLE
BINIUS-502: pair two Merkle openings' climbs into shared hash cores

### DIFF
--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -145,6 +145,23 @@ impl Binius64BuilderChannel {
 		array::from_fn(|_| self.shared.input_wire(kind))
 	}
 
+	/// Allocates the input wires one query's opening occupies: its leaf, then its branch.
+	///
+	/// The tape carries an opening in this order, so a replay fills the wires in it too.
+	fn input_opening(
+		&mut self,
+		leaf_size: usize,
+		branch_len: usize,
+	) -> (Vec<Element>, Vec<Digest>) {
+		let leaf = (0..leaf_size)
+			.map(|_| self.input_element("opening"))
+			.collect();
+		let branch = (0..branch_len)
+			.map(|_| self.input_digest("merkle_branch"))
+			.collect();
+		(leaf, branch)
+	}
+
 	/// Lifts a wire pair to the element type the protocol sees.
 	fn elem(&self, [lo, hi]: Element) -> SymbolicElem {
 		SymbolicElem::wires(&self.shared, lo, hi)
@@ -342,6 +359,9 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 	/// The opened values stay circuit inputs, since they are proof data.
 	/// They stop being *free*: each leaf is hashed and climbed to a layer the root fixes.
 	///
+	/// Queries are climbed two at a time, sharing the hash cores their levels compress in.
+	/// The advice is still read one query's leaf and branch at a time, as the tape carries it.
+	///
 	/// Only the low index bits spanning the tree depth are ever read while climbing.
 	/// A caller must therefore supply an index already bounded below the leaf count.
 	///
@@ -366,16 +386,34 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 		merkle::verify_layer(&builder, commitment.root, &layer);
 
 		// Every query then climbs from its own leaf up to that layer.
+		// Two climbs are independent, so they share hash cores, which halves what a level costs.
 		let mut values = Vec::with_capacity(indices.len() * commitment.leaf_size);
-		for index in indices {
-			let leaf = (0..commitment.leaf_size)
-				.map(|_| self.input_element("opening"))
-				.collect::<Vec<_>>();
-			let branch = (0..tree_depth - layer_depth)
-				.map(|_| self.input_digest("merkle_branch"))
-				.collect::<Vec<_>>();
+		let mut pairs = indices.chunks_exact(2);
+		for pair in &mut pairs {
+			// The tape carries a leaf and a branch per query, whatever shares a core.
+			let openings = [(); 2]
+				.map(|()| self.input_opening(commitment.leaf_size, tree_depth - layer_depth));
 
-			// Hashes the leaf, climbs the branch, then matches the layer entry the index addresses.
+			// Both leaves hashed, both branches climbed, then each index picks its layer entry.
+			let builder = self.merkle_subcircuit("opening");
+			let indices = array::from_fn(|q| pair[q].to_wire(&builder));
+			merkle::verify_opening_2x(
+				&builder,
+				indices,
+				[&openings[0].0, &openings[1].0],
+				layer_depth,
+				tree_depth,
+				&layer,
+				[&openings[0].1, &openings[1].1],
+			);
+			for (leaf, _) in openings {
+				values.extend(leaf.into_iter().map(|element| self.elem(element)));
+			}
+		}
+		// An odd query count leaves the last climb with no partner to share cores with.
+		if let [index] = pairs.remainder() {
+			let (leaf, branch) = self.input_opening(commitment.leaf_size, tree_depth - layer_depth);
+
 			let builder = self.merkle_subcircuit("opening");
 			let index = index.to_wire(&builder);
 			merkle::verify_opening(

--- a/crates/recursion/src/merkle.rs
+++ b/crates/recursion/src/merkle.rs
@@ -43,27 +43,33 @@
 //! One single-lane block compression is 726 AND constraints.
 //! A gate costs one constraint whatever its width, so two compressions can share one core.
 //! Running them as the two 32-bit lanes of that core brings each to about 380.
-//! Both places that hash independent values take this route:
+//! Every place that hashes independent values takes this route:
 //!
 //! - folding a layer of digests up to the root above it
 //! - hashing the leaves of a whole committed vector
+//! - climbing two openings' authentication paths in step
 //!
-//! | what is measured                        | AND          | BMUL          |
-//! | --------------------------------------- | ------------ | ------------- |
-//! | a one-element leaf digest               | 697          | 0             |
-//! | a sixteen-element leaf digest           | 2279         | 0             |
-//! | two one-element leaves sharing a core   | 707 per pair | 0             |
-//! | one inner node on its own core          | 742          | 0             |
-//! | one inner node sharing a core           | 380 per node | 0             |
-//! | one node of a verified layer's fold     | 380 per node | 0             |
-//! | one climbed level of an opening         | 738          | 8             |
-//! | picking the layer entry of an opening   | 0            | 4 * (2^L - 1) |
+//! A climb is sequential, so an opening cannot share cores with itself.
+//! Two openings can, since the queries are independent, which is what the last of those does.
+//! An odd query count leaves one opening climbing on its own.
+//!
+//! | what is measured                        | AND           | BMUL          |
+//! | --------------------------------------- | ------------- | ------------- |
+//! | a one-element leaf digest               | 697           | 0             |
+//! | a sixteen-element leaf digest           | 2279          | 0             |
+//! | two one-element leaves sharing a core   | 707 per pair  | 0             |
+//! | one inner node on its own core          | 742           | 0             |
+//! | one inner node sharing a core           | 380 per node  | 0             |
+//! | one node of a verified layer's fold     | 380 per node  | 0             |
+//! | one climbed level of a lone opening     | 738           | 8             |
+//! | one climbed level of a paired opening   | 377 per query | 8 per query   |
+//! | picking the layer entry of an opening   | 0             | 4 * (2^L - 1) |
 //!
 //! Write `D` for the tree depth and `L` for the depth of the layer an opening climbs to.
-//! One opening therefore costs
+//! One opening of a pair therefore costs
 //!
 //! ```text
-//!     AND  = leaf digest + 738 * (D - L)
+//!     AND  = half a shared leaf digest + 377 * (D - L)
 //!     BMUL = 8 * (D - L) + 4 * (2^L - 1)
 //! ```
 //!
@@ -74,13 +80,13 @@
 //! Raising `L` by one level changes the bill per query, out of `n_q` queries, by
 //!
 //! ```text
-//!     AND  :  -738 + 380 * 2^L / n_q
+//!     AND  :  -377 + 380 * 2^L / n_q
 //!     BMUL :  +4 * 2^L - 8
 //! ```
 //!
 //! The two columns behave nothing alike.
 //!
-//! - The AND column breaks even at `2^L = 1.94 * n_q`, one level above the native rule.
+//! - The AND column breaks even at `2^L = 0.99 * n_q`, which is the native rule itself.
 //! - That native rule sets the layer depth to `ceil(log2(n_q))`.
 //! - The BMUL column gains nothing past `L = 1`, since the entry selector grows with the layer.
 //! - The climb it shortens gives back only eight selects a level, which never covers that.
@@ -89,25 +95,19 @@
 //! At `D = 20`, `n_q = 100` and one-element leaves, charging a BMUL like an AND:
 //!
 //! ```text
-//!     L = 6 :  11280 AND + 364 BMUL
-//!     L = 7 :  10782 AND + 612 BMUL
-//!     L = 8 :  10526 AND + 1116 BMUL
+//!     L = 6 :  5876 AND + 364 BMUL
+//!     L = 7 :  5740 AND + 612 BMUL
+//!     L = 8 :  5846 AND + 1116 BMUL
 //! ```
 //!
-//! AND leads BMUL by more than an order of magnitude, so the AND column decides.
+//! AND still leads BMUL several times over, so the AND column decides.
 //!
-//! - On AND alone the cheapest choice is `L = 8`.
-//! - Charging BMUL at the same rate moves it to `L = 7`.
+//! - On AND alone the cheapest choice is `L = 7`.
+//! - Charging BMUL at the same rate moves it to `L = 6`.
+//! - Both sit a level below where lone climbs would put them, since a level now costs half.
 //! - Neither is a constant, since both track `log2(n_q)`.
 //! - A different query count means re-running the arithmetic above.
 //! - Which column is scarce depends on what the rest of the circuit put in each one.
-//!
-//! One lever is still open.
-//! A climb is sequential, so an opening cannot share cores with itself.
-//! Two openings can, since the queries are independent.
-//!
-//! Verifying a pair of them in shared cores costs about 380 AND per level per query.
-//! That halves what raising `L` saves, so the AND-optimal `L` drops by roughly one level.
 
 use std::array;
 
@@ -273,6 +273,8 @@ pub fn verify_vector(builder: &CircuitBuilder, root: Digest, data: &[Element], b
 /// The digest the climb arrives at must equal the layer entry the remaining index bits address.
 /// That is what ties the opened leaf to the root the layer was verified against.
 ///
+/// [`verify_opening_2x`] climbs two openings at once, for about half the AND cost a level here.
+///
 /// # Why the index is a wire
 ///
 /// A caller may derive the query index in-circuit, so it cannot be a build-time constant.
@@ -343,6 +345,92 @@ pub fn verify_opening(
 			.try_into()
 			.expect("the multiplexer returns one wire per digest wire"),
 	);
+}
+
+/// Verifies two Merkle openings at once, climbing them in the two lanes of shared cores.
+///
+/// A climb is sequential, so an opening cannot share cores with itself.
+/// Two openings can, since the queries are independent at every level:
+///
+/// ```text
+///     level k:  (running digest of query q, sibling k of query q)  ->  its digest at level k + 1
+/// ```
+///
+/// Both queries open the same commitment, so their climbs span the same levels.
+/// Only the hashing is shared: each query orders its own pair by its own index bit, as
+/// [`verify_opening`] does, and matches its own layer entry at the top.
+///
+/// # Panics
+///
+/// Panics unless all of the following hold.
+///
+/// - The layer depth is at most the tree depth.
+/// - The tree depth is below the wire width.
+/// - The layer holds one digest per node at its own depth.
+/// - Both leaves hold the same number of elements.
+/// - Both authentication paths hold one sibling per level between the two depths.
+pub fn verify_opening_2x(
+	builder: &CircuitBuilder,
+	indices: [Wire; 2],
+	values: [&[Element]; 2],
+	layer_depth: usize,
+	tree_depth: usize,
+	layer_digests: &[Digest],
+	branches: [&[Digest]; 2],
+) {
+	assert!(layer_depth <= tree_depth, "precondition: layer_depth must be at most tree_depth");
+	assert!(tree_depth < Word::BITS, "precondition: tree_depth must be below the wire width");
+	assert_eq!(
+		layer_digests.len(),
+		1 << layer_depth,
+		"precondition: layer_digests must have 2^layer_depth entries"
+	);
+	for branch in branches {
+		assert_eq!(
+			branch.len(),
+			tree_depth - layer_depth,
+			"precondition: each branch must have tree_depth - layer_depth siblings"
+		);
+	}
+
+	let builder = builder.subcircuit("verify_opening_2x");
+
+	// Both leaves hold the same number of elements, so the two lanes hash them in lockstep.
+	let mut digests = leaf_digest_2x(&builder.subcircuit("leaf"), values);
+
+	for level in 0..tree_depth - layer_depth {
+		let b = builder.subcircuit(format!("climb[{level}]"));
+
+		// Ordering a pair reads one query's own index bit, so it stays per query.
+		let nodes = array::from_fn(|q| {
+			// A select gate reads bit 63 alone, so lift this level's index bit up to it.
+			let on_right = b.shl(indices[q], (Word::BITS - 1 - level) as u32);
+			let (digest, sibling) = (digests[q], branches[q][level]);
+			// Order the pair by that bit, putting the running digest on the side it names.
+			let left = array::from_fn(|j| b.select(on_right, sibling[j], digest[j]));
+			let right = array::from_fn(|j| b.select(on_right, digest[j], sibling[j]));
+			(left, right)
+		});
+
+		// The two nodes are independent, so one two-lane compression carries both up a level.
+		digests = compress_node_2x(&b, nodes);
+	}
+
+	// The multiplexer reads its candidates as slices, one per layer entry.
+	let entries = layer_digests.iter().map(|d| &d[..]).collect::<Vec<_>>();
+	for (q, digest) in digests.into_iter().enumerate() {
+		// The climb consumed one index bit per level, so the bits above them address the layer.
+		let layer_index = builder.shr(indices[q], (tree_depth - layer_depth) as u32);
+		let selected = multi_wire_multiplex(&builder, &entries, layer_index);
+		// Each query is bound to the entry its own index addresses, hence to the root above it.
+		builder.assert_eq_v(
+			format!("layer_digest[{q}]"),
+			digest,
+			selected
+				.try_into()
+				.expect("the multiplexer returns one wire per digest wire"),
+		);
+	}
 }
 
 /// The digest of one leaf: SHA-256 over its elements, sixteen little-endian bytes each.

--- a/crates/recursion/src/merkle/tests.rs
+++ b/crates/recursion/src/merkle/tests.rs
@@ -15,6 +15,7 @@ use binius_iop::merkle_tree::MerkleTreeScheme;
 use binius_iop_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
 use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use digest::Output;
+use proptest::prelude::*;
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 use sha2::{Digest as _, Sha256};
 
@@ -702,11 +703,158 @@ fn verify_opening_rejects_a_wrong_index() {
 	}
 }
 
+/// Builds a circuit that verifies a pair of openings in shared cores, and reports the outcome.
+///
+/// Both openings come from one tree, so they climb to the same layer.
+/// Each query keeps its own claimed index, so a negative case can move one and leave the other.
+fn run_opening_2x(
+	openings: [&Opening; 2],
+	layer_depth: usize,
+	tree_depth: usize,
+	claimed_indices: [u64; 2],
+) -> Result<(), PopulateError> {
+	assert_eq!(openings[0].layer, openings[1].layer, "both openings must climb to one layer");
+
+	let builder = CircuitBuilder::new();
+	// The same wire roles as a single opening, one set per query.
+	let indices: [Wire; 2] = array::from_fn(|_| builder.add_inout());
+	let values = openings.map(|opening| element_wires(&builder, opening.values.len()));
+	let branch = openings.map(|opening| digest_wires(&builder, opening.branch.len()));
+	// The layer is shared, since it is checked once against the root and climbed to by both.
+	let layer: Vec<Digest> = (0..openings[0].layer.len())
+		.map(|_| array::from_fn(|_| builder.add_inout()))
+		.collect();
+	verify_opening_2x(
+		&builder,
+		indices,
+		[&values[0], &values[1]],
+		layer_depth,
+		tree_depth,
+		&layer,
+		[&branch[0], &branch[1]],
+	);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	for q in 0..2 {
+		w[indices[q]] = Word(claimed_indices[q]);
+		fill_elements(&mut w, &values[q], &openings[q].values);
+		fill_digests(&mut w, &branch[q], &openings[q].branch);
+	}
+	fill_digests(&mut w, &layer, &openings[0].layer);
+
+	// Both leaf hashes, both climbs and both layer lookups are evaluated here.
+	circuit.populate_wire_witness(&mut w)?;
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("a satisfied circuit must verify");
+	Ok(())
+}
+
+/// What a differential case does to the pair of openings before verifying them.
+///
+/// Each mutation is one of the ones the single-opening negative tests use, aimed at one query.
+#[derive(Clone, Copy, Debug)]
+enum Tamper {
+	/// Leaves both openings as the native committer produced them.
+	None,
+	/// Flips the lowest bit of the sibling one query uses at the bottom level.
+	Sibling(usize),
+	/// Adds one to the first value under one query's leaf.
+	Value(usize),
+	/// Verifies one query at an index its path does not belong to.
+	Index(usize),
+}
+
+proptest! {
+	// Three circuits a case, each one built and evaluated, so the cases are not cheap.
+	#![proptest_config(ProptestConfig::with_cases(32))]
+
+	#[test]
+	fn verify_opening_2x_matches_two_solo_openings(
+		// Trees of 2 to 8 leaves, holding 1 or 2 elements per leaf.
+		log_len in 1usize..=3,
+		batch_size in 1usize..=2,
+		// Reduced below to a depth the tree has, since the two are drawn independently.
+		layer_draw in 0usize..=3,
+		// Likewise reduced to leaf indices, and free to coincide.
+		first in 0usize..8,
+		second in 0usize..8,
+		tamper in prop_oneof![
+			Just(Tamper::None),
+			(0usize..2).prop_map(Tamper::Sibling),
+			(0usize..2).prop_map(Tamper::Value),
+			(0usize..2).prop_map(Tamper::Index),
+		],
+		// Varying the seed varies the committed values, not just the shape.
+		seed: u64,
+	) {
+		// Invariant: verifying two openings in shared cores accepts exactly when verifying each on
+		// its own accepts, and a rejection is attributed to the query that earned it.
+		//
+		// The second half is what rules out cross-wiring: a pair that mixed the two climbs could
+		// still accept honest openings and reject tampered ones, but would blame the wrong query.
+		let layer_depth = layer_draw.min(log_len);
+		let indices = [first, second].map(|index| index % (1 << log_len));
+
+		let mut rng = StdRng::seed_from_u64(seed);
+		let data = random_values(&mut rng, batch_size << log_len);
+		// One tree, opened at both indices, so both openings share a layer.
+		let mut openings =
+			indices.map(|index| prove_opening(&data, batch_size, log_len, layer_depth, index));
+		let mut claimed = indices.map(|index| index as u64);
+
+		match tamper {
+			Tamper::None => {}
+			// At the full layer depth the climb is empty, so there is no sibling to corrupt.
+			Tamper::Sibling(q) => {
+				if let Some(sibling) = openings[q].branch.first_mut() {
+					sibling[0] ^= 1;
+				}
+			}
+			Tamper::Value(q) => openings[q].values[0] += B128::from(1u128),
+			// Flipping bit 0 names another leaf, whether it reorders a pair or moves the entry.
+			Tamper::Index(q) => claimed[q] ^= 1,
+		}
+
+		// Reference behaviour: each query verified on its own, by the single-opening gadget.
+		let solo: [Result<(), PopulateError>; 2] =
+			array::from_fn(|q| run_opening(&openings[q], layer_depth, log_len, claimed[q]));
+		let paired =
+			run_opening_2x([&openings[0], &openings[1]], layer_depth, log_len, claimed);
+
+		if solo.iter().all(Result::is_ok) {
+			prop_assert!(
+				paired.is_ok(),
+				"the pair rejected two openings that each verify alone: {paired:?}"
+			);
+		} else {
+			let error = paired.expect_err("the pair must reject what a solo verification rejects");
+			// Only the layer comparison can catch any of these, and only for a failing query.
+			assert_failed_paths(&error, ".verify_opening_2x.layer_digest");
+			for (q, result) in solo.iter().enumerate() {
+				if result.is_ok() {
+					let path = format!(".verify_opening_2x.layer_digest[{q}]");
+					prop_assert!(
+						!error.failures.iter().any(|failure| failure.path.starts_with(&path)),
+						"query {q} verifies alone, so the pair must not fail it: {:?}",
+						error.failures
+					);
+				}
+			}
+		}
+	}
+}
+
 /// AND constraints one climbed level of an opening costs.
 ///
 /// The module docs derive the layer-depth trade-off from this number, so a change here means the
 /// trade-off needs re-deriving.
 const LEVEL_AND: usize = 738;
+
+/// AND constraints one climbed level costs each query, when two openings share cores.
+const PAIRED_LEVEL_AND: usize = 377;
 
 /// AND constraints one inner node costs on its own core.
 const NODE_AND: usize = 742;
@@ -779,6 +927,65 @@ fn verify_opening_follows_the_documented_cost_model() {
 	let (wide, _) = opening_cost(20, 7, 16);
 	println!("verify_opening depth=20 layer=7 leaf=16: AND={wide}");
 	assert!(wide > narrow, "a sixteen-element leaf hashes more blocks than a one-element leaf");
+}
+
+/// The cost of verifying two openings of the same tree shape in shared cores.
+fn opening_cost_2x(tree_depth: usize, layer_depth: usize, leaf_size: usize) -> (usize, usize) {
+	cost(|builder| {
+		// One set of wires per query, over the one layer both climbs land on.
+		let indices: [Wire; 2] = array::from_fn(|_| builder.add_inout());
+		let values = [(); 2].map(|()| element_wires(builder, leaf_size));
+		let branch = [(); 2].map(|()| digest_wires(builder, tree_depth - layer_depth));
+		let layer: Vec<Digest> = (0..1usize << layer_depth)
+			.map(|_| array::from_fn(|_| builder.add_inout()))
+			.collect();
+		verify_opening_2x(
+			builder,
+			indices,
+			[&values[0], &values[1]],
+			layer_depth,
+			tree_depth,
+			&layer,
+			[&branch[0], &branch[1]],
+		);
+	})
+}
+
+#[test]
+fn verify_opening_2x_follows_the_documented_cost_model() {
+	// Invariant: pairing two climbs halves what a level costs each of them, and changes nothing
+	// about the selects, since ordering a pair and picking a layer entry stay per query.
+	//
+	// Fixture state: depth 20 trees with one-element leaves, at five layer depths.
+	// Each shape is measured again one level deeper, so the difference isolates one level.
+	for layer_depth in [0usize, 1, 4, 7, 8] {
+		let (and, bmul) = opening_cost_2x(20, layer_depth, 1);
+		let (deeper_and, deeper_bmul) = opening_cost_2x(21, layer_depth, 1);
+
+		// Two queries, each ordering one pair per level and picking one layer entry.
+		assert_eq!(
+			bmul,
+			2 * (8 * (20 - layer_depth) + 4 * ((1 << layer_depth) - 1)),
+			"BMUL at layer depth {layer_depth}"
+		);
+		assert_eq!(deeper_bmul - bmul, 16, "one more level orders one more pair per query");
+
+		// One shared node hash per level, so each query pays half of it.
+		assert_eq!(
+			(deeper_and - and) / 2,
+			PAIRED_LEVEL_AND,
+			"AND per climbed level per query at layer depth {layer_depth}"
+		);
+
+		// Printed so the figures quoted in the module docs can be re-read off a test run.
+		println!("verify_opening_2x depth=20 layer={layer_depth} leaf=1: AND={and} BMUL={bmul}");
+	}
+
+	// Sharing cores must be what pays for itself, so a pair costs less than two lone climbs.
+	let (paired, _) = opening_cost_2x(20, 7, 1);
+	let (solo, _) = opening_cost(20, 7, 1);
+	println!("two solo openings: AND={}, one paired: AND={paired}", 2 * solo);
+	assert!(paired < 2 * solo, "a shared core must beat two separate ones");
 }
 
 #[test]

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -456,6 +456,25 @@ fn one_circuit_verifies_two_different_openings() {
 	}
 }
 
+#[test]
+fn an_odd_query_count_verifies_in_circuit() {
+	// Invariant: the openings of one commitment climb in pairs, so an odd query count leaves the
+	// last one climbing alone, and both routes must reach the same layer.
+	//
+	// Fixture state: the native shape at 31 queries, so every opened commitment has a leftover.
+	let shape = Shape {
+		n_test_queries: 31,
+		..NATIVE_SHAPE
+	};
+	let setup = shape.setup();
+	let opening = prove(&shape, &setup, 8);
+	let verifier = record(&shape, &setup);
+
+	verifier
+		.check_opening(&shape, &setup, &opening)
+		.expect("the leftover query must verify beside the paired ones");
+}
+
 /// Returns `proof` with the low bit of one byte flipped.
 fn corrupt(proof: &[u8], offset: usize) -> Vec<u8> {
 	// One bit is the smallest change a sound protocol must still reject.


### PR DESCRIPTION
Closes [BINIUS-502](https://linear.app/jimpo/issue/BINIUS-502).

Verifies two Merkle openings in the two 32-bit lanes of one compression chain instead of one core each.
Same checks, same transcript, ~34% off the whole recursive verifier.

### The problem

Merkle openings dominate the recursive verifier, and each query climbs its authentication path alone.
One SHA-256 block compression per level, 738 AND constraints for that level.

A gate here costs one AND constraint whatever its operand width.
So a single-lane climb leaves the other 32 bits of every core idle.

### The idea

A climb is sequential: level `k + 1` consumes level `k`'s output.
So one opening can never share a core with itself.

Two openings can — at any level, query A's compression and query B's do not depend on each other.

```
today:  query A level k  ->  its own core   (738 AND)
        query B level k  ->  its own core   (738 AND)

paired: query A level k  \
                          -> one core       (754 AND, both lanes busy)
        query B level k  /
```

`leaf_digest_2x` and `compress_node_2x` already existed for exactly this trick.
`verify_vector` pairs independent leaves with them; the module doc has named cross-query pairing as an unexploited lever since BINIUS-430/471.

### Per climbed level, per query

- **before:** 738 AND
- **after:** 377 AND

→ 1.96x, on the dominant term of the dominant phase.

### The change

```
recv_openings:
- for index in indices                      // one verify_opening per query
+ for pair in indices.chunks_exact(2)       // one verify_opening_2x per pair
+ if let [index] = pairs.remainder()        // solo fallback for an odd count
```

`verify_opening_2x` hashes both leaves with `leaf_digest_2x`, then spends one `compress_node_2x` per level for both queries.
Everything else stays per query: the index-bit `select` that orders each pair, the layer multiplexer, and the equality assertion against the layer entry.

### Soundness

Only the compression is shared, so the two paths never touch.
Each query is bound to the entry its own index addresses, under its own named assertion.

Cross-wiring two authentication paths would be a soundness bug rather than a regression, so equivalence is proved, not assumed:

- a proptest over random shapes, leaf widths, layer depths and index pairs asserts the pair accepts **exactly** when running solo `verify_opening` twice would both accept;
- and asserts a rejection is never blamed on a query that verifies alone, which is what rules out cross-wiring;
- tampers are the existing negative tests' own: corrupted sibling, corrupted leaf value, wrong claimed index, aimed at one query at a time.

Three injected cross-wiring bugs were each caught by that test before being reverted: crossed siblings, swapped output lanes, and a crossed layer index.

The transcript is untouched.
Advice is still read one query's leaf and branch at a time, so `WitnessFillerChannel` needed no change — confirmed by the recorded input count being identical, and by the replay-driven acceptance tests.

### Scope

- **new:** `verify_opening_2x`, its differential proptest, its cost test, and an odd-query acceptance test (31 queries, which exercises the solo fallback through a real build and replay).
- **changed:** `recv_openings`, and the cost model in `merkle.rs`'s module docs.
- **untouched:** `verify_opening`, `filler.rs`, and every byte of the proof tape.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all --check` — clean
- `cargo test -p binius-recursion` — 47 tests pass, including the end-to-end recursion pipeline

### Benchmark

`crates/recursion/tests/basefold_opening.rs`, AND constraints:

| n_vars | rate | queries | before | after | change |
|---|---|---|---|---|---|
| 8 | 1 | 32 | 226,950 | 148,822 | -34.4% |
| 10 | 1 | 32 | 341,924 | 217,588 | -36.4% |
| 8 | 2 | 32 | 281,836 | 180,604 | -35.9% |
| 8 | 1 | 16 | 144,804 | 94,188 | -35.0% |
| 8 | 1 | 64 | 276,940 | 185,324 | -33.1% |

The Merkle-opening phase itself goes from 188,352 to 108,480 AND on the native shape, measured on the two commitment shapes it actually opens.
BMUL and the recorded input count are bit-identical throughout, since only hashing was shared.
Committed words halve as well, 524,288 to 262,144.

### Layer depth, re-derived

The docs' layer-depth trade-off is derived from the per-level cost, so halving a level changes it.
Raising the layer depth `L` by one now costs `-377 + 380 * 2^L / n_q` AND per query.

- break-even moves from `2^L = 1.94 * n_q` to `2^L = 0.99 * n_q`, which lands exactly on the native `ceil(log2(n_q))` rule;
- at depth 20 with 100 queries, the AND-optimal `L` drops from 8 to 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)