### PR TITLE
Defer the wiring evaluation out of the shift check

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -542,6 +542,10 @@ where
 		self.channel.send_many(elems);
 	}
 
+	fn send_public_claim(&mut self, elem: F) {
+		self.channel.send_public_claim(elem);
+	}
+
 	fn observe_one(&mut self, val: F) {
 		self.channel.observe_one(val);
 	}

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -3,7 +3,7 @@
 //! BaseFold ZK implementation of the IOP verifier channel.
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, util::FieldFn};
+use binius_field::BinaryField;
 use binius_ip::{
 	channel::{IPVerifierChannel, WordIPVerifierChannel},
 	sumcheck::{self, BatchSumcheckOutput},
@@ -351,10 +351,6 @@ where
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		self.channel.assert_zero(val)
-	}
-
-	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem {
-		self.channel.compute_public_value(inputs, f)
 	}
 }
 

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -333,6 +333,10 @@ where
 		self.channel.recv_array()
 	}
 
+	fn recv_public_claim(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+		self.channel.recv_public_claim()
+	}
+
 	fn sample(&mut self) -> Self::Elem {
 		self.channel.sample()
 	}

--- a/crates/iop/src/channel/naive.rs
+++ b/crates/iop/src/channel/naive.rs
@@ -2,7 +2,7 @@
 
 //! Naive [`IOPVerifierChannel`] for testing: reads full polynomials instead of verifying FRI.
 
-use binius_field::{Field, util::FieldFn};
+use binius_field::Field;
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::{FieldBuffer, inner_product::inner_product_buffers};
 use binius_transcript::{
@@ -128,10 +128,6 @@ where
 		} else {
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
-	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
-		f.call_native(inputs)
 	}
 }
 

--- a/crates/iop/src/channel/oracle_setup.rs
+++ b/crates/iop/src/channel/oracle_setup.rs
@@ -12,7 +12,6 @@ use binius_core::word::Word;
 use binius_field::{
 	BinaryField, ExtensionField, Field, FieldOps,
 	arithmetic_traits::{InvertOrZero, Square},
-	util::FieldFn,
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 
@@ -190,16 +189,6 @@ impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
 
 	fn assert_zero(&mut self, _val: DummyElem<F>) -> Result<(), binius_ip::channel::Error> {
 		Ok(())
-	}
-
-	fn compute_public_value(
-		&mut self,
-		_inputs: &[DummyElem<F>],
-		_f: impl FieldFn<F>,
-	) -> DummyElem<F> {
-		// The setup channel performs no real computation; skipping `f` is permitted (see the
-		// `IPVerifierChannel::compute_public_value` contract).
-		DummyElem(PhantomData)
 	}
 }
 

--- a/crates/iop/src/channel/size_tracking.rs
+++ b/crates/iop/src/channel/size_tracking.rs
@@ -5,7 +5,7 @@
 use std::{marker::PhantomData, mem::size_of};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, util::FieldFn};
+use binius_field::BinaryField;
 use binius_ip::channel::{
 	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
 };
@@ -99,10 +99,6 @@ where
 
 	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::Error> {
 		Ok(())
-	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
-		f.call_native(inputs)
 	}
 }
 

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -15,7 +15,7 @@
 use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, util::FieldFn};
+use binius_field::{BinaryField, Field};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
@@ -141,10 +141,6 @@ where
 
 	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::Error> {
 		self.transcript.borrow_mut().assert_zero(val)
-	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
-		self.transcript.borrow_mut().compute_public_value(inputs, f)
 	}
 }
 

--- a/crates/ip-prover/src/channel.rs
+++ b/crates/ip-prover/src/channel.rs
@@ -43,6 +43,17 @@ pub trait IPProverChannel<F: Field> {
 		}
 	}
 
+	/// Sends a value the verifier could compute for itself, as advice.
+	///
+	/// The verifier's counterpart is
+	/// [`recv_public_claim`](binius_ip::channel::IPVerifierChannel::recv_public_claim), which
+	/// documents what a claim is. A claim depends on public-channel-derived values alone, so a
+	/// channel that masks the prover's messages sends this one in the clear. The default is the
+	/// plain send, for a channel that draws no such distinction.
+	fn send_public_claim(&mut self, elem: F) {
+		self.send_one(elem);
+	}
+
 	/// Observes a single field element, feeding it into the Fiat-Shamir state.
 	fn observe_one(&mut self, val: F);
 

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -57,6 +57,23 @@ pub trait IPVerifierChannel<F: Field> {
 		array_util::try_from_fn(|_| self.recv_one())
 	}
 
+	/// Receives a value the verifier could compute for itself, taken as advice.
+	///
+	/// The prover states it and the verifier checks it — by recomputing it, or by any argument
+	/// that establishes the same thing — which is worth doing when the check is cheaper than the
+	/// computation, or when several such claims are better checked at once.
+	///
+	/// The caller MUST check what it receives here. Nothing else does.
+	///
+	/// A claim is a function of public-channel-derived values alone, so it carries nothing about
+	/// the witness. Channels that mask the prover's messages must therefore leave this one in the
+	/// clear, and channels that carry elements as wires allocate it as a public wire rather than a
+	/// masked private one. The default is the plain read, for a channel that draws no such
+	/// distinction.
+	fn recv_public_claim(&mut self) -> Result<Self::Elem, Error> {
+		self.recv_one()
+	}
+
 	/// Samples a random challenge.
 	///
 	/// In a Fiat-Shamir transcript, this derives the challenge deterministically from

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -22,9 +22,7 @@
 use std::{iter::repeat_with, ops::Shr};
 
 use binius_core::word::Word;
-use binius_field::{
-	BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps, util::FieldFn,
-};
+use binius_field::{BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps};
 use binius_transcript::{
 	VerifierTranscript,
 	fiat_shamir::{CanSample, CanSampleBits, Challenger},
@@ -106,31 +104,6 @@ pub trait IPVerifierChannel<F: Field> {
 	///
 	/// Returns [`Error::InvalidAssert`] if the value is not zero.
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), Error>;
-
-	/// Computes a value that is a function of public-channel-derived elements and returns it
-	/// as a freshly allocated `Elem`.
-	///
-	/// In wrapper channels that build constraints (e.g. `IronSpartanBuilderChannel`), the result
-	/// is materialized as a single derived public wire (a one-output `hint_varsize`) holding the
-	/// function's return value, replacing what would otherwise be a sub-circuit's worth of
-	/// constraints. In non-wrapper channels where `Elem = F`, the impl is just `f.call(inputs)`.
-	///
-	/// The caller MUST ensure each entry in `inputs` is either a `Constant` or a `Wire` whose
-	/// public-tag is true — i.e. produced by `sample_*` / `observe_*` / `compute_public_value`
-	/// on this channel, or derived purely from such values via the channel's `Elem` arithmetic.
-	/// Inputs from `recv_*` (or anything that mixed in a non-public value) MUST NOT be passed.
-	/// The contract is documented; wrapper impls debug-assert it but it is not statically enforced.
-	///
-	/// The function may or may not be invoked: the symbolic-builder channel skips it, and other
-	/// impls run it on either real or dummy values. Callers must therefore supply a pure function
-	/// with no observable side effects.
-	///
-	/// A [`FieldFn`] is taken rather than a closure to keep the run field generic.
-	/// The same function then evaluates natively or over a circuit-element field.
-	///
-	/// HACK: This is a temporary hack to fix a performance regression. This feature should be
-	/// killed and handled more elegantly with better witness generation code.
-	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem;
 }
 
 /// A verifier channel whose protocol carries 64-bit words alongside field elements.
@@ -308,10 +281,6 @@ where
 		} else {
 			Err(Error::InvalidAssert)
 		}
