### PR TITLE
BINIUS-501: read chip-call operands off the value table without rebuilding each instance

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -5,7 +5,9 @@ use std::{iter, mem::MaybeUninit};
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
 
-use super::{ValueIndex, ValueVec};
+#[cfg(test)]
+use super::ValueVec;
+use super::{ValueIndex, WordSource};
 use crate::word::Word;
 
 /// A different variants of shifting a value.
@@ -832,16 +834,26 @@ impl ShiftedValueIndex {
 		Self::single(value_index, Shift::rotr32(amount))
 	}
 
-	/// Evaluates this term against a witness.
+	/// Evaluates this term against a word source.
 	///
 	/// A term names one value and a sequence of two shifts to apply to it.
 	/// It contributes one shifted word to the XOR that forms an operand.
 	#[inline]
-	pub fn eval(&self, witness: &ValueVec) -> Word {
+	pub fn eval(&self, source: &impl WordSource) -> Word {
 		// Look up the referenced word, then apply the two shifts in sequence, inner first.
 		let [inner, outer] = self.shift_seq;
-		outer.apply(inner.apply(witness[self.value_index]))
+		outer.apply(inner.apply(source.word(self.value_index)))
 	}
+}
+
+/// Evaluates an operand — the XOR of its shifted-value terms — against any [`WordSource`].
+///
+/// An empty operand evaluates to the zero word, the XOR identity.
+#[inline]
+pub fn eval_operand(source: &impl WordSource, operand: &[ShiftedValueIndex]) -> Word {
+	operand
+		.iter()
+		.fold(Word::ZERO, |acc, term| acc ^ term.eval(source))
 }
 
 impl SerializeBytes for ShiftedValueIndex {

--- a/crates/core/src/constraint_system/value_table.rs
+++ b/crates/core/src/constraint_system/value_table.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Deref;
 
-use super::{ValueIndex, ValueVec, ValueVecLayout};
+use super::{ValueIndex, ValueSegment, ValueVec, ValueVecLayout, WordSource};
 use crate::word::Word;
 
 /// The witness for a batch of `2^k` independent instances of one circuit, in wire-major order.
@@ -153,10 +153,61 @@ impl<Data: Deref<Target = [Word]>> ValueTable<Data> {
 
 		values
 	}
+
+	/// Returns a [`WordSource`] view of one instance's row.
+	///
+	/// Reads only the words an operand names, each straight off its strided row.
+	/// [`Self::instance_value_vec`] gathers the whole hidden segment instead.
+	///
+	/// # Panics
+	///
+	/// Panics under the same conditions as [`Self::instance_value_vec`].
+	pub fn instance_words<'a>(
+		&'a self,
+		instance: usize,
+		constants: &'a [Word],
+	) -> TableInstance<'a, Data> {
+		assert!(instance < self.n_instances(), "instance index out of range");
+		assert_eq!(
+			constants.len(),
+			self.layout.n_const,
+			"constants length must match the layout's constant count"
+		);
+		TableInstance {
+			table: self,
+			instance,
+			constants,
+		}
+	}
+}
+
+/// A [`WordSource`] view of one instance of a [`ValueTable`], as returned by
+/// [`ValueTable::instance_words`].
+#[derive(Clone, Copy)]
+pub struct TableInstance<'a, Data> {
+	table: &'a ValueTable<Data>,
+	instance: usize,
+	constants: &'a [Word],
+}
+
+impl<Data: Deref<Target = [Word]>> WordSource for TableInstance<'_, Data> {
+	#[inline]
+	fn word(&self, index: ValueIndex) -> Word {
+		// Constants live outside the table; the caller supplies them.
+		if index.segment() == ValueSegment::Constant {
+			return self.constants[index.index() as usize];
+		}
+
+		// Every other segment is a hidden row, the same one `instance_value_vec` gathers.
+		let row = self.table.layout.word_offset(index) - self.table.layout.offset_inout();
+		self.table.data[(row << self.table.log_instances) + self.instance]
+	}
 }
 
 #[cfg(test)]
 mod tests {
+	use proptest::{collection, prelude::any, prop_assert_eq, proptest};
+
 	use super::*;
 
 	/// A layout of one constant, two inout values and one private value.
@@ -222,5 +273,59 @@ mod tests {
 	#[should_panic(expected = "constants length must match")]
 	fn the_wrong_number_of_constants_is_rejected() {
 		table().instance_value_vec(0, &[]);
+	}
+
+	#[test]
+	fn instance_words_reads_back_as_its_own_column() {
+		let table = table();
+		let constants = [Word::from_u64(0xc0)];
+
+		for instance in 0..2 {
+			let words = table.instance_words(instance, &constants);
+			assert_eq!(words.word(ValueIndex::constant(0)), constants[0]);
+			assert_eq!(words.word(ValueIndex::inout(0)), Word::from_u64(instance as u64));
+			assert_eq!(words.word(ValueIndex::inout(1)), Word::from_u64(0x10 + instance as u64));
+			assert_eq!(words.word(ValueIndex::private(0)), Word::from_u64(0x20 + instance as u64));
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "instance index out of range")]
+	fn instance_words_past_the_last_instance_panics() {
+		table().instance_words(2, &[Word::from_u64(0xc0)]);
+	}
+
+	#[test]
+	#[should_panic(expected = "constants length must match")]
+	fn instance_words_rejects_the_wrong_number_of_constants() {
+		table().instance_words(0, &[]);
+	}
+
+	proptest! {
+		// Pins the table-row reads `TableInstance` does against the reference: reconstructing the
+		// instance as a whole `ValueVec` and indexing into that instead.
+		#[test]
+		fn instance_words_matches_instance_value_vec(
+			data in collection::vec(any::<u64>(), 6..=6),
+			constant in any::<u64>(),
+		) {
+			let data: Vec<Word> = data.into_iter().map(Word::from_u64).collect();
+			let table = ValueTable::from_hidden_words(layout(), 1, data);
+			let constants = [Word::from_u64(constant)];
+			let indices = [
+				ValueIndex::constant(0),
+				ValueIndex::inout(0),
+				ValueIndex::inout(1),
+				ValueIndex::private(0),
+			];
+
+			for instance in 0..table.n_instances() {
+				let reference = table.instance_value_vec(instance, &constants);
+				let words = table.instance_words(instance, &constants);
+				for &index in &indices {
+					prop_assert_eq!(words.word(index), reference[index]);
+				}
+			}
+		}
 	}
 }

--- a/crates/core/src/constraint_system/value_vec.rs
+++ b/crates/core/src/constraint_system/value_vec.rs
@@ -209,10 +209,7 @@ impl ValueVec {
 	/// An empty operand evaluates to the zero word, the XOR identity.
 	#[inline]
 	pub fn eval_operand(&self, operand: &[ShiftedValueIndex]) -> Word {
-		// Fold each shifted term into the running XOR, starting from the identity.
-		operand
-			.iter()
-			.fold(Word::ZERO, |acc, term| acc ^ term.eval(self))
+		super::shift::eval_operand(self, operand)
 	}
 }
 
@@ -228,6 +225,22 @@ impl IndexMut<ValueIndex> for ValueVec {
 	fn index_mut(&mut self, index: ValueIndex) -> &mut Self::Output {
 		let offset = self.word_offset(index);
 		&mut self.data[offset]
+	}
+}
+
+/// A source of words addressable by [`ValueIndex`].
+///
+/// [`ValueVec`] reads its own buffer.
+/// A [`ValueTable`](super::ValueTable) row reads a strided column instead.
+pub trait WordSource {
+	/// Returns the word at the given index.
+	fn word(&self, index: ValueIndex) -> Word;
+}
+
+impl WordSource for ValueVec {
+	#[inline]
+	fn word(&self, index: ValueIndex) -> Word {
+		self[index]
 	}
 }
 

--- a/crates/frontend/src/artifact/chip.rs
+++ b/crates/frontend/src/artifact/chip.rs
@@ -8,8 +8,9 @@ use std::mem;
 
 use binius_compute::GlobalAllocator;
 use binius_core::{
-	ValueTable, ValueVec, Word,
+	ValueTable, Word, WordSource,
 	error::{ChipName, OperandFault},
+	eval_operand,
 	m4::{ChipCall, ConstraintSystemM4, EmbeddedConstraintSystem, WitnessM4},
 };
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -332,14 +333,12 @@ impl CircuitM4 {
 				})
 				.map_err(|source| PopulateM4Error::Chip { chip_id, source })?;
 
