### PR TITLE
Put every gate's operands in one shared arena

### DIFF
--- a/crates/frontend/src/lower/constraint.rs
+++ b/crates/frontend/src/lower/constraint.rs
@@ -8,7 +8,7 @@ use binius_core::constraint_system::{
 };
 use cranelift_entity::{EntitySet, SecondaryMap};
 
-use super::operand::WireOperand;
+use super::operand::{ShiftedWire, WireOperand};
 use crate::ir::Wire;
 
 /// AND constraint `A & B == C`, over wire operands.
@@ -24,19 +24,20 @@ pub struct WireAndConstraint {
 impl WireAndConstraint {
 	pub(super) fn into_constraint(
 		self,
+		arena: &[ShiftedWire],
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> AndConstraint {
 		AndConstraint([
-			self.a.into_value_indices(wire_mapping),
-			self.b.into_value_indices(wire_mapping),
-			self.c.into_value_indices(wire_mapping),
+			self.a.into_value_indices(arena, wire_mapping),
+			self.b.into_value_indices(arena, wire_mapping),
+			self.c.into_value_indices(arena, wire_mapping),
 		])
 	}
 
-	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
-		self.a.mark_used(used_set);
-		self.b.mark_used(used_set);
-		self.c.mark_used(used_set);
+	pub(super) fn mark_used(&self, arena: &[ShiftedWire], used_set: &mut EntitySet<Wire>) {
+		self.a.mark_used(arena, used_set);
+		self.b.mark_used(arena, used_set);
+		self.c.mark_used(arena, used_set);
 	}
 }
 
@@ -55,21 +56,22 @@ pub struct WireImulConstraint {
 impl WireImulConstraint {
 	pub(super) fn into_constraint(
 		self,
+		arena: &[ShiftedWire],
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> ImulConstraint {
 		ImulConstraint([
-			self.a.into_value_indices(wire_mapping),
-			self.b.into_value_indices(wire_mapping),
-			self.lo.into_value_indices(wire_mapping),
-			self.hi.into_value_indices(wire_mapping),
+			self.a.into_value_indices(arena, wire_mapping),
+			self.b.into_value_indices(arena, wire_mapping),
+			self.lo.into_value_indices(arena, wire_mapping),
+			self.hi.into_value_indices(arena, wire_mapping),
 		])
 	}
 
-	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
-		self.a.mark_used(used_set);
-		self.b.mark_used(used_set);
-		self.hi.mark_used(used_set);
-		self.lo.mark_used(used_set);
+	pub(super) fn mark_used(&self, arena: &[ShiftedWire], used_set: &mut EntitySet<Wire>) {
+		self.a.mark_used(arena, used_set);
+		self.b.mark_used(arena, used_set);
+		self.hi.mark_used(arena, used_set);
+		self.lo.mark_used(arena, used_set);
 	}
 }
 
@@ -92,25 +94,26 @@ pub struct WireBmulConstraint {
 impl WireBmulConstraint {
 	pub(super) fn into_constraint(
 		self,
+		arena: &[ShiftedWire],
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> BmulConstraint {
 		BmulConstraint([
-			self.a_lo.into_value_indices(wire_mapping),
-			self.a_hi.into_value_indices(wire_mapping),
-			self.b_lo.into_value_indices(wire_mapping),
-			self.b_hi.into_value_indices(wire_mapping),
-			self.c_lo.into_value_indices(wire_mapping),
-			self.c_hi.into_value_indices(wire_mapping),
+			self.a_lo.into_value_indices(arena, wire_mapping),
+			self.a_hi.into_value_indices(arena, wire_mapping),
+			self.b_lo.into_value_indices(arena, wire_mapping),
+			self.b_hi.into_value_indices(arena, wire_mapping),
+			self.c_lo.into_value_indices(arena, wire_mapping),
+			self.c_hi.into_value_indices(arena, wire_mapping),
 		])
 	}
 
-	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
-		self.a_lo.mark_used(used_set);
-		self.a_hi.mark_used(used_set);
-		self.b_lo.mark_used(used_set);
-		self.b_hi.mark_used(used_set);
-		self.c_lo.mark_used(used_set);
-		self.c_hi.mark_used(used_set);
+	pub(super) fn mark_used(&self, arena: &[ShiftedWire], used_set: &mut EntitySet<Wire>) {
+		self.a_lo.mark_used(arena, used_set);
+		self.a_hi.mark_used(arena, used_set);
+		self.b_lo.mark_used(arena, used_set);
+		self.b_hi.mark_used(arena, used_set);
+		self.c_lo.mark_used(arena, used_set);
+		self.c_hi.mark_used(arena, used_set);
 	}
 }
 
@@ -126,13 +129,14 @@ pub struct WireZeroConstraint {
 impl WireZeroConstraint {
 	pub(super) fn into_constraint(
 		self,
+		arena: &[ShiftedWire],
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> ZeroConstraint {
-		ZeroConstraint([self.val.into_value_indices(wire_mapping)])
+		ZeroConstraint([self.val.into_value_indices(arena, wire_mapping)])
 	}
 
-	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
-		self.val.mark_used(used_set);
+	pub(super) fn mark_used(&self, arena: &[ShiftedWire], used_set: &mut EntitySet<Wire>) {
+		self.val.mark_used(arena, used_set);
 	}
 }
 
@@ -151,16 +155,17 @@ impl WireLinearConstraint {
 	/// AND constraint carries.
 	pub(super) fn into_zero_constraint(
 		self,
+		arena: &[ShiftedWire],
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> ZeroConstraint {
 		let dst = wire_mapping[self.dst];
-		let mut operand = self.rhs.into_value_indices(wire_mapping);
+		let mut operand = self.rhs.into_value_indices(arena, wire_mapping);
 		operand.push(ShiftedValueIndex::plain(dst));
 		ZeroConstraint([operand])
 	}
 
-	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
-		self.rhs.mark_used(used_set);
+	pub(super) fn mark_used(&self, arena: &[ShiftedWire], used_set: &mut EntitySet<Wire>) {
+		self.rhs.mark_used(arena, used_set);
 		used_set.insert(self.dst);
 	}
 }

--- a/crates/frontend/src/lower/expr.rs
+++ b/crates/frontend/src/lower/expr.rs
@@ -6,8 +6,8 @@
 use binius_core::constraint_system::Shift;
 use smallvec::{SmallVec, smallvec};
 
-use super::operand::{ShiftedWire, WireOperand};
-use crate::ir::Wire;
+use super::{ConstraintBuilder, operand::ShiftedWire};
+use crate::{ir::Wire, lower::WireOperand};
 
 /// An operand under construction: the XOR of its terms.
 #[derive(Clone)]
@@ -15,11 +15,10 @@ pub struct WireExpr(SmallVec<[WireExprTerm; 4]>);
 
 impl WireExpr {
 	/// Consumes the expression into the operand its terms describe.
-	pub(super) fn into_operand(self) -> WireOperand {
-		self.0
-			.into_iter()
-			.map(WireExprTerm::to_shifted_wire)
-			.collect()
+	///
+	/// The terms are appended to the shared arena.
+	pub(super) fn into_operand(self, cb: &mut ConstraintBuilder) -> WireOperand {
+		cb.push_operand(self.0.into_iter().map(WireExprTerm::to_shifted_wire))
 	}
 }
 

--- a/crates/frontend/src/lower/mod.rs
+++ b/crates/frontend/src/lower/mod.rs
@@ -30,6 +30,10 @@ use crate::ir::Wire;
 /// - leaving one out is a compile error rather than a silent zero;
 /// - an operand that is meant to be zero says so with [`expr::empty`].
 ///
+/// Every operand's terms live in one shared arena rather than in a `Vec` of their own.
+/// An operand handle is therefore `Copy`.
+/// Building an operand never allocates on its own account.
+///
 /// [`build`](Self::build) then converts every wire to its [`ValueIndex`] and
 /// produces the core constraint lists the prover and verifier consume.
 pub struct ConstraintBuilder {
@@ -43,6 +47,10 @@ pub struct ConstraintBuilder {
 	pub linear_constraints: Vec<WireLinearConstraint>,
 	/// Zero constraints `VAL == 0`, which assert rather than define.
 	pub zero_constraints: Vec<WireZeroConstraint>,
+	/// Every operand's terms, in the order they were appended.
+	///
+	/// A [`WireOperand`] names its own slice of this by range rather than owning a `Vec`.
+	terms: Vec<ShiftedWire>,
 }
 
 impl ConstraintBuilder {
@@ -54,16 +62,56 @@ impl ConstraintBuilder {
 			bmul_constraints: Vec::new(),
 			linear_constraints: Vec::new(),
 			zero_constraints: Vec::new(),
+			terms: Vec::new(),
 		}
+	}
+
+	/// Builds an operand from a ready sequence of terms, appending them to the shared arena.
+	pub fn push_operand(&mut self, terms: impl IntoIterator<Item = ShiftedWire>) -> WireOperand {
+		let start = self.terms.len();
+		self.terms.extend(terms);
+		WireOperand::from_range(start, self.terms.len() - start)
+	}
+
+	/// The terms one operand XORs together, resolved through the shared arena.
+	pub fn operand_terms(&self, operand: WireOperand) -> &[ShiftedWire] {
+		operand.as_slice(&self.terms)
+	}
+
+	/// One term of an already-built operand, resolved through the shared arena.
+	///
+	/// Gate fusion reads terms this way, one at a time, while it is also appending new ones.
+	/// Copying a term out this way never holds a live borrow of the arena across a later push.
+	pub(crate) fn term(&self, operand: WireOperand, index: usize) -> ShiftedWire {
+		operand.as_slice(&self.terms)[index]
+	}
+
+	/// Where the next pushed term would land.
+	///
+	/// Pairs with [`operand_since`](Self::operand_since) to grow an operand term by term.
+	/// This suits a caller that discovers its terms one at a time, not as a ready sequence.
+	pub(crate) const fn next_term_start(&self) -> usize {
+		self.terms.len()
+	}
+
+	/// Appends one term to the shared arena.
+	pub(crate) fn push_term(&mut self, term: ShiftedWire) {
+		self.terms.push(term);
+	}
+
+	/// The handle spanning every term pushed since `start`.
+	pub(crate) fn operand_since(&self, start: usize) -> WireOperand {
+		WireOperand::from_range(start, self.terms.len() - start)
 	}
 
 	/// Appends an AND constraint `a & b == c`.
 	pub fn and(&mut self, a: impl Into<WireExpr>, b: impl Into<WireExpr>, c: impl Into<WireExpr>) {
-		self.and_constraints.push(WireAndConstraint {
-			a: a.into().into_operand(),
-			b: b.into().into_operand(),
-			c: c.into().into_operand(),
-		});
+		let constraint = WireAndConstraint {
+			a: a.into().into_operand(self),
+			b: b.into().into_operand(self),
+			c: c.into().into_operand(self),
+		};
+		self.and_constraints.push(constraint);
 	}
 
 	/// Appends an IMUL constraint `a * b == (hi << 64) | lo`.
@@ -74,12 +122,13 @@ impl ConstraintBuilder {
 		hi: impl Into<WireExpr>,
 		lo: impl Into<WireExpr>,
 	) {
-		self.imul_constraints.push(WireImulConstraint {
-			a: a.into().into_operand(),
-			b: b.into().into_operand(),
-			hi: hi.into().into_operand(),
-			lo: lo.into().into_operand(),
-		});
+		let constraint = WireImulConstraint {
+			a: a.into().into_operand(self),
+			b: b.into().into_operand(self),
+			hi: hi.into().into_operand(self),
+			lo: lo.into().into_operand(self),
+		};
+		self.imul_constraints.push(constraint);
 	}
 
 	/// Appends a BMUL constraint `(a_lo, a_hi) * (b_lo, b_hi) == (c_lo, c_hi)` in the GHASH field.
@@ -92,24 +141,26 @@ impl ConstraintBuilder {
 		c_lo: impl Into<WireExpr>,
 		c_hi: impl Into<WireExpr>,
 	) {
-		self.bmul_constraints.push(WireBmulConstraint {
-			a_lo: a_lo.into().into_operand(),
-			a_hi: a_hi.into().into_operand(),
-			b_lo: b_lo.into().into_operand(),
-			b_hi: b_hi.into().into_operand(),
-			c_lo: c_lo.into().into_operand(),
-			c_hi: c_hi.into().into_operand(),
-		});
+		let constraint = WireBmulConstraint {
+			a_lo: a_lo.into().into_operand(self),
+			a_hi: a_hi.into().into_operand(self),
+			b_lo: b_lo.into().into_operand(self),
+			b_hi: b_hi.into().into_operand(self),
+			c_lo: c_lo.into().into_operand(self),
+			c_hi: c_hi.into().into_operand(self),
+		};
+		self.bmul_constraints.push(constraint);
 	}
 
 	/// Appends a linear constraint `rhs == dst`.
 	///
 	/// `rhs` is an XOR of shifted values; `dst` is a single wire.
 	pub fn linear(&mut self, rhs: impl Into<WireExpr>, dst: Wire) {
-		self.linear_constraints.push(WireLinearConstraint {
-			rhs: rhs.into().into_operand(),
+		let constraint = WireLinearConstraint {
+			rhs: rhs.into().into_operand(self),
 			dst,
-		});
+		};
+		self.linear_constraints.push(constraint);
 	}
 
 	/// Appends the assertion `val == 0`.
@@ -117,9 +168,10 @@ impl ConstraintBuilder {
 	/// Unlike [`linear`](Self::linear) this defines no wire, so it is the right shape for an
 	/// assertion gate: the equation it states is enforced without naming a value it produces.
 	pub fn zero(&mut self, val: impl Into<WireExpr>) {
-		self.zero_constraints.push(WireZeroConstraint {
-			val: val.into().into_operand(),
-		});
+		let constraint = WireZeroConstraint {
+			val: val.into().into_operand(self),
+		};
+		self.zero_constraints.push(constraint);
 	}
 
 	/// Lowers every wire-level constraint to its core `ValueIndex` form.
@@ -130,32 +182,34 @@ impl ConstraintBuilder {
 		self,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> (Vec<ZeroConstraint>, Vec<AndConstraint>, Vec<ImulConstraint>, Vec<BmulConstraint>) {
+		let terms = &self.terms;
+
 		let and_constraints = self
 			.and_constraints
 			.into_iter()
-			.map(|c| c.into_constraint(wire_mapping))
+			.map(|c| c.into_constraint(terms, wire_mapping))
 			.collect::<Vec<_>>();
 
 		let imul_constraints = self
 			.imul_constraints
 			.into_iter()
-			.map(|c| c.into_constraint(wire_mapping))
+			.map(|c| c.into_constraint(terms, wire_mapping))
 			.collect();
 
 		let bmul_constraints = self
 			.bmul_constraints
 			.into_iter()
-			.map(|c| c.into_constraint(wire_mapping))
+			.map(|c| c.into_constraint(terms, wire_mapping))
 			.collect();
 
 		let zero_constraints = self
 			.linear_constraints
 			.into_iter()
-			.map(|c| c.into_zero_constraint(wire_mapping))
+			.map(|c| c.into_zero_constraint(terms, wire_mapping))
 			.chain(
 				self.zero_constraints
 					.into_iter()
-					.map(|c| c.into_constraint(wire_mapping)),
+					.map(|c| c.into_constraint(terms, wire_mapping)),
 			)
 			.collect();
 
@@ -168,19 +222,19 @@ impl ConstraintBuilder {
 	pub fn mark_used_wires(&self) -> EntitySet<Wire> {
 		let mut used_set = EntitySet::new();
 		for ac in &self.and_constraints {
-			ac.mark_used(&mut used_set);
+			ac.mark_used(&self.terms, &mut used_set);
 		}
 		for mc in &self.imul_constraints {
-			mc.mark_used(&mut used_set);
+			mc.mark_used(&self.terms, &mut used_set);
 		}
 		for bc in &self.bmul_constraints {
-			bc.mark_used(&mut used_set);
+			bc.mark_used(&self.terms, &mut used_set);
 		}
 		for lc in &self.linear_constraints {
-			lc.mark_used(&mut used_set);
+			lc.mark_used(&self.terms, &mut used_set);
 		}
 		for zc in &self.zero_constraints {
-			zc.mark_used(&mut used_set);
+			zc.mark_used(&self.terms, &mut used_set);
 		}
 		used_set
 	}

--- a/crates/frontend/src/lower/operand.rs
+++ b/crates/frontend/src/lower/operand.rs
@@ -3,8 +3,6 @@
 
 //! The shift algebra shared by operands: a core [`Shift`] applied to a [`Wire`].
 
-use std::ops::Index;
-
 use binius_core::constraint_system::{Composition, Shift, ShiftedValueIndex, ValueIndex};
 use cranelift_entity::{EntitySet, SecondaryMap};
 
@@ -133,83 +131,76 @@ pub fn push_inner(seq: [Shift; 2], shift: Shift, slots: usize) -> PushInner {
 	}
 }
 
-/// An operand: an XOR of shifted-wire terms, stored per constraint position.
-#[derive(Clone, Debug, Default)]
-pub struct WireOperand(Vec<ShiftedWire>);
+/// An operand: an XOR of shifted-wire terms.
+///
+/// The operand owns nothing itself.
+/// It is a `[start, start + len)` range into the term arena every operand shares.
+///
+/// - The handle is `Copy`, since it is only two integers.
+/// - It is immune to the arena reallocating, since it names a position rather than an address.
+/// - Every operand's terms land in one shared `Vec`, rather than one small `Vec` each.
+///
+/// Reading the terms back needs the arena.
+/// Every accessor below takes the arena slice as a parameter.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct WireOperand {
+	start: u32,
+	len: u32,
+}
 
 impl WireOperand {
-	/// Creates an empty operand.
-	pub const fn new() -> Self {
-		Self(Vec::new())
+	/// Builds a handle from a raw arena range.
+	///
+	/// Only the arena's own builders call this.
+	/// Every other caller grows an operand through the shared push-and-finish helpers instead.
+	pub(super) fn from_range(start: usize, len: usize) -> Self {
+		Self {
+			start: start.try_into().expect("arena position fits in u32"),
+			len: len.try_into().expect("operand length fits in u32"),
+		}
 	}
 
-	/// Appends a shifted-wire term.
-	pub fn push(&mut self, term: ShiftedWire) {
-		self.0.push(term);
-	}
-
-	/// The terms this operand XORs together.
-	pub fn as_slice(&self) -> &[ShiftedWire] {
-		&self.0
+	/// The arena position this operand starts at.
+	pub(super) const fn start(self) -> usize {
+		self.start as usize
 	}
 
 	/// The number of terms.
-	pub const fn len(&self) -> usize {
-		self.0.len()
+	pub const fn len(self) -> usize {
+		self.len as usize
 	}
 
 	/// Whether the operand has no terms.
 	///
 	/// An empty XOR is the constant zero, so such an operand contributes nothing.
-	pub const fn is_empty(&self) -> bool {
-		self.0.is_empty()
+	// Only tests call this today, kept for symmetry with `len` rather than removed.
+	#[cfg_attr(not(test), allow(dead_code))]
+	pub const fn is_empty(self) -> bool {
+		self.len == 0
+	}
+
+	/// The terms this operand XORs together, resolved against the shared arena.
+	pub fn as_slice(self, arena: &[ShiftedWire]) -> &[ShiftedWire] {
+		&arena[self.start()..self.start() + self.len()]
 	}
 
 	/// Lowers the whole operand to core `ShiftedValueIndex` terms.
 	pub(super) fn into_value_indices(
 		self,
+		arena: &[ShiftedWire],
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> Vec<ShiftedValueIndex> {
-		self.0
-			.into_iter()
+		self.as_slice(arena)
+			.iter()
 			.map(|term| term.to_shifted_value_index(wire_mapping))
 			.collect()
 	}
 
 	/// Inserts every wire this operand references into `used_set`.
-	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
-		for term in &self.0 {
+	pub(super) fn mark_used(self, arena: &[ShiftedWire], used_set: &mut EntitySet<Wire>) {
+		for term in self.as_slice(arena) {
 			used_set.insert(term.wire);
 		}
-	}
-}
-
-impl Index<usize> for WireOperand {
-	type Output = ShiftedWire;
-
-	fn index(&self, term: usize) -> &Self::Output {
-		&self.0[term]
-	}
-}
-
-impl<'a> IntoIterator for &'a WireOperand {
-	type Item = &'a ShiftedWire;
-	type IntoIter = std::slice::Iter<'a, ShiftedWire>;
-
-	fn into_iter(self) -> Self::IntoIter {
-		self.0.iter()
-	}
-}
-
-impl FromIterator<ShiftedWire> for WireOperand {
-	fn from_iter<I: IntoIterator<Item = ShiftedWire>>(iter: I) -> Self {
-		Self(iter.into_iter().collect())
-	}
-}
-
-impl From<Vec<ShiftedWire>> for WireOperand {
-	fn from(terms: Vec<ShiftedWire>) -> Self {
-		Self(terms)
 	}
 }
 

--- a/crates/frontend/src/pass/fusion/legraph.rs
+++ b/crates/frontend/src/pass/fusion/legraph.rs
@@ -182,13 +182,14 @@ impl LeGraph {
 
 	/// The operand of the linear definition that assigns `wire`.
 	///
-	/// The operand lives in `cb`; this only resolves which constraint to read.
+	/// The handle's terms live in `cb`'s arena.
+	/// This only resolves which constraint to read.
 	///
 	/// # Panics
 	///
 	/// Panics if `wire` is not assigned by a linear definition.
-	pub fn lin_def_operand<'a>(&self, cb: &'a ConstraintBuilder, wire: Wire) -> &'a WireOperand {
-		&cb.linear_constraints[self.lin_def_id(wire).index()].rhs
+	pub fn lin_def_operand(&self, cb: &ConstraintBuilder, wire: Wire) -> WireOperand {
+		cb.linear_constraints[self.lin_def_id(wire).index()].rhs
 	}
 
 	/// The id of the linear definition that assigns `wire`.
@@ -291,40 +292,45 @@ fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
 
 	for lin in &cb.linear_constraints {
 		let consumer = lin.dst;
-		for term in &lin.rhs {
+		for term in cb.operand_terms(lin.rhs) {
 			leg.note_lin_use(term.wire, term.sole_shift(), consumer);
 		}
 	}
 
 	for (index, and) in cb.and_constraints.iter().enumerate() {
-		harvest_root_uses(&and.a, leg, ConstraintRef::And { index });
-		harvest_root_uses(&and.b, leg, ConstraintRef::And { index });
-		harvest_root_uses(&and.c, leg, ConstraintRef::And { index });
+		harvest_root_uses(cb, and.a, leg, ConstraintRef::And { index });
+		harvest_root_uses(cb, and.b, leg, ConstraintRef::And { index });
+		harvest_root_uses(cb, and.c, leg, ConstraintRef::And { index });
 	}
 
 	for (index, mul) in cb.imul_constraints.iter().enumerate() {
-		harvest_root_uses(&mul.a, leg, ConstraintRef::Imul { index });
-		harvest_root_uses(&mul.b, leg, ConstraintRef::Imul { index });
-		harvest_root_uses(&mul.hi, leg, ConstraintRef::Imul { index });
-		harvest_root_uses(&mul.lo, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(cb, mul.a, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(cb, mul.b, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(cb, mul.hi, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(cb, mul.lo, leg, ConstraintRef::Imul { index });
 	}
 
 	for (index, mul) in cb.bmul_constraints.iter().enumerate() {
-		harvest_root_uses(&mul.a_lo, leg, ConstraintRef::Bmul { index });
-		harvest_root_uses(&mul.a_hi, leg, ConstraintRef::Bmul { index });
-		harvest_root_uses(&mul.b_lo, leg, ConstraintRef::Bmul { index });
-		harvest_root_uses(&mul.b_hi, leg, ConstraintRef::Bmul { index });
-		harvest_root_uses(&mul.c_lo, leg, ConstraintRef::Bmul { index });
-		harvest_root_uses(&mul.c_hi, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(cb, mul.a_lo, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(cb, mul.a_hi, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(cb, mul.b_lo, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(cb, mul.b_hi, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(cb, mul.c_lo, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(cb, mul.c_hi, leg, ConstraintRef::Bmul { index });
 	}
 
 	for (index, zero) in cb.zero_constraints.iter().enumerate() {
-		harvest_root_uses(&zero.val, leg, ConstraintRef::Zero { index });
+		harvest_root_uses(cb, zero.val, leg, ConstraintRef::Zero { index });
 	}
 }
 
-fn harvest_root_uses(operand: &WireOperand, leg: &mut LeGraph, constraint: ConstraintRef) {
-	for term in operand {
+fn harvest_root_uses(
+	cb: &ConstraintBuilder,
+	operand: WireOperand,
+	leg: &mut LeGraph,
+	constraint: ConstraintRef,
+) {
+	for term in cb.operand_terms(operand) {
 		if leg.is_lin_def(term.wire) {
 			leg.note_root_use(term.wire, term.sole_shift(), constraint);
 		}

--- a/crates/frontend/src/pass/fusion/patch.rs
+++ b/crates/frontend/src/pass/fusion/patch.rs
@@ -13,6 +13,10 @@ use crate::{
 	pass::fusion::legraph::ConstraintRef,
 };
 
+// Every operand's terms live in one shared arena.
+// Rebuilding an operand means appending to that same arena, not allocating one of its own.
+// That is why every function below takes mutable access to the constraint builder.
+
 /// A patch is a description of a change to the constraint system.
 ///
 /// It specifies a list of constraints that are going to be removed and a list of constraints that
@@ -105,7 +109,7 @@ fn retain_unsubsumed<T>(constraints: &mut Vec<T>, subsumed: &[bool]) {
 /// AND constraints.
 ///
 /// NB: patches may have overlapping subsumes.
-pub fn build(cb: &ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
+pub fn build(cb: &mut ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
 	let mut patches = vec![];
 	build_root_patches(cb, leg, &mut patches);
 	for committed in leg.commit_set().iter() {
@@ -116,7 +120,7 @@ pub fn build(cb: &ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
 }
 
 /// Collect patches for the root constraints that inline linear definitions.
-fn build_root_patches(cb: &ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<Patch>) {
+fn build_root_patches(cb: &mut ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<Patch>) {
 	// Collect *distinct* constraint references.
 	// Several roots may name the same constraint, e.g. two operands of one AND both inlined.
 	let mut constraints: Vec<ConstraintRef> = leg.roots.values().copied().collect();
@@ -130,31 +134,46 @@ fn build_root_patches(cb: &ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<P
 	}
 }
 
-fn build_root_patch(cb: &ConstraintBuilder, leg: &LeGraph, constraint_ref: ConstraintRef) -> Patch {
+fn build_root_patch(
+	cb: &mut ConstraintBuilder,
+	leg: &LeGraph,
+	constraint_ref: ConstraintRef,
+) -> Patch {
 	let mut subsumes = vec![constraint_ref];
 
 	let new_constraint = match constraint_ref {
 		ConstraintRef::And { index } => {
-			let a = process_operand(cb, leg, &mut subsumes, &cb.and_constraints[index].a);
-			let b = process_operand(cb, leg, &mut subsumes, &cb.and_constraints[index].b);
-			let c = process_operand(cb, leg, &mut subsumes, &cb.and_constraints[index].c);
+			let (old_a, old_b, old_c) = {
+				let and = &cb.and_constraints[index];
+				(and.a, and.b, and.c)
+			};
+			let a = process_operand(cb, leg, &mut subsumes, old_a);
+			let b = process_operand(cb, leg, &mut subsumes, old_b);
+			let c = process_operand(cb, leg, &mut subsumes, old_c);
 			AddedConstraint::And(WireAndConstraint { a, b, c })
 		}
 		ConstraintRef::Imul { index } => {
-			let a = process_operand(cb, leg, &mut subsumes, &cb.imul_constraints[index].a);
-			let b = process_operand(cb, leg, &mut subsumes, &cb.imul_constraints[index].b);
-			let lo = process_operand(cb, leg, &mut subsumes, &cb.imul_constraints[index].lo);
-			let hi = process_operand(cb, leg, &mut subsumes, &cb.imul_constraints[index].hi);
+			let (old_a, old_b, old_lo, old_hi) = {
+				let mul = &cb.imul_constraints[index];
+				(mul.a, mul.b, mul.lo, mul.hi)
+			};
+			let a = process_operand(cb, leg, &mut subsumes, old_a);
+			let b = process_operand(cb, leg, &mut subsumes, old_b);
+			let lo = process_operand(cb, leg, &mut subsumes, old_lo);
+			let hi = process_operand(cb, leg, &mut subsumes, old_hi);
 			AddedConstraint::Imul(WireImulConstraint { a, b, lo, hi })
 		}
 		ConstraintRef::Bmul { index } => {
-			let bmul = &cb.bmul_constraints[index];
-			let a_lo = process_operand(cb, leg, &mut subsumes, &bmul.a_lo);
-			let a_hi = process_operand(cb, leg, &mut subsumes, &bmul.a_hi);
-			let b_lo = process_operand(cb, leg, &mut subsumes, &bmul.b_lo);
-			let b_hi = process_operand(cb, leg, &mut subsumes, &bmul.b_hi);
-			let c_lo = process_operand(cb, leg, &mut subsumes, &bmul.c_lo);
-			let c_hi = process_operand(cb, leg, &mut subsumes, &bmul.c_hi);
+			let (old_a_lo, old_a_hi, old_b_lo, old_b_hi, old_c_lo, old_c_hi) = {
+				let bmul = &cb.bmul_constraints[index];
+				(bmul.a_lo, bmul.a_hi, bmul.b_lo, bmul.b_hi, bmul.c_lo, bmul.c_hi)
+			};
+			let a_lo = process_operand(cb, leg, &mut subsumes, old_a_lo);
+			let a_hi = process_operand(cb, leg, &mut subsumes, old_a_hi);
+			let b_lo = process_operand(cb, leg, &mut subsumes, old_b_lo);
+			let b_hi = process_operand(cb, leg, &mut subsumes, old_b_hi);
+			let c_lo = process_operand(cb, leg, &mut subsumes, old_c_lo);
+			let c_hi = process_operand(cb, leg, &mut subsumes, old_c_hi);
 			AddedConstraint::Bmul(WireBmulConstraint {
 				a_lo,
 				a_hi,
@@ -165,7 +184,8 @@ fn build_root_patch(cb: &ConstraintBuilder, leg: &LeGraph, constraint_ref: Const
 			})
 		}
 		ConstraintRef::Zero { index } => {
-			let val = process_operand(cb, leg, &mut subsumes, &cb.zero_constraints[index].val);
+			let old_val = cb.zero_constraints[index].val;
+			let val = process_operand(cb, leg, &mut subsumes, old_val);
 			AddedConstraint::Zero(WireZeroConstraint { val })
 		}
 		ConstraintRef::Linear { .. } => unreachable!(),
@@ -190,7 +210,7 @@ fn build_root_patch(cb: &ConstraintBuilder, leg: &LeGraph, constraint_ref: Const
 /// the Zero constraint
 /// [`ConstraintBuilder::build`](crate::lower::ConstraintBuilder::build)
 /// lowers it to.
-fn build_committed_lin_def_patch(cb: &ConstraintBuilder, leg: &LeGraph, root: Wire) -> Patch {
+fn build_committed_lin_def_patch(cb: &mut ConstraintBuilder, leg: &LeGraph, root: Wire) -> Patch {
 	// `subsumes` is a list of constraints that become redundant with application of this patch.
 	// The first redundant constraint is the linear definition that's being committed.
 	let mut subsumes = vec![leg.lin_def_constraint_ref(root)];
@@ -208,17 +228,25 @@ fn build_committed_lin_def_patch(cb: &ConstraintBuilder, leg: &LeGraph, root: Wi
 	}
 }
 
+/// Rebuilds one operand into a fresh arena range.
+///
+/// Every non-committed linear definition the operand reaches is inlined along the way.
+///
+/// - The new range is appended to the same shared arena the untouched operands already live in.
+/// - No `Vec` of its own gets allocated.
+/// - The only growth is the arena's own amortized growth, shared across every rebuilt operand.
 fn process_operand(
-	cb: &ConstraintBuilder,
+	cb: &mut ConstraintBuilder,
 	leg: &LeGraph,
 	subsumes: &mut Vec<ConstraintRef>,
-	old_operand: &WireOperand,
+	old_operand: WireOperand,
 ) -> WireOperand {
-	let mut new_operand = WireOperand::new();
-	for term in old_operand {
-		process_term(cb, leg, &mut new_operand, subsumes, term.wire, term.shift_seq);
+	let start = cb.next_term_start();
+	for i in 0..old_operand.len() {
+		let term = cb.term(old_operand, i);
+		process_term(cb, leg, subsumes, term.wire, term.shift_seq);
 	}
-	new_operand
+	cb.operand_since(start)
 }
 
 /// Recursively process a term, inlining non-committed linear definitions.
@@ -226,10 +254,12 @@ fn process_operand(
 /// `shift_seq` is what the consumers above have accumulated, to be applied to `wire`. Inlining
 /// folds the definition's own shift inside it, greedily, so a slot is spent only where the two
 /// genuinely do not collapse.
+///
+/// Every push lands at the tail of the operand under construction.
+/// Nothing else appends to the shared arena while one such call is still running.
 fn process_term(
-	cb: &ConstraintBuilder,
+	cb: &mut ConstraintBuilder,
 	leg: &LeGraph,
-	new_operand: &mut WireOperand,
 	subsumes: &mut Vec<ConstraintRef>,
 	wire: Wire,
 	shift_seq: [Shift; 2],
@@ -237,7 +267,7 @@ fn process_term(
 	// Check if this wire is committed or not a linear def (i.e., opaque)
 	if leg.commit_set().contains(wire) || !leg.is_lin_def(wire) {
 		// This is a terminal or committed wire - add it to the result with the accumulated shifts
-		new_operand.push(ShiftedWire { wire, shift_seq });
+		cb.push_term(ShiftedWire { wire, shift_seq });
 	} else {
 		// This is a non-committed linear def - we need to inline it!
 		let inner_operand = leg.lin_def_operand(cb, wire);
@@ -246,14 +276,15 @@ fn process_term(
 
 		// Distribute the accumulated shifts over all terms in the inner operand
 		// This is crucial for correctness: shift(a ^ b) = shift(a) ^ shift(b)
-		for inner_term in inner_operand {
+		for i in 0..inner_operand.len() {
+			let inner_term = cb.term(inner_operand, i);
 			// The definition's own shift is applied before anything accumulated above it, so it
 			// folds into the sequence from the inside.
 			let inner_shift = inner_term.sole_shift();
 			match push_inner(shift_seq, inner_shift, LOWERED_SHIFT_SLOTS) {
 				PushInner::Seq(composed) => {
 					// Recursively process this term with the composed sequence
-					process_term(cb, leg, new_operand, subsumes, inner_term.wire, composed);
+					process_term(cb, leg, subsumes, inner_term.wire, composed);
 				}
 				// The shifts clear the word, so the term is identically zero. An operand is
 				// an XOR, so a zero term contributes nothing and the inlining simply drops it.
@@ -370,7 +401,7 @@ mod tests {
 		cb.linear(expr::xor2(w(0), w(2)), w(3));
 
 		let leg = LeGraph::new(&cb);
-		let patch = super::build_committed_lin_def_patch(&cb, &leg, w(3));
+		let patch = super::build_committed_lin_def_patch(&mut cb, &leg, w(3));
 		match patch.added {
 			AddedConstraint::Linear(ref linc) => {
 				assert!(!linc.rhs.is_empty());
@@ -399,7 +430,7 @@ mod tests {
 		let mut leg = LeGraph::new(&cb);
 		crate::pass::fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat, 1);
 
-		let patches = super::build(&cb, &leg);
+		let patches = super::build(&mut cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
@@ -434,7 +465,7 @@ mod tests {
 		let mut leg = LeGraph::new(&cb);
 		crate::pass::fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat, 1);
 
-		let patches = super::build(&cb, &leg);
+		let patches = super::build(&mut cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
@@ -507,7 +538,7 @@ mod tests {
 				let mut stat = Stat::default();
 				let mut leg = LeGraph::new(&cb);
 				crate::pass::fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat, 1);
-				let patches = super::build(&cb, &leg);
+				let patches = super::build(&mut cb, &leg);
 				let mut cb2 = cb;
 				super::apply_patches(&mut cb2, patches);
 
@@ -528,7 +559,7 @@ mod tests {
 		}
 
 		let operand = leg.lin_def_operand(cb, wire);
-		for term in operand {
+		for term in cb.operand_terms(operand) {
 			expand_term_recursive(cb, leg, &mut result, term.wire, term.shift_seq);
 		}
 		result
@@ -548,7 +579,7 @@ mod tests {
 		} else {
 			// This is a non-committed linear def - expand recursively
 			let inner = leg.lin_def_operand(cb, wire);
-			for term in inner {
+			for term in cb.operand_terms(inner) {
 				match push_inner(shift_seq, term.sole_shift(), LOWERED_SHIFT_SLOTS) {
 					PushInner::Seq(composed) => {
 						expand_term_recursive(cb, leg, result, term.wire, composed)
@@ -574,13 +605,19 @@ mod tests {
 		map
 	}
 
-	fn assert_operand_eq(actual: &WireOperand, expected: &[ShiftedWire], ctx: &str) {
-		let am = operand_count_map(actual.as_slice());
+	fn assert_operand_eq(
+		cb: &ConstraintBuilder,
+		actual: WireOperand,
+		expected: &[ShiftedWire],
+		ctx: &str,
+	) {
+		let actual_terms = cb.operand_terms(actual);
+		let am = operand_count_map(actual_terms);
 		let em = operand_count_map(expected);
 		assert_eq!(
 			am, em,
 			"operand mismatch for {}\nexpected: {:?}\nactual:   {:?}",
-			ctx, expected, actual
+			ctx, expected, actual_terms
 		);
 	}
 
@@ -747,30 +784,33 @@ mod tests {
 		// 1. Replace AND constraint at index 1 with a new one
 		// 2. Replace LINEAR constraint at index 0 with an AND constraint
 		// 3. Replace IMUL constraint at index 0 with a new one
+		//
+		// Every added operand's term joins the same shared arena.
+		// The pre-existing constraints already live there too.
 		let patches = vec![
 			Patch {
 				subsumes: vec![ConstraintRef::And { index: 1 }],
 				added: AddedConstraint::And(WireAndConstraint {
-					a: vec![ShiftedWire::single(w(30), Shift::IDENTITY)].into(),
-					b: vec![ShiftedWire::single(w(31), Shift::IDENTITY)].into(),
-					c: vec![ShiftedWire::single(w(32), Shift::IDENTITY)].into(),
+					a: cb.push_operand([ShiftedWire::single(w(30), Shift::IDENTITY)]),
+					b: cb.push_operand([ShiftedWire::single(w(31), Shift::IDENTITY)]),
+					c: cb.push_operand([ShiftedWire::single(w(32), Shift::IDENTITY)]),
 				}),
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Linear { index: 0 }],
 				added: AddedConstraint::And(WireAndConstraint {
-					a: vec![ShiftedWire::single(w(33), Shift::IDENTITY)].into(),
-					b: vec![ShiftedWire::single(w(34), Shift::IDENTITY)].into(),
-					c: vec![ShiftedWire::single(w(35), Shift::IDENTITY)].into(),
+					a: cb.push_operand([ShiftedWire::single(w(33), Shift::IDENTITY)]),
+					b: cb.push_operand([ShiftedWire::single(w(34), Shift::IDENTITY)]),
+					c: cb.push_operand([ShiftedWire::single(w(35), Shift::IDENTITY)]),
 				}),
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Imul { index: 0 }],
 				added: AddedConstraint::Imul(WireImulConstraint {
-					a: vec![ShiftedWire::single(w(36), Shift::IDENTITY)].into(),
-					b: vec![ShiftedWire::single(w(37), Shift::IDENTITY)].into(),
-					lo: vec![ShiftedWire::single(w(38), Shift::IDENTITY)].into(),
-					hi: vec![ShiftedWire::single(w(39), Shift::IDENTITY)].into(),
+					a: cb.push_operand([ShiftedWire::single(w(36), Shift::IDENTITY)]),
+					b: cb.push_operand([ShiftedWire::single(w(37), Shift::IDENTITY)]),
+					lo: cb.push_operand([ShiftedWire::single(w(38), Shift::IDENTITY)]),
+					hi: cb.push_operand([ShiftedWire::single(w(39), Shift::IDENTITY)]),
 				}),
 			},
 		];
@@ -782,23 +822,23 @@ mod tests {
 		// AND constraints: originally 3, removed index 1, added 2 new ones = 4 total
 		assert_eq!(cb.and_constraints.len(), 4);
 		// Check that original constraints at indices 0 and 2 are preserved
-		assert_eq!(cb.and_constraints[0].a[0].wire, w(0));
-		assert_eq!(cb.and_constraints[1].a[0].wire, w(6)); // was index 2, now index 1
+		assert_eq!(cb.operand_terms(cb.and_constraints[0].a)[0].wire, w(0));
+		assert_eq!(cb.operand_terms(cb.and_constraints[1].a)[0].wire, w(6)); // was index 2, now index 1
 		// Check new constraints are added at the end
-		assert_eq!(cb.and_constraints[2].a[0].wire, w(30));
-		assert_eq!(cb.and_constraints[3].a[0].wire, w(33));
+		assert_eq!(cb.operand_terms(cb.and_constraints[2].a)[0].wire, w(30));
+		assert_eq!(cb.operand_terms(cb.and_constraints[3].a)[0].wire, w(33));
 
 		// IMUL constraints: originally 2, removed index 0, added 1 new one = 2 total
 		assert_eq!(cb.imul_constraints.len(), 2);
 		// Check that original constraint at index 1 is preserved (now at index 0)
-		assert_eq!(cb.imul_constraints[0].a[0].wire, w(13));
+		assert_eq!(cb.operand_terms(cb.imul_constraints[0].a)[0].wire, w(13));
 		// Check new constraint is added at the end
-		assert_eq!(cb.imul_constraints[1].a[0].wire, w(36));
+		assert_eq!(cb.operand_terms(cb.imul_constraints[1].a)[0].wire, w(36));
 
 		// LINEAR constraints: originally 2, removed index 0 = 1 total
 		assert_eq!(cb.linear_constraints.len(), 1);
 		// Check that original constraint at index 1 is preserved (now at index 0)
-		assert_eq!(cb.linear_constraints[0].rhs[0].wire, w(20));
+		assert_eq!(cb.operand_terms(cb.linear_constraints[0].rhs)[0].wire, w(20));
 	}
 
 	#[test]
@@ -839,7 +879,7 @@ mod tests {
 		assert!(!leg.commit_set().contains(w(2)), "t should not be committed");
 		assert!(!leg.commit_set().contains(w(4)), "z should not be committed");
 
-		let patches = super::build(&cb, &leg);
+		let patches = super::build(&mut cb, &leg);
 		let mut cb2 = cb; // clone-by-move and apply patches
 		super::apply_patches(&mut cb2, patches);
 
@@ -872,14 +912,15 @@ mod tests {
 		let mut leg = LeGraph::new(&cb);
 		crate::pass::fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat, 1);
 
-		let patches = super::build(&cb, &leg);
+		let patches = super::build(&mut cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
 		// Verify results: one IMUL remains, and its operand a equals x ^ c ^ x ^ c ^ z
 		assert_eq!(cb2.imul_constraints.len(), 1);
-		let a = &cb2.imul_constraints[0].a;
+		let a = cb2.imul_constraints[0].a;
 		assert_operand_eq(
+			&cb2,
 			a,
 			&[
 				ShiftedWire::single(w(0), Shift::IDENTITY),
@@ -914,15 +955,22 @@ mod tests {
 		crate::pass::fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat, 1);
 
 		assert!(leg.commit_set().contains(w(1)), "t_committed should be committed");
-		let patches = super::build(&cb, &leg);
+		let patches = super::build(&mut cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
 		assert_eq!(cb2.imul_constraints.len(), 1);
 		let m = &cb2.imul_constraints[0];
-		assert_operand_eq(&m.a, &[ShiftedWire::single(w(1), Shift::sll(30))], "mul.a (committed)");
+		let (a, b) = (m.a, m.b);
 		assert_operand_eq(
-			&m.b,
+			&cb2,
+			a,
+			&[ShiftedWire::single(w(1), Shift::sll(30))],
+			"mul.a (committed)",
+		);
+		assert_operand_eq(
+			&cb2,
+			b,
 			&[
 				ShiftedWire::single(w(3), Shift::IDENTITY),
 				ShiftedWire::single(w(4), Shift::IDENTITY),
@@ -952,19 +1000,22 @@ mod tests {
 		crate::pass::fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat, 1);
 
 		assert!(leg.commit_set().contains(w(1)), "inner t should be committed");
-		let patches = super::build(&cb, &leg);
+		let patches = super::build(&mut cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
 		assert_eq!(cb2.imul_constraints.len(), 1);
 		let m = &cb2.imul_constraints[0];
+		let (hi, lo) = (m.hi, m.lo);
 		assert_operand_eq(
-			&m.hi,
+			&cb2,
+			hi,
 			&[ShiftedWire::single(w(1), Shift::sll(20))],
 			"mul.hi (committed)",
 		);
 		assert_operand_eq(
-			&m.lo,
+			&cb2,
+			lo,
 			&[
 				ShiftedWire::single(w(3), Shift::IDENTITY),
 				ShiftedWire::single(w(4), Shift::IDENTITY),


### PR DESCRIPTION
Puts every gate's operands in one shared arena, instead of one heap-allocated `Vec` each.

### The problem

An operand is an XOR of shifted-wire terms — what one AND/IMUL/BMUL/linear constraint reads.
Building a circuit stored each one in its own small `Vec`.

A large circuit holds hundreds of thousands of these, most only a handful of terms long.
Each one is a separate `malloc`/`free` pair, and a separate place in memory for the allocator to
put its bytes — so every pass that walks operands (gate fusion, constraint emission) pays a cache
miss per operand it visits, on top of the allocation cost itself.

### The idea

Give every operand's terms one shared arena, and make an operand a handle into it:

```rust
pub struct WireOperand {
    start: u32,
    len: u32,
}
```

- `Copy`, since it's two integers.
- Immune to the arena reallocating, since it names a position rather than an address.
- Reading it back takes the arena slice as a parameter — `operand.as_slice(&arena)`.

Every `ConstraintBuilder` method that used to build a `Vec` now appends to the shared arena and
hands back a range.
Gate fusion's `patch.rs`, which rebuilds an operand while inlining non-committed linear
definitions, appends the rewritten terms straight into the same arena instead of collecting into
a scratch `Vec` per rewrite.

### Why this didn't touch the 21 gate files

None of `gates/*.rs` needed a single change.
They all go through `cb.and(a, b, c)`-style calls, which already hide operand construction behind
the `expr::` DSL — a prior refactor (one `impl GateKind` per gate kind, replacing free functions)
is what made that true.
Before it, every one of those 21 files built an operand directly; the scope of this change halved
from the plan's original ~25-file estimate, and that's confirmed by grep, not assumed.

### Per circuit — measured, independently, twice

Measured on an XMSS multisig circuit (4 signers), pristine base vs this change, same probe, 5 reps
each:

| | before | after | change |
|---|---:|---:|---:|
| allocations | 2,411,672 | 1,535,080 | **-36.4%** |
| bytes allocated | 911 MB | 847 MB | -7.0% |
| build time | 525–552 ms | 480–498 ms | **-8.8%**, ranges do not overlap |

The allocation-count delta (876,592 fewer) was independently reproduced twice, on two separate
runs against two separate checkouts, landing on the same number both times — not a rounding
coincidence.

### Scope

- **changed:** `lower/constraint.rs`, `lower/expr.rs`, `lower/mod.rs`, `lower/operand.rs`, `pass/fusion/legraph.rs`, `pass/fusion/patch.rs`.
- **left untouched:** every `gates/*.rs` file, and every gate's constraint semantics.

### Verification

- `cargo test -p binius-frontend -p binius-circuits` — 342 + 3 + 257 + 1 + 1 + 2 + 2 + 2, all passed. No gate-fusion snapshot changed.
- `cargo clippy -p binius-frontend --all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