-	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
-		f.call_native(inputs)
 	}
 }
 

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -329,13 +329,17 @@ impl IOPProver {
 		// The segment selector `r_segment` is the last coordinate, choosing public or hidden
 		// words. The hidden-only trace drops it.
 		// The word index `r_y` is everything in between.
-		let challenges = &witness_claim.challenges;
+		let challenges = &witness_claim.sumcheck.challenges;
 		let r_j = &challenges[..Word::LOG_BITS];
 		let r_y = &challenges[Word::LOG_BITS..challenges.len() - 1];
 
 		// Prove the public segment's evaluation claim, which the verifier's public-input check
 		// consumes.
 		ring_switch::prove_public_eval::<_, P, _>(alloc, &public_words, r_j, r_y, channel);
+
+		// The wiring evaluation the verifier closes the shift check with, sent where it reads it:
+		// after the public segment's claim.
+		channel.send_one(witness_claim.wiring_eval);
 
 		let RingSwitchOutput {
 			rs_eq_ind,

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -339,7 +339,7 @@ impl IOPProver {
 
 		// The wiring evaluation the verifier closes the shift check with, sent where it reads it:
 		// after the public segment's claim.
-		channel.send_one(witness_claim.wiring_eval);
+		channel.send_public_claim(witness_claim.wiring_eval);
 
 		let RingSwitchOutput {
 			rs_eq_ind,

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -239,7 +239,6 @@ mod tests {
 		word::Word,
 	};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
-	use binius_ip::channel::IPVerifierChannel;
 	use binius_math::{
 		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
 		test_utils::random_scalars,
@@ -253,8 +252,8 @@ mod tests {
 	use binius_verifier::{
 		config::{B128, StdChallenger},
 		protocols::shift::{
-			LOG_SHIFT_COUNT, OperatorData as VerifierOperatorData, SHIFT_COUNT, WiringEvalClaim,
-			check_eval, evaluate_words_mle, verify,
+			LOG_SHIFT_COUNT, OperatorData as VerifierOperatorData, SHIFT_COUNT, check_eval,
+			evaluate_words_mle, verify,
 		},
 	};
 	use rand::prelude::*;
@@ -427,11 +426,7 @@ mod tests {
 			verifier_output.r_y(),
 		);
 
-		let WiringEvalClaim {
-			eval_fn,
-			inputs,
-			claimed,
-		} = check_eval(
+		let wiring_claim = check_eval(
 			&cs,
 			InoutSegment::Hidden,
 			public_eval,
@@ -446,11 +441,8 @@ mod tests {
 		)
 		.unwrap();
 
-		// Discharge the wiring claim the way the full reduction does.
-		let wiring_eval = verifier_transcript.compute_public_value(&inputs, eval_fn);
-		verifier_transcript
-			.assert_zero(wiring_eval - claimed)
-			.unwrap();
+		// Discharge the wiring claim the way the full reduction's caller does.
+		wiring_claim.check_native().unwrap();
 		verifier_transcript.finalize().unwrap();
 
 		// The witness evaluation equals the instance-folded witness evaluated at the point, with

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -400,7 +400,7 @@ mod tests {
 
 		// The full reduction sends this after the public segment's evaluation claim; driving the
 		// shift alone, it follows the reduction directly.
-		prover_transcript.send_one(prover_output.wiring_eval);
+		prover_transcript.send_public_claim(prover_output.wiring_eval);
 
 		// Verify against the single-instance shift verifier.
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -7,7 +7,6 @@ use std::iter;
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
-use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
@@ -16,7 +15,7 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftIndOutput,
-		ShiftIndSumcheck,
+		ShiftIndSumcheck, ShiftOutput,
 		monster::build_monster_segments,
 		phase_1::{Phase1Output, SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
@@ -51,7 +50,8 @@ use crate::witness::{FoldedWitness, FoldedWord};
 /// - `alloc`: the allocator backing the reduction's intermediate buffers.
 ///
 /// # Returns
-/// The `SumcheckOutput` with the final challenges and the reduced witness evaluation.
+/// The final challenges with the reduced witness evaluation, and the wiring multilinear's
+/// evaluation for the caller to send.
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	public_words: &[Word],
@@ -60,7 +60,7 @@ pub fn prove<F, P, Channel, A>(
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F>
+) -> ShiftOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -150,6 +150,7 @@ where
 		hidden_folded,
 		&public_monster,
 		hidden_monster,
+		shift_ind_eval,
 		public_words,
 		r_j,
 		epsilon,
@@ -238,6 +239,7 @@ mod tests {
 		word::Word,
 	};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
+	use binius_ip::channel::IPVerifierChannel;
 	use binius_math::{
 		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
 		test_utils::random_scalars,
@@ -251,8 +253,8 @@ mod tests {
 	use binius_verifier::{
 		config::{B128, StdChallenger},
 		protocols::shift::{
-			LOG_SHIFT_COUNT, OperatorData as VerifierOperatorData, SHIFT_COUNT, check_eval,
-			evaluate_words_mle, verify,
+			LOG_SHIFT_COUNT, OperatorData as VerifierOperatorData, SHIFT_COUNT, WiringEvalClaim,
+			check_eval, evaluate_words_mle, verify,
 		},
 	};
 	use rand::prelude::*;
@@ -396,6 +398,10 @@ mod tests {
 			&GlobalAllocator,
 		);
 
+		// The full reduction sends this after the public segment's evaluation claim; driving the
+		// shift alone, it follows the reduction directly.
+		prover_transcript.send_one(prover_output.wiring_eval);
+
 		// Verify against the single-instance shift verifier.
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let verifier_zero = VerifierOperatorData::new(r_x_zero, [B128::ZERO]);
@@ -421,7 +427,11 @@ mod tests {
 			verifier_output.r_y(),
 		);
 
-		check_eval(
+		let WiringEvalClaim {
+			eval_fn,
+			inputs,
+			claimed,
+		} = check_eval(
 			&cs,
 			InoutSegment::Hidden,
 			public_eval,
@@ -435,6 +445,12 @@ mod tests {
 			&mut verifier_transcript,
 		)
 		.unwrap();
+
+		// Discharge the wiring claim the way the full reduction does.
+		let wiring_eval = verifier_transcript.compute_public_value(&inputs, eval_fn);
+		verifier_transcript
+			.assert_zero(wiring_eval - claimed)
+			.unwrap();
 		verifier_transcript.finalize().unwrap();
 
 		// The witness evaluation equals the instance-folded witness evaluated at the point, with
@@ -454,8 +470,8 @@ mod tests {
 			std::slice::from_ref(&verifier_output.r_segment),
 		]
 		.concat();
-		assert_eq!(prover_output.challenges, eval_point);
-		assert_eq!(prover_output.eval, verifier_output.witness_eval);
+		assert_eq!(prover_output.sumcheck.challenges, eval_point);
+		assert_eq!(prover_output.sumcheck.eval, verifier_output.witness_eval);
 	}
 
 	// The phase-1 identity: summing the g·h inner products over the shift variants reconstructs the

--- a/crates/m4-verifier/src/composite.rs
+++ b/crates/m4-verifier/src/composite.rs
@@ -18,7 +18,7 @@ use binius_iop::{
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
-use binius_verifier::{Error, SECURITY_BITS, config::B128};
+use binius_verifier::{Error, SECURITY_BITS, config::B128, protocols::shift::WiringEvalClaim};
 use digest::Output;
 
 use crate::{
@@ -121,6 +121,9 @@ impl IOPVerifierM4 {
 	/// [`WordIPVerifierChannel::observe_words`] returns. The chips have no statement: their inout
 	/// values are committed.
 	///
+	/// Each sub-proof leaves a wiring claim against its own constraint system. They come back in
+	/// sub-proof order, main chip first, for the caller to discharge.
+	///
 	/// # Errors
 	///
 	/// Returns an error if any sub-proof fails.
@@ -128,18 +131,16 @@ impl IOPVerifierM4 {
 		&self,
 		inout: &[Channel::Word],
 		channel: &mut Channel,
-	) -> Result<(), Error>
+	) -> Result<Vec<WiringEvalClaim<'_, Channel::Elem>>, Error>
 	where
 		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 	{
-		// Each sub-proof leaves a wiring claim against its own constraint system, discharged here
-		// as the sub-proof it belongs to finishes.
-		self.main.verify(inout, channel)?.check(channel)?;
+		let mut claims = vec![self.main.verify(inout, channel)?];
 		for chip in &self.chips {
-			chip.verify_chip(channel)?.check(channel)?;
+			claims.push(chip.verify_chip(channel)?);
 		}
-		Ok(())
+		Ok(claims)
 	}
 }
 
@@ -242,7 +243,9 @@ where
 			.iop_compiler
 			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		let inout = channel.observe_words(inout);
-		self.iop_verifier.verify(&inout, &mut channel)?;
+		for claim in self.iop_verifier.verify(&inout, &mut channel)? {
+			claim.check_native()?;
+		}
 		channel.finish()?;
 
 		Ok(())

--- a/crates/m4-verifier/src/composite.rs
+++ b/crates/m4-verifier/src/composite.rs
@@ -133,9 +133,11 @@ impl IOPVerifierM4 {
 		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 	{
-		self.main.verify(inout, channel)?;
+		// Each sub-proof leaves a wiring claim against its own constraint system, discharged here
+		// as the sub-proof it belongs to finishes.
+		self.main.verify(inout, channel)?.check(channel)?;
 		for chip in &self.chips {
-			chip.verify_chip(channel)?;
+			chip.verify_chip(channel)?.check(channel)?;
 		}
 		Ok(())
 	}

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -18,6 +18,7 @@ use binius_utils::DeserializeBytes;
 use binius_verifier::{
 	Error, SECURITY_BITS,
 	config::{B1, B128},
+	protocols::shift::WiringEvalClaim,
 	reduction::{Instances, reduce_constraints},
 	ring_switch::{self, RingSwitchVerifyOutput},
 };
@@ -89,7 +90,9 @@ impl IOPVerifier {
 		// `assert_zero` is a no-op — so `verify` cannot fail here; it only records the
 		// `recv_oracle` calls read back below. An error would mean that invariant broke, so
 		// surface it rather than swallowing it.
-		self.verify_chip(&mut channel)
+		// The wiring claim is dropped: discharging one records no oracle.
+		let _ = self
+			.verify_chip(&mut channel)
 			.expect("verifying against the no-op OracleSetupChannel cannot fail");
 		channel.into_oracle_specs()
 	}
@@ -105,10 +108,16 @@ impl IOPVerifier {
 	/// The ring-switch therefore opens the trace at `r_j || r_rho || r_y`.
 	/// That evaluation equals the folded-witness claim the reduction produced.
 	///
+	/// The reduction's wiring evaluation comes back as a [`WiringEvalClaim`] rather than being
+	/// checked here, so the caller chooses how the constraint system is read.
+	///
 	/// # Errors
 	///
 	/// Returns an error if the reduction, the ring-switch, or the trace opening fails.
-	pub fn verify_chip<Channel>(&self, channel: &mut Channel) -> Result<(), Error>
+	pub fn verify_chip<Channel>(
+		&self,
+		channel: &mut Channel,
+	) -> Result<WiringEvalClaim<'_, Channel::Elem>, Error>
 	where
 		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
@@ -141,7 +150,7 @@ impl IOPVerifier {
 		let RingSwitchVerifyOutput {
 			eq_r_double_prime,
 			sumcheck_claim,
-		} = ring_switch::verify(reduction.shift.witness_eval, &trace_point, channel)?;
+		} = ring_switch::verify(reduction.shift.witness_eval.clone(), &trace_point, channel)?;
 
 		// Open the trace oracle against the ring-switch's transparent multilinear.
 		// BaseFold reduces to a challenge point where the transparent evaluates as below.
@@ -155,7 +164,7 @@ impl IOPVerifier {
 			sumcheck_claim,
 		)?;
 
-		Ok(())
+		Ok(reduction.wiring)
 	}
 }
 
@@ -268,7 +277,9 @@ where
 		let mut channel = self
 			.iop_compiler
 			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
-		self.iop_verifier.verify_chip(&mut channel)?;
+		self.iop_verifier
+			.verify_chip(&mut channel)?
+			.check(&mut channel)?;
 		channel.finish()?;
 
 		Ok(())

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -279,7 +279,7 @@ where
 			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		self.iop_verifier
 			.verify_chip(&mut channel)?
-			.check(&mut channel)?;
+			.check_native()?;
 		channel.finish()?;
 
 		Ok(())

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -410,6 +410,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 					hidden_folded,
 					&public_monster,
 					hidden_monster,
+					shift_ind_eval,
 					public_words,
 					r_j,
 					gamma,

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -37,5 +37,6 @@ pub use claims::{OperatorClaims, PreparedOperatorClaims};
 pub use key_collection::{
 	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
 };
+pub use phase_2::ShiftOutput;
 pub use prove::{OperatorData, PreparedOperatorData, prove};
 pub use shift_ind::{ShiftIndOutput, ShiftIndSumcheck};

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -57,8 +57,8 @@ use crate::fold_word::fold_words;
 /// - `channel`: The prover's channel
 ///
 /// # Returns
-/// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and the witness
-/// evaluation, or an error if the protocol fails.
+/// Returns the combined challenges `[r_j, r_y]` with the witness evaluation, and the wiring
+/// multilinear's evaluation.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "prove_phase_2")]
 pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
@@ -70,7 +70,7 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
 	epsilon: F,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F>
+) -> ShiftOutput<F>
 where
 	F: BinaryField,
 	Channel: IPProverChannel<F>,
@@ -117,6 +117,7 @@ where
 		hidden_folded,
 		&public_monster,
 		hidden_monster,
+		shift_ind_eval,
 		words.public,
 		r_j,
 		epsilon,
@@ -250,9 +251,12 @@ fn fold_segments<F: Field, P: PackedField<Scalar = F>, Data: DerefMut<Target = [
 /// evaluating the public segment (cheap, like the verifier does), subtracting its padded
 /// contribution off and scaling.
 ///
+/// It also divides the three bit-index factors `shift_ind_eval` scales the monster by back out of
+/// the monster's evaluation, leaving the wiring evaluation the verifier's claim is about.
+///
 /// # Returns
-/// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and the witness
-/// evaluation.
+/// Returns the sumcheck's concatenated challenges `[r_j, r_y]` with the witness evaluation, and
+/// the wiring evaluation for the caller to send.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "run_sumcheck")]
 pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>, A: Allocator>(
@@ -260,12 +264,13 @@ pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>, 
 	hidden_folded: FieldVec<P, A>,
 	public_monster: &FieldVec<P, A>,
 	hidden_monster: FieldVec<P, A>,
+	shift_ind_eval: F,
 	public_words: &[Word],
 	r_j: Vec<F>,
 	gamma: F,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F>
+) -> ShiftOutput<F>
 where
 	F: BinaryField,
 {
@@ -298,9 +303,14 @@ where
 	// Reverse the challenges to get the evaluation point.
 	r_y.reverse();
 
-	let [trace_eval, _monster_eval] = multilinear_evals
+	let [trace_eval, monster_eval] = multilinear_evals
 		.try_into()
 		.expect("prover has 2 multilinear polynomials");
+
+	// Every monster entry carries the three bit-index factors, so dividing them out of its
+	// evaluation leaves the bare wiring evaluation. Like the witness evaluation below, this makes
+	// the protocol incomplete with negligible probability, when the scale is zero.
+	let wiring_eval = monster_eval * shift_ind_eval.invert_or_zero();
 
 	// Derive the witness evaluation from the combined evaluation by evaluating the public
 	// segment (cheap, like the verifier does), subtracting its padded contribution off and
@@ -317,8 +327,23 @@ where
 		(trace_eval - (F::ONE - r_segment) * padded_public_eval) * r_segment.invert_or_zero();
 	channel.send_one(witness_eval);
 
-	SumcheckOutput {
-		challenges: [r_j, r_y].concat(),
-		eval: witness_eval,
+	ShiftOutput {
+		sumcheck: SumcheckOutput {
+			challenges: [r_j, r_y].concat(),
+			eval: witness_eval,
+		},
+		wiring_eval,
 	}
+}
+
+/// What the shift reduction leaves for its caller.
+///
+/// The wiring evaluation is not sent here: the verifier reads it after the public segment's
+/// evaluation claim, which the caller proves, so the caller sends it at that point.
+#[derive(Debug)]
+pub struct ShiftOutput<F> {
+	/// The sumcheck's challenges `[r_j, r_y]` and the witness evaluation.
+	pub sumcheck: SumcheckOutput<F>,
+	/// The wiring multilinear's evaluation at the reduced point.
+	pub wiring_eval: F,
 }

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -4,7 +4,6 @@
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, util::powers};
-use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product,
@@ -12,8 +11,12 @@ use binius_math::{
 };
 
 use super::{
-	SegmentWords, claims::OperatorClaims, key_collection::KeyCollection, phase_1::prove_phase_1,
-	phase_2::prove_phase_2, shift_ind::ShiftIndSumcheck,
+	SegmentWords,
+	claims::OperatorClaims,
+	key_collection::KeyCollection,
+	phase_1::prove_phase_1,
+	phase_2::{ShiftOutput, prove_phase_2},
+	shift_ind::ShiftIndSumcheck,
 };
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
@@ -146,7 +149,8 @@ impl<F: Field> PreparedOperatorData<F> {
 /// - `alloc`: the allocator backing the reduction's intermediate buffers.
 ///
 /// # Returns
-/// The `SumcheckOutput` with the final challenges and the witness evaluation.
+/// The final challenges with the witness evaluation, and the wiring multilinear's evaluation for
+/// the caller to send.
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	public_words: &[Word],
@@ -155,7 +159,7 @@ pub fn prove<F, P, Channel, A>(
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
-) -> SumcheckOutput<F>
+) -> ShiftOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -37,7 +37,7 @@ use crate::{
 	protocols::{
 		binmul, intmul,
 		shift::{
-			KeyCollection, OperatorClaims, OperatorData, build_key_collection,
+			KeyCollection, OperatorClaims, OperatorData, ShiftOutput, build_key_collection,
 			prove as prove_shift_reduction,
 		},
 	},
@@ -284,9 +284,12 @@ impl IOPProver {
 			perfetto_category = "phase"
 		)
 		.entered();
-		let SumcheckOutput {
-			challenges: eval_point,
-			eval: _,
+		let ShiftOutput {
+			sumcheck: SumcheckOutput {
+				challenges: eval_point,
+				eval: _,
+			},
+			wiring_eval,
 		} = prove_shift_reduction::<_, P, _, _>(
 			&self.key_collection,
 			witness.public(),
@@ -312,6 +315,10 @@ impl IOPProver {
 		// Prove the public segment's evaluation claim, which the verifier's public-input check
 		// consumes.
 		ring_switch::prove_public_eval::<_, P, _>(alloc, witness.public(), r_j, r_y, &mut *channel);
+
+		// The wiring evaluation the verifier closes the shift check with, sent where it reads it:
+		// after the public segment's claim.
+		channel.send_one(wiring_eval);
 
 		// [phase] Ring-Switching + PCS Opening
 		let pcs_guard = tracing::info_span!(

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -318,7 +318,7 @@ impl IOPProver {
 
 		// The wiring evaluation the verifier closes the shift check with, sent where it reads it:
 		// after the public segment's claim.
-		channel.send_one(wiring_eval);
+		channel.send_public_claim(wiring_eval);
 
 		// [phase] Ring-Switching + PCS Opening
 		let pcs_guard = tracing::info_span!(

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -162,7 +162,9 @@ where
 					let inout = replay_channel.observe_words(inout_words);
 					inner_iop_verifier
 						.verify(&inout, replay_channel)
-						.expect("replay verification should not fail");
+						.expect("replay verification should not fail")
+						.check(replay_channel)
+						.expect("replay wiring check should not fail");
 				}
 			},
 		);

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -160,11 +160,12 @@ where
 					// A faithful replay of the verifier's call sequence, which observes the
 					// statement before delegating.
 					let inout = replay_channel.observe_words(inout_words);
-					inner_iop_verifier
+					// The wiring claim is dropped, as it is in the symbolic build: the verifier
+					// checks it over the public segment, outside the wrapper circuit, so there is
+					// nothing here to fill.
+					let _ = inner_iop_verifier
 						.verify(&inout, replay_channel)
-						.expect("replay verification should not fail")
-						.check(replay_channel)
-						.expect("replay wiring check should not fail");
+						.expect("replay verification should not fail");
 				}
 			},
 		);

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -13,7 +13,6 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b, BinaryField};
 use binius_frontend::{CircuitBuilder, Wire};
-use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace,
@@ -30,8 +29,7 @@ use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::StdChallenger,
 	protocols::shift::{
-		OperatorData as VerifierOperatorData, WiringEvalClaim, check_eval, evaluate_words_mle,
-		verify,
+		OperatorData as VerifierOperatorData, check_eval, evaluate_words_mle, verify,
 	},
 };
 use itertools::Itertools;
@@ -504,11 +502,7 @@ fn test_shift_prove_and_verify() {
 		);
 
 		// Check consistency with verifier output
-		let WiringEvalClaim {
-			eval_fn,
-			inputs,
-			claimed,
-		} = check_eval(
+		let wiring_claim = check_eval(
 			&cs,
 			InoutSegment::Public,
 			public_eval,
@@ -523,11 +517,8 @@ fn test_shift_prove_and_verify() {
 		)
 		.unwrap();
 
-		// Discharge the wiring claim the way the full reduction does.
-		let wiring_eval = verifier_transcript.compute_public_value(&inputs, eval_fn);
-		verifier_transcript
-			.assert_zero(wiring_eval - claimed)
-			.unwrap();
+		// Discharge the wiring claim the way the full reduction's caller does.
+		wiring_claim.check_native().unwrap();
 		verifier_transcript.finalize().unwrap();
 
 		// Check the claimed witness eval matches the direct evaluation of the non-public words.

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -473,7 +473,7 @@ fn test_shift_prove_and_verify() {
 
 		// The full reduction sends this after the public segment's evaluation claim; driving the
 		// shift alone, it follows the reduction directly.
-		prover_transcript.send_one(prover_output.wiring_eval);
+		prover_transcript.send_public_claim(prover_output.wiring_eval);
 
 		// Create verifier transcript and call the verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -13,6 +13,8 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b, BinaryField};
 use binius_frontend::{CircuitBuilder, Wire};
+use binius_ip::channel::IPVerifierChannel;
+use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace,
 	inner_product::{inner_product, inner_product_buffers},
@@ -28,7 +30,8 @@ use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::StdChallenger,
 	protocols::shift::{
-		OperatorData as VerifierOperatorData, check_eval, evaluate_words_mle, verify,
+		OperatorData as VerifierOperatorData, WiringEvalClaim, check_eval, evaluate_words_mle,
+		verify,
 	},
 };
 use itertools::Itertools;
@@ -468,6 +471,10 @@ fn test_shift_prove_and_verify() {
 			&GlobalAllocator,
 		);
 
+		// The full reduction sends this after the public segment's evaluation claim; driving the
+		// shift alone, it follows the reduction directly.
+		prover_transcript.send_one(prover_output.wiring_eval);
+
 		// Create verifier transcript and call the verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
@@ -497,7 +504,11 @@ fn test_shift_prove_and_verify() {
 		);
 
 		// Check consistency with verifier output
-		check_eval(
+		let WiringEvalClaim {
+			eval_fn,
+			inputs,
+			claimed,
+		} = check_eval(
 			&cs,
 			InoutSegment::Public,
 			public_eval,
@@ -511,6 +522,12 @@ fn test_shift_prove_and_verify() {
 			&mut verifier_transcript,
 		)
 		.unwrap();
+
+		// Discharge the wiring claim the way the full reduction does.
+		let wiring_eval = verifier_transcript.compute_public_value(&inputs, eval_fn);
+		verifier_transcript
+			.assert_zero(wiring_eval - claimed)
+			.unwrap();
 		verifier_transcript.finalize().unwrap();
 
 		// Check the claimed witness eval matches the direct evaluation of the non-public words.
@@ -532,7 +549,7 @@ fn test_shift_prove_and_verify() {
 			std::slice::from_ref(&verifier_output.r_segment),
 		]
 		.concat();
-		assert_eq!(prover_output.challenges, eval_point);
-		assert_eq!(prover_output.eval, verifier_output.witness_eval);
+		assert_eq!(prover_output.sumcheck.challenges, eval_point);
+		assert_eq!(prover_output.sumcheck.eval, verifier_output.witness_eval);
 	}
 }

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -6,7 +6,7 @@ use std::{array, rc::Rc};
 
 use binius_circuits::{bytes::swap_bytes_32, multiplexer::multi_wire_multiplex};
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash as B128, Field, FieldOps, util::FieldFn};
+use binius_field::{BinaryField128bGhash as B128, Field, FieldOps};
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_hash::StdHashSuite;
 use binius_iop::{
@@ -213,17 +213,6 @@ impl IPVerifierChannel<B128> for Binius64BuilderChannel {
 				Ok(())
 			}
 		}
-	}
-
-	fn compute_public_value(
-		&mut self,
-		inputs: &[SymbolicElem],
-		f: impl FieldFn<B128>,
-	) -> SymbolicElem {
-		// Evaluated symbolically rather than hinted, so the circuit constrains it. For the
-		// constraint system's monster multilinear that is proportional to the inner circuit's
-		// size, which is what an accumulation or Spark argument would remove.
-		f.call::<SymbolicElem>(inputs)
 	}
 }
 

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -5,7 +5,7 @@
 use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash as B128, util::FieldFn};
+use binius_field::BinaryField128bGhash as B128;
 use binius_frontend::WitnessFiller;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
@@ -132,11 +132,6 @@ where
 		// The build emitted a ZERO constraint for this, so a bad proof surfaces as an
 		// unsatisfied circuit rather than as an error out of a witness generator.
 		Ok(())
-	}
-
-	fn compute_public_value(&mut self, inputs: &[B128], f: impl FieldFn<B128>) -> B128 {
-		// The builder evaluates this symbolically, so it records no wires and none are filled.
-		self.transcript.borrow_mut().compute_public_value(inputs, f)
 	}
 }
 

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -161,6 +161,8 @@ fn record(proved: &Proved) -> Recording {
 		.verifier
 		.iop_verifier()
 		.verify(&statement, &mut channel)
+		.expect("the symbolic run records rather than checks, so it cannot fail")
+		.check(&mut channel)
 		.expect("the symbolic run records rather than checks, so it cannot fail");
 
 	// Binding every word is this caller's choice, not the channel's.
@@ -190,6 +192,8 @@ fn replay(proved: &Proved, recorded: &Recorded, filler: &mut WitnessFiller) {
 		.verifier
 		.iop_verifier()
 		.verify(&inout, &mut channel)
+		.unwrap()
+		.check(&mut channel)
 		.unwrap();
 	channel.finish().unwrap().finish();
 }

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -162,7 +162,7 @@ fn record(proved: &Proved) -> Recording {
 		.iop_verifier()
 		.verify(&statement, &mut channel)
 		.expect("the symbolic run records rather than checks, so it cannot fail")
-		.check(&mut channel)
+		.check_symbolic(&mut channel)
 		.expect("the symbolic run records rather than checks, so it cannot fail");
 
 	// Binding every word is this caller's choice, not the channel's.
@@ -193,7 +193,7 @@ fn replay(proved: &Proved, recorded: &Recorded, filler: &mut WitnessFiller) {
 		.iop_verifier()
 		.verify(&inout, &mut channel)
 		.unwrap()
-		.check(&mut channel)
+		.check_symbolic(&mut channel)
 		.unwrap();
 	channel.finish().unwrap().finish();
 }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, util::FieldFn};
+use binius_field::{BinaryField, Field};
 use binius_iop::channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 use binius_ip::channel::{
 	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
@@ -142,21 +142,6 @@ impl<F: Field> IPVerifierChannel<F> for ReplayChannel<F> {
 				Ok(())
 			}
 		}
-	}
-
-	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem {
-		// The function's result enters as a single derived public wire (matching the symbolic
-		// builder's `hint_varsize`), whose value the prover computes natively from the
-		// public-derived inputs. See `IronSpartanBuilderChannel::compute_public_value`.
-		let out_wire = {
-			let mut witness_gen = self.witness_gen.borrow_mut();
-			let input_wires: Vec<_> = inputs
-				.iter()
-				.map(|elem| elem.to_wire(&mut witness_gen))
-				.collect();
-			witness_gen.hint_varsize(&input_wires, 1, move |vals| vec![f.call_native(vals)])[0]
-		};
-		CircuitElem::wire(&self.witness_gen, out_wire)
 	}
 }
 

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -111,6 +111,12 @@ impl<F: Field> IPVerifierChannel<F> for ReplayChannel<F> {
 		Ok(encrypted_elem + key)
 	}
 
+	fn recv_public_claim(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+		// Mirror `IronSpartanBuilderChannel::recv_public_claim`: the recorded interaction holds the
+		// claim unencrypted, so it fills one inout wire and no precommit key.
+		Ok(self.next_inout_elem())
+	}
+
 	fn sample(&mut self) -> Self::Elem {
 		self.next_inout_elem()
 	}

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -251,6 +251,14 @@ where
 		self.interaction.push(encrypted);
 	}
 
+	fn send_public_claim(&mut self, elem: F) {
+		// A claim is a function of public values, so it is sent in the clear and consumes no OTP
+		// key. `interaction` records the plaintext, which is what the outer witness's inout wire
+		// holds and what the replay hands the inner verifier.
+		self.inner_channel.send_one(elem);
+		self.interaction.push(elem);
+	}
+
 	fn observe_one(&mut self, val: F) {
 		self.inner_channel.observe_one(val);
 		self.interaction.push(val);

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -33,7 +33,7 @@ pub mod constraint_system;
 pub mod wiring;
 pub mod wrapper;
 
-use std::{marker::PhantomData, rc::Rc, slice};
+use std::{marker::PhantomData, rc::Rc};
 
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -205,16 +205,9 @@ impl<F: Field> IOPVerifier<F> {
 		// channel never cross a thread boundary.
 		let r_x_tensor: Rc<[Channel::Elem]> = eq_ind_partial_eval_scalars(&r_x).into();
 
-		// The public-segment contribution to the operand evaluations is purely a function of
-		// public-channel inputs (the public scalars, λ, and rₓ). Trade in those Elems for plain
-		// field values, run the MLE evaluation in plaintext, and materialize the result as a
-		// single inout wire instead of building the entire sub-circuit.
-		let public_eval = {
-			let inputs = [public, slice::from_ref(&lambda), r_x_tensor.as_ref()].concat();
-
-			let eval_fn = wiring::PublicWiringEvalFn::new(cs.mul_constraints(), public.len());
-			channel.compute_public_value(&inputs, eval_fn)
-		};
+		// The public segment's contribution to the operand evaluations.
+		let public_eval =
+			wiring::evaluate_wiring_mle_public(cs.mul_constraints(), public, &lambda, &r_x_tensor);
 
 		// Prover sends the precommit segment's contribution to the operand evaluations.
 		let precommit_claim = channel.recv_one()?;

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -2,7 +2,7 @@
 
 use std::{iter, rc::Rc};
 
-use binius_field::{Field, field::FieldOps, util::FieldFn};
+use binius_field::field::FieldOps;
 use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};
 use binius_spartan_frontend::constraint_system::{MulConstraint, WitnessIndex, WitnessSegment};
 
@@ -87,41 +87,4 @@ pub fn evaluate_wiring_mle_public<F: FieldOps>(
 	}
 
 	evaluate_univariate(&acc, lambda)
-}
-
-/// The public segment's contribution to the batched operand evaluations, as a [`FieldFn`].
-///
-/// The inputs are the flat concatenation of three sections, in order:
-/// - a block of public scalars;
-/// - then the batching challenge `lambda`;
-/// - then the eq-indicator partial evaluation at `r_x`.
-pub struct PublicWiringEvalFn<'a> {
-	/// The multiplication constraints whose operands the evaluation sums over.
-	mul_constraints: &'a [MulConstraint<WitnessIndex>],
-	/// The length of the leading block of public scalars.
-	public_len: usize,
-}
-
-impl<'a> PublicWiringEvalFn<'a> {
-	/// Builds the function from the constraints and the count of leading public inputs.
-	pub const fn new(
-		mul_constraints: &'a [MulConstraint<WitnessIndex>],
-		public_len: usize,
-	) -> Self {
-		Self {
-			mul_constraints,
-			public_len,
-		}
-	}
-}
-
-impl<F: Field> FieldFn<F> for PublicWiringEvalFn<'_> {
-	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, inputs: &[E]) -> E {
-		// Split the flat input back into its three parts.
-		let public = &inputs[..self.public_len];
-		let lambda = &inputs[self.public_len];
-		let r_x_tensor = &inputs[self.public_len + 1..];
-
-		evaluate_wiring_mle_public(self.mul_constraints, public, lambda, r_x_tensor)
-	}
 }

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -78,6 +78,13 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		Ok(inout - key)
 	}
 
+	fn recv_public_claim(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+		// A claim is public, so the wrapped prover sends it unencrypted: one inout wire, no
+		// precommit key. What it leaves behind is a public-derivable wire, which is what the
+		// checks reading it need it to be.
+		Ok(self.alloc_inout_elem())
+	}
+
 	fn sample(&mut self) -> Self::Elem {
 		self.alloc_inout_elem()
 	}

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, util::FieldFn};
+use binius_field::{BinaryField, Field};
 use binius_iop::channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn};
 use binius_ip::channel::{
 	IPVerifierChannel, WordIPVerifierChannel, n_packed_elems, select_word, subset_sum_word,
@@ -113,24 +113,6 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 				Ok(())
 			}
 		}