-			// Read this chip's own calls off each active instance, for the chips after it to
-			// serve. Building the instance is what costs here — a value vector allocated and
-			// gathered word by word — so the instances are walked on the outside and every call
-			// one makes is read off it, rather than the chip being walked once per callee.
+			// Read this chip's own calls off each active instance, for the chips after it to serve.
+			// `instance_words` reads each call's operands straight off the table's strided rows.
 			if !chip.chip_calls.is_empty() {
 				let constants = &chip.circuit.constraint_system().constants;
 				for instance in 0..*n_active {
-					let values = table.instance_value_vec(instance, constants);
+					let values = table.instance_words(instance, constants);
 					for call in &chip.chip_calls {
 						pending[call.chip_id][call.first_instance + instance] =
 							eval_call(&values, call);
@@ -358,10 +357,10 @@ impl CircuitM4 {
 }
 
 /// Evaluates the inout operands of one chip call against the caller's values.
-fn eval_call(values: &ValueVec, call: &ChipCall) -> Vec<Word> {
+fn eval_call(values: &impl WordSource, call: &ChipCall) -> Vec<Word> {
 	call.inout
 		.iter()
-		.map(|operand| values.eval_operand(operand))
+		.map(|operand| eval_operand(values, operand))
 		.collect()
 }
 


### PR DESCRIPTION
Closes [BINIUS-501](https://linear.app/jimpo/issue/BINIUS-501/m4-read-chip-call-operands-off-the-value-table-without-rebuilding-each).

`CircuitM4::generate_witness` now reads a chip's calls straight off the value table instead of rebuilding the whole instance first. Pure refactor — no behavior change.

### The problem

Each chip's calls are read off its populated table like this:

```
for instance in 0..*n_active {
    let values = table.instance_value_vec(instance, constants);
    for call in &chip.chip_calls {
        pending[call.chip_id][call.first_instance + instance] = eval_call(&values, call);
    }
}
```

`instance_value_vec` allocates a fresh `ValueVec` over the *full* layout and gathers every hidden row of that instance, one strided load per row.
The loop then reads only the call operands off it.

On `prove_hash_based_sig` (512 signers), the XMSS chip holds ~29.3k hidden words per instance but its calls only touch 54 × 36 = 1,944 of them — 6.6% of what gets gathered.
Measured cost: the gather step took as long as evaluating the whole chip (59.5 ms out of 142 ms total witness generation, 42%).

### The idea

Add a `WordSource` trait — a word lookup by `ValueIndex` — and make operand evaluation generic over it instead of hardcoded to `ValueVec`:

```
trait WordSource {
    fn word(&self, index: ValueIndex) -> Word;
}
```

`ValueVec` implements it by indexing its own buffer.
A new `TableInstance` view implements it by indexing straight into the `ValueTable`'s strided column for one instance — no gathering, no allocation.
`ShiftedValueIndex::eval` and a new free `eval_operand` are generic over `WordSource`, so the same evaluation code runs against either backing.

### Per instance

- **before:** gather ~29.3k words into a fresh `ValueVec`, then read 1,944 of them
- **after:** read only the 1,944 words the calls name, directly off the table

→ the gather step touches ~15x fewer words for this circuit's shape.

### The change

```diff
- let values = table.instance_value_vec(instance, constants);
+ let values = table.instance_words(instance, constants);
  for call in &chip.chip_calls {
      pending[call.chip_id][call.first_instance + instance] =
-         eval_call(&values, call);
+         eval_call(&values, call);   // eval_call is now generic over WordSource
  }
```

`eval_call` itself changes from `fn eval_call(values: &ValueVec, ...)` to `fn eval_call(values: &impl WordSource, ...)`, so it serves both the main circuit's real `ValueVec` and a chip's `TableInstance` row unchanged.

### Scope

- **new:** `WordSource` trait (`value_vec.rs`), generic `eval_operand` (`shift.rs`), `TableInstance` + `ValueTable::instance_words` (`value_table.rs`)
- **changed:** `ShiftedValueIndex::eval` takes `&impl WordSource` instead of `&ValueVec`; `CircuitM4::generate_witness`'s gather loop and `eval_call` (`chip.rs`)
- **left untouched:** `ValueTable::instance_value_vec` stays as the reference implementation, still used elsewhere and by the new test
- the parallel `populate_batch_parallel` step above this loop is unaffected

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core -p binius-frontend --all-targets` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p binius-core -p binius-frontend --lib` — 257 frontend + core's suite pass, including a new proptest pinning `TableInstance::word` against `instance_value_vec` over random hidden-word data

### Benchmark

Throwaway micro-benchmark reproducing the ticket's exact shape (512 instances, ~29.3k hidden words/instance, 54 calls × 36 inout words each), release mode:

| path | time |
|---|---|
| `instance_value_vec` + `eval_operand` (before) | 74.7 ms |
| `instance_words` + `eval_operand` (after) | 4.2 ms |

~17-21× faster on this step, consistent across repeated runs. The 74.7 ms lines up with the ticket's measured 59.5 ms for this exact step on the real circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)