### PR TITLE
Clean up shift module's mod.rs: drop stale doc(hidden), move SegmentWords out

### DIFF
--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -1,36 +1,14 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_core::word::Word;
-
-/// The value vector's two committed segments, each at the width the protocol addresses it at.
-///
-/// A circuit declares fewer values than the reductions address: the public segment is padded to a
-/// power of two and the hidden segment to at least that width. Both phases of the shift reduction
-/// read the segments at those padded widths, so [`prove()`] fills them once and hands the pair down
-/// rather than having each phase re-derive the split.
-#[derive(Clone, Copy)]
-pub struct SegmentWords<'a> {
-	/// The constants and inout values, zero-filled to the public segment width.
-	pub public: &'a [Word],
-	/// The private values, zero-filled to the hidden segment width.
-	pub hidden: &'a [Word],
-}
-
-mod key_collection;
-// `monster`, `phase_1`, and `phase_2` are internal implementation, exposed (via `#[doc(hidden)]`
-// `pub mod`) only so the `shift_reduction` benchmark can time individual phase functions (see
-// `benches/shift_reduction.rs`). Not a stable API.
 mod claims;
-#[doc(hidden)]
+mod key_collection;
 pub mod monster;
-#[doc(hidden)]
 pub mod outer;
-#[doc(hidden)]
 pub mod phase_1;
-#[doc(hidden)]
 pub mod phase_2;
 mod prove;
+mod segment_words;
 mod shift_ind;
 
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
@@ -39,4 +17,5 @@ pub use key_collection::{
 };
 pub use phase_2::ShiftOutput;
 pub use prove::{OperatorData, PreparedOperatorData, prove};
+pub use segment_words::SegmentWords;
 pub use shift_ind::{ShiftIndOutput, ShiftIndSumcheck};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -78,7 +78,7 @@ impl<F: Field> OuterSlotWeights<F> {
 /// # Arguments
 ///
 /// The amount is an index over the reduction's amount axis rather than a validated
-/// [`Shift`](binius_core::constraint_system::Shift) amount: that axis spans `Word::BITS` for every
+/// [`Shift`] amount: that axis spans `Word::BITS` for every
 /// variant, and a half-word variant reads it modulo its own 32-bit width.
 ///
 /// Every cell of `row` is written, so the caller need not zero it first. A caller reading one

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -180,7 +180,7 @@ impl<P: PackedField> SparseShiftRows<P> {
 	///
 	/// # Panics
 	///
-	/// Panics unless there is one [`row_len`] run of values per index, and every index is below
+	/// Panics unless there is one `row_len` run of values per index, and every index is below
 	/// the row space.
 	pub fn new(indices: Vec<u32>, values: Vec<P>, log_rows: usize) -> Self {
 		assert_eq!(

--- a/crates/prover/src/protocols/shift/segment_words.rs
+++ b/crates/prover/src/protocols/shift/segment_words.rs
@@ -1,0 +1,18 @@
+// Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+use binius_core::word::Word;
+
+/// The value vector's two committed segments, each at the width the protocol addresses it at.
+///
+/// A circuit declares fewer values than the reductions address: the public segment is padded to a
+/// power of two and the hidden segment to at least that width. Both phases of the shift reduction
+/// read the segments at those padded widths, so [`prove()`](super::prove::prove) fills them once
+/// and hands the pair down rather than having each phase re-derive the split.
+#[derive(Clone, Copy)]
+pub struct SegmentWords<'a> {
+	/// The constants and inout values, zero-filled to the public segment width.
+	pub public: &'a [Word],
+	/// The private values, zero-filled to the hidden segment width.
+	pub hidden: &'a [Word],
+}


### PR DESCRIPTION
Pure refactor — no behavior change, no soundness impact.

### The problem

`crates/prover/src/protocols/shift/mod.rs` was doing two jobs at once.
Every other file in the `shift` module follows one pattern: a submodule plus a `pub use` re-export.
`SegmentWords` broke that pattern — a full struct definition, with its own doc comment and `#[derive]`, sitting directly in the wiring file.

Separately, the explanatory comment for `#[doc(hidden)]` was itself misplaced:

```
mod key_collection;
// `monster`, `phase_1`, and `phase_2` are internal implementation, exposed (via `#[doc(hidden)]`
// `pub mod`) only so the `shift_reduction` benchmark can time individual phase functions...
mod claims;
#[doc(hidden)]
pub mod monster;
```

It sat between `mod key_collection;` and `mod claims;` — neither of which it describes — instead of directly above the `#[doc(hidden)] pub mod` block it explains.

### The change

- Moved `SegmentWords` out of `mod.rs` into its own `segment_words.rs`, matching the file's own convention (`mod segment_words;` + `pub use segment_words::SegmentWords;`).
- Dropped `#[doc(hidden)]` from `monster`, `outer`, `phase_1`, and `phase_2`, and removed the comment that justified it.
- Unhiding those modules made rustdoc actually check their doc comments (hidden items are skipped), which surfaced two pre-existing broken-doc-link issues, fixed alongside:
  - `monster.rs`: `` [`Shift`](binius_core::constraint_system::Shift) `` was a redundant explicit link target — `Shift` is already imported, so `` [`Shift`] `` resolves the same way.
  - `phase_1.rs`: a doc comment on the public `SparseShiftRows::new` linked to `` [`row_len`] ``, a private function — not resolvable from public docs, so it became a plain code span.

### Scope

- **changed:** `mod.rs`, `monster.rs`, `phase_1.rs`.
- **new:** `segment_words.rs`.
- **left untouched:** the module's actual logic — this is doc/organization only.

### Verification

- `cargo check -p binius-prover`, `cargo doc -p binius-prover --no-deps` — clean (both were previously erroring or would error once hidden was dropped).
- `cargo test -p binius-prover shift` — 30 unit tests + the `shift.rs` integration test, all passing.
- `cargo clippy -p binius-prover --tests`, `cargo fmt --check -p binius-prover` — clean.
- Confirmed the pre-existing `binius-arith-bench` doc error surfaced by `cargo doc --workspace` is unrelated and reproduces identically on unmodified `main` — left untouched, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)