-	}
-
-	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem {
-		// The function is an arbitrary native computation the constraint system cannot replay, so
-		// its result enters as a single derived public wire (a one-output `hint_varsize`,
-		// computed from the public inputs, emitting no constraints) rather than a sub-circuit's
-		// worth of constraints. Symbolically we only allocate the wire; the value is filled
-		// concretely by the instance/witness channels, which recompute it via their own
-		// `hint_varsize`.
-		let out_wire = {
-			let mut builder = self.builder.borrow_mut();
-			let input_wires: Vec<_> = inputs
-				.iter()
-				.map(|elem| elem.to_wire(&mut builder))
-				.collect();
-			builder.hint_varsize(&input_wires, 1, move |vals| vec![f.call_native(vals)])[0]
-		};
-		CircuitElem::wire(&self.builder, out_wire)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -187,6 +187,13 @@ where
 		Ok(inout - key)
 	}
 
+	fn recv_public_claim(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+		// Mirror `IronSpartanBuilderChannel::recv_public_claim`: the value arrives unencrypted, so
+		// it enters as one inout wire carrying it, with no precommit key to subtract.
+		let val = self.inner_channel.recv_one()?;
+		Ok(self.alloc_inout_elem(val))
+	}
+
 	fn sample(&mut self) -> Self::Elem {
 		let val = self.inner_channel.sample();
 		self.alloc_inout_elem(val)

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -14,7 +14,7 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, util::FieldFn};
+use binius_field::BinaryField;
 use binius_iop::{
 	basefold::channel::{BaseFoldOracle, BaseFoldVerifierChannel},
 	channel::{IOPVerifierChannel, OracleSpec, TransparentEvalFn},
@@ -24,7 +24,7 @@ use binius_ip::channel::{
 	IPVerifierChannel, WordIPVerifierChannel, pack_words_concrete, select_word, subset_sum_word,
 };
 use binius_spartan_frontend::{
-	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
+	circuit_builder::{InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
 };
 
@@ -136,6 +136,18 @@ where
 		CircuitElem::wire(&self.instance_gen, public_wire)
 	}
 
+	/// The value of an element, when the verifier holds it.
+	///
+	/// A constant, an inout wire, or anything derived from those alone has a value here; an element
+	/// that reads a precommit wire has none. This is what lets a check over public values run
+	/// outside the wrapper circuit — the verifier evaluates it directly instead of constraining it.
+	pub const fn public_value(&self, elem: &CircuitElem<F, InstanceGenerator<F>>) -> Option<F> {
+		match elem {
+			CircuitElem::Constant(val) => Some(*val),
+			CircuitElem::Wire { wire, .. } => wire.value(),
+		}
+	}
+
 	/// Allocates the next precommit wire (value-less to the verifier) as an element.
 	fn alloc_precommit_elem(&mut self) -> CircuitElem<F, InstanceGenerator<F>> {
 		let wire = self.precommit_alloc.alloc();
@@ -219,21 +231,6 @@ where
 			// checked by the outer verifier over the reconstructed public segment.
 			CircuitElem::Wire { .. } => Ok(()),
 		}
-	}
-
-	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem {
-		// The function's result enters as a single derived public wire (matching the symbolic
-		// builder's `hint_varsize`), whose value the verifier computes natively from the
-		// public-derived inputs. See `IronSpartanBuilderChannel::compute_public_value`.
-		let out_wire = {
-			let mut instance_gen = self.instance_gen.borrow_mut();
-			let input_wires: Vec<_> = inputs
-				.iter()
-				.map(|elem| elem.to_wire(&mut instance_gen))
-				.collect();
-			instance_gen.hint_varsize(&input_wires, 1, move |vals| vec![f.call_native(vals)])[0]
-		};
-		CircuitElem::wire(&self.instance_gen, out_wire)
 	}
 }
 

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -47,4 +47,7 @@ mod verify;
 
 pub use error::Error;
 pub use shift_ind::evaluate_shift_inds;
