### PR TITLE
Drop unnecessary UFCS on associated consts/methods with one applicable trait bound

### DIFF
--- a/crates/arith-bench/src/ghash/clmul.rs
+++ b/crates/arith-bench/src/ghash/clmul.rs
@@ -32,7 +32,7 @@ use crate::{PackedUnderlier, Underlier, underlier::OpsClmul};
 /// by 1 and conditionally XOR with X^{-1} if the LSB was set.
 #[inline]
 pub fn mul_inv_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
-	let inv_x = <U as PackedUnderlier<u128>>::broadcast(super::INV_X);
+	let inv_x = U::broadcast(super::INV_X);
 
 	// Put bit 0 of each 64-bit lane into bit 63.
 	let lsb_at_top = U::slli_epi64::<63>(x);
@@ -61,7 +61,7 @@ pub fn mul_inv_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
 /// (`X^128 ≡ X^7 + X^2 + X + 1 = 0x87`).
 #[inline]
 pub fn mul_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
-	let poly = <U as PackedUnderlier<u128>>::broadcast(0x87);
+	let poly = U::broadcast(0x87);
 
 	// Full 128-bit left shift by one, per 128-bit lane.
 	let shifted = shift_left_1(x);
@@ -165,7 +165,7 @@ pub fn square<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
 fn gf2_128_reduce<U: Underlier + OpsClmul + PackedUnderlier<u128>>(mut t0: U, t1: U) -> U {
 	// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87
 	const POLY: u128 = 0x87;
-	let poly = <U as PackedUnderlier<u128>>::broadcast(POLY);
+	let poly = U::broadcast(POLY);
 
 	// t0 = t0 XOR (t1 << 64)
 	// In SIMD, left shift by 64 bits is shifting by 8 bytes
@@ -183,7 +183,7 @@ fn gf2_128_reduce<U: Underlier + OpsClmul + PackedUnderlier<u128>>(mut t0: U, t1
 fn gf2_128_shift_reduce<U: Underlier + OpsClmul + PackedUnderlier<u128>>(t1: U) -> U {
 	// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87
 	const POLY: u128 = 0x87;
-	let poly = <U as PackedUnderlier<u128>>::broadcast(POLY);
+	let poly = U::broadcast(POLY);
 
 	// t0 = t1 << 64
 	// In SIMD, left shift by 64 bits is shifting by 8 bytes
@@ -263,7 +263,7 @@ pub fn reduce_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(
 ) -> [U; 2] {
 	// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87
 	const POLY: u128 = 0x87;
-	let poly = <U as PackedUnderlier<u128>>::broadcast(POLY);
+	let poly = U::broadcast(POLY);
 
 	let t2_hi_times_poly = [
 		U::clmulepi64::<0x01>(t2[0], poly),

--- a/crates/arith-bench/src/monbijou/x86_64.rs
+++ b/crates/arith-bench/src/monbijou/x86_64.rs
@@ -227,7 +227,7 @@ pub fn reduce<U: Underlier + OpsClmul + PackedUnderlier<u64>>([prod_0, prod_1]: 
 	// The reduction polynomial X^64 + X^4 + X^3 + X + 1 is represented as 0x1B
 	// This is the bit representation of the lower-degree terms (X^4 + X^3 + X + 1)
 	const POLY: u64 = 0x1B;
-	let poly = <U as PackedUnderlier<u64>>::broadcast(POLY);
+	let poly = U::broadcast(POLY);
 
 	// Step 2: First reduction - multiply high 64 bits by reduction polynomial
 	// This effectively computes: high_bits * (X^4 + X^3 + X + 1) mod X^128

--- a/crates/arith-bench/src/polyval/clmul.rs
+++ b/crates/arith-bench/src/polyval/clmul.rs
@@ -91,7 +91,7 @@ fn mont_reduce<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x23: U, x01: U) 
 	//    [D1:D0] = [B0 ⊕ C1 : B1 ⊕ C0]
 	// Output: [D1 ⊕ X3 : D0 ⊕ X2]
 	static POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
-	let poly = <U as PackedUnderlier<u128>>::broadcast(POLY);
+	let poly = U::broadcast(POLY);
 	let a = pmull(x01, poly);
 	let b = U::xor(x01, U::swap_hi_lo_64(a));
 	let c = pmull2(b, poly);

--- a/crates/arith-bench/src/rijndael/gfni.rs
+++ b/crates/arith-bench/src/rijndael/gfni.rs
@@ -23,6 +23,6 @@ pub fn inv<U: Underlier + OpsGfni + PackedUnderlier<u64>>(x: U) -> U {
 		0b00000001,
 	]);
 
-	let identity_map = <U as PackedUnderlier<u64>>::broadcast(IDENTITY_MAP);
+	let identity_map = U::broadcast(IDENTITY_MAP);
 	OpsGfni::gf2p8affineinv::<0>(x, identity_map)
 }

--- a/crates/arith-bench/src/rijndael/russian_peasant.rs
+++ b/crates/arith-bench/src/rijndael/russian_peasant.rs
@@ -47,7 +47,7 @@ pub trait RijndaelBytewise: Underlier + PackedUnderlier<u8> {
 pub fn mul<U: RijndaelBytewise>(a: U, b: U) -> U {
 	// Low byte of the reduction polynomial (x^4 + x^3 + x + 1), XORed in whenever a byte doubling
 	// carries out of bit 7.
-	let poly = <U as PackedUnderlier<u8>>::broadcast(0x1b);
+	let poly = U::broadcast(0x1b);
 
 	let mut r = U::ZERO;
 	// MSB-first double-and-add. On step `k` we test bit `i = 7 - k` of `b`: shifting `b` left by

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -485,23 +485,17 @@ where
 	#[inline]
 	unsafe fn set_unchecked(&mut self, index: usize, val: Scalar) {
 		// Safety: `index < Self::N` by the caller's contract.
-		unsafe {
-			<U as Divisible<Scalar::Underlier>>::set_unchecked(
-				&mut self.0,
-				index,
-				val.to_underlier(),
-			)
-		};
+		unsafe { U::set_unchecked(&mut self.0, index, val.to_underlier()) };
 	}
 
 	#[inline]
 	fn broadcast(val: Scalar) -> Self {
-		<U as Divisible<Scalar::Underlier>>::broadcast(val.to_underlier()).into()
+		U::broadcast(val.to_underlier()).into()
 	}
 
 	#[inline]
 	fn from_iter(iter: impl Iterator<Item = Scalar>) -> Self {
-		<U as Divisible<Scalar::Underlier>>::from_iter(iter.map(Scalar::to_underlier)).into()
+		U::from_iter(iter.map(Scalar::to_underlier)).into()
 	}
 }
 
@@ -518,12 +512,10 @@ where
 	fn make_mask(selectors: impl Iterator<Item = bool>) -> U {
 		// Build a per-lane all-ones/all-zeros sub-underlier for each scalar slot and pack into U.
 		// A selected lane produces fill_with_bit(1) (every bit set); unselected gives ZERO.
-		<U as Divisible<Scalar::Underlier>>::from_iter(
+		U::from_iter(
 			selectors
-				.take(<Self as Divisible<Scalar>>::N)
-				.map(|selected| {
-					<Scalar::Underlier as UnderlierType>::fill_with_bit(u8::from(selected))
-				}),
+				.take(Self::N)
+				.map(|selected| Scalar::Underlier::fill_with_bit(u8::from(selected))),
 		)
 	}
 
@@ -540,7 +532,7 @@ where
 	U: UnderlierType + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {
-	// LOG_WIDTH defaults to `<Self as Divisible<Scalar>>::LOG_N`, the same `(U::BITS /
+	// LOG_WIDTH defaults to `Self::LOG_N`, the same `(U::BITS /
 	// Scalar::N_BITS).ilog2()` count. Scalar element access (`get_unchecked`/`set_unchecked`) is
 	// provided by the `Divisible<Scalar>` impl, which routes through `U:
 	// Divisible<Scalar::Underlier>`.

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -245,7 +245,7 @@ mod tests {
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::{ClMulUnderlier, WideGhashProduct};
-	use crate::{Divisible, Random, WideMul, arch::OptimalPackedB128, arithmetic_traits::MulXWide};
+	use crate::{Random, WideMul, arch::OptimalPackedB128, arithmetic_traits::MulXWide};
 
 	/// Scaling by X commutes with the reduction: scaling the unreduced product matches multiplying
 	/// the reduced product by X (the field element 2) in every 128-bit lane.

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -251,7 +251,7 @@ mod tests {
 	/// the reduced product by X (the field element 2) in every 128-bit lane.
 	#[allow(dead_code)]
 	fn check_mul_x_wide<U: ClMulUnderlier>(mut rng: impl Rng) {
-		let x = <U as Divisible<u128>>::broadcast(2);
+		let x = U::broadcast(2);
 
 		for _ in 0..64 {
 			let wide = WideGhashProduct::wide_mul(U::random(&mut rng), U::random(&mut rng));

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -127,7 +127,7 @@ pub trait FieldOps:
 	///
 	/// ## Preconditions
 	///
-	/// * `elems.len()` must equal `<Self::Scalar as ExtensionField<FSub>>::DEGREE`
+	/// * `elems.len()` must equal `Self::Scalar::DEGREE`
 	fn square_transpose<FSub: Field>(elems: &mut [Self])
 	where
 		Self::Scalar: ExtensionField<FSub>;

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -151,7 +151,7 @@ mod tests {
 	where
 		GhashSq256b: ExtensionField<F>,
 	{
-		let degree = <GhashSq256b as ExtensionField<F>>::DEGREE;
+		let degree = GhashSq256b::DEGREE;
 		assert_eq!(values.len(), degree);
 		let coords: Vec<F> = values
 			.iter()

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -52,7 +52,7 @@ pub trait PackedField:
 	/// Base-2 logarithm of the number of field elements packed into one packed element.
 	///
 	/// This is the number of scalars the packed field divides into, i.e. its `Divisible` log-count.
-	const LOG_WIDTH: usize = <Self as Divisible<Self::Scalar>>::LOG_N;
+	const LOG_WIDTH: usize = Self::LOG_N;
 
 	/// The number of field elements packed into one packed element.
 	///

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -311,7 +311,7 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		Divisible, Field, PackedField, Random,
+		Field, PackedField, Random,
 		arithmetic_traits::{InvertOrZero, Square},
 		field::FieldOps,
 	};
@@ -362,7 +362,7 @@ mod tests {
 		let a = P::random(&mut rng);
 		let s = GhashSq256b::random(&mut rng);
 
-		let broadcast = <P as Divisible<GhashSq256b>>::broadcast(s);
+		let broadcast = P::broadcast(s);
 		let scaled = a * s;
 		for i in 0..P::WIDTH {
 			assert_eq!(broadcast.get(i), s);

--- a/crates/field/src/sliced_packed_field.rs
+++ b/crates/field/src/sliced_packed_field.rs
@@ -64,7 +64,7 @@ use crate::{
 /// A packed extension field stored as `N` packed subfield coordinate registers.
 ///
 /// `F` is the extension scalar, `PSub` the packed subfield holding one coordinate of every lane,
-/// and `N = <F as ExtensionField<PSub::Scalar>>::DEGREE` the extension degree. See the module
+/// and `N = F::DEGREE` the extension degree. See the module
 /// documentation for the layout and for which operations are generic here versus supplied per
 /// concrete extension.
 ///
@@ -277,7 +277,7 @@ where
 {
 	#[inline]
 	fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-		iter.fold(<Self as Divisible<F>>::broadcast(F::ONE), |acc, x| acc * x)
+		iter.fold(Self::broadcast(F::ONE), |acc, x| acc * x)
 	}
 }
 
@@ -288,7 +288,7 @@ where
 {
 	#[inline]
 	fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
-		iter.fold(<Self as Divisible<F>>::broadcast(F::ONE), |acc, x| acc * *x)
+		iter.fold(Self::broadcast(F::ONE), |acc, x| acc * *x)
 	}
 }
 
@@ -303,7 +303,7 @@ where
 
 	#[inline]
 	fn add(self, rhs: F) -> Self {
-		self + <Self as Divisible<F>>::broadcast(rhs)
+		self + Self::broadcast(rhs)
 	}
 }
 
@@ -316,7 +316,7 @@ where
 
 	#[inline]
 	fn sub(self, rhs: F) -> Self {
-		self - <Self as Divisible<F>>::broadcast(rhs)
+		self - Self::broadcast(rhs)
 	}
 }
 
@@ -330,7 +330,7 @@ where
 
 	#[inline]
 	fn mul(self, rhs: F) -> Self {
-		self * <Self as Divisible<F>>::broadcast(rhs)
+		self * Self::broadcast(rhs)
 	}
 }
 
@@ -364,7 +364,7 @@ where
 {
 	#[inline]
 	fn mul_assign(&mut self, rhs: F) {
-		*self = *self * <Self as Divisible<F>>::broadcast(rhs);
+		*self = *self * Self::broadcast(rhs);
 	}
 }
 
@@ -469,7 +469,7 @@ where
 
 	#[inline]
 	fn one() -> Self {
-		<Self as Divisible<F>>::broadcast(F::ONE)
+		Self::broadcast(F::ONE)
 	}
 
 	fn square_transpose<FSub: Field>(elems: &mut [Self])
@@ -486,7 +486,7 @@ where
 			let column = (0..degree).map(|j| elems[j].get(lane)).collect::<Vec<F>>();
 			for (i, elem) in elems.iter_mut().enumerate() {
 				let transposed = <F as ExtensionField<FSub>>::from_bases(
-					(0..degree).map(|j| <F as ExtensionField<FSub>>::get_base(&column[j], i)),
+					(0..degree).map(|j| F::get_base(&column[j], i)),
 				);
 				elem.set(lane, transposed);
 			}
@@ -501,7 +501,7 @@ where
 	Self:
 		Square + InvertOrZero + Mul<Output = Self> + WideMul<Output: Debug + Send + Sync + 'static>,
 {
-	// LOG_WIDTH defaults to `<Self as Divisible<F>>::LOG_N == PSub::LOG_WIDTH`; scalar access is
+	// LOG_WIDTH defaults to `Self::LOG_N == PSub::LOG_WIDTH`; scalar access is
 	// provided by the `Divisible<F>` impl above.
 
 	#[inline]

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -122,7 +122,7 @@ where
 	FSub: Field,
 	F: ExtensionField<FSub> + FieldOps<Scalar = F>,
 {
-	let degree = <F as ExtensionField<FSub>>::DEGREE;
+	let degree = F::DEGREE;
 
 	let elems: Vec<F> = (0..degree).map(|i| F::basis(i)).collect();
 
@@ -145,12 +145,12 @@ where
 	FSub: Field,
 	P: FieldOps<Scalar: ExtensionField<FSub>> + PackedField,
 {
-	let degree = <P::Scalar as ExtensionField<FSub>>::DEGREE;
+	let degree = P::Scalar::DEGREE;
 
 	let elems: Vec<P> = (0..degree)
 		.map(|i| {
 			P::from_fn(|_k| {
-				<P::Scalar as ExtensionField<FSub>>::from_bases(
+				P::Scalar::from_bases(
 					(0..degree).map(|j| if j == i { FSub::ONE } else { FSub::ZERO }),
 				)
 			})

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -60,7 +60,7 @@ where
 	FE: PackedField<Scalar: ExtensionField<F>> + WithUnderlier,
 	PackedSubfield<FE, F>: PackedField<Scalar = F>,
 {
-	square_transpose(<FE::Scalar as ExtensionField<F>>::LOG_DEGREE, cast_bases_mut::<F, FE>(values))
+	square_transpose(FE::Scalar::LOG_DEGREE, cast_bases_mut::<F, FE>(values))
 }
 
 #[cfg(test)]

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -205,7 +205,7 @@ where
 	U: Divisible<T> + Pod + Send + Sync,
 	T: Send + 'static,
 {
-	const LOG_N: usize = <U as Divisible<T>>::LOG_N + checked_log_2(N);
+	const LOG_N: usize = U::LOG_N + checked_log_2(N);
 
 	#[inline]
 	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = T> + Send + Clone {
@@ -224,8 +224,8 @@ where
 
 	#[inline]
 	unsafe fn get_unchecked(&self, index: usize) -> T {
-		let u_index = index >> <U as Divisible<T>>::LOG_N;
-		let sub_index = index & (<U as Divisible<T>>::N - 1);
+		let u_index = index >> U::LOG_N;
+		let sub_index = index & (U::N - 1);
 		// Safety: `index < Self::N` by the caller's contract, so `sub_index < <U as
 		// Divisible<T>>::N` and `u_index < N`.
 		unsafe { Divisible::<T>::get_unchecked(self.0.get_unchecked(u_index), sub_index) }
@@ -233,8 +233,8 @@ where
 
 	#[inline]
 	unsafe fn set_unchecked(&mut self, index: usize, val: T) {
-		let u_index = index >> <U as Divisible<T>>::LOG_N;
-		let sub_index = index & (<U as Divisible<T>>::N - 1);
+		let u_index = index >> U::LOG_N;
+		let sub_index = index & (U::N - 1);
 		// Safety: `index < Self::N` by the caller's contract, so `sub_index < <U as
 		// Divisible<T>>::N` and `u_index < N`.
 		unsafe { Divisible::<T>::set_unchecked(self.0.get_unchecked_mut(u_index), sub_index, val) };

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -163,7 +163,7 @@ mod tests {
 	fn iota<E: Field + ExtensionField<BinaryField1b>>(j: usize, m: usize) -> E {
 		(0..m)
 			.filter(|t| (j >> t) & 1 == 1)
-			.map(<E as ExtensionField<BinaryField1b>>::basis)
+			.map(E::basis)
 			.fold(E::ZERO, |acc, b| acc + b)
 	}
 

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -22,7 +22,7 @@
 use std::{iter::repeat_with, ops::Shr};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps};
+use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_transcript::{
 	VerifierTranscript,
 	fiat_shamir::{CanSample, CanSampleBits, Challenger},
@@ -203,9 +203,7 @@ where
 				.flat_map(|(i, word)| {
 					(0..Word::BITS)
 						.filter(|&bit| word.extract_bit(bit))
-						.map(move |bit| {
-							<F as ExtensionField<BinaryField1b>>::basis(i * Word::BITS + bit)
-						})
+						.map(move |bit| F::basis(i * Word::BITS + bit))
 				})
 				.sum::<F>();
 			E::from(packed)

--- a/crates/ip/src/logup_star/pushforward.rs
+++ b/crates/ip/src/logup_star/pushforward.rs
@@ -180,7 +180,7 @@ where
 		.iter()
 		.enumerate()
 		.map(|(t, coord)| {
-			let basis_t = E::from(<F as ExtensionField<BinaryField1b>>::basis(t));
+			let basis_t = E::from(F::basis(t));
 			basis_t * coord.clone()
 		})
 		.fold(E::zero(), |acc, term| acc + term);

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -38,7 +38,7 @@ where
 	/// * `elems` must have length equal to the extension degree, otherwise this will pad or
 	///   truncate.
 	pub fn new(mut elems: Vec<FE>) -> Self {
-		elems.resize(<FE::Scalar as ExtensionField<F>>::DEGREE, FE::zero());
+		elems.resize(FE::Scalar::DEGREE, FE::zero());
 		Self {
 			elems,
 			_marker: PhantomData,
@@ -47,12 +47,12 @@ where
 
 	/// Returns $\kappa$, the base-2 logarithm of the extension degree.
 	pub const fn kappa() -> usize {
-		<FE::Scalar as ExtensionField<F>>::LOG_DEGREE
+		FE::Scalar::LOG_DEGREE
 	}
 
 	/// Returns the multiplicative identity element, one.
 	pub fn one() -> Self {
-		let mut elems = vec![FE::zero(); <FE::Scalar as ExtensionField<F>>::DEGREE];
+		let mut elems = vec![FE::zero(); FE::Scalar::DEGREE];
 		elems[0] = FE::one();
 		Self {
 			elems,
@@ -67,7 +67,7 @@ where
 
 	/// Constructs a [`TensorAlgebra`] in the vertical subring.
 	pub fn from_vertical(x: FE) -> Self {
-		let mut elems = vec![FE::zero(); <FE::Scalar as ExtensionField<F>>::DEGREE];
+		let mut elems = vec![FE::zero(); FE::Scalar::DEGREE];
 		elems[0] = x;
 		Self {
 			elems,
@@ -117,7 +117,7 @@ where
 {
 	fn default() -> Self {
 		Self {
-			elems: vec![FE::zero(); <FE::Scalar as ExtensionField<F>>::DEGREE],
+			elems: vec![FE::zero(); FE::Scalar::DEGREE],
 			_marker: PhantomData,
 		}
 	}
@@ -130,7 +130,7 @@ where
 {
 	/// Returns the byte size of an element.
 	pub const fn byte_size() -> usize {
-		mem::size_of::<FE>() << <FE as ExtensionField<F>>::LOG_DEGREE
+		mem::size_of::<FE>() << FE::LOG_DEGREE
 	}
 
 	/// Tensor product of a vertical subring element and a horizontal subring element.

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -5,7 +5,7 @@ use std::{iter, marker::PhantomData};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField, BinaryField1b, Divisible, ExtensionField, PackedField};
+use binius_field::{BinaryField, Divisible, PackedField};
 use binius_iop_prover::{
 	channel::IOPProverChannel,
 	logup_star::{self, Looker},
@@ -309,8 +309,7 @@ where
 		let mut iota_table = Vec::with_capacity(1usize << LIMB_BITS);
 		iota_table.push(F::ZERO);
 		for row in 1..1usize << LIMB_BITS {
-			let low_bit_basis =
-				<F as ExtensionField<BinaryField1b>>::basis(row.trailing_zeros() as usize);
+			let low_bit_basis = F::basis(row.trailing_zeros() as usize);
 			iota_table.push(iota_table[row & (row - 1)] + low_bit_basis);
 		}
 		drop(embed_guard);

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -471,7 +471,7 @@ impl<F: Field, B: CircuitBuilder<Field = F>> FieldOps for CircuitElem<F, B> {
 	where
 		Self::Scalar: ExtensionField<FSub>,
 	{
-		let degree = <F as ExtensionField<FSub>>::DEGREE;
+		let degree = F::DEGREE;
 		assert_eq!(elems.len(), degree);
 
 		if degree == 1 {

--- a/crates/spartan-verifier/src/wrapper/gadgets.rs
+++ b/crates/spartan-verifier/src/wrapper/gadgets.rs
@@ -23,7 +23,7 @@ use binius_spartan_frontend::circuit_builder::CircuitBuilder;
 ///
 /// # Panics
 ///
-/// * If `inputs.len() != <B::Field as ExtensionField<FSub>>::DEGREE`
+/// * If `inputs.len() != B::Field::DEGREE`
 ///
 /// Instantiating this with a `B::Field` of characteristic other than 2 fails to compile.
 pub fn square_transpose<B: CircuitBuilder, FSub: Field>(
@@ -40,7 +40,7 @@ where
 		);
 	}
 
-	let degree = <B::Field as ExtensionField<FSub>>::DEGREE;
+	let degree = B::Field::DEGREE;
 	assert_eq!(inputs.len(), degree);
 
 	if degree == 1 {
@@ -59,11 +59,8 @@ where
 		.map(|i| {
 			(0..degree)
 				.map(|j| {
-					let [c] = builder.hint([inputs[i]], move |[x]| {
-						[B::Field::from(
-							<B::Field as ExtensionField<FSub>>::get_base(&x, j),
-						)]
-					});
+					let [c] = builder
+						.hint([inputs[i]], move |[x]| [B::Field::from(B::Field::get_base(&x, j))]);
 					c
 				})
 				.collect::<Vec<_>>()
@@ -105,13 +102,13 @@ fn basis_linear_combination<B: CircuitBuilder, FSub: Field>(
 where
 	B::Field: ExtensionField<FSub>,
 {
-	assert_eq!(scalars.len(), <B::Field as ExtensionField<FSub>>::DEGREE);
+	assert_eq!(scalars.len(), B::Field::DEGREE);
 
 	// basis(0) is always ONE, so the first term is just scalars[0].
 	let mut scalars = scalars.enumerate();
 	let (_, first) = scalars.next().expect("degree must be at least 1");
 	scalars.fold(first, |sum, (j, scalar)| {
-		let basis = builder.constant(<B::Field as ExtensionField<FSub>>::basis(j));
+		let basis = builder.constant(B::Field::basis(j));
 		let term = builder.mul(scalar, basis);
 		builder.add(sum, term)
 	})

--- a/crates/verifier/src/protocols/binmul.rs
+++ b/crates/verifier/src/protocols/binmul.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, BinaryField1b, ExtensionField, field::FieldOps};
+use binius_field::{BinaryField, field::FieldOps};
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck::SumcheckOutput};
 use binius_math::inner_product::inner_product_scalars;
 
@@ -79,10 +79,10 @@ where
 	// Precompute the basis-element vectors used to recombine a (lo, hi) per-bit column pair into
 	// the packed field element evaluation alpha = sum_i basis(i) * lo[i] + basis(64 + i) * hi[i].
 	let basis_lo: Vec<C::Elem> = (0..Word::BITS)
-		.map(|i| C::Elem::from(<F as ExtensionField<BinaryField1b>>::basis(i)))
+		.map(|i| C::Elem::from(F::basis(i)))
 		.collect();
 	let basis_hi: Vec<C::Elem> = (0..Word::BITS)
-		.map(|i| C::Elem::from(<F as ExtensionField<BinaryField1b>>::basis(Word::BITS + i)))
+		.map(|i| C::Elem::from(F::basis(Word::BITS + i)))
 		.collect();
 	let recombine = |lo: &[C::Elem], hi: &[C::Elem]| -> C::Elem {
 		inner_product_scalars(lo.iter().cloned(), basis_lo.iter().cloned())

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -4,7 +4,7 @@
 use std::iter;
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps};
+use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_iop::{channel::IOPVerifierChannel, logup_star};
 use binius_ip::{
 	channel::IPVerifierChannel,
@@ -338,7 +338,7 @@ where
 			let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
 			(0..LIMB_BITS)
 				.map(|u| {
-					let basis = <F as ExtensionField<BinaryField1b>>::basis(u);
+					let basis = F::basis(u);
 					per_word_evals[tree][limb * LIMB_BITS + u].clone() * C::Elem::from(basis)
 				})
 				.fold(C::Elem::zero(), |acc, term| acc + term)

--- a/crates/verifier/src/ring_switch.rs
+++ b/crates/verifier/src/ring_switch.rs
@@ -55,7 +55,7 @@ where
 	C: IPVerifierChannel<F>,
 	C::Elem: FieldOps<Scalar = F> + From<F>,
 {
-	let log_packing = <F as ExtensionField<B1>>::LOG_DEGREE;
+	let log_packing = F::LOG_DEGREE;
 	let (eval_point_low, _eval_point_high) = eval_point.split_at(log_packing);
 
 	// Receive s_hat_v
@@ -106,7 +106,7 @@ where
 	F: FieldOps<Scalar: BinaryField>,
 {
 	assert_eq!(z_vals.len(), query.len()); // pre-condition
-	assert_eq!(expanded_row_batch_query.len(), <F::Scalar as ExtensionField<B1>>::DEGREE,); // pre-condition
+	assert_eq!(expanded_row_batch_query.len(), F::Scalar::DEGREE,); // pre-condition
 
 	let tensor_eval = iter::zip(z_vals, query).fold(
 		TensorAlgebra::<B1, F>::from_vertical(F::one()),


### PR DESCRIPTION
Simplifies fully-qualified trait syntax down to the plain associated-item path wherever the fully-qualified form isn't actually load-bearing.

### The problem

The codebase has ~78 call sites like `<FE::Scalar as ExtensionField<F>>::DEGREE`, `<Scalar as ExtensionField<FSub>>::LOG_DEGREE`, `<U as Divisible<T>>::N`, `<F as ExtensionField<BinaryField1b>>::basis`, and similar.

The fully-qualified `<Type as Trait<Args>>::item` form only earns its keep when Rust genuinely can't pick a single candidate for `item` — i.e. the type in scope has *two* applicable trait bounds that both provide an item of that name.
In every other case, the plain `Type::item` resolves identically, because the compiler only has one trait bound to consult.
Most of these call sites are the plain case: one generic function, one `ExtensionField<F>` (or `Divisible<T>`) bound in scope, no ambiguity — so the qualification was pure noise.

### The idea

For each occurrence, try simplifying `<X as Trait<Args>>::item` to `X::item` and let the compiler be the judge: if it still compiles, the qualification was unnecessary; if it produces an ambiguous-associated-item error, the qualification is load-bearing and stays.

### The change

```diff
- elems.resize(<FE::Scalar as ExtensionField<F>>::DEGREE, FE::zero());
+ elems.resize(FE::Scalar::DEGREE, FE::zero());
```
```diff
- let log_packing = <F as ExtensionField<B1>>::LOG_DEGREE;
+ let log_packing = F::LOG_DEGREE;
```
```diff
- <U as Divisible<Scalar::Underlier>>::broadcast(val.to_underlier()).into()
+ U::broadcast(val.to_underlier()).into()
```

66 of the 78 occurrences simplified this way, across `binius-field`, `binius-math`, `binius-verifier`, `binius-prover`, `binius-ip`, `binius-ip-prover`, `binius-iop`, `binius-iop-prover`, `binius-spartan-verifier`, and `binius-arith-bench`.

### Left qualified — genuine exceptions

Each of these was confirmed by an actual "multiple applicable items in scope" compile error before reverting to the qualified form:

- `field.rs`, `spartan-verifier/wrapper/circuit_elem.rs` — `FieldOps::square_transpose` and `ExtensionField::square_transpose` share a name on the same type.
- `field/sliced_packed_field.rs`, `field/arch/portable/packed.rs` — the type in scope carries two distinct `ExtensionField<_>` bounds simultaneously (an impl-level one plus a method-level one, or a `BinaryField` supertrait implying one).
- `field/underlier/underlier_type.rs`, `field/arch/strategies.rs` — a `Divisible<U1>` supertrait collides with an explicit `Divisible<T>`/`Divisible<SubU>` bound in the same scope.
- `field/arch/aarch64/m128.rs` — the concrete `M128` type implements `Divisible<T>` for five different `T`, all visible at once.
- `prover/ring_switch.rs`, `ip-prover/logup_star/prove.rs` — a concrete field type has two `ExtensionField` impls and no argument/return-type context to disambiguate.
- `spartan-verifier/lib.rs` — deliberately qualified already, per an existing comment pinning a generic channel parameter.
- `iop-prover/merkle_tree/mod.rs`, `iop/fri/common.rs` — these are type-position associated-type projections (`M::Scheme::Digest`), which don't get the same one-hop shorthand Rust grants to value-position consts/methods.

### Scope

- Pure syntax change — no behavior change, no public API change.
- Only the 25 files touched above; no other call sites of the same trait items were modified.

### Verification

- `cargo check -p <crate> --all-targets` clean on all 10 touched crates.
- `cargo clippy -p <crate> --all-targets` clean on all 10 touched crates.
- `cargo +nightly fmt --all` (fell back to stable `cargo fmt` where nightly components weren't relevant — repo's `rustfmt.toml` nightly options applied via the workspace toolchain) — clean, `cargo fmt --check` passes.
- `cargo test -p <crate>` (including doctests) passes on all 10 touched crates.
- Spot-checked `binius-field`, `binius-math`, `binius-prover` with `--features rayon` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)