### PR TITLE
Rename OblongZerocheckProver::execute to round_message

### DIFF
--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -89,7 +89,8 @@ where
 	/// The constructor:
 	/// 1. Computes the equality indicator polynomial from the big field challenges
 	/// 2. Uses the NTT lookup to efficiently compute the univariate polynomial evaluations
-	/// 3. Caches these evaluations for later use in the execute() method
+	/// 3. Caches these evaluations for later use in the [`round_message`](Self::round_message)
+	///    method
 	pub fn new(
 		log_words: usize,
 		first_col: Data,
@@ -136,7 +137,7 @@ where
 	///
 	/// The polynomial evaluations are precomputed in the constructor using the NTT lookup table
 	/// for efficiency. This method simply returns the cached result.
-	pub const fn execute(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
+	pub const fn round_message(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
 		&self.univariate_round_message
 	}
 
@@ -237,7 +238,7 @@ where
 		channel: &mut impl IPProverChannel<F>,
 		alloc: &A,
 	) -> AndCheckOutput<F> {
-		let univariate_message_coeffs = self.execute();
+		let univariate_message_coeffs = self.round_message();
 
 		channel.send_many(univariate_message_coeffs);
 


### PR DESCRIPTION
Pure rename — no behavior change.

### The problem

`OblongZerocheckProver::execute` looks like it implements this codebase's `SumcheckProver::execute` convention.
It doesn't.

Every other `.execute()` in this codebase — 25 call sites across `ip-prover`'s sumcheck/fracaddcheck/prodcheck modules and the shift protocol — is `SumcheckProver::execute(&mut self) -> Vec<RoundCoeffs<F>>`: it advances the prover's round state and returns fresh coefficients.
This one takes `&self`, mutates nothing, and returns a cached `&[F; ROWS_PER_HYPERCUBE_VERTEX]` — a plain getter for something `new()` already computed.
A reader who knows the codebase's own pattern will misread it as a round-advancing step.

### The idea

Rename it to what it actually is: `round_message()`.
The doc already calls the value "the univariate polynomial R₀(Z)" / "round message" — the new name matches the existing vocabulary instead of colliding with an unrelated trait.

### The change

```diff
- pub const fn execute(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
+ pub const fn round_message(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
      &self.univariate_round_message
  }
```

Its one caller (`prove_with_channel`) and one doc mention updated to match.

### Scope

- **changed:** `crates/prover/src/and_reduction/prover.rs` only
- confirmed the benchmark's own `.execute()` call belongs to a different, unrelated `quadratic_mlecheck_prover` result — left untouched

### Verification

- `cargo check -p binius-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets` — clean
- `cargo test -p binius-prover --lib and_reduction` — 5 passed
- `cargo +nightly fmt -p binius-prover -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)