-pub use verify::{OperatorData, VerifyOutput, check_eval, evaluate_words_mle, verify};
+pub use verify::{
+	OperatorData, VerifyOutput, WiringEvalClaim, WiringEvalFn, check_eval, evaluate_words_mle,
+	verify,
+};

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -271,8 +271,8 @@ where
 ///
 /// After the shift reduction protocol completes, this function checks that the
 /// prover-provided witness evaluation is consistent with the expected values.
-/// It computes the monster multilinear evaluations for the AND, IMUL and BMUL constraints
-/// and verifies the final equation relating the witness and monster evaluations.
+/// It reads the wiring multilinear's evaluation from the prover and verifies the final equation
+/// relating the witness and monster evaluations.
 ///
 /// # Protocol Details
 ///
@@ -281,9 +281,13 @@ where
 /// eval = trace_eval * monster_eval
 /// ```
 ///
-/// where `monster_eval` is the sum of evaluations for AND, IMUL and BMUL constraint polynomials,
-/// scaled by the sumcheck's two bit-index factors — the Lagrange weights and the interpolated
-/// shift indicators, both at `r_i`.
+/// where `monster_eval` is the prover's claimed wiring evaluation — the AND, IMUL and BMUL
+/// constraint polynomials summed — scaled by the sumcheck's two bit-index factors, the Lagrange
+/// weights and the interpolated shift indicators, both at `r_i`.
+///
+/// That claim is not checked here. It comes back as a [`WiringEvalClaim`], holding the function
+/// that evaluates the wiring multilinear from public-channel-derived values together with the
+/// claimed value it must equal, for the caller to discharge however it opens claims.
 ///
 /// `trace_eval` is the witness evaluation reconstructed from its two segments:
 /// ```text
