### PR TITLE
Document the memory/parallelism trade-off behind N_FIXED_LARGE_CHALLENGES

### DIFF
--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -18,6 +18,19 @@ use itertools::izip;
 use super::ntt_lookup::NTTLookup;
 
 /// Number of big field zerocheck challenges whose equality indicator is expanded per window.
+///
+/// This value controls a memory-versus-parallelism trade-off.
+///
+/// Doubling it doubles the number of precomputed multiplication tables built for one call.
+/// Each table holds 256 field elements.
+/// That is real, measurable memory cost.
+///
+/// Doubling it also doubles the number of words handled together in one parallel chunk of the
+/// round message computation.
+/// That makes the parallel work coarser-grained.
+///
+/// Halving it shrinks both costs.
+/// The price is building more, smaller tables and chunks.
 const N_FIXED_LARGE_CHALLENGES: usize = 4;
 
 /// Generates a univariate polynomial for the sumcheck protocol in AND constraint reduction.


### PR DESCRIPTION
Doc-only — the constant's value is unchanged.

### The problem

`N_FIXED_LARGE_CHALLENGES = 4` documents *what* it is ("number of big field zerocheck challenges whose equality indicator is expanded per window") but not *why 4*.
Its sibling constant, the small-field challenge count, is fully justified two doc blocks up ("we choose k=3 because we want them to be in a field isomorphic to the 8-bit NTT domain field").

Checked `git log -S"N_FIXED_LARGE_CHALLENGES"` for the original reasoning — the commit that introduced it (#1597, a hot-loop restructuring) explains what the value produces (a 16-way subchunk layout) but never states why 16 over any other power of two.

### The idea

Rather than invent a specific "we benchmarked X" justification that doesn't exist in the history, document the concrete, verifiable trade-off the value controls: doubling it doubles both the number of precomputed 256-entry lookup tables built per call (real memory) and the width of one parallel chunk in the round-message computation (coarser-grained parallelism); halving it does the opposite.

### The change

```diff
  /// Number of big field zerocheck challenges whose equality indicator is expanded per window.
+ ///
+ /// This value controls a memory-versus-parallelism trade-off.
+ /// Doubling it doubles the number of precomputed multiplication tables built for one call.
+ /// Each table holds 256 field elements — real, measurable memory cost.
+ /// Doubling it also doubles the number of words handled together in one parallel chunk.
+ /// That makes the parallel work coarser-grained.
+ /// Halving it shrinks both costs, at the price of more, smaller tables and chunks.
  const N_FIXED_LARGE_CHALLENGES: usize = 4;
```

### Scope

- **changed:** `crates/prover/src/and_reduction/sumcheck_round_messages.rs` — doc comment only, value unchanged

### Verification

- `cargo check -p binius-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets` — clean
- `cargo test -p binius-prover --lib and_reduction` — 5 passed
- `cargo +nightly fmt -p binius-prover -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)