### PR TITLE
BINIUS-462: pack phase-1 h directly into its destination buffer

### DIFF
--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -9,7 +9,6 @@ use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
-use bytemuck::zeroed_vec;
 use tracing::instrument;
 
 use super::{
@@ -187,18 +186,36 @@ where
 	F: BinaryField,
 {
 	assert_eq!(psi.len(), Word::BITS, "the weights are indexed by bit position");
+	assert_eq!(
+		Word::BITS % P::WIDTH,
+		0,
+		"a row of Word::BITS weights must be packed-element aligned"
+	);
 
-	// One row of `Word::BITS` weights per `(variant, amount)`, variant most significant.
-	let mut data = zeroed_vec::<F>(1 << SHIFT_OPERATOR_LOG_LEN);
-	for (variant, block) in
-		iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS))
-	{
-		for (amount, row) in block.chunks_exact_mut(Word::BITS).enumerate() {
-			shift_operator_row(variant, amount, row, psi);
+	// One row of `Word::BITS` weights per `(variant, amount)`, variant most significant, packed
+	// `P::WIDTH` scalars at a time straight into the destination buffer. The scratch row is
+	// reused across every pair rather than collected into a second full-size buffer.
+	let row_packed_len = Word::BITS / P::WIDTH;
+	let packed_len = 1 << SHIFT_OPERATOR_LOG_LEN.saturating_sub(P::LOG_WIDTH);
+	let mut values = alloc.alloc::<P>(packed_len);
+	let mut row = [F::ZERO; Word::BITS];
+	for (variant, block) in iter::zip(
+		ShiftVariant::ALL,
+		values
+			.spare_capacity_mut()
+			.chunks_exact_mut(Word::BITS * row_packed_len),
+	) {
+		for (amount, packed_row) in block.chunks_exact_mut(row_packed_len).enumerate() {
+			shift_operator_row(variant, amount, &mut row, psi);
+			for (slot, chunk) in iter::zip(packed_row, row.chunks_exact(P::WIDTH)) {
+				slot.write(P::from_scalars(chunk.iter().copied()));
+			}
 		}
 	}
+	// Safety: the loop above wrote every one of the `packed_len` slots.
+	unsafe { values.set_len(packed_len) };
 
-	FieldBuffer::from_values_in(alloc, &data)
+	FieldBuffer::new(SHIFT_OPERATOR_LOG_LEN, values)
 }
 
 /// Constructs the "monster multilinear" that combines all shift operations into a single


### PR DESCRIPTION
Closes [BINIUS-462](https://linear.app/jimpo/issue/BINIUS-462).

`shift_operator_table` (phase 1's `h` multilinear) drew two full-size buffers and copied between them; this draws the destination once and packs rows straight into it. Pure refactor — no behavior change.

### The problem

`shift_operator_table` builds phase 1's `h` multilinear, `2^15` field elements (512 KB) regardless of circuit size — a fixed cost paid on every proof.
It did this in two passes:

- `zeroed_vec::<F>(1 << SHIFT_OPERATOR_LOG_LEN)` — a 512 KB scalar `Vec`, zeroed, then completely overwritten row by row.
- `FieldBuffer::from_values_in(alloc, &data)` — a *second* 512 KB buffer drawn from the allocator, packing the first into it.

The zeroing is pure waste: `fill_h_row`/`shift_operator_row` writes every element of every row, so nothing ever reads the zeros.
The second buffer is a straight copy of the first.
On small circuits (e.g. keccak) this was measurable — the single largest fixed cost left in phase 1 — and it's also where first-touch page-fault variance on two fresh 512 KB regions shows up under load.

### The idea

The destination is packed (`[P]`), the source rows are scalar (`&mut [F]`).
A row is `Word::BITS` scalars, and `P::WIDTH` divides `Word::BITS`, so every row lands packed-element aligned in the destination — no need to build the whole scalar table first.

```
alloc.alloc::<P>(packed_len)              // one destination buffer, once
for each (variant, amount):
    shift_operator_row(.., &mut row, psi) // small Word::BITS-scalar scratch, reused every iteration
    pack row straight into its spare-capacity slice of the destination
set_len(packed_len)                       // every slot was written above
```

The scratch row is tiny (64 scalars, stack-sized) and reused across every `(variant, amount)` pair — it replaces the 512 KB intermediate entirely.

### The change

```diff
- let mut data = zeroed_vec::<F>(1 << SHIFT_OPERATOR_LOG_LEN);
- for (variant, block) in iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS)) {
-     for (amount, row) in block.chunks_exact_mut(Word::BITS).enumerate() {
-         shift_operator_row(variant, amount, row, psi);
-     }
- }
- FieldBuffer::from_values_in(alloc, &data)
+ let mut values = alloc.alloc::<P>(packed_len);
+ let mut row = [F::ZERO; Word::BITS];
+ for (variant, block) in iter::zip(ShiftVariant::ALL, values.spare_capacity_mut().chunks_exact_mut(..)) {
+     for (amount, packed_row) in block.chunks_exact_mut(row_packed_len).enumerate() {
+         shift_operator_row(variant, amount, &mut row, psi);
+         for (slot, chunk) in iter::zip(packed_row, row.chunks_exact(P::WIDTH)) {
+             slot.write(P::from_scalars(chunk.iter().copied()));
+         }
+     }
+ }
+ unsafe { values.set_len(packed_len) };
+ FieldBuffer::new(SHIFT_OPERATOR_LOG_LEN, values)
```

A defensive `assert_eq!(Word::BITS % P::WIDTH, 0, ..)` makes the packed-alignment invariant explicit rather than implicit.

### Soundness

`h` is a deterministic function of `r_zhat_prime` and the domain subspace, so this is exactly behavior-preserving — same values, different allocation path.
`shift_operator_row` itself (including the `sar` variant's read-then-accumulate onto the sign position) is untouched, so its correctness carries over unchanged.

### Scope

- **changed:** `crates/prover/src/protocols/shift/monster.rs`, `shift_operator_table` only.
- **left untouched:** `shift_operator_row`, every caller's signature, all other phase-1/phase-2 code.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-prover --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo test -p binius-prover --lib protocols::shift::` — 30/30 pass, with and without `--features rayon`, including `h_op_consistency` (pins against the succinct `evaluate_h_op`) and the `shift_operator_table_matches_the_indicator_definition` / `..._is_linear_in_the_weights` proptests.

### Benchmark

Existing `phase1_build_h_parts` bench (`crates/prover/benches/shift_reduction.rs`), which calls `shift_operator_table` directly against a plain `GlobalAllocator`, release/bench profile, `RUSTFLAGS="-C target-cpu=native"`:

| | time |
|---|---|
| before (two allocations + copy) | 59.4 µs |
| after (single alloc, direct pack) | 22.8 µs |

Criterion reports **−61.8% (p = 0.00)**, "Performance has improved," on the paired before/after run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)