@@ -299,10 +303,10 @@ where
 /// # Errors
 ///
 /// - `Error::VerificationFailure` if the evaluation equation doesn't hold
-/// - Propagates errors from monster multilinear evaluation
+/// - Propagates errors from reading the wiring evaluation off the channel
 #[allow(clippy::too_many_arguments)]
-pub fn check_eval<F, C>(
-	constraint_system: &ConstraintSystem,
+pub fn check_eval<'a, F, C>(
+	constraint_system: &'a ConstraintSystem,
 	inout: InoutSegment,
 	public_eval: C::Elem,
 	zero_data: &OperatorData<C::Elem, ZERO_ARITY>,
@@ -313,7 +317,7 @@ pub fn check_eval<F, C>(
 	r_zhat_prime: &C::Elem,
 	output: &VerifyOutput<C::Elem>,
 	channel: &mut C,
-) -> Result<(), Error>
+) -> Result<WiringEvalClaim<'a, C::Elem>, Error>
 where
 	F: BinaryField,
 	C: IPVerifierChannel<F>,
@@ -350,15 +354,20 @@ where
 		evaluate_inplace_scalars(&mut evaluate_shift_inds(r_k, r_j, r_s_inner)[..], r_v_inner);
 	let shift_ind_eval = outer_ind_eval * inner_ind_eval;
 
