### PR TITLE
Compress sha256_fixed's trailing block in the paired core

### DIFF
--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -144,11 +144,19 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		block_idx += 2;
 	}
 	if block_idx < n_blocks {
-		state = sha256_compress(
-			&builder.subcircuit(format!("sha256_fixed_compress[{block_idx}]")),
-			state,
-			blocks[block_idx],
-		);
+		let sub = builder.subcircuit(format!("sha256_fixed_compress[{block_idx}]"));
+		state = if block_idx > 0 {
+			// The trailing odd block has no partner, but it still runs through the paired core
+			// with the second lane dead, so a registered chip serves it instead of leaving one
+			// compression behind in main. The dead lane chews on the leftover high halves and
+			// its output lands in the high halves, which the digest clearing below discards.
+			// In gates the two cores emit the same circuit, so nothing changes without a chip.
+			sha256_compress_2x(&sub, state, blocks[block_idx])
+		} else {
+			// A single-block message keeps the single-lane core: its empty high halves are what
+			// lets the digest skip the clearing below.
+			sha256_compress(&sub, state, blocks[block_idx])
+		};
 	}
 
 	// The escaping digest is the one place a clean high half is required.
@@ -621,9 +629,9 @@ mod tests {
 	}
 
 	// The layers between `sha256_fixed` and `sha256_compress_2x` are untouched by the chip: block
-	// pairs land as calls because the builder holds the chip, not because anything in between was
-	// told. Lengths cover one pair, a pair plus a trailing single-lane block, two pairs, and two
-	// pairs plus a trailing single.
+	// pairs, and the trailing odd block riding the paired core with a dead lane, land as calls
+	// because the builder holds the chip, not because anything in between was told. Lengths cover
+	// one pair, a pair plus a trailing block, two pairs, and two pairs plus a trailing block.
 	#[test]
 	fn a_registered_chip_serves_every_paired_compression() {
 		for &len in &[64usize, 128, 192, 300] {

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -13,13 +13,13 @@ Constraints
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,021
+└─ Distinct value indices: 20,957
    ├─ Distinct shifted value indices: 12,629
-   └─ Distinct unshifted value indices: 8,392
+   └─ Distinct unshifted value indices: 8,328
 
 Value Vector
-├─ Public Section: 404 (not committed)
-│  ├─ Constants: 140
+├─ Public Section: 340 (not committed)
+│  ├─ Constants: 76
 │  └─ Inout: 264
 ├─ Private Section: 8,254
 │  ├─ Witness: 0


### PR DESCRIPTION
## What

The numbers in #2180 carry a residue: an odd block count leaves the one trailing compression in main as a single-lane call, 679 AND constraints that a registered chip cannot serve.

The single-lane and paired cores emit the same circuit (both are `compress_inner`), differing only in whether the round constants occupy one lane or both. So the trailing block can run through the paired core with the second lane dead: the dead lane chews on the state's leftover high halves and its output lands in the high halves, which the digest clearing at the end of `sha256_fixed` already discards.

In gates the two cores emit the same constraints, and the trailing block stops minting its own single-lane round constants, sharing the replicated ones the pairs already hold. The sha256 example's snapshot moves only in its constants line (140 -> 76, in the uncommitted public section); the other twelve snapshots pass untouched, with AND, ZERO and committed counts unchanged everywhere.

With a chip registered the trailing compression becomes one more instance and main keeps no compression at all.

## Numbers

Chip registered, `sha256_fixed`, odd block counts:

| message | main AND | main committed | chip instances |
|---|---|---|---|
| 300 B | 715 -> 0 | 1,118 -> 167 | 2 -> 3 |
| 1 KiB | 679 -> 0 | 1,451 -> 540 | 8 -> 9 |
| 4 KiB | 679 -> 0 | 2,987 -> 2,076 | 32 -> 33 |
| 16 KiB | 679 -> 0 | 9,131 -> 8,220 | 128 -> 129 |

## Correctness

Single-block messages keep the single-lane core: their empty high halves are what lets the digest skip the clearing, and a registered chip stays uncalled there, as the existing test pins. The sha256 suite passes unchanged (the fixed tests compare against the sha2 reference across odd and even block counts) and the chip test's odd lengths now exercise the trailing call. `clippy --all-targets -- -D warnings` and `fmt --check` are clean.

## Scope

`sha256_fixed` only. `sha256_varlen` keeps its single-lane trailing compression, since its digest multiplexer reads every intermediate state and routing would spend eight clears in the gates path. `blake3_compress` is the analogous single-lane call #2141 left inline; it is untouched here.