### PR TITLE
Narrow OblongZerocheckProver's PChallenge generic to the methods that need it

### DIFF
--- a/crates/prover/src/and_reduction/prove.rs
+++ b/crates/prover/src/and_reduction/prove.rs
@@ -65,7 +65,7 @@ where
 		log_constraint_count.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
 	let big_field_zerocheck_challenges = channel.sample_many(n_extra_zerocheck_challenges);
 
-	let prover = OblongZerocheckProver::<_, PChallenge, _>::new(
+	let prover = OblongZerocheckProver::<_, _>::new(
 		log_constraint_count,
 		a,
 		b,
@@ -73,7 +73,7 @@ where
 		&prover_message_domain,
 	);
 
-	prover.prove_with_channel(channel, alloc)
+	prover.prove_with_channel::<PChallenge, _>(channel, alloc)
 }
 
 #[cfg(test)]

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{marker::PhantomData, ops::Deref};
+use std::ops::Deref;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -28,14 +28,10 @@ use crate::fold_word::BitAxisFolder;
 ///
 /// See [`binius_verifier::protocols::bitand`] for the protocol specification.
 ///
-/// The type parameter `PChallenge` is the packed field over the challenge field `FChallenge` used
-/// for the multilinear sumcheck rounds that follow the univariate round. Packing these rounds over
-/// a wide field provides SIMD acceleration.
-///
 /// The columns are generic over their backing store `Data` (anything that dereferences to
 /// `[Word]`), so callers can supply pooled buffers ([`PoolVec`](binius_compute::PoolVec)) or plain
 /// `Vec<Word>` interchangeably.
-pub struct OblongZerocheckProver<FChallenge, PChallenge, Data>
+pub struct OblongZerocheckProver<FChallenge, Data>
 where
 	FChallenge: BinaryField,
 {
@@ -45,13 +41,11 @@ where
 	big_field_zerocheck_challenges: Vec<FChallenge>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
-	_marker: PhantomData<PChallenge>,
 }
 
-impl<F, PChallenge, Data> OblongZerocheckProver<F, PChallenge, Data>
+impl<F, Data> OblongZerocheckProver<F, Data>
 where
 	F: BinaryField + From<B8>,
-	PChallenge: PackedField<Scalar = F>,
 	Data: Deref<Target = [Word]>,
 {
 	/// Creates a new oblong zerocheck prover for AND constraint reduction.
@@ -115,7 +109,6 @@ where
 			univariate_round_message,
 			big_field_zerocheck_challenges,
 			univariate_round_message_domain: prover_message_domain.isomorphic(),
-			_marker: PhantomData,
 		}
 	}
 
@@ -166,7 +159,11 @@ where
 	/// 3. Combines the zerocheck challenges (small field + big field)
 	/// 4. Evaluates the univariate polynomial at the challenge to get the sumcheck claim
 	/// 5. Constructs the AND reduction sumcheck prover with the folded multilinears
-	pub fn fold_and_send_reduced_prover<'alloc, A: Allocator>(
+	pub fn fold_and_send_reduced_prover<
+		'alloc,
+		PChallenge: PackedField<Scalar = F>,
+		A: Allocator,
+	>(
 		self,
 		round_message_domain: &BinarySubspace<F>,
 		challenge: F,
@@ -232,7 +229,7 @@ where
 	/// 2. **Challenge**: Sample univariate challenge z via Fiat-Shamir
 	/// 3. **Transition**: Fold oblong multilinears at Z = z
 	/// 4. **Phase 2**: Execute sumcheck protocol on folded multilinears
-	pub fn prove_with_channel<A: Allocator>(
+	pub fn prove_with_channel<PChallenge: PackedField<Scalar = F>, A: Allocator>(
 		self,
 		channel: &mut impl IPProverChannel<F>,
 		alloc: &A,
@@ -244,7 +241,7 @@ where
 		let univariate_sumcheck_challenge = channel.sample();
 		let univariate_round_message_domain = self.univariate_round_message_domain.clone();
 		let sumcheck_prover = tracing::debug_span!("Fold univariate round").in_scope(|| {
-			self.fold_and_send_reduced_prover(
+			self.fold_and_send_reduced_prover::<PChallenge, A>(
 				&univariate_round_message_domain,
 				univariate_sumcheck_challenge,
 				alloc,
@@ -325,7 +322,7 @@ mod test {
 		// Prover is instantiated
 		let big_field_zerocheck_challenges = prover_challenger
 			.sample_vec(log_num_rows - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
-		let prover = OblongZerocheckProver::<_, OptimalPackedB128, _>::new(
+		let prover = OblongZerocheckProver::<_, _>::new(
 			log_num_rows,
 			first_mlv.clone(),
 			second_mlv.clone(),
@@ -333,7 +330,8 @@ mod test {
 			&prover_message_domain,
 		);
 
-		let prove_output = prover.prove_with_channel(&mut prover_challenger, &GlobalAllocator);
+		let prove_output = prover
+			.prove_with_channel::<OptimalPackedB128, _>(&mut prover_challenger, &GlobalAllocator);
 
 		// Verifier is instantiated
 		let mut verifier_challenger = prover_challenger.into_verifier();


### PR DESCRIPTION
Pure refactor — no behavior change.

### The problem

`OblongZerocheckProver<FChallenge, PChallenge, Data>` carries `PChallenge` as a struct-wide generic, backed by a `PhantomData<PChallenge>` field just to make it legal.
Tracing every use in the file, only one method touches it: `fold_and_send_reduced_prover`, which calls `folder.fold_bitand_operands::<PChallenge, _>(...)`.
`new()` never sees it.
Constructing a bare prover — for a test, or to inspect the round message alone — forced a caller to already know what packed field the *later* multilinear rounds would use.

### The idea

Move `PChallenge` off the struct and onto the one method that needs it, threaded through to `prove_with_channel`.

### The change

```diff
- pub struct OblongZerocheckProver<FChallenge, PChallenge, Data> { ...  _marker: PhantomData<PChallenge> }
+ pub struct OblongZerocheckProver<FChallenge, Data> { ... }

- pub fn fold_and_send_reduced_prover<'alloc, A: Allocator>(...)
+ pub fn fold_and_send_reduced_prover<'alloc, PChallenge: PackedField<Scalar = F>, A: Allocator>(...)

- pub fn prove_with_channel<A: Allocator>(...)
+ pub fn prove_with_channel<PChallenge: PackedField<Scalar = F>, A: Allocator>(...)
```

The one call site moves its turbofish accordingly:

```diff
- let prover = OblongZerocheckProver::<_, PChallenge, _>::new(...);
- prover.prove_with_channel(channel, alloc)
+ let prover = OblongZerocheckProver::new(...);
+ prover.prove_with_channel::<PChallenge, _>(channel, alloc)
```

### Scope

- **changed:** `crates/prover/src/and_reduction/prover.rs`, `crates/prover/src/and_reduction/mod.rs`
- also its own test module in `prover.rs`, updated the same way

### Verification

- `cargo check -p binius-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets` — clean
- `cargo test -p binius-prover --lib and_reduction` — 5 passed
- `cargo +nightly fmt -p binius-prover -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)