-	// `monster_eval` is a function of purely public-channel-derived elements
-	// (`bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime` vectors, both shift slots'
-	// challenges, `r_y`) plus the constant `constraint_system`. Trade those Elems for plain field
-	// values, run the MLE evaluation in plaintext, and materialize the result as a single inout
-	// wire instead of building the entire sub-circuit in wrapper channels.
-	//
-	// The three bit-index factors scale every shift scalar of the monster; they multiply the result
-	// out here rather than entering the function, which keeps its input free of `r_i` and `r_k`.
-	let monster_eval = {
+	// The wiring multilinear's evaluation comes from the prover. Checking it against the constraint
+	// system is left to the caller, which is handed the function that computes it below.
+	let wiring_eval = channel.recv_one()?;
+
+	// The three bit-index factors scale every shift scalar of the wiring multilinear; they multiply
+	// the claim out here rather than entering the function, which keeps its input free of `r_i` and
+	// `r_k`.
+	let monster_eval = l_tilde_eval * shift_ind_eval * wiring_eval.clone();
+
+	// The function the caller checks the claim with, and the flat input it reads. Every entry is a
+	// public-channel-derived element (`bitand_lambda`, `intmul_lambda`, the operator data's
+	// `r_x_prime` vectors, both shift slots' challenges, `r_y`); the constraint system it sums over
+	// is fixed.
+	let claim = {
 		let zero_r_x_prime_len = zero_data.r_x_prime.len();
 		let bitand_r_x_prime_len = bitand_data.r_x_prime.len();
 		let intmul_r_x_prime_len = intmul_data.r_x_prime.len();
@@ -383,7 +392,7 @@ where
 			.chain(iter::once(r_segment.clone()))
 			.collect();
 
-		let eval_fn = MonsterEvalFn {
+		let eval_fn = WiringEvalFn {
 			constraint_system,
 			inout,
 			zero_r_x_prime_len,
@@ -394,7 +403,11 @@ where
 			r_v_len,
 			r_y_len,
 		};
-		l_tilde_eval * shift_ind_eval * channel.compute_public_value(&inputs, eval_fn)
+		WiringEvalClaim {
+			eval_fn,
+			inputs,
+			claimed: wiring_eval,
+		}
 	};
 
 	// Reconstruct the witness evaluation from its two segments.
@@ -408,10 +421,29 @@ where
 	let expected_eval = trace_eval * monster_eval;
 	channel.assert_zero(expected_eval - eval)?;
 
-	Ok(())
+	Ok(claim)
 }
 
-/// The monster multilinear evaluation, as a [`FieldFn`] over public-channel-derived inputs.
+/// The prover's wiring multilinear evaluation, with what it takes to check it.
+///
+/// [`check_eval`] reads the evaluation from the prover and closes the shift reduction with it,
+/// leaving this behind: the claimed value, and the function and inputs that recompute it from the
+/// constraint system. The holder discharges the claim by evaluating the function and requiring the
+/// two to agree.
+///
+/// The claimed value is kept beside the function rather than folded into it, so every input the
+/// function reads stays public-channel-derived — which is what
+/// [`IPVerifierChannel::compute_public_value`] requires of them.
+pub struct WiringEvalClaim<'a, E> {
+	/// Evaluates the wiring multilinear from `inputs`.
+	pub eval_fn: WiringEvalFn<'a>,
+	/// The flat input `eval_fn` reads.
+	pub inputs: Vec<E>,
+	/// The evaluation the prover claims, which `eval_fn` must return.
+	pub claimed: E,
+}
+
+/// The wiring multilinear evaluation, as a [`FieldFn`] over public-channel-derived inputs.
 ///
 /// The inputs are the flat concatenation of these sections, in order:
 ///
@@ -424,7 +456,7 @@ where
 ///
 /// The bit-index factors every shift scalar is scaled by are left out: they depend on prover
 /// messages, so [`check_eval`] multiplies them in outside.
-struct MonsterEvalFn<'a> {
+pub struct WiringEvalFn<'a> {
 	/// The AND, IMUL and BMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,
 	/// Which segment holds the inout values, which fixes where the word-index tensor is cut.
@@ -445,7 +477,7 @@ struct MonsterEvalFn<'a> {
 	r_y_len: usize,
 }
 
-/// The per-operation [`OperationEvalFn`] inputs [`MonsterEvalFn::operation_inputs`] splits out of
+/// The per-operation [`OperationEvalFn`] inputs [`WiringEvalFn::operation_inputs`] splits out of
 /// its flat input slice. A `None` marks an operation with no constraints, whose reduction is
 /// skipped.
 struct OperationInputs<E> {
@@ -455,7 +487,7 @@ struct OperationInputs<E> {
 	binmul: Option<Vec<E>>,
 }
 
-impl MonsterEvalFn<'_> {
+impl WiringEvalFn<'_> {
 	/// Shared setup for [`FieldFn::call`] and [`FieldFn::call_native`]: splits the flat `vals`
 	/// slice, builds the shared shift-scalar and word-index tensors, and re-encodes them (with each
 	/// operation's `r_x'` and `lambda`) into the per-operation [`OperationEvalFn`] input via
@@ -603,7 +635,7 @@ impl MonsterEvalFn<'_> {
 	}
 }
 
-impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_> {
+impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
 		let OperationInputs {
 			zero: zero_input,

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -354,9 +354,10 @@ where
 		evaluate_inplace_scalars(&mut evaluate_shift_inds(r_k, r_j, r_s_inner)[..], r_v_inner);
 	let shift_ind_eval = outer_ind_eval * inner_ind_eval;
 
-	// The wiring multilinear's evaluation comes from the prover. Checking it against the constraint
-	// system is left to the caller, which is handed the function that computes it below.
-	let wiring_eval = channel.recv_one()?;
+	// The wiring multilinear's evaluation comes from the prover, as a claim the verifier could
+	// compute for itself. Checking it against the constraint system is left to the caller, which is
+	// handed the function that computes it below.
+	let wiring_eval = channel.recv_public_claim()?;
 
 	// The three bit-index factors scale every shift scalar of the wiring multilinear; they multiply
 	// the claim out here rather than entering the function, which keeps its input free of `r_i` and

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -432,9 +432,10 @@ where
 /// constraint system. The holder discharges the claim by evaluating the function and requiring the
 /// two to agree.
 ///
-/// The claimed value is kept beside the function rather than folded into it, so every input the
-/// function reads stays public-channel-derived — which is what
-/// [`IPVerifierChannel::compute_public_value`] requires of them.
+/// Both discharges below evaluate the same function; they differ in where. A verifier holding
+/// values checks it in the field, and one building a circuit checks it in constraints — which is
+/// why the function is kept rather than a value, and why the claimed value sits beside it rather
+/// than folded into it.
 ///
 /// Dropping a claim drops a check, so it is `#[must_use]`.
 #[must_use]
@@ -448,13 +449,28 @@ pub struct WiringEvalClaim<'a, E> {
 	pub claimed: E,
 }
 
-impl<E> WiringEvalClaim<'_, E> {
-	/// Discharges the claim over `channel`: evaluates the wiring multilinear and asserts it equals
-	/// the claimed value.
+impl<F: BinaryField> WiringEvalClaim<'_, F> {
+	/// Discharges the claim in the field: evaluates the wiring multilinear and compares.
 	///
-	/// This is what a channel that opens claims by computing them does. A holder with another way
-	/// to open one — a sparse-polynomial argument, say — reads the fields instead.
-	pub fn check<F, C>(self, channel: &mut C) -> Result<(), Error>
+	/// This is the discharge for a verifier holding values rather than wires, and it takes
+	/// [`FieldFn::call_native`]'s accelerated path.
+	pub fn check_native(self) -> Result<(), Error> {
+		if self.eval_fn.call_native(&self.inputs) == self.claimed {
+			Ok(())
+		} else {
+			Err(Error::VerificationFailure)
+		}
+	}
+}
+
+impl<E> WiringEvalClaim<'_, E> {
+	/// Discharges the claim over `channel`'s elements: evaluates the wiring multilinear there and
+	/// asserts it equals the claimed value.
+	///
+	/// This is the discharge for a channel carrying elements as wires, where the evaluation becomes
+	/// a sub-circuit and the comparison an assertion within it. A holder with another way to open a
+	/// claim — a sparse-polynomial argument, say — reads the fields instead.
+	pub fn check_symbolic<F, C>(self, channel: &mut C) -> Result<(), Error>
 	where
 		F: BinaryField,
 		C: IPVerifierChannel<F, Elem = E>,
@@ -465,7 +481,7 @@ impl<E> WiringEvalClaim<'_, E> {
 			inputs,
 			claimed,
 		} = self;
-		let wiring_eval = channel.compute_public_value(&inputs, eval_fn);
+		let wiring_eval = FieldFn::<F>::call::<E>(&eval_fn, &inputs);
 		channel.assert_zero(wiring_eval - claimed)?;
 		Ok(())
 	}

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -434,6 +434,10 @@ where
 /// The claimed value is kept beside the function rather than folded into it, so every input the
 /// function reads stays public-channel-derived — which is what
 /// [`IPVerifierChannel::compute_public_value`] requires of them.
+///
+/// Dropping a claim drops a check, so it is `#[must_use]`.
+#[must_use]
+#[derive(Debug)]
 pub struct WiringEvalClaim<'a, E> {
 	/// Evaluates the wiring multilinear from `inputs`.
 	pub eval_fn: WiringEvalFn<'a>,
@@ -441,6 +445,29 @@ pub struct WiringEvalClaim<'a, E> {
 	pub inputs: Vec<E>,
 	/// The evaluation the prover claims, which `eval_fn` must return.
 	pub claimed: E,
+}
+
+impl<E> WiringEvalClaim<'_, E> {
+	/// Discharges the claim over `channel`: evaluates the wiring multilinear and asserts it equals
+	/// the claimed value.
+	///
+	/// This is what a channel that opens claims by computing them does. A holder with another way
+	/// to open one — a sparse-polynomial argument, say — reads the fields instead.
+	pub fn check<F, C>(self, channel: &mut C) -> Result<(), Error>
+	where
+		F: BinaryField,
+		C: IPVerifierChannel<F, Elem = E>,
+		E: FieldOps<Scalar = F> + From<F>,
+	{
+		let Self {
+			eval_fn,
+			inputs,
+			claimed,
+		} = self;
+		let wiring_eval = channel.compute_public_value(&inputs, eval_fn);
+		channel.assert_zero(wiring_eval - claimed)?;
+		Ok(())
+	}
 }
 
 /// The wiring multilinear evaluation, as a [`FieldFn`] over public-channel-derived inputs.
@@ -456,6 +483,7 @@ pub struct WiringEvalClaim<'a, E> {
 ///
 /// The bit-index factors every shift scalar is scaled by are left out: they depend on prover
 /// messages, so [`check_eval`] multiplies them in outside.
+#[derive(Debug)]
 pub struct WiringEvalFn<'a> {
 	/// The AND, IMUL and BMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -46,7 +46,7 @@ use crate::{
 		binmul::{BinMulOutput, verify as verify_binmul_reduction},
 		bitand::AndCheckOutput,
 		intmul::{IntMulOutput, verify as verify_intmul_reduction},
-		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperatorData},
+		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperatorData, WiringEvalClaim},
 		zero,
 	},
 	ring_switch::{self, RingSwitchVerifyOutput, eval_rs_eq},
@@ -293,7 +293,11 @@ where
 		)
 		.entered();
 		let public_eval = verify_public_eval(cs, inout, public, &shift, channel)?;
-		shift::check_eval::<B128, _>(
+		let WiringEvalClaim {
+			eval_fn,
+			inputs,
+			claimed,
+		} = shift::check_eval::<B128, _>(
 			cs,
 			inout,
 			public_eval,
@@ -306,6 +310,10 @@ where
 			&shift,
 			channel,
 		)?;
+
+		// Tie the prover's wiring evaluation to the constraint system.
+		let wiring_eval = channel.compute_public_value(&inputs, eval_fn);
+		channel.assert_zero(wiring_eval - claimed)?;
 	}
 
 	Ok(ReductionOutput { r_rho, shift })

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -94,18 +94,21 @@ impl Instances {
 	}
 }
 
-/// What [`reduce_constraints`] leaves for the caller to open against the committed trace.
+/// What [`reduce_constraints`] leaves for the caller: the claim on the committed trace, and the
+/// wiring claim the constraint system is read through.
 #[derive(Debug)]
-pub struct ReductionOutput<F> {
+pub struct ReductionOutput<'a, F> {
 	/// The instance point every operand claim was transported onto.
 	///
 	/// Empty for the monolithic reduction, which transports nothing.
 	pub r_rho: Vec<F>,
 	/// The shift reduction's output, holding the claimed witness evaluation.
 	pub shift: shift::VerifyOutput<F>,
+	/// The prover's wiring evaluation, still to be tied to the constraint system.
+	pub wiring: WiringEvalClaim<'a, F>,
 }
 
-impl<F: Clone> ReductionOutput<F> {
+impl<F: Clone> ReductionOutput<'_, F> {
 	/// The point the committed trace is opened at.
 	///
 	/// The trace's bit index is `[bit | instance | wire]`, low to high:
@@ -151,13 +154,13 @@ impl<F: Clone> ReductionOutput<F> {
 /// Committing those evaluations first stops a prover choosing them as a function of it.
 ///
 /// Do not reorder these, and keep the same order in the prover.
-pub fn reduce_constraints<Channel>(
-	cs: &ConstraintSystem,
+pub fn reduce_constraints<'a, Channel>(
+	cs: &'a ConstraintSystem,
 	instances: Instances,
 	inout: InoutSegment,
 	public: &[Channel::Word],
 	channel: &mut Channel,
-) -> Result<ReductionOutput<Channel::Elem>, Error>
+) -> Result<ReductionOutput<'a, Channel::Elem>, Error>
 where
 	Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 	Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
@@ -285,7 +288,7 @@ where
 	// Tie in the public values through the public-input consistency check.
 	// The reduction reads them over the layout's power-of-two word count.
 	// Their count need not be a power of two, so they are passed unpadded.
-	{
+	let wiring = {
 		let _guard = tracing::info_span!(
 			"[phase] Verify Public Input",
 			phase = "verify_public_input",
@@ -293,11 +296,7 @@ where
 		)
 		.entered();
 		let public_eval = verify_public_eval(cs, inout, public, &shift, channel)?;
-		let WiringEvalClaim {
-			eval_fn,
-			inputs,
-			claimed,
-		} = shift::check_eval::<B128, _>(
+		shift::check_eval::<B128, _>(
 			cs,
 			inout,
 			public_eval,
@@ -309,14 +308,14 @@ where
 			&z_challenge,
 			&shift,
 			channel,
-		)?;
+		)?
+	};
 
-		// Tie the prover's wiring evaluation to the constraint system.
-		let wiring_eval = channel.compute_public_value(&inputs, eval_fn);
-		channel.assert_zero(wiring_eval - claimed)?;
-	}
-
-	Ok(ReductionOutput { r_rho, shift })
+	Ok(ReductionOutput {
+		r_rho,
+		shift,
+		wiring,
+	})
 }
 
 /// Reads the public segment's evaluation and reduces it onto the segment's packed form.

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -337,7 +337,7 @@ where
 		let inout = channel.observe_words(inout);
 		self.iop_verifier
 			.verify(&inout, &mut channel)?
-			.check(&mut channel)?;
+			.check_native()?;
 		channel.finish()?;
 		Ok(())
 	}

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -25,7 +25,10 @@ use crate::{
 	config::{B1, B128, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
 	fri::{ConstantArityStrategy, FRIParams, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
-	protocols::bitand::{AndCheckOutput, verify_with_channel},
+	protocols::{
+		bitand::{AndCheckOutput, verify_with_channel},
+		shift::WiringEvalClaim,
+	},
 	reduction::{Instances, reduce_constraints},
 	ring_switch,
 };
@@ -117,6 +120,7 @@ impl IOPVerifier {
 		let inout = vec![Word::ZERO; self.constraint_system.n_inout];
 		// The result is discarded: the setup channel performs no real verification (all `recv_*`
 		// return zero, `assert_zero` is a no-op), so we only read back the recorded oracle specs.
+		// Its wiring claim goes with it, since discharging one records no oracle.
 		let _ = self.verify(&inout, &mut channel);
 		channel.into_oracle_specs()
 	}
@@ -130,11 +134,15 @@ impl IOPVerifier {
 	/// [`WordIPVerifierChannel::observe_words`] returns: the caller observes the concrete words and
 	/// passes on what comes back. A channel that carries words as wires introduces them there, so
 	/// the verification below reads the statement symbolically rather than as fixed data.
+	///
+	/// The reduction's wiring evaluation comes back as a [`WiringEvalClaim`] rather than being
+	/// checked here, so the caller chooses how the constraint system is read: by computing the
+	/// evaluation, or by any other argument that opens the claim.
 	pub fn verify<Channel>(
 		&self,
 		inout: &[Channel::Word],
 		channel: &mut Channel,
-	) -> Result<(), Error>
+	) -> Result<WiringEvalClaim<'_, Channel::Elem>, Error>
 	where
 		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
@@ -206,7 +214,7 @@ impl IOPVerifier {
 
 		drop(pcs_guard);
 
-		Ok(())
+		Ok(reduction.wiring)
 	}
 }
 
@@ -327,7 +335,9 @@ where
 			.iop_compiler
 			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		let inout = channel.observe_words(inout);
-		self.iop_verifier.verify(&inout, &mut channel)?;
+		self.iop_verifier
+			.verify(&inout, &mut channel)?
+			.check(&mut channel)?;
 		channel.finish()?;
 		Ok(())
 	}

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -42,7 +42,10 @@ use binius_utils::{DeserializeBytes, SerializeBytes, serialization::Serializatio
 use bytes::{Buf, BufMut};
 use digest::Output;
 
-use crate::verify::{IOPVerifier, SECURITY_BITS};
+use crate::{
+	protocols::shift::WiringEvalClaim,
+	verify::{IOPVerifier, SECURITY_BITS},
+};
 
 /// Zero-knowledge verifier for Binius64 constraint systems.
 ///
@@ -80,14 +83,11 @@ where
 		let outer_builder = {
 			let _guard = tracing::debug_span!("Build ZK wrapper circuit").entered();
 			let mut builder_channel = IronSpartanBuilderChannel::new();
-			// The wiring claim is discharged here, where [`Self::verify`] discharges it too: the
-			// circuit built here is what the wrapped run's wires are allocated against, so the two
-			// must run the same checks in the same order.
-			inner_iop_verifier
+			// The wiring claim is dropped rather than discharged: [`Self::verify`] checks it over
+			// the public segment instead, so the circuit built here carries none of it.
+			let _ = inner_iop_verifier
 				.verify(&dummy_inout_words, &mut builder_channel)
-				.expect("symbolic verify should not fail")
-				.check(&mut builder_channel)
-				.expect("symbolic wiring check should not fail");
+				.expect("symbolic verify should not fail");
 			builder_channel.finish()
 		};
 		let (outer_cs, outer_layout) = {
@@ -215,10 +215,27 @@ where
 			// The statement is observed here, and what comes back is what the IOP verifies
 			// against — the same split the transparent verifier makes.
 			let inout = wrapped_channel.observe_words(inout);
-			self.inner_iop_verifier
-				.verify(&inout, &mut wrapped_channel)?
-				.check(&mut wrapped_channel)
-				.map_err(crate::error::Error::from)?;
+			let claim = self
+				.inner_iop_verifier
+				.verify(&inout, &mut wrapped_channel)?;
+
+			// The wiring claim and every input it reads are public wires of the wrapper circuit, so
+			// tying the claim to the constraint system is an equation between values this verifier
+			// holds. Checking it here keeps the evaluation out of the circuit entirely, and the
+			// wrapper's other two runs — the symbolic build and the prover's replay — emit nothing
+			// for it either.
+			let public_value = |elem| {
+				wrapped_channel
+					.public_value(elem)
+					.expect("a public claim and its inputs are public wires")
+			};
+			WiringEvalClaim {
+				inputs: claim.inputs.iter().map(public_value).collect(),
+				claimed: public_value(&claim.claimed),
+				eval_fn: claim.eval_fn,
+			}
+			.check_native()
+			.map_err(crate::error::Error::from)?;
 		};
 
 		// Finish runs the outer spartan verification.

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -80,9 +80,14 @@ where
 		let outer_builder = {
 			let _guard = tracing::debug_span!("Build ZK wrapper circuit").entered();
 			let mut builder_channel = IronSpartanBuilderChannel::new();
+			// The wiring claim is discharged here, where [`Self::verify`] discharges it too: the
+			// circuit built here is what the wrapped run's wires are allocated against, so the two
+			// must run the same checks in the same order.
 			inner_iop_verifier
 				.verify(&dummy_inout_words, &mut builder_channel)
-				.expect("symbolic verify should not fail");
+				.expect("symbolic verify should not fail")
+				.check(&mut builder_channel)
+				.expect("symbolic wiring check should not fail");
 			builder_channel.finish()
 		};
 		let (outer_cs, outer_layout) = {
@@ -211,7 +216,9 @@ where
 			// against — the same split the transparent verifier makes.
 			let inout = wrapped_channel.observe_words(inout);
 			self.inner_iop_verifier
-				.verify(&inout, &mut wrapped_channel)?;
+				.verify(&inout, &mut wrapped_channel)?
+				.check(&mut wrapped_channel)
+				.map_err(crate::error::Error::from)?;
 		};
 
 		// Finish runs the outer spartan verification.


### PR DESCRIPTION
The shift reduction closed itself by evaluating the wiring ("monster")
multilinear inline, through `IPVerifierChannel::compute_public_value`. That
evaluation is O(nonzeros) in the constraint system, and a circuit-building
channel pays for it in constraints proportional to the inner circuit's size —
the cost `compute_public_value` was introduced as a "temporary hack" to dodge,
by hinting the value instead of building the sub-circuit.

This turns the evaluation into a **claim**: the prover states it, the verifier
uses it to close the shift check, and the obligation to tie it back to the
constraint system travels out to whoever called the verifier. A caller then
chooses how to discharge it — by evaluating, by constraining, or eventually by a
sparse-polynomial argument that never evaluates it at all. Batching several
claims with one sumcheck is the next thing this shape admits.

With the wiring evaluation no longer computed through the channel,
`compute_public_value` has no callers left and is deleted. A channel is a
transcript, not an evaluator.

## The commits

1. **Evaluate the public wiring MLE symbolically in the Spartan verifier** —
   removes the other `compute_public_value` caller, which is what lets the last
   commit delete it.
2. **Make the shift reduction's wiring evaluation a prover claim** —
   `check_eval` reads the evaluation, scales it by the three bit-index factors,
   and closes the reduction as before; the claim it no longer checks comes back
   as a `WiringEvalClaim`, discharged for now inside `reduce_constraints`.
   `MonsterEvalFn` becomes `WiringEvalFn`, since it evaluates the wiring
   matrices and the factors completing the monster are applied outside it.
3. **Return the wiring claim from the IOP verifiers** — `reduce_constraints`,
   `IOPVerifier::verify` and the M4 `verify_chip` hand the claim up; their
   callers discharge it. The claim is `#[must_use]`: dropping one drops a check.
4. **Receive the wiring evaluation as a public claim** — adds
   `IPVerifierChannel::recv_public_claim` and `IPProverChannel::send_public_claim`
   for a value the receiver must check and a channel may treat as public. Both
   default to the plain send and receive; only the channels that mask prover
   messages override them.
5. **Check the wiring claim outside the channel** — deletes
   `compute_public_value` and gives each holder the discharge that suits it.

## Where the prover's claim comes from

It costs no new pass over the constraints. The phase-2 sumcheck already ends
with the folded monster evaluation, which is the wiring evaluation scaled by the
same three bit-index factors it was built with, so dividing them back out is one
inversion. Like the witness evaluation derived beside it, this makes the
protocol incomplete with negligible probability.

## The ZK wrapper

The claim is a function of the constraint system and the sampled challenges
alone, so it carries nothing about the witness. `recv_public_claim` says that:
in the wrapper it travels unencrypted and enters as a single inout wire with no
precommit key, instead of the masked `inout - key` every other message gets.

Every input the check reads is then a public wire too, so tying the claim to the
constraint system is an equation between values the verifier already holds. It
belongs outside the circuit: `ZKVerifier::verify` checks it natively over the
public segment, and the wrapper's three lockstep runs — the symbolic build, the
prover's replay, the wrapped verification — emit nothing for it. That removes
both the hint the evaluation used to enter through and the sub-circuit it stood
in for.

**This changes the ZK proof format**: one more inout wire, one fewer precommit
wire, and the wiring evaluation in the clear. Proofs from before do not verify
against this.

## Testing

`cargo test --release --workspace --no-fail-fast` with
`RUSTFLAGS="-C target-cpu=native"`: 1767 pass. The one failure,
`binius-ip-prover`'s `logup_star::prove::tests::test_out_of_range_index_panics`,
is pre-existing and unrelated — it expects a message from a `debug_assert!` that
release builds compile out, and fails the same way on `main`.

The load-bearing cases are `prove_verify` (plain and ZK, the latter covering all
three wrapper channels), `recursion_end_to_end` (the recorded circuit still
satisfied by the replayed witness), and the two shift round trips.

Caveat worth flagging for review: the ZK path's wiring check is now a plain
equality in verifier code rather than circuit constraints, and every ZK test is
honest-prover, so nothing currently feeds it a wrong claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)