### PR TITLE
Drop extrapolate_line_packed, keep the single generic extrapolate_line

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -18,7 +18,7 @@ use binius_ip_prover::{
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldSliceMut, FieldVec,
 	inner_product::inner_product_par,
-	line::{extrapolate_line, extrapolate_line_packed},
+	line::extrapolate_line,
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
 	ntt::AdditiveNTT,
 };
@@ -283,7 +283,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 				.into_par_iter()
 				.with_min_task(WorkPerItem::FieldMuls)
 				.for_each(|(message_i, &mask_i)| {
-					*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
+					*message_i = extrapolate_line(*message_i, mask_i, gamma_broadcast);
 				});
 		}
 	}

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -122,7 +122,7 @@ mod test {
 	use binius_math::{
 		FieldBuffer,
 		inner_product::inner_product_buffers,
-		line::extrapolate_line_packed,
+		line::extrapolate_line,
 		multilinear::eq::eq_ind_partial_eval,
 		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 		test_utils::{random_field_buffer, random_scalars},
@@ -202,7 +202,7 @@ mod test {
 		(witness_prime.as_mut(), mask.as_ref())
 			.into_par_iter()
 			.for_each(|(w, &m)| {
-				*w = extrapolate_line_packed(*w, m, gamma_broadcast);
+				*w = extrapolate_line(*w, m, gamma_broadcast);
 			});
 
 		let eval_point_eq = eq_ind_partial_eval::<P>(evaluation_point);

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::{BinaryField, ExtensionField};
-use binius_math::{line::extrapolate_line_packed, ntt::AdditiveNTT};
+use binius_math::{line::extrapolate_line, ntt::AdditiveNTT};
 
 use super::{FRIParams, error::Error};
 use crate::merkle_channel::MerkleIPVerifierChannel;
@@ -24,7 +24,7 @@ where
 	let (mut u, mut v) = values;
 	v += u;
 	u += v * t;
-	extrapolate_line_packed(u, v, r)
+	extrapolate_line(u, v, r)
 }
 
 /// Calculate FRI fold of `values` at a `chunk_index` with random folding challenges.

--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -11,7 +11,7 @@ use binius_ip::{
 use binius_math::{
 	FieldBuffer, FieldVec,
 	batch_invert::BatchInversion,
-	line::extrapolate_line_packed,
+	line::extrapolate_line,
 	multilinear::eq::{eq_ind_partial_eval, eq_one_var},
 };
 use binius_utils::rayon::{
@@ -340,8 +340,8 @@ where
 			// Fold the highest variable to combine the two halves into the next layer's claim.
 			let r = channel.sample();
 
-			let next_num = extrapolate_line_packed(num_0, num_1, r);
-			let next_den = extrapolate_line_packed(den_0, den_1, r);
+			let next_num = extrapolate_line(num_0, num_1, r);
+			let next_den = extrapolate_line(den_0, den_1, r);
 
 			// Sumcheck binds variables high-to-low; reverse to low-to-high for the claim point.
 			let mut next_point = output.challenges;
@@ -615,7 +615,7 @@ where
 	// aligned with the selector `eq` weights on subsequent layers; the padded entries are 0/1.
 	let next_fractions = izip!(&num_0s, &num_1s, &den_0s, &den_1s)
 		.map(|(&num_0, &num_1, &den_0, &den_1)| {
-			(extrapolate_line_packed(num_0, num_1, r), extrapolate_line_packed(den_0, den_1, r))
+			(extrapolate_line(num_0, num_1, r), extrapolate_line(den_0, den_1, r))
 		})
 		.collect();
 

--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -7,7 +7,7 @@ use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
 	FieldBuffer, FieldVec,
-	line::extrapolate_line_packed,
+	line::extrapolate_line,
 	multilinear::eq::{eq_ind_partial_eval, eq_one_var},
 };
 use binius_utils::rayon::{
@@ -178,7 +178,7 @@ where
 			channel.send_many(&[eval_0, eval_1]);
 
 			let r = channel.sample();
-			let next_eval = extrapolate_line_packed(eval_0, eval_1, r);
+			let next_eval = extrapolate_line(eval_0, eval_1, r);
 
 			let mut next_point = challenges;
 			next_point.reverse();
@@ -429,7 +429,7 @@ fn prove_layer_rounds<A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 
 	// Update claimed products for next iteration, dropping the padded (2^k) selector slots.
 	let next_claimed_products = iter::zip(&vals_0[..n], &vals_1[..n])
-		.map(|(e0, e1)| extrapolate_line_packed(*e0, *e1, r))
+		.map(|(e0, e1)| extrapolate_line(*e0, *e1, r))
 		.collect();
 
 	(next_claimed_products, next_point)

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -25,7 +25,7 @@ use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec,
-	line::extrapolate_line_packed,
+	line::extrapolate_line,
 	multilinear::fold::{fold_highest_var, fold_highest_var_inplace},
 };
 use binius_utils::rayon;
@@ -577,7 +577,7 @@ impl<'a, P: PackedField> PreFoldColumnChunk<'a, P> {
 
 	/// Folds a column half, interpolating its two segments on the round's variable.
 	fn fold(self, challenge_broadcast: &P) -> &'a [P] {
-		self.fold_with(|lo, hi| extrapolate_line_packed(lo, hi, *challenge_broadcast))
+		self.fold_with(|lo, hi| extrapolate_line(lo, hi, *challenge_broadcast))
 	}
 
 	/// Contracts an eq expansion by summing its two segments.

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -14,8 +14,7 @@ use binius_compute::Allocator;
 use binius_field::{Field, PackedField, util::powers};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_math::{
-	FieldVec, field_buffer::FieldBuffer, line::extrapolate_line_packed,
-	univariate::evaluate_univariate,
+	FieldVec, field_buffer::FieldBuffer, line::extrapolate_line, univariate::evaluate_univariate,
 };
 
 use super::{common::MleCheckProver, round_state::RoundState};
@@ -178,7 +177,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 			.map(|(i, &z_i)| {
 				let g_at_0 = self.get_coeff(i, 0);
 				let g_at_1 = self.evaluate_univariate(i, F::ONE);
-				extrapolate_line_packed(g_at_0, g_at_1, z_i)
+				extrapolate_line(g_at_0, g_at_1, z_i)
 			})
 			.sum()
 	}
@@ -231,12 +230,12 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>
 		let n_vars = eval_point.len();
 
 		// Precompute suffix_sums[j] = (1-z_j)*g_j(0) + z_j*g_j(1)
-		// This equals extrapolate_line_packed(g_j(0), g_j(1), z_j)
+		// This equals extrapolate_line(g_j(0), g_j(1), z_j)
 		let suffix_sums: Vec<F> = iter::zip(0..n_vars, &eval_point)
 			.map(|(i, &z_j)| {
 				let g_at_0 = mask.get_coeff(i, 0);
 				let g_at_1 = mask.evaluate_univariate(i, F::ONE);
-				extrapolate_line_packed(g_at_0, g_at_1, z_j)
+				extrapolate_line(g_at_0, g_at_1, z_j)
 			})
 			.collect();
 

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -253,7 +253,7 @@ pub fn libra_eval<F: FieldOps>(
 #[cfg(test)]
 mod tests {
 	use binius_field::{Random, arch::OptimalB128 as B128};
-	use binius_math::{line::extrapolate_line_packed, test_utils::random_scalars};
+	use binius_math::{line::extrapolate_line, test_utils::random_scalars};
 	use rand::prelude::*;
 
 	use super::*;
@@ -263,7 +263,7 @@ mod tests {
 
 		let v0 = coeffs.evaluate(&F::ZERO);
 		let v1 = coeffs.evaluate(&F::ONE);
-		let eval = extrapolate_line_packed(v0, v1, alpha);
+		let eval = extrapolate_line(v0, v1, alpha);
 
 		let proof = RoundProof::truncate(coeffs.clone());
 		assert_eq!(proof.recover(eval, alpha), coeffs);

--- a/crates/math/src/line.rs
+++ b/crates/math/src/line.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{PackedField, field::FieldOps};
+use binius_field::field::FieldOps;
 
 /// Extrapolates a line through two points.
 ///
@@ -16,32 +16,6 @@ pub fn extrapolate_line<F: FieldOps>(x0: F, x1: F, z: F) -> F {
 	x0.clone() + (x1 - x0) * z
 }
 
-/// Extrapolates lines through a pair of packed fields at a packed vector of points.
-///
-/// Given two points (0, x0) and (1, x1), this function evaluates the line through these
-/// points at parameter z using the formula: x0 + (x1 - x0) * z
-///
-/// # Properties
-/// - When z = 0, returns x0
-/// - When z = 1, returns x1
-/// - The function is linear in z
-/// - Operates on packed field elements for SIMD efficiency
-///
-/// # Arguments
-/// * `x0` - The y-coordinate at z = 0
-/// * `x1` - The y-coordinate at z = 1
-/// * `z` - The evaluation point(s)
-///
-/// # Returns
-/// The interpolated/extrapolated value(s) at point(s) z
-#[inline]
-pub fn extrapolate_line_packed<P>(x0: P, x1: P, z: P) -> P
-where
-	P: PackedField,
-{
-	x0 + (x1 - x0) * z
-}
-
 #[cfg(test)]
 mod tests {
 	use binius_field::{Field, Random, field::FieldOps};
@@ -54,7 +28,7 @@ mod tests {
 	type F = B128;
 
 	#[test]
-	fn test_extrapolate_line_packed_boundary_values() {
+	fn test_extrapolate_line_boundary_values() {
 		let mut rng = StdRng::seed_from_u64(0);
 
 		// Test with scalar field
@@ -64,10 +38,10 @@ mod tests {
 		let one = F::ONE;
 
 		// When z = 0, should return x0
-		assert_eq!(extrapolate_line_packed(x0, x1, zero), x0);
+		assert_eq!(extrapolate_line(x0, x1, zero), x0);
 
 		// When z = 1, should return x1
-		assert_eq!(extrapolate_line_packed(x0, x1, one), x1);
+		assert_eq!(extrapolate_line(x0, x1, one), x1);
 
 		// Test with packed field
 		let x0_packed = P::random(&mut rng);
@@ -76,14 +50,14 @@ mod tests {
 		let one_packed = P::one();
 
 		// When z = 0, should return x0
-		assert_eq!(extrapolate_line_packed(x0_packed, x1_packed, zero_packed), x0_packed);
+		assert_eq!(extrapolate_line(x0_packed, x1_packed, zero_packed), x0_packed);
 
 		// When z = 1, should return x1
-		assert_eq!(extrapolate_line_packed(x0_packed, x1_packed, one_packed), x1_packed);
+		assert_eq!(extrapolate_line(x0_packed, x1_packed, one_packed), x1_packed);
 	}
 
 	#[test]
-	fn test_extrapolate_line_packed_linearity() {
+	fn test_extrapolate_line_linearity() {
 		let mut rng = StdRng::seed_from_u64(0);
 
 		// Generate random points and values
@@ -96,9 +70,9 @@ mod tests {
 		// Test linearity property: f(αz0 + (1-α)z1) = αf(z0) + (1-α)f(z1)
 		let z_combined = alpha * z0 + (F::ONE - alpha) * z1;
 
-		let f_z0 = extrapolate_line_packed(x0, x1, z0);
-		let f_z1 = extrapolate_line_packed(x0, x1, z1);
-		let f_combined = extrapolate_line_packed(x0, x1, z_combined);
+		let f_z0 = extrapolate_line(x0, x1, z0);
+		let f_z1 = extrapolate_line(x0, x1, z1);
+		let f_combined = extrapolate_line(x0, x1, z_combined);
 
 		let expected = alpha * f_z0 + (F::ONE - alpha) * f_z1;
 

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -12,7 +12,7 @@ use binius_utils::{
 	},
 };
 
-use crate::{FieldBuffer, FieldVec, field_buffer::BufferData, line::extrapolate_line_packed};
+use crate::{FieldBuffer, FieldVec, field_buffer::BufferData, line::extrapolate_line};
 
 /// Computes the partial evaluation of a multilinear on its highest variable, inplace.
 ///
@@ -33,9 +33,7 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: BufferData<P>>(
 		(lo.as_mut(), hi.as_mut())
 			.into_par_iter()
 			.with_min_task(WorkPerItem::FieldMuls)
-			.for_each(|(lo_i, hi_i)| {
-				*lo_i = extrapolate_line_packed(*lo_i, *hi_i, broadcast_scalar)
-			});
+			.for_each(|(lo_i, hi_i)| *lo_i = extrapolate_line(*lo_i, *hi_i, broadcast_scalar));
 	}
 
 	values.truncate(values.log_len() - 1);
@@ -72,7 +70,7 @@ pub fn fold_highest_var<A: Allocator, P: PackedField, Data: Deref<Target = [P]>>
 		.into_par_iter()
 		.with_min_task(WorkPerItem::FieldMuls)
 		.for_each(|(out, &lo_i, &hi_i)| {
-			out.write(extrapolate_line_packed(lo_i, hi_i, broadcast_scalar));
+			out.write(extrapolate_line(lo_i, hi_i, broadcast_scalar));
 		});
 	// SAFETY: the parallel loop initialized all `len` slots.
 	unsafe { data.set_len(len) };

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -271,7 +271,7 @@ mod tests {
 	use crate::{
 		BinarySubspace,
 		inner_product::inner_product,
-		line::extrapolate_line_packed,
+		line::extrapolate_line,
 		test_utils::{B128, random_scalars},
 	};
 
@@ -379,7 +379,7 @@ mod tests {
 			let x1 = B128::random(&mut rng);
 			// Use a smaller field element for z to test the subfield scalar multiplication
 			let z = B128::from(rng.next_u64() as u128);
-			assert_eq!(extrapolate_line_packed(x0, x1, z), x0 + (x1 - x0) * z);
+			assert_eq!(extrapolate_line(x0, x1, z), x0 + (x1 - x0) * z);
 		}
 	}
 

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -61,7 +61,7 @@ use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_ip_prover::channel::{IPProverChannel, WordIPProverChannel};
 use binius_math::{
 	inner_product::inner_product_buffers,
-	line::extrapolate_line_packed,
+	line::extrapolate_line,
 	multilinear::eq::eq_ind_partial_eval,
 	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 	test_utils::{random_field_buffer, random_scalars},
@@ -224,7 +224,7 @@ fn prove(shape: &Shape, setup: &Setup, seed: u64) -> Opening {
 	let broadcast = P::broadcast(gamma);
 	(witness_prime.as_mut(), mask.as_ref())
 		.into_par_iter()
-		.for_each(|(w, &m)| *w = extrapolate_line_packed(*w, m, broadcast));
+		.for_each(|(w, &m)| *w = extrapolate_line(*w, m, broadcast));
 
 	// The claim is the folded polynomial against the equality indicator, which is pi'(r).
 	// It exists only once gamma does, so it is bound here rather than up front.

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -119,7 +119,7 @@ mod tests {
 
 	use binius_field::{BinaryField128bGhash as B128, Field, Random, arithmetic_traits::Square};
 	use binius_math::{
-		line::extrapolate_line_packed,
+		line::extrapolate_line as extrapolate_line_math,
 		multilinear,
 		test_utils::{random_field_buffer, random_scalars},
 		univariate,
@@ -217,7 +217,7 @@ mod tests {
 		let y0_val = B128::random(&mut rng);
 		let y1_val = B128::random(&mut rng);
 		let z_val = B128::random(&mut rng);
-		let expected = extrapolate_line_packed(y0_val, y1_val, z_val);
+		let expected = extrapolate_line_math(y0_val, y1_val, z_val);
 
 		test_helper::<ExtrapolateLineCircuit, 4>([y0_val, y1_val, z_val, expected]).unwrap();
 	}


### PR DESCRIPTION
`extrapolate_line_packed` was a redundant twin of `extrapolate_line` — same formula, subset of types.

### The problem

`crates/math/src/line.rs` had two functions:

```
extrapolate_line<F: FieldOps>(x0, x1, z) -> F           // x0.clone() + (x1 - x0) * z
extrapolate_line_packed<P: PackedField>(x0, x1, z) -> P  // x0 + (x1 - x0) * z
```

`PackedField` is already a supertrait of `FieldOps`, and `Field: PackedField<Scalar = Self>` makes every scalar field a width-1 packed field.
So every valid call to `extrapolate_line_packed` was already a valid call to `extrapolate_line` — the two bodies differ only by a no-op `.clone()` (packed fields are `Copy`, so cloning is free).

One caller (`iop-prover/src/basefold/channel.rs`) was already importing both names side by side on the same types, which is what surfaced the duplication.

### The change

- Removed `extrapolate_line_packed` from `crates/math/src/line.rs`.
- Repointed its ~13 call sites to `extrapolate_line`, across `ip-prover`, `ip`, `iop-prover`, `iop`, `recursion`, and `spartan-frontend`.
- `spartan-frontend/src/circuits.rs` has its own, unrelated `extrapolate_line` (a circuit-gadget version that takes a `Builder`), so its test module aliases the math import to `extrapolate_line_math` to avoid a name clash with the glob `use super::*`.

Pure refactor — no behavior change.

### Scope

- **removed:** `extrapolate_line_packed`
- **changed:** its call sites and imports (`ip-prover`, `ip`, `iop-prover`, `iop`, `recursion`, `spartan-frontend`)
- **left untouched:** `extrapolate_line`'s implementation, and the unrelated circuit-gadget `extrapolate_line` in `spartan-frontend`

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-math -p binius-spartan-frontend -p binius-ip-prover -p binius-ip -p binius-iop-prover -p binius-iop -p binius-recursion --all-targets` — clean
- `cargo +nightly fmt --all` — applied
- `cargo test` on the same crate set — all passing (line.rs's two tests renamed to `test_extrapolate_line_boundary_values` / `test_extrapolate_line_linearity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)