### PR TITLE
Reorganize the top-level project docs, and lint all features in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,13 @@ jobs:
       - name: Run platform diagnostics
         if: github.event_name != 'push'
         run: cargo test -p binius-utils --features platform-diagnostics test_platform_diagnostics -- --nocapture
+      # `--all-features` so that feature-gated code (rayon, perfetto, trace_multiplications, …) is
+      # linted too. Every optional feature in the workspace is off by default, so without this the
+      # gated code is never compiled and bitrots silently. The cost is that clippy cannot reuse the
+      # Compile step's artifacts, since the feature unification differs.
       - name: Run clippy
         if: github.event_name != 'push'
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Run tests
         if: github.event_name != 'push'
         run: cargo nextest run --workspace --no-fail-fast ${{ matrix.arch.test_args }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ and [Clippy](https://doc.rust-lang.org/clippy/). See [DEVELOPMENT.md](DEVELOPMEN
 cross-compilation checks that architecture-specific crates need. The remaining sections document conventions that
 cannot be enforced with automated tooling.
 
+### Code comments
+
+**Code comments explain current behavior, not change history.** Do not write comments that reference how the code used to work ("Previously X", "Changed from A to B", "Used to call Y"). Comments must make sense in the context of the current code, independently of its history. Context about what changed and why belongs in the commit description and PR body, not in source code.
+
 ### Documentation
 
 We follow guidance from the [rustdoc book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html). The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,80 +8,9 @@ All source files should include a copyright header. New files should start with 
 
 Many code formatting and style rules are enforced using
 [rustfmt](https://doc.rust-lang.org/book/appendix-04-useful-development-tools.html#automatic-formatting-with-rustfmt)
-and [Clippy](https://doc.rust-lang.org/clippy/). The remaining sections document conventions that cannot be enforced
-with automated tooling.
-
-### Running automated checks
-
-The codebase is formatted with a nightly version of `cargo fmt` because stable doesn't support all of the rustfmt
-options we use. You can run the formatter and linter with
-
-```bash
-$ cargo +nightly-2026-07-01 fmt  # see prek.toml for the exact nightly version checked by CI
-$ cargo clippy --all --all-features --tests --benches --examples -- -D warnings
-```
-
-[prek](https://prek.j178.dev/) hooks are configured to run `rustfmt`. You can also invoke it via prek:
-
-```bash
-$ prek run rustfmt --all-files
-```
-
-### Cross-compilation
-
-`binius-field` and `binius-arith-bench` contain architecture-specific optimizations: CLMUL/SIMD
-implementations of `GF(2^128)` (and related) arithmetic, selected at compile time with
-`#[cfg(target_arch = ...)]` and `#[cfg(target_feature = ...)]`. Code on an *inactive* arch/feature
-path is never type-checked by your native build, so it is easy to break the `aarch64` paths from an
-`x86_64` host (or vice versa) and not notice until CI fails — CI builds `x86_64` (both portable and
-`-Ctarget-cpu=native`), `aarch64`, and `wasm32`.
-
-When you touch these crates, cross-compile them for the target(s) you are not running natively.
-You do **not** need an emulator — compiling is enough to type-check the inactive paths.
-
-> **The optimized paths are gated behind target features that are off in the baseline target**
-> (e.g. `aes`/PMULL on `aarch64`, `pclmulqdq` on `x86_64`). A cross-build with *default* features
-> compiles only the portable fallback, which gives false confidence. Enable the features (via the
-> `RUSTFLAGS` below) to actually type-check the optimized code. On your native arch,
-> `-Ctarget-cpu=native` does the same thing.
-
-One-time setup (targets are added to the pinned toolchain in `rust-toolchain.toml`):
-
-```bash
-rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu wasm32-wasip1 wasm32-unknown-unknown
-
-# Only needed to *link* aarch64 test/bench binaries (`--all-targets`) or crates with C build
-# dependencies. `cargo check` and a plain library `cargo build` do not link, so they don't need it.
-sudo apt-get install -y gcc-aarch64-linux-gnu
-export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
-```
-
-Compile the architecture-specific crates for the non-native arch and for wasm:
-
-```bash
-# aarch64 — +neon,+aes enables the PMULL/CLMUL GHASH paths (not just the portable fallback)
-RUSTFLAGS="-C target-feature=+neon,+aes" \
-  cargo check --target aarch64-unknown-linux-gnu -p binius-field -p binius-arith-bench
-
-# x86_64 — a consistent SIMD+CLMUL set (avx2 is required for the 256-bit vpclmulqdq paths;
-# add +avx512f for the 512-bit path). On an x86_64 host, `-C target-cpu=native` is simpler.
-RUSTFLAGS="-C target-feature=+sse2,+avx2,+pclmulqdq,+vpclmulqdq" \
-  cargo check --target x86_64-unknown-linux-gnu -p binius-field -p binius-arith-bench
-
-# wasm32 — matches CI (binius-field on wasm32-unknown-unknown; the wider crate set on wasm32-wasip1)
-cargo build -p binius-field --target wasm32-unknown-unknown
-cargo build -p binius-field --target wasm32-wasip1
-```
-
-(All four commands above are verified to compile cleanly. The 512-bit AVX-512 path —
-`+sse2,+avx2,+avx512f,+pclmulqdq,+vpclmulqdq` — also compiles cleanly, including
-`cargo build --all-targets` and a full `--workspace` build, even on a host without AVX-512:
-its `std::arch::x86_64::_mm512_*` intrinsics are stable on the pinned toolchain. Older Rust,
-where those intrinsics were unstable, rejects this build.)
-
-`cargo check` is the fast type-check of the library paths. To lint tests and benches the way CI
-does, swap in `cargo clippy --target <triple> -p binius-field -p binius-arith-bench --all-targets
--- -D warnings` (this links, so it needs the cross C toolchain above).
+and [Clippy](https://doc.rust-lang.org/clippy/). See [DEVELOPMENT.md](DEVELOPMENT.md) for how to run them, and for the
+cross-compilation checks that architecture-specific crates need. The remaining sections document conventions that
+cannot be enforced with automated tooling.
 
 ### Documentation
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,14 +104,10 @@ does, swap in `cargo clippy --target <triple> -p binius-field -p binius-arith-be
 | **Circuit** | High-level representation of computation built with `CircuitBuilder` |
 | **Constraint system** | Low-level AND/MUL constraints compiled from a circuit |
 
-## Coding Guidelines
-
-**Code comments explain current behavior, not change history.** Do not write comments that reference how the code used to work ("Previously X", "Changed from A to B", "Used to call Y"). Comments must make sense in the context of the current code, independently of its history. Context about what changed and why belongs in the commit description and PR body, not in source code.
-
 ## Documentation
 
 ### Development Guidelines
-[CONTRIBUTING.md](CONTRIBUTING.md) covers code style, naming conventions, copyright headers, error handling, and other development conventions.
+[CONTRIBUTING.md](CONTRIBUTING.md) covers code style, naming conventions, copyright headers, code comment conventions, error handling, and other development conventions.
 
 ### README
 The [README.md](README.md) is the project's entry point, covering what Binius64 is, dependencies, build instructions, and links to external documentation.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# Development
 
 Quick-start context for AI agents and developers working with Binius64.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,14 +9,84 @@ cargo build                    # Debug build
 cargo build --release          # Release build
 cargo test                     # Run tests
 cargo test -p <crate>          # Test specific crate
-cargo +nightly-2026-07-01 fmt  # Format code (pinned nightly; see prek.toml)
-cargo clippy --all --all-features --tests --benches --examples -- -D warnings
-cargo doc --no-deps --document-private-items   # Build rustdoc
-typos                          # Check for typos
-prek run --all-files           # Run all checks
 ```
 
 For optimal performance: `export RUSTFLAGS="-C target-cpu=native"`
+
+## Running automated checks
+
+The codebase is formatted with a nightly version of `cargo fmt` because stable doesn't support all of the rustfmt
+options we use. You can run the formatter, the linter, the documentation build and the spell checker with
+
+```bash
+$ cargo +nightly-2026-07-01 fmt  # see prek.toml for the exact nightly version checked by CI
+$ cargo clippy --all --all-features --tests --benches --examples -- -D warnings
+$ cargo doc --no-deps --document-private-items
+$ typos
+```
+
+[prek](https://prek.j178.dev/) hooks are configured to run these checks. You can invoke one hook, or all of them:
+
+```bash
+$ prek run rustfmt --all-files
+$ prek run --all-files
+```
+
+## Cross-compilation
+
+`binius-field` and `binius-arith-bench` contain architecture-specific optimizations: CLMUL/SIMD
+implementations of `GF(2^128)` (and related) arithmetic, selected at compile time with
+`#[cfg(target_arch = ...)]` and `#[cfg(target_feature = ...)]`. Code on an *inactive* arch/feature
+path is never type-checked by your native build, so it is easy to break the `aarch64` paths from an
+`x86_64` host (or vice versa) and not notice until CI fails — CI builds `x86_64` (both portable and
+`-Ctarget-cpu=native`), `aarch64`, and `wasm32`.
+
+When you touch these crates, cross-compile them for the target(s) you are not running natively.
+You do **not** need an emulator — compiling is enough to type-check the inactive paths.
+
+> **The optimized paths are gated behind target features that are off in the baseline target**
+> (e.g. `aes`/PMULL on `aarch64`, `pclmulqdq` on `x86_64`). A cross-build with *default* features
+> compiles only the portable fallback, which gives false confidence. Enable the features (via the
+> `RUSTFLAGS` below) to actually type-check the optimized code. On your native arch,
+> `-Ctarget-cpu=native` does the same thing.
+
+One-time setup (targets are added to the pinned toolchain in `rust-toolchain.toml`):
+
+```bash
+rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu wasm32-wasip1 wasm32-unknown-unknown
+
+# Only needed to *link* aarch64 test/bench binaries (`--all-targets`) or crates with C build
+# dependencies. `cargo check` and a plain library `cargo build` do not link, so they don't need it.
+sudo apt-get install -y gcc-aarch64-linux-gnu
+export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+```
+
+Compile the architecture-specific crates for the non-native arch and for wasm:
+
+```bash
+# aarch64 — +neon,+aes enables the PMULL/CLMUL GHASH paths (not just the portable fallback)
+RUSTFLAGS="-C target-feature=+neon,+aes" \
+  cargo check --target aarch64-unknown-linux-gnu -p binius-field -p binius-arith-bench
+
+# x86_64 — a consistent SIMD+CLMUL set (avx2 is required for the 256-bit vpclmulqdq paths;
+# add +avx512f for the 512-bit path). On an x86_64 host, `-C target-cpu=native` is simpler.
+RUSTFLAGS="-C target-feature=+sse2,+avx2,+pclmulqdq,+vpclmulqdq" \
+  cargo check --target x86_64-unknown-linux-gnu -p binius-field -p binius-arith-bench
+
+# wasm32 — matches CI (binius-field on wasm32-unknown-unknown; the wider crate set on wasm32-wasip1)
+cargo build -p binius-field --target wasm32-unknown-unknown
+cargo build -p binius-field --target wasm32-wasip1
+```
+
+(All four commands above are verified to compile cleanly. The 512-bit AVX-512 path —
+`+sse2,+avx2,+avx512f,+pclmulqdq,+vpclmulqdq` — also compiles cleanly, including
+`cargo build --all-targets` and a full `--workspace` build, even on a host without AVX-512:
+its `std::arch::x86_64::_mm512_*` intrinsics are stable on the pinned toolchain. Older Rust,
+where those intrinsics were unstable, rejects this build.)
+
+`cargo check` is the fast type-check of the library paths. To lint tests and benches the way CI
+does, swap in `cargo clippy --target <triple> -p binius-field -p binius-arith-bench --all-targets
+-- -D warnings` (this links, so it needs the cross C toolchain above).
 
 ## Key Terminology
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ options we use. You can run the formatter, the linter, the documentation build a
 
 ```bash
 $ cargo +nightly-2026-07-01 fmt  # see prek.toml for the exact nightly version checked by CI
-$ cargo clippy --all --all-features --tests --benches --examples -- -D warnings
+$ cargo clippy --workspace --all-targets --all-features -- -D warnings
 $ cargo doc --no-deps --document-private-items
 $ typos
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,11 +7,26 @@ Quick-start context for AI agents and developers working with Binius64.
 ```bash
 cargo build                    # Debug build
 cargo build --release          # Release build
-cargo test                     # Run tests
-cargo test -p <crate>          # Test specific crate
 ```
 
 For optimal performance: `export RUSTFLAGS="-C target-cpu=native"`
+
+## Testing
+
+Run the tests with [cargo-nextest](https://nexte.st/), which is what CI runs. It executes each test in its own process,
+so a panic or a hang is attributed to a single test, and its output is easier to read than libtest's.
+
+```bash
+$ cargo install cargo-nextest --locked     # one-time setup
+
+$ cargo nextest run --workspace            # Run the test suite
+$ cargo nextest run -p <crate>             # Test a specific crate
+$ cargo nextest run -E 'test(<substring>)' # Run the tests matching a filter expression
+$ cargo test --doc --workspace             # Doc tests; nextest does not run these
+```
+
+nextest cannot run doc tests ([nextest#16](https://github.com/nextest-rs/nextest/issues/16)), so `cargo test --doc`
+stays a separate command. CI runs it as its own step for the same reason.
 
 ## Running automated checks
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ $ RUSTFLAGS="-Ctarget-cpu=native" cargo run --release --example sha512 prove --m
 
 Multithreading using [Rayon](https://github.com/rayon-rs/rayon) is available, but it is disabled by default. This is controlled by the `rayon` Cargo feature. To run an example with multithreading enabled, use `--features rayon`.
 
+## Development
+
+For build, test, and lint commands, project terminology, and an index of the project documentation,
+see [DEVELOPMENT.md](DEVELOPMENT.md).
+
 ## Architecture
 
 For repository structure and architectural details, see [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/README.md
+++ b/README.md
@@ -99,22 +99,6 @@ being listed as a contributor to the repo.
 Binius64 was originally developed by [Irreducible](https://www.irreducible.com), with funding from
 [Bain Capital Crypto](https://baincapitalcrypto.com/) and [Paradigm](https://www.paradigm.xyz/).
 
-## Contributing
-
-Developers (both human and artificial intelligence) should read the [CONTRIBUTING.md](CONTRIBUTING.md) file before submitting pull requests.
-
-The project welcomes first time contributions from developers who want to learn more about Binius64 and make an impact
-on the open source cryptography community.
-
-If you are new to the project and don't know where to start, you can look for [open issues labeled
-`good first issue`](https://github.com/IrreducibleOSS/binius/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22) or add
-test coverage for existing code. Adding unit tests is a great way to learn how to interact with the codebase, make a
-meaningful contribution, and maybe even find bugs!
-
-On the other hand, _we do not accept typo fix PRs from first-time contributors_. These are not significant enough to
-justify the additional work for maintainers nor any potential benefits, tangible or intangible, one might get from
-being listed as a contributor to the repo.
-
 ## Licensing
 
 ```

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -595,7 +595,7 @@ where
 			// Try to extract params from the appropriate matches for richer context
 			// This will succeed for most commands (prove, stat, save, etc.)
 			// and fail gracefully for commands without params (like load-prove)
-			let matches_for_params = matches.subcommand().map(|(_, sub)| sub).unwrap_or(&matches);
+			let matches_for_params = matches.subcommand().map(|(_, sub)| sub).unwrap_or(matches);
 
 			if let Ok(params) = E::Params::from_arg_matches(matches_for_params)
 				&& let Some(param_summary) = E::param_summary(&params)

--- a/tools/clippy-changed-packages.sh
+++ b/tools/clippy-changed-packages.sh
@@ -38,5 +38,5 @@ done
 
 ((${#args[@]} == 0)) && exit 0
 
-echo "clippy: cargo clippy ${args[*]} --all-targets" >&2
-exec cargo clippy "${args[@]}" --all-targets -- -D warnings
+echo "clippy: cargo clippy ${args[*]} --all-targets --all-features" >&2
+exec cargo clippy "${args[@]}" --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Documentation-only, except for the last two commits, which align the clippy command between CI and the docs.

## The docs split had drifted

`AGENTS.md` is named for AI agents, but its content is the developer quick-start: build and test commands, key terminology, and an index of the other docs. Nothing in it is agent-specific. Meanwhile `CONTRIBUTING.md`, which is about how to *write* code here, held two sections about how to *run* the toolchain. And the same commands appeared in both files, in different spellings.

After this PR the two files do not overlap:

- **`DEVELOPMENT.md`** — commands, environment, terminology
- **`CONTRIBUTING.md`** — conventions

`README.md` stays the entry point and links to both.

## Commits

1. **Rename `AGENTS.md` to `DEVELOPMENT.md`.** No tracked file referenced `AGENTS.md` except its own title. The rename gives up auto-discovery by tooling that keys on the `AGENTS.md` filename; agents working in this repo are pointed at the file explicitly, so nothing depended on that. `README.md` gains a Development section linking it, alongside the existing Architecture and Contributing pointers.
2. **Move the toolchain instructions from `CONTRIBUTING.md` to `DEVELOPMENT.md`** — "Running automated checks" and "Cross-compilation". `DEVELOPMENT.md`'s Build Commands block already listed the fmt/clippy/rustdoc/typos/prek commands, so this deduped rather than concatenated: the block keeps the build lines, and those commands are consolidated in the moved section.
3. **Move the code-comment convention the other way.** "Code comments explain current behavior, not change history" is a style rule, so it belongs in `CONTRIBUTING.md`.
4. **Recommend cargo-nextest and rewrite the documented test commands.** CI has run `cargo nextest run --workspace` since BINIUS-151, but the docs still said `cargo test`, so a locally green suite was not necessarily the suite CI ran. nextest cannot run doc tests ([nextest#16](https://github.com/nextest-rs/nextest/issues/16)) and `CONTRIBUTING.md` relies on doc examples as regression tests, so `cargo test --doc --workspace` stays a separate documented command — as it is a separate CI step. Every command was run against `binius-utils` to confirm it works as written.
5. **Remove the duplicated Contributing section from `README.md`.** It appeared twice, identical apart from one sentence's wording.
6. **Fix a needless borrow in the perfetto-gated CLI tracing setup.** See below.
7. **Lint all features in CI, and document that as the clippy command.**

## Why `--all-features` in CI

CI ran `cargo clippy --workspace --all-targets -- -D warnings`, which lints only the default feature set. Every optional feature in the workspace is off by default — `rayon`, `perfetto`, `platform-diagnostics`, `benchmark_alternative_strategies`, `trace_multiplications`, `test-utils`, `test-circuits` — and no CI job turns any of them on for clippy. That code was never linted, and it bitrots without anyone noticing.

Adding `--all-features` immediately caught one: `crates/examples/src/cli.rs:598` passed `&matches` where `matches` is already a `&clap::ArgMatches`, so the compiler dereferenced it right back. It sits inside `#[cfg(feature = "perfetto")]`, which is why CI never saw it. Fixed in its own commit (6) so that every commit here is green.

`DEVELOPMENT.md` had documented a third spelling, `cargo clippy --all --all-features --tests --benches --examples`, which named a different target set than CI and so could pass where CI failed. It now gives CI's command verbatim. `tools/clippy-changed-packages.sh` gains `--all-features` for the same reason: the pre-push hook exists to predict CI's result for the packages you touched, which it cannot do while linting a narrower feature set.

**Trade-off worth knowing:** the `Compile` step builds with default features, so clippy can no longer reuse its artifacts and recompiles the dependency tree under the wider feature unification, once per matrix leg. If that shows up as a meaningful slowdown, the options are to give `Compile` `--all-features` too (which shifts the recompile onto the test step) or to split clippy into its own job with its own cache.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` exits 0
- Default-feature clippy on `binius-examples` still passes, so commit 6 stands alone
- `cargo +nightly-2026-07-01 fmt --check` clean; `typos` clean on all edited docs
- Both documented nextest commands run against `binius-utils`
- Every relative markdown link in the four top-level docs resolves; no `AGENTS` reference remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)