### PR TITLE
Make reading a pooled wire impossible, then pool by default

### DIFF
--- a/crates/circuits/src/bignum/big_uint_divide.rs
+++ b/crates/circuits/src/bignum/big_uint_divide.rs
@@ -108,6 +108,12 @@ mod tests {
 
 		let (q, r) = BigUintDivideHint::call(&builder, &[d0, d1], &[m]);
 
+		// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+		// Promoting them to public outputs is what the test needs to read them back.
+		for &wire in q.iter().chain(&r) {
+			builder.mark_inout(wire);
+		}
+
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
 		circuit.populate_wire_witness(&mut w).unwrap();
@@ -131,6 +137,12 @@ mod tests {
 		let m1 = builder.add_constant_64(0);
 
 		let (q, r) = BigUintDivideHint::call(&builder, &[d0, d1], &[m0, m1]);
+
+		// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+		// Promoting them to public outputs is what the test needs to read them back.
+		for &wire in q.iter().chain(&r) {
+			builder.mark_inout(wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();

--- a/crates/circuits/src/bignum/big_uint_mod_pow.rs
+++ b/crates/circuits/src/bignum/big_uint_mod_pow.rs
@@ -84,6 +84,12 @@ mod tests {
 		let c = builder.add_constant_64(0x123456789abcdef0);
 		let modpow = BigUintModPowHint::call(&builder, &[c], &[c, c], &[c, c, c]);
 
+		// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+		// Promoting them to public outputs is what the test needs to read them back.
+		for &wire in &modpow {
+			builder.mark_inout(wire);
+		}
+
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
 		circuit.populate_wire_witness(&mut w).unwrap();

--- a/crates/circuits/src/bignum/mod_inverse.rs
+++ b/crates/circuits/src/bignum/mod_inverse.rs
@@ -110,6 +110,12 @@ mod tests {
 
 		let (quotient, inverse) = ModInverseHint::call(&builder, &[b], &[m0, m1]);
 
+		// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+		// Promoting them to public outputs is what the test needs to read them back.
+		for &wire in quotient.iter().chain(&inverse) {
+			builder.mark_inout(wire);
+		}
+
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
 		circuit.populate_wire_witness(&mut w).unwrap();
@@ -134,6 +140,12 @@ mod tests {
 		let m1 = builder.add_constant_64(0x3ffff7ffffffffff);
 
 		let (quotient, inverse) = ModInverseHint::call(&builder, &[b], &[m0, m1]);
+
+		// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+		// Promoting them to public outputs is what the test needs to read them back.
+		for &wire in quotient.iter().chain(&inverse) {
+			builder.mark_inout(wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();

--- a/crates/circuits/src/bignum/tests.rs
+++ b/crates/circuits/src/bignum/tests.rs
@@ -108,6 +108,11 @@ fn test_karatsuba_sqr_single_case() {
 	let a = BigUint::new_witness(&builder, n);
 	let mul = karatsuba_mul(&builder, &a, &a);
 
+	// Nothing else reads these limbs, so pin them or pooling could reclaim their slots first.
+	for &limb in &mul.limbs {
+		builder.force_commit(limb);
+	}
+
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
 
@@ -321,6 +326,11 @@ proptest! {
 
 		let result = textbook_mul(&builder, &a, &b);
 
+		// Nothing else reads these limbs, so pin them or pooling could reclaim their slots first.
+		for &limb in &result.limbs {
+			builder.force_commit(limb);
+		}
+
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
 
@@ -353,6 +363,11 @@ proptest! {
 
 		let a = BigUint::new_witness(&builder, a_limbs.len());
 		let result = textbook_square(&builder, &a);
+
+		// Nothing else reads these limbs, so pin them or pooling could reclaim their slots first.
+		for &limb in &result.limbs {
+			builder.force_commit(limb);
+		}
 
 		let cs = builder.build();
 
@@ -394,6 +409,10 @@ proptest! {
 		let lt_flag = biguint_lt(&builder, &a, &b);
 		let eq_flag = biguint_eq(&builder, &a, &b);
 
+		// Nothing else reads these, so pin them or pooling could reclaim their slots first.
+		builder.force_commit(lt_flag);
+		builder.force_commit(eq_flag);
+
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
 
@@ -421,6 +440,11 @@ proptest! {
 
 		let square_result = textbook_square(&builder, &a);
 		let mul_result = textbook_mul(&builder, &a, &a);
+
+		// Nothing else reads these limbs, so pin them or pooling could reclaim their slots first.
+		for &limb in square_result.limbs.iter().chain(&mul_result.limbs) {
+			builder.force_commit(limb);
+		}
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -379,6 +379,11 @@ mod tests {
 			.collect();
 
 		let output = concat(&b, &inputs);
+		// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+		// Promoting them to public outputs is what the test needs to read them back.
+		for &wire in &output.data {
+			b.mark_inout(wire);
+		}
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -330,6 +330,9 @@ mod tests {
 		assert_eq(&builder, "result_x", &result.x, &expected_x);
 		assert_eq(&builder, "result_y", &result.y, &expected_y);
 
+		// The infinity flag is never constrained, only read below, so pin it before build.
+		builder.force_commit(result.is_point_at_infinity);
+
 		// Build and verify the circuit
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
@@ -395,6 +398,9 @@ mod tests {
 
 		assert_eq(&builder, "msm_x", &result.x, &expected_x);
 		assert_eq(&builder, "msm_y", &result.y, &expected_y);
+
+		// The infinity flag is never constrained, only read below, so pin it before build.
+		builder.force_commit(result.is_point_at_infinity);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();

--- a/crates/circuits/src/ecdsa/tests.rs
+++ b/crates/circuits/src/ecdsa/tests.rs
@@ -34,6 +34,9 @@ pub fn test_bitcoin_ecdsa_test_vector() {
 
 	let signature_valid = bitcoin_verify(&builder, pk, &z, &r, &s);
 
+	// The validity flag is never constrained, only read below, so pin it before build.
+	builder.force_commit(signature_valid);
+
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
 	cs.populate_wire_witness(&mut w).unwrap();

--- a/crates/circuits/src/fixed_byte_vec.rs
+++ b/crates/circuits/src/fixed_byte_vec.rs
@@ -369,6 +369,8 @@ mod tests {
 		let slice = byte_vec.slice_const_range(&b, 3..11);
 
 		assert_eq!(slice.data.len(), 1, "Slice should have 1 word");
+		// The test writes this directly, so pin it or pooling could reclaim its slot first.
+		b.force_commit(slice.data[0]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -432,6 +434,8 @@ mod tests {
 		let slice = byte_vec.slice_const_range(&b, 3..8);
 
 		assert_eq!(slice.data.len(), 1, "Slice should have 1 word");
+		// The test writes this directly, so pin it or pooling could reclaim its slot first.
+		b.force_commit(slice.data[0]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -559,6 +563,10 @@ mod tests {
 		let slice = byte_vec.slice_const_range(&b, 5..21);
 
 		assert_eq!(slice.data.len(), 2, "Slice should have 2 words");
+		// The test writes these directly, so pin them or pooling could reclaim their slots first.
+		for &wire in &slice.data {
+			b.force_commit(wire);
+		}
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -621,6 +629,10 @@ mod tests {
 		let slice = byte_vec.slice_const_range(&b, 5..16);
 
 		assert_eq!(slice.data.len(), 2, "Slice should have 2 words");
+		// The test writes these directly, so pin them or pooling could reclaim their slots first.
+		for &wire in &slice.data {
+			b.force_commit(wire);
+		}
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -215,6 +215,10 @@ mod tests {
 
 		let mut state_wires = input_wires;
 		circuit_fn(&builder, &mut state_wires);
+		// The test reads these directly, so pin them or pooling could reclaim their slots first.
+		for &wire in &state_wires {
+			builder.force_commit(wire);
+		}
 		let circuit = builder.build();
 
 		let mut expected_output = input_state;

--- a/crates/circuits/src/secp256k1/endosplit.rs
+++ b/crates/circuits/src/secp256k1/endosplit.rs
@@ -199,6 +199,15 @@ mod tests {
 			let (k1_neg, k2_neg, k1_abs, k2_abs) =
 				Secp256k1EndosplitHint::call(&builder, &k);
 
+			// A hint emits no constraint of its own, so pinning alone leaves these uncommitted.
+			// Promoting them to public outputs is what the test needs to read them back.
+			builder.mark_inout(k1_neg);
+			builder.mark_inout(k2_neg);
+			builder.mark_inout(k1_abs[0]);
+			builder.mark_inout(k1_abs[1]);
+			builder.mark_inout(k2_abs[0]);
+			builder.mark_inout(k2_abs[1]);
+
 			let circuit = builder.build();
 			let mut w = circuit.new_witness_filler();
 			circuit.populate_wire_witness(&mut w).unwrap();

--- a/crates/circuits/src/secp256k1/tests.rs
+++ b/crates/circuits/src/secp256k1/tests.rs
@@ -28,6 +28,9 @@ fn test_secp256k1_group_order() {
 		}
 	}
 
+	// The test reads this directly, so pin it or pooling could reclaim its slot first.
+	builder.force_commit(acc.is_point_at_infinity);
+
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
 	cs.populate_wire_witness(&mut w).unwrap();
@@ -48,6 +51,11 @@ fn test_secp256k1_pow2pow137() {
 	for _i in 0..137 {
 		acc = curve.double(&builder, &acc);
 		acc = curve.add(&builder, &generator, &acc);
+	}
+
+	// The test reads these directly, so pin them or pooling could reclaim their slots first.
+	for &limb in acc.x.limbs.iter().chain(acc.y.limbs.iter()) {
+		builder.force_commit(limb);
 	}
 
 	let cs = builder.build();
@@ -76,6 +84,18 @@ fn test_secp256k1_generator_double_and_add() {
 	let generator = Secp256k1Affine::generator(&builder);
 	let double = curve.double(&builder, &generator);
 	let triple = curve.add(&builder, &double, &generator);
+
+	// The test reads these directly, so pin them or pooling could reclaim their slots first.
+	for &limb in double
+		.x
+		.limbs
+		.iter()
+		.chain(double.y.limbs.iter())
+		.chain(triple.x.limbs.iter())
+		.chain(triple.y.limbs.iter())
+	{
+		builder.force_commit(limb);
+	}
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 19,076
 ├─ Committed Trace: 19,180 used (58.5% of 2^15)
 │  [▓▓▓▓▓░░░░░] spare: 13,588
-└─ Scratch (uncommitted): 40,112 (peak live: 65)
+└─ Scratch (uncommitted): 65 (peak live: 65)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 135,294
 ├─ Committed Trace: 135,303 used (51.6% of 2^18)
 │  [▓▓▓▓▓░░░░░] spare: 126,841
-└─ Scratch (uncommitted): 108,909 (peak live: 109)
+└─ Scratch (uncommitted): 109 (peak live: 109)
 

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 7,696
 ├─ Committed Trace: 7,832 used (95.6% of 2^13)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 360
-└─ Scratch (uncommitted): 7,728 (peak live: 25)
+└─ Scratch (uncommitted): 25 (peak live: 25)
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 11,132
 ├─ Committed Trace: 11,268 used (68.8% of 2^14)
 │  [▓▓▓▓▓▓░░░░] spare: 5,116
-└─ Scratch (uncommitted): 15,108 (peak live: 41)
+└─ Scratch (uncommitted): 41 (peak live: 41)
 

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 4,069
 ├─ Committed Trace: 4,069 used (99.3% of 2^12)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 27
-└─ Scratch (uncommitted): 5,859 (peak live: 30)
+└─ Scratch (uncommitted): 30 (peak live: 30)
 

--- a/crates/examples/snapshots/blake3_compress.snap
+++ b/crates/examples/snapshots/blake3_compress.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 0
 ├─ Committed Trace: 168 used (65.6% of 2^8)
 │  [▓▓▓▓▓▓░░░░] spare: 88
-└─ Scratch (uncommitted): 9,024 (peak live: 18)
+└─ Scratch (uncommitted): 18 (peak live: 18)
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 187,577
 ├─ Committed Trace: 187,577 used (71.6% of 2^18)
 │  [▓▓▓▓▓▓▓░░░] spare: 74,567
-└─ Scratch (uncommitted): 146,087 (peak live: 254)
+└─ Scratch (uncommitted): 254 (peak live: 254)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 189,236
 ├─ Committed Trace: 189,236 used (72.2% of 2^18)
 │  [▓▓▓▓▓▓▓░░░] spare: 72,908
-└─ Scratch (uncommitted): 150,675 (peak live: 256)
+└─ Scratch (uncommitted): 256 (peak live: 256)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 148,388
 ├─ Committed Trace: 148,841 used (56.8% of 2^18)
 │  [▓▓▓▓▓░░░░░] spare: 113,303
-└─ Scratch (uncommitted): 203,023 (peak live: 729)
+└─ Scratch (uncommitted): 729 (peak live: 729)
 

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 4,779
 ├─ Committed Trace: 4,779 used (58.3% of 2^13)
 │  [▓▓▓▓▓░░░░░] spare: 3,413
-└─ Scratch (uncommitted): 17,406 (peak live: 27)
+└─ Scratch (uncommitted): 27 (peak live: 27)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 8,254
 ├─ Committed Trace: 8,254 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,130
-└─ Scratch (uncommitted): 17,442 (peak live: 30)
+└─ Scratch (uncommitted): 30 (peak live: 30)
 

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 10,269
 ├─ Committed Trace: 10,269 used (62.7% of 2^14)
 │  [▓▓▓▓▓▓░░░░] spare: 6,115
-└─ Scratch (uncommitted): 21,402 (peak live: 13)
+└─ Scratch (uncommitted): 13 (peak live: 13)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 253,499
 ├─ Committed Trace: 254,880 used (97.2% of 2^18)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 7,264
-└─ Scratch (uncommitted): 325,149 (peak live: 1,547)
+└─ Scratch (uncommitted): 1,547 (peak live: 1,547)
 

--- a/crates/frontend/src/artifact/circuit.rs
+++ b/crates/frontend/src/artifact/circuit.rs
@@ -41,11 +41,13 @@ pub struct Circuit {
 	inout: Vec<Wire>,
 	eval_form: EvalForm,
 	scratch_peak_live: usize,
+	scratch_pooled: bool,
 }
 
 impl Circuit {
 	/// Creates a new circuit with the given shared data and wire mapping. Only used during building
 	/// by the circuit builder.
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn new(
 		built_gates: BuiltGates,
 		constraint_system: ConstraintSystem,
@@ -54,6 +56,7 @@ impl Circuit {
 		inout: Vec<Wire>,
 		eval_form: EvalForm,
 		scratch_peak_live: usize,
+		scratch_pooled: bool,
 	) -> Self {
 		let BuiltGates {
 			path_spec_tree,
@@ -68,6 +71,7 @@ impl Circuit {
 			inout,
 			eval_form,
 			scratch_peak_live,
+			scratch_pooled,
 		}
 	}
 
@@ -107,6 +111,15 @@ impl Circuit {
 	#[inline(always)]
 	pub fn witness_row(&self, wire: Wire) -> usize {
 		self.value_vec_layout.word_offset(self.witness_index(wire))
+	}
+
+	/// Whether this circuit's scratch segment shares slots between uncommitted values.
+	///
+	/// A shared slot can end up holding a different value than the wire that first wrote it.
+	/// So a scratch-segment wire is safe to read back only when this is `false`.
+	#[inline(always)]
+	pub(crate) const fn scratch_pooled(&self) -> bool {
+		self.scratch_pooled
 	}
 
 	/// Creates a new witness filler for this circuit.

--- a/crates/frontend/src/artifact/witness.rs
+++ b/crates/frontend/src/artifact/witness.rs
@@ -8,10 +8,27 @@ use std::{
 	ops::{Index, IndexMut},
 };
 
-use binius_core::{ValueVec, Word};
+use binius_core::{ValueIndex, ValueSegment, ValueVec, Word};
 use binius_utils::strided_array::StridedArray2DViewMut;
 
 use crate::{Circuit, Wire};
+
+/// Panics if the wire's storage is a scratch slot shared with another value.
+///
+/// Scratch pooling reclaims a slot once its current value's last read has run.
+/// A shared slot then holds whatever value most recently claimed it, not this wire's.
+/// So this rejects the read outright rather than returning that wrong value.
+fn assert_not_pooled(circuit: &Circuit, wire: Wire, index: ValueIndex) {
+	assert!(
+		!circuit.scratch_pooled() || index.segment() != ValueSegment::Scratch,
+		"wire {wire:?} cannot be read back through a witness filler: its storage is a scratch \
+		 slot shared with another value under scratch pooling, and the slot may already hold a \
+		 different value by the time the circuit has finished evaluating. Disable scratch \
+		 pooling for this build (set `Options::enable_scratch_pooling` to `false`), or make this \
+		 value committed instead of scratch, e.g. by marking it inout or referencing it from a \
+		 constraint."
+	);
+}
 
 /// A single assertion that did not hold while populating the witness.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -126,14 +143,24 @@ impl WitnessFiller<'_> {
 impl Index<Wire> for WitnessFiller<'_> {
 	type Output = Word;
 
+	/// # Panics
+	///
+	/// Panics if the wire's storage is a pooled scratch slot shared with another value.
 	fn index(&self, wire: Wire) -> &Self::Output {
-		&self.value_vec[self.circuit.witness_index(wire)]
+		let index = self.circuit.witness_index(wire);
+		assert_not_pooled(self.circuit, wire, index);
+		&self.value_vec[index]
 	}
 }
 
 impl IndexMut<Wire> for WitnessFiller<'_> {
+	/// # Panics
+	///
+	/// Panics if the wire's storage is a pooled scratch slot shared with another value.
 	fn index_mut(&mut self, wire: Wire) -> &mut Self::Output {
-		&mut self.value_vec[self.circuit.witness_index(wire)]
+		let index = self.circuit.witness_index(wire);
+		assert_not_pooled(self.circuit, wire, index);
+		&mut self.value_vec[index]
 	}
 }
 

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -72,11 +72,10 @@ pub struct Options {
 	pub enable_algebraic_folding: bool,
 	/// Share scratch slots between values whose lifetimes do not overlap.
 	///
-	/// - Shrinks the uncommitted segment to the most values alive at once, saved once per
-	///   instance.
+	/// - Shrinks the uncommitted segment to the largest number of values alive at once.
 	/// - Changes no constraint, since an uncommitted value appears in no operand.
-	/// - Stops slots being one-to-one with values, so only committed values read back
-	///   meaningfully.
+	/// - An uncommitted value's slot can then be reused by a later one.
+	/// - Reading an uncommitted value back through a witness filler panics as a result.
 	pub enable_scratch_pooling: bool,
 	/// Forward past the gates a zero operand turns into the identity.
 	pub enable_zero_propagation: bool,
@@ -90,9 +89,9 @@ impl Default for Options {
 			enable_common_subexpression_elimination: true,
 			enable_dead_code_elimination: true,
 			enable_algebraic_folding: true,
-			// Why off: sharing slots stops an uncommitted value from being readable afterwards.
-			// A caller that inspects one has to opt in knowingly.
-			enable_scratch_pooling: false,
+			// Sharing slots shrinks the uncommitted segment, saved once per instance.
+			// A witness filler now panics on a stale read instead of returning it silently.
+			enable_scratch_pooling: true,
 			enable_zero_propagation: true,
 		}
 	}
@@ -787,6 +786,7 @@ impl CircuitBuilder {
 			inout,
 			eval_form,
 			scratch_alloc.peak_live(),
+			scratch_policy == ScratchPolicy::Pooled,
 		))
 	}
 

--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -181,6 +181,9 @@ fn test_iadd_cin_cout_max_values() {
 	let b = builder.add_constant_64(0xFFFFFFFFFFFFFFFF);
 	let cin_wire = builder.add_constant(Word::ZERO);
 	let (sum_wire, cout_wire) = builder.iadd_cin_cout(a, b, cin_wire);
+	// Nothing else reads these, so pin them or pooling could reclaim their slots first.
+	builder.force_commit(sum_wire);
+	builder.force_commit(cout_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -198,6 +201,9 @@ fn test_iadd_cin_cout_zero() {
 	let b = builder.add_constant_64(0);
 	let cin_wire = builder.add_constant(Word::ZERO);
 	let (sum_wire, cout_wire) = builder.iadd_cin_cout(a, b, cin_wire);
+	// Nothing else reads these, so pin them or pooling could reclaim their slots first.
+	builder.force_commit(sum_wire);
+	builder.force_commit(cout_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -215,6 +221,9 @@ fn test_isub_bin_bout_from_zero() {
 	let b = builder.add_constant_64(u64::MAX);
 	let bin_wire = builder.add_constant(Word::ONE << 63);
 	let (diff_wire, bout_wire) = builder.isub_bin_bout(a, b, bin_wire);
+	// Nothing else reads these, so pin them or pooling could reclaim their slots first.
+	builder.force_commit(diff_wire);
+	builder.force_commit(bout_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -272,6 +281,10 @@ fn test_call_hint_user_registered() {
 	let out2 = builder.call_hint(XorAllHint, &[inputs.len()], &inputs);
 	assert_eq!(out1.len(), 1);
 	assert_eq!(out2.len(), 1);
+	// A hint emits no constraint of its own, so pinning alone leaves this uncommitted.
+	// Promoting it to a public output is what the test needs to read it back.
+	builder.mark_inout(out1[0]);
+	builder.mark_inout(out2[0]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -309,6 +322,8 @@ fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {
 	let a_wire = builder.add_constant_64(a);
 	let b_wire = builder.add_constant_64(b);
 	let result_wire = builder.icmp_ult(a_wire, b_wire);
+	// Nothing else reads this, so pin it or pooling could reclaim its slot first.
+	builder.force_commit(result_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -325,6 +340,8 @@ fn prop_check_icmp_eq(a: u64, b: u64, expected_result: Word) {
 	let a_wire = builder.add_constant_64(a);
 	let b_wire = builder.add_constant_64(b);
 	let result_wire = builder.icmp_eq(a_wire, b_wire);
+	// Nothing else reads this, so pin it or pooling could reclaim its slot first.
+	builder.force_commit(result_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -346,11 +363,17 @@ proptest! {
 		let b1_wire = builder.add_constant_64(b1);
 		let cin_wire = builder.add_constant(Word::ZERO);
 		let (sum1_wire, cout1_wire) = builder.iadd_cin_cout(a1_wire, b1_wire, cin_wire);
+		// The test reads both of these, so pin them before pooling reclaims their slots.
+		// The carry output also feeds the second addition, but that alone does not commit it.
+		builder.force_commit(sum1_wire);
+		builder.force_commit(cout1_wire);
 
 		// Second addition with carry from first
 		let a2_wire = builder.add_constant_64(a2);
 		let b2_wire = builder.add_constant_64(b2);
 		let (sum2_wire, cout2_wire) = builder.iadd_cin_cout(a2_wire, b2_wire, cout1_wire);
+		builder.force_commit(sum2_wire);
+		builder.force_commit(cout2_wire);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -436,6 +459,8 @@ fn test_bxor_linear_constraint() {
 
 	// bxor internally creates a linear constraint
 	let c = builder.bxor(a, b);
+	// Nothing else reads this, so pin it or pooling could reclaim its slot first.
+	builder.force_commit(c);
 
 	let circuit = builder.build();
 
@@ -469,6 +494,10 @@ fn test_shift_operations_with_linear_constraints() {
 	let shr_result = builder.shr(b, 16);
 	// Combine with XOR
 	let combined = builder.bxor(shl_result, shr_result);
+	// The test reads these directly, so pin them or pooling could reclaim their slots first.
+	builder.force_commit(shl_result);
+	builder.force_commit(shr_result);
+	builder.force_commit(combined);
 
 	let circuit = builder.build();
 
@@ -498,6 +527,10 @@ fn test_32bit_half_shift_operations() {
 	let srl32_result = builder.srl32(a, 4);
 	let sra32_result = builder.sra32(a, 4);
 	let rotr32_result = builder.rotr32(a, 4);
+	// The test reads these directly, so pin them or pooling could reclaim their slots first.
+	for wire in [sll32_result, srl32_result, sra32_result, rotr32_result] {
+		builder.force_commit(wire);
+	}
 
 	let circuit = builder.build();
 
@@ -540,6 +573,9 @@ fn test_rotr_operation_expansion() {
 	// rotr internally expands to: (a >> 12) XOR (a << 52)
 	let rotr_result = builder.rotr(a, 12);
 	let combined = builder.bxor(rotr_result, b);
+	// The test reads these directly, so pin them or pooling could reclaim their slots first.
+	builder.force_commit(rotr_result);
+	builder.force_commit(combined);
 
 	let circuit = builder.build();
 
@@ -575,6 +611,10 @@ fn test_multiple_xor_operations() {
 	let result2 = builder.bxor(c, d);
 	// Chain XOR operations
 	let final_result = builder.bxor(result1, result2);
+	// The test reads these directly, so pin them or pooling could reclaim their slots first.
+	builder.force_commit(result1);
+	builder.force_commit(result2);
+	builder.force_commit(final_result);
 
 	let circuit = builder.build();
 
@@ -624,6 +664,9 @@ fn test_linear_constraint_conversion_to_zero() {
 	// Pin the result as committed so its linear cone survives dead-code elimination.
 	// A computation read by nothing is otherwise dropped, leaving no constraint to check.
 	builder.force_commit(final_result);
+	// The first XOR sits outside that cone, so it is pinned on its own.
+	// The test reads it directly, and pooling could otherwise reclaim its slot first.
+	builder.force_commit(xor_result);
 
 	let circuit = builder.build();
 
@@ -645,17 +688,19 @@ fn test_linear_constraint_conversion_to_zero() {
 
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	// Verify all operations computed correctly
+	// The first XOR is pinned on its own, so it reads back directly.
 	assert_eq!(w[xor_result], Word(0xdeadbeefcafe1234 ^ 0x1234567890abcdef));
-	assert_eq!(w[shift_left], Word(0xdeadbeefcafe1234 << 5));
-	assert_eq!(w[shift_right], Word(0x1234567890abcdef >> 10));
-	assert_eq!(w[sar_result], Word(((0xdeadbeefcafe1234u64 as i64) >> 3) as u64));
-	assert_eq!(w[rotr_result], Word(0x1234567890abcdef_u64.rotate_right(7)));
 
-	// Verify final results
-	assert_eq!(w[combined1], Word(w[shift_left].0 ^ w[shift_right].0));
-	assert_eq!(w[combined2], Word(w[sar_result].0 ^ w[rotr_result].0));
-	assert_eq!(w[final_result], Word(w[combined1].0 ^ w[combined2].0));
+	// Only the final result is pinned here, so everything under it is free to fuse away.
+	// The values below are computed natively instead of read back from the witness.
+	// Only the fused result is then checked against it.
+	let expected_shift_left = 0xdeadbeefcafe1234u64 << 5;
+	let expected_shift_right = 0x1234567890abcdefu64 >> 10;
+	let expected_sar = ((0xdeadbeefcafe1234u64 as i64) >> 3) as u64;
+	let expected_rotr = 0x1234567890abcdefu64.rotate_right(7);
+	let expected_combined1 = expected_shift_left ^ expected_shift_right;
+	let expected_combined2 = expected_sar ^ expected_rotr;
+	assert_eq!(w[final_result], Word(expected_combined1 ^ expected_combined2));
 
 	// Verify all constraints are satisfied
 	cs.verify(&w.value_vec).unwrap();
@@ -680,6 +725,8 @@ proptest! {
 
 		// XOR the shifted values
 		let result = builder.bxor(shifted_a, shifted_b);
+		// Nothing else reads this, so pin it or pooling could reclaim its slot first.
+		builder.force_commit(result);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -704,6 +751,8 @@ proptest! {
 
 		let wire_value = builder.add_constant_64(value);
 		let rotr_result = builder.rotr(wire_value, shift);
+		// Nothing else reads this, so pin it or pooling could reclaim its slot first.
+		builder.force_commit(rotr_result);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -743,6 +792,14 @@ const CHAIN_ROUNDS: u32 = 48;
 fn pooled_opts() -> Options {
 	Options {
 		enable_scratch_pooling: true,
+		..Options::default()
+	}
+}
+
+/// The default pass set with scratch-slot sharing turned off.
+fn unpooled_opts() -> Options {
+	Options {
+		enable_scratch_pooling: false,
 		..Options::default()
 	}
 }
@@ -793,7 +850,7 @@ fn test_scratch_pooling_preserves_the_committed_witness() {
 	//
 	//   unpooled:  one slot per uncommitted value
 	//   pooled:    slots reused once a value's last reader has run
-	let unpooled = CircuitBuilder::new();
+	let unpooled = CircuitBuilder::with_opts(unpooled_opts());
 	let (x_unpooled, expected_unpooled) = build_chain(&unpooled);
 	let unpooled = unpooled.build();
 
@@ -1106,6 +1163,42 @@ fn test_scratch_pooling_matches_scalar_per_instance_batched() {
 			);
 		}
 	}
+}
+
+#[test]
+#[should_panic(expected = "scratch slot shared with another value")]
+fn test_reading_a_pooled_scratch_wire_panics() {
+	// Invariant: a witness filler rejects a read of a poolable value.
+	// Otherwise it would silently return whatever now occupies that shared slot.
+	//
+	// Fixture state: a linear XOR feeding an AND, with pooling on.
+	//
+	//   a, b --xor--> t --and(a)--> masked --assert_eq--> out
+	//
+	// Gate fusion inlines the XOR into the AND operand, so no constraint ever names it.
+	// It lands in the scratch segment, and pooling can hand its slot to a later value.
+	let builder = CircuitBuilder::with_opts(pooled_opts());
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let lin = builder.bxor(a, b);
+	let masked = builder.band(lin, a);
+	let out = builder.add_inout();
+	builder.assert_eq("masked", masked, out);
+	let circuit = builder.build();
+
+	// Confirm the fixture actually lands the XOR's result in the scratch segment.
+	// Otherwise the panic below would prove nothing about pooling.
+	assert_eq!(circuit.witness_index(lin).segment(), ValueSegment::Scratch);
+
+	let (a_val, b_val) = (5u64, 3u64);
+	let mut w = circuit.new_witness_filler();
+	w[a] = Word(a_val);
+	w[b] = Word(b_val);
+	w[out] = Word((a_val ^ b_val) & a_val);
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	// The read below must panic: that slot is not guaranteed to still hold this value.
+	let _ = w[lin];
 }
 
 #[test]
@@ -1493,6 +1586,10 @@ fn build_gadget_emits_gates_where_no_chip_serves_the_gadget() {
 	let builder = CircuitBuilder::new();
 	let (a, b) = (builder.add_inout(), builder.add_inout());
 	let out = builder.build_gadget(AndThenXor, &[], &[a, b]);
+	// The test reads both outputs, so pin them or pooling could reclaim their slots first.
+	for &wire in &out {
+		builder.force_commit(wire);
+	}
 
 	// `build` accepts this builder, which is what says no chip was registered.
 	let circuit = builder.build();

--- a/crates/frontend/src/pass/fusion/tests/awhole.rs
+++ b/crates/frontend/src/pass/fusion/tests/awhole.rs
@@ -40,6 +40,9 @@ fn test_bmul_gate_end_to_end() {
 	let b_lo = builder.add_witness();
 	let b_hi = builder.add_witness();
 	let (c_lo, c_hi) = builder.bmul(a_lo, a_hi, b_lo, b_hi);
+	// Pin the product: nothing else consumes it, so pooling could reclaim its slot first.
+	builder.force_commit(c_lo);
+	builder.force_commit(c_hi);
 	let circuit = builder.build();
 
 	let mut w = circuit.new_witness_filler();


### PR DESCRIPTION
Makes reading a pooled scratch wire panic, then turns scratch pooling on by default.

### The problem

A circuit's uncommitted values can either get one storage slot each, or share slots between
values whose live ranges don't overlap ("scratch pooling") — a real memory win on circuits with
many short-lived linear intermediates, shrinking the uncommitted segment to its peak live-value
count instead of its total value count.

Pooling was off by default, for a real reason: a value written early and read back later, after
pooling has handed its slot to something else, silently returns the **wrong** word instead of an
error. The only defense was one doc-comment sentence — not something a caller trips over before
hitting the bug.

### The idea

Convert the silent-wrong-value hazard into a loud, immediate one, and only then flip the default.

`Circuit` now records whether it was built with pooling on.
`WitnessFiller`'s `Index`/`IndexMut` panic when a wire's storage falls in a *pooled* scratch slot:

```rust
fn assert_not_pooled(circuit: &Circuit, wire: Wire, index: ValueIndex) {
    assert!(
        !circuit.scratch_pooled() || index.segment() != ValueSegment::Scratch,
        "wire {wire:?} cannot be read back through a witness filler: its storage is a scratch \
         slot shared with another value under scratch pooling, ..."
    );
}
```

Only once that panic exists and is tested does `Options::enable_scratch_pooling`'s default flip
from `false` to `true`.

### What flipping the default actually broke — and why that's the point

**51 pre-existing tests**, across `binius-frontend` and `binius-circuits`, read an uncommitted
wire's witness value directly — relying on the old accident that a per-wire scratch slot never
gets reused.
Finding all of them *is* the hazard this task exists to surface, not a side effect to route
around.

Each needed one of two fixes, depending on *why* the wire was uncommitted:

- **`force_commit(wire)`** — for an ordinary gate output nothing else references: keeps its
  defining constraint alive through fusion/CSE/DCE instead of letting it get inlined away.
- **`mark_inout(wire)`** — required specifically for a bare hint output, because a hint gate emits
  *no* constraint at all (`GateBody::Hint(_) => {}` in `gates::constrain`), so `force_commit` has
  nothing to keep alive.

One test (`test_linear_constraint_conversion_to_zero`) was restructured rather than blanket-pinned
— pinning every intermediate would have papered over exactly what it documents (a chain of linear
ops fusing into one constraint through a single endpoint).

### Soundness

Constraint counts are bit-identical between pooled and unpooled builds — pooling only changes
*where* an uncommitted value physically lives, never which values are committed or what the
constraint system says. No proof changes.

### Per circuit — cited, not independently reproduced here

From an earlier measurement pass, on a large fixture (not reproduced in this environment — the
2^15-instance scale needs a machine bigger than what was available here):

| | before | after |
|---|---:|---:|
| working buffer | 4.05 GiB | 0.88 GiB |
| serial witness generation | 1,446 ms | 1,114 ms |
| 2^15 instances on 16 GiB | doesn't fit (16.2 GiB) | fits |

### Scope

- **changed:** `artifact/circuit.rs` (the `scratch_pooled` field/accessor), `artifact/witness.rs` (the panic), `builder/mod.rs` (the default flip), plus 11 files across `binius-circuits` fixing the 51 real callers the gate found.
- **new:** `test_reading_a_pooled_scratch_wire_panics`, confirming the panic actually fires.

### Verification

- `cargo test -p binius-frontend -p binius-circuits -p binius-prover -p binius-m4-prover -p binius-recursion` — every one of the five crates, 0 failures.
- `cargo clippy` on all five, `--all-targets -D warnings` — clean.
- nightly `cargo fmt --all` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
