### PR TITLE
Avoid Vec allocation for BinMul/IntMul per-bit output evals

### DIFF
--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -128,12 +128,12 @@ where
 	// Send the raw per-bit output evaluations of each word column at r_x. One folder is built for
 	// the shared point and reused across all six columns.
 	let folder = WordFolder::<F>::new(&eval_point);
-	let a_lo_evals = folder.fold(a_lo).to_vec();
-	let a_hi_evals = folder.fold(a_hi).to_vec();
-	let b_lo_evals = folder.fold(b_lo).to_vec();
-	let b_hi_evals = folder.fold(b_hi).to_vec();
-	let c_lo_evals = folder.fold(c_lo).to_vec();
-	let c_hi_evals = folder.fold(c_hi).to_vec();
+	let a_lo_evals = folder.fold(a_lo);
+	let a_hi_evals = folder.fold(a_hi);
+	let b_lo_evals = folder.fold(b_lo);
+	let b_hi_evals = folder.fold(b_hi);
+	let c_lo_evals = folder.fold(c_lo);
+	let c_hi_evals = folder.fold(c_hi);
 
 	channel.send_many(&a_lo_evals);
 	channel.send_many(&a_hi_evals);
@@ -268,7 +268,7 @@ mod tests {
 		let z_tensor = eq_ind_partial_eval::<F>(&z_challenge);
 		let consistency_check_eval_point = [z_challenge, eval_point].concat();
 		let get_consistency_check_eval =
-			|evals: Vec<F>| izip!(evals, z_tensor.as_ref()).map(|(x, y)| x * y).sum();
+			|evals: [F; Word::BITS]| izip!(evals, z_tensor.as_ref()).map(|(x, y)| x * y).sum();
 
 		let test_cases = [
 			(&a_lo, a_lo_evals),

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -400,8 +400,7 @@ where
 		// verifier binds the stacked-index claim via the GF(2)-linearity of the embedding, the `b`
 		// evals via sum_i eq(r_I^b, i) * b(i, r_out) = B(r_out), and the parity bits directly.
 		let output_guard = tracing::debug_span!("Compute output bit evals").entered();
-		let per_bit_evals =
-			|exponents: &[Word]| fold_across_words::<_, P>(exponents, r_out).to_vec();
+		let per_bit_evals = |exponents: &[Word]| fold_across_words::<_, P>(exponents, r_out);
 		let a_evals = per_bit_evals(a_exponents);
 		let c_lo_evals = per_bit_evals(c_lo_exponents);
 		let c_hi_evals = per_bit_evals(c_hi_exponents);

--- a/crates/verifier/src/protocols/binmul.rs
+++ b/crates/verifier/src/protocols/binmul.rs
@@ -15,17 +15,17 @@ use crate::Error;
 /// constraint to per-bit evaluation claims on the six word columns at a common evaluation point
 /// `eval_point` ($r_x \in K^\ell$).
 ///
-/// Each `*_evals` vector holds `Word::BITS` per-bit evaluation claims $\widetilde{z}(r_x, i)$ for
+/// Each `*_evals` array holds `Word::BITS` per-bit evaluation claims $\widetilde{z}(r_x, i)$ for
 /// $i \in \{0, \ldots, 63\}$.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BinMulOutput<F> {
 	pub eval_point: Vec<F>,
-	pub a_lo_evals: Vec<F>,
-	pub a_hi_evals: Vec<F>,
-	pub b_lo_evals: Vec<F>,
-	pub b_hi_evals: Vec<F>,
-	pub c_lo_evals: Vec<F>,
-	pub c_hi_evals: Vec<F>,
+	pub a_lo_evals: [F; Word::BITS],
+	pub a_hi_evals: [F; Word::BITS],
+	pub b_lo_evals: [F; Word::BITS],
+	pub b_hi_evals: [F; Word::BITS],
+	pub c_lo_evals: [F; Word::BITS],
+	pub c_hi_evals: [F; Word::BITS],
 }
 
 /// Verify the binary-field multiplication check (BinMul) reduction.
@@ -69,12 +69,12 @@ where
 	eval_point.reverse();
 
 	// The prover sends the six per-bit evaluation columns at r_x.
-	let a_lo_evals = channel.recv_many(Word::BITS)?;
-	let a_hi_evals = channel.recv_many(Word::BITS)?;
-	let b_lo_evals = channel.recv_many(Word::BITS)?;
-	let b_hi_evals = channel.recv_many(Word::BITS)?;
-	let c_lo_evals = channel.recv_many(Word::BITS)?;
-	let c_hi_evals = channel.recv_many(Word::BITS)?;
+	let a_lo_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let a_hi_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let b_lo_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let b_hi_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let c_lo_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let c_hi_evals = channel.recv_array::<{ Word::BITS }>()?;
 
 	// Precompute the basis-element vectors used to recombine a (lo, hi) per-bit column pair into
 	// the packed field element evaluation alpha = sum_i basis(i) * lo[i] + basis(64 + i) * hi[i].

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -10,10 +10,10 @@ use itertools::iterate;
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntMulOutput<F> {
 	pub eval_point: Vec<F>,
-	pub a_evals: Vec<F>,
-	pub b_evals: Vec<F>,
-	pub c_lo_evals: Vec<F>,
-	pub c_hi_evals: Vec<F>,
+	pub a_evals: [F; Word::BITS],
+	pub b_evals: [F; Word::BITS],
+	pub c_lo_evals: [F; Word::BITS],
+	pub c_hi_evals: [F; Word::BITS],
 }
 
 /// Output of Phase 1: GKR reduction of the exponentiation product tree.

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -323,10 +323,10 @@ where
 	let r_out = challenges.as_slice();
 
 	// The prover sends the raw per-bit evaluations at r_out.
-	let a_evals = channel.recv_many(Word::BITS)?;
-	let c_lo_evals = channel.recv_many(Word::BITS)?;
-	let c_hi_evals = channel.recv_many(Word::BITS)?;
-	let b_evals = channel.recv_many(Word::BITS)?;
+	let a_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let c_lo_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let c_hi_evals = channel.recv_array::<{ Word::BITS }>()?;
+	let b_evals = channel.recv_array::<{ Word::BITS }>()?;
 
 	// Bind the per-bit evals to the folded index claim. The index entries are the GF(2)-linear
 	// embeddings iota(e_{t,l}) = Σ_u basis(u) · bit_u(e_{t,l}), and bit u of limb l is bit
@@ -368,7 +368,7 @@ where
 
 	// Bind the prover's raw per-bit evals to the single recombined rerandomization claim:
 	// b(r_I^b, r_out) = sum_i eq(r_I^b, i) * b(i, r_out).
-	let b_at_rx = evaluate_inplace_scalars(b_evals.clone(), r_ib);
+	let b_at_rx = evaluate_inplace_scalars(&mut b_evals.clone()[..], r_ib);
 	let expected_b_rerand_eval = b_eq_eval * &b_at_rx;
 
 	let expected_unbatched_evals = [

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -462,7 +462,8 @@ impl<F: FieldOps> OperationClaim<F, INTMUL_ARITY> {
 			c_lo_evals,
 			c_hi_evals,
 		} = intmul_output;
-		let oblong = |evals: Vec<F>| inner_product_scalars(evals, lagrange.iter().cloned());
+		let oblong =
+			|evals: [F; Word::BITS]| inner_product_scalars(evals, lagrange.iter().cloned());
 		let (r_rho, r_x) = r_out_mul.split_at(log_instances);
 		Self::new(
 			[
@@ -493,7 +494,8 @@ impl<F: FieldOps> OperationClaim<F, BINMUL_ARITY> {
 			c_lo_evals,
 			c_hi_evals,
 		} = binmul_output;
-		let oblong = |evals: Vec<F>| inner_product_scalars(evals, lagrange.iter().cloned());
+		let oblong =
+			|evals: [F; Word::BITS]| inner_product_scalars(evals, lagrange.iter().cloned());
 		let (r_rho, r_x) = r_out_binmul.split_at(log_instances);
 		Self::new(
 			[


### PR DESCRIPTION
Pure refactor — no behavior change, no soundness impact.

### The problem

`WordFolder::fold` and `fold_across_words` already hand back a fixed-size `[F; Word::BITS]` array of per-bit evaluations.
But `BinMulOutput` and `IntMulOutput` declared their `*_evals` fields as `Vec<F>`.
So the prover had to call `.to_vec()` on an array it already had, just to fit the struct — a pure-waste heap allocation, six times per `BinMul::prove` call and four times per `IntMul::prove` call.
The verifier had the same problem on the way in: it called `channel.recv_many(Word::BITS)` (which builds a `Vec`) instead of the already-existing `channel.recv_array::<N>()`.

### The idea

Change the eval fields on both output structs from `Vec<F>` to `[F; Word::BITS]`, matching what the fold functions actually produce. That lets both sides drop their allocation:

```
prover:   folder.fold(a_lo).to_vec()        ->  folder.fold(a_lo)
verifier: channel.recv_many(Word::BITS)?    ->  channel.recv_array::<{ Word::BITS }>()?
```

### The change

- `crates/verifier/src/protocols/binmul.rs`: `BinMulOutput`'s six `*_evals` fields become `[F; Word::BITS]`; `verify` uses `recv_array` instead of `recv_many`.
- `crates/verifier/src/protocols/intmul/common.rs`: `IntMulOutput`'s four `*_evals` fields become `[F; Word::BITS]`.
- `crates/verifier/src/protocols/intmul/verify.rs`: the matching four `recv_many` calls become `recv_array`; `evaluate_inplace_scalars(b_evals.clone(), r_ib)` becomes `evaluate_inplace_scalars(&mut b_evals.clone()[..], r_ib)` since `evaluate_inplace_scalars` requires `impl DerefMut<Target = [F]>`, which an owned array doesn't implement directly.
- `crates/prover/src/protocols/binmul.rs`: drop the six `.to_vec()` calls; one test closure's explicit `Vec<F>` annotation becomes `[F; Word::BITS]`.
- `crates/prover/src/protocols/intmul/prove.rs`: drop the `.to_vec()` in the `per_bit_evals` closure.
- `crates/verifier/src/reduction.rs`: two `oblong` closures (`from_intmul`, `from_binmul`) had explicit `Vec<F>` parameter annotations, updated to `[F; Word::BITS]`.

### Scope

- **changed:** the six files above.
- **left untouched:** every other call site that reads or forwards these fields — `channel.send_many` (`&[F; N]` unsize-coerces to `&[F]`), `inner_product`/`inner_product_scalars` (arrays implement `IntoIterator<Item = F>` by value), `m4-prover`'s `Operation::from_mul_check` (takes `&[F]`, same coercion), array destructuring/indexing in `verify.rs` and both prover test modules. None of these needed edits.

### Verification

- `cargo check`/`cargo build --workspace` — clean.
- `cargo test -p binius-prover -p binius-verifier -p binius-m4-prover`, both with and without `--features rayon` — all passing.
- `cargo clippy -p binius-prover -p binius-verifier -p binius-m4-prover --tests` — clean.
- `cargo fmt` on the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)