### PR TITLE
BINIUS-507: Merge same-round oracle commitments into one

### DIFF
--- a/crates/iop-prover/src/channel/merge.rs
+++ b/crates/iop-prover/src/channel/merge.rs
@@ -1,0 +1,744 @@
+// Copyright 2026 The Binius Developers
+
+//! A channel decorator that merges oracles committed within the same interaction round.
+//!
+//! This is the prover-side half of a matching pair.
+//! Whatever it commits here must be received by a matching verifier-side decorator.
+
+use std::{cmp::Reverse, ops::DerefMut};
+
+use binius_compute::Allocator;
+use binius_field::{Field, PackedField};
+use binius_iop::channel::OracleSpec;
+use binius_ip_prover::channel::{IPProverChannel, WordIPProverChannel};
+use binius_math::{FieldBuffer, FieldSlice, FieldVec};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
+
+use crate::channel::IOPProverChannel;
+
+/// A handle to an oracle sent through the merging decorator.
+#[derive(Debug, Clone, Copy)]
+pub struct MergeOracle {
+	index: usize,
+}
+
+/// Records where one constituent oracle lives inside its round's combined oracle.
+#[derive(Clone, Copy)]
+struct Mapping {
+	/// Which round's combined oracle this constituent belongs to.
+	group: usize,
+
+	/// The constituent's position among its round-mates, as a block index.
+	///
+	/// Its own `2^n` scalars begin at scalar `block_index * 2^n`.
+	block_index: usize,
+
+	/// The base-2 logarithm of the combined oracle's length.
+	combined_log_len: usize,
+}
+
+/// Tracks one oracle from the moment it is sent until its round is flushed.
+struct Record {
+	/// The base-2 logarithm of the oracle's own length.
+	log_msg_len: usize,
+
+	/// Where this oracle ends up inside its round's combined oracle.
+	///
+	/// Filled in once that round is flushed.
+	mapping: Option<Mapping>,
+}
+
+/// The combined oracle actually committed for one round.
+///
+/// Kept alive until every constituent oracle is finalized.
+struct Group<P: PackedField, A: Allocator, Oracle> {
+	/// The handle the underlying channel returned for the combined oracle.
+	outer: Oracle,
+
+	/// The combined witness data.
+	///
+	/// Kept until every constituent has been handed back.
+	/// Then forwarded to the underlying channel exactly once, in their place.
+	buffer: Option<FieldVec<P, A>>,
+
+	/// How many constituent oracles make up this round.
+	n_members: usize,
+
+	/// How many of those constituents have been handed back so far.
+	n_finalized: usize,
+}
+
+/// A prover channel decorator that merges one round's oracles into one combined oracle.
+///
+/// # Overview
+///
+/// An interaction round is the run of oracles sent between two challenge samples.
+///
+/// Committing each oracle separately costs one commitment per oracle.
+/// One Merkle tree per oracle, for example.
+///
+/// This decorator buffers a round's oracles instead.
+/// It commits them together as one larger oracle.
+/// That cuts the cost to one commitment per round.
+///
+/// A round's oracles are sorted from largest to smallest, then laid out end to end.
+/// That ordering makes every oracle's position exact.
+///
+/// Every earlier oracle is at least as large as the current one.
+/// So their combined space is a whole multiple of the current oracle's size.
+///
+/// A round of a single oracle needs no combining.
+/// It is forwarded unchanged, at zero cost.
+///
+/// Every oracle in a round must declare the same witness-dependence.
+///
+/// A commitment is masked as a whole, never partly.
+/// So mixing witness-carrying and structural oracles in one round is not supported.
+///
+/// # Timing
+///
+/// A round's oracles are committed the moment a challenge is sampled.
+/// Not the moment they arrive.
+///
+/// A real Fiat-Shamir transcript works the same way.
+/// A challenge can only be derived after its commitments are absorbed.
+/// So committing cannot wait past the sample that follows a round.
+///
+/// # Opening
+///
+/// A verifier only ever holds a formula for a transparent polynomial.
+///
+/// This side holds the actual coefficients instead.
+/// A constituent's own transparent polynomial becomes one for the combined oracle.
+/// Write its values into a zero buffer, at the constituent's own position.
+/// Every other position stays zero.
+///
+/// That placement is the same polynomial a verifier reaches by formula.
+/// One side holds it as explicit values.
+/// The other evaluates it on demand.
+pub struct MergeProverChannel<'a, P, A, C>
+where
+	P: PackedField,
+	A: Allocator,
+	C: IOPProverChannel<P, A>,
+{
+	/// The underlying channel every oracle, challenge, and opening passes through.
+	inner: C,
+
+	/// Fine-grained specs, one per oracle this channel's caller will send.
+	///
+	/// Not the coarser, one-per-round specs the underlying channel uses.
+	oracle_specs: &'a [OracleSpec],
+
+	/// The allocator this channel draws its combined and padded buffers from.
+	alloc: A,
+
+	/// Buffers received for the current round, not yet sent to the underlying channel.
+	pending: Vec<FieldVec<P, A>>,
+
+	/// Every oracle sent so far, in arrival order.
+	records: Vec<Record>,
+
+	/// Every round committed so far, in commit order.
+	groups: Vec<Group<P, A, C::Oracle>>,
+}
+
+impl<'a, P, A, C> MergeProverChannel<'a, P, A, C>
+where
+	P: PackedField,
+	A: Allocator,
+	C: IOPProverChannel<P, A>,
+{
+	/// Creates a new merging prover channel over an underlying channel.
+	///
+	/// # Arguments
+	///
+	/// * `inner` — the channel every combined oracle is committed to, already configured with the
+	///   coarser, one-per-round spec list this decorator will produce.
+	/// * `oracle_specs` — the fine-grained specs for every oracle this channel's caller will pass
+	///   through, in arrival order.
+	/// * `alloc` — where this channel draws its combined and padded buffers from.
+	pub const fn new(inner: C, oracle_specs: &'a [OracleSpec], alloc: A) -> Self {
+		Self {
+			inner,
+			oracle_specs,
+			alloc,
+			pending: Vec::new(),
+			records: Vec::new(),
+			groups: Vec::new(),
+		}
+	}
+
+	/// Commits the current round's queued buffers as one combined oracle.
+	///
+	/// Does nothing if every sent oracle is already committed.
+	fn flush(&mut self) {
+		// Nothing new has arrived since the last flush.
+		if self.pending.is_empty() {
+			return;
+		}
+		let first_index = self.records.len() - self.pending.len();
+
+		// Order this round largest to smallest.
+		//
+		// This lets every position be a whole number of block sizes.
+		// That holds once every earlier buffer is at least as large.
+		let mut order: Vec<usize> = (0..self.pending.len()).collect();
+		order.sort_by_key(|&k| Reverse(self.pending[k].log_len()));
+
+		// Size the combined oracle to fit every buffer end to end.
+		let total_len: usize = order
+			.iter()
+			.map(|&k| 1usize << self.pending[k].log_len())
+			.sum();
+		let combined_log_len = log2_ceil_usize(total_len);
+
+		// Lay every buffer into the combined data.
+		// Record where each one landed.
+		//
+		// Every step adds a whole multiple of the next block's size.
+		// So each offset divides evenly by that buffer's own size.
+		let mut combined = FieldBuffer::zeros_in(&self.alloc, combined_log_len);
+		let mut block_indices = vec![0usize; self.pending.len()];
+		let mut offset = 0usize;
+		for &k in &order {
+			let n_k = self.pending[k].log_len();
+			let block_index = offset >> n_k;
+			block_indices[k] = block_index;
+			place_block(&mut combined, self.pending[k].as_view(), block_index);
+			offset += 1 << n_k;
+		}
+
+		// Commit the whole round as one oracle on the underlying channel.
+		//
+		// The combined data stays alive in its own round record.
+		// It is still needed once every constituent is handed back.
+		let outer = self.inner.send_oracle(combined.as_view());
+		let group_index = self.groups.len();
+		let n_members = self.pending.len();
+		self.groups.push(Group {
+			outer,
+			buffer: Some(combined),
+			n_members,
+			n_finalized: 0,
+		});
+
+		// Record where each constituent oracle landed.
+		for k in 0..n_members {
+			self.records[first_index + k].mapping = Some(Mapping {
+				group: group_index,
+				block_index: block_indices[k],
+				combined_log_len,
+			});
+		}
+
+		self.pending.clear();
+	}
+
+	/// Commits any oracles still queued and returns the underlying channel.
+	///
+	/// # Panics
+	///
+	/// Panics if any declared oracle has not yet been sent.
+	pub fn into_inner(mut self) -> C {
+		self.flush();
+		let n_remaining = self.oracle_specs.len() - self.records.len();
+		assert!(n_remaining == 0, "into_inner called but {n_remaining} oracle specs remaining",);
+		self.inner
+	}
+}
+
+/// Writes one buffer into a fixed-size block of another.
+///
+/// Every other position of the destination is left untouched.
+///
+/// # Panics
+///
+/// Panics if the block does not fit at the given index.
+fn place_block<P, Data>(dst: &mut FieldBuffer<P, Data>, src: FieldSlice<'_, P>, block_index: usize)
+where
+	P: PackedField,
+	Data: DerefMut<Target = [P]>,
+{
+	// The destination block starts at a whole multiple of the source's own length.
+	//
+	// A block index of zero starts at the very first scalar.
+	let n = src.log_len();
+	let offset = block_index << n;
+	assert!(offset + (1 << n) <= dst.len(), "pre-condition: the block must fit in the destination");
+
+	// Copy every scalar across.
+	// Everywhere else in the destination stays as it was.
+	for i in 0..1usize << n {
+		dst.set(offset + i, src.get(i));
+	}
+}
+
+impl<F, P, A, C> IPProverChannel<F> for MergeProverChannel<'_, P, A, C>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	A: Allocator,
+	C: IOPProverChannel<P, A>,
+{
+	fn send_one(&mut self, elem: F) {
+		self.inner.send_one(elem);
+	}
+
+	fn send_many(&mut self, elems: &[F]) {
+		self.inner.send_many(elems);
+	}
+
+	fn observe_one(&mut self, val: F) {
+		self.inner.observe_one(val);
+	}
+
+	fn observe_many(&mut self, vals: &[F]) {
+		self.inner.observe_many(vals);
+	}
+
+	fn sample(&mut self) -> F {
+		// Commit this round before deriving its challenge.
+		//
+		// A real transcript must absorb a commitment first.
+		// Only then can it derive a challenge that depends on it.
+		self.flush();
+		self.inner.sample()
+	}
+}
+
+impl<F, P, A, C> WordIPProverChannel<F> for MergeProverChannel<'_, P, A, C>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	A: Allocator,
+	C: IOPProverChannel<P, A> + WordIPProverChannel<F>,
+{
+	type Word = C::Word;
+
+	fn observe_words(&mut self, words: &[Self::Word]) {
+		self.inner.observe_words(words);
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Self::Word {
+		self.inner.sample_bits(bits)
+	}
+}
+
+impl<'a, F, P, A, C> IOPProverChannel<P, A> for MergeProverChannel<'a, P, A, C>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	A: Allocator,
+	C: IOPProverChannel<P, A>,
+{
+	type Oracle = MergeOracle;
+
+	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
+		&self.oracle_specs[self.records.len()..]
+	}
+
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
+		// Every oracle this channel will send is declared up front.
+		//
+		// Reject anything past that count.
+		// Do not silently accept an undeclared oracle.
+		let remaining = self.remaining_oracle_specs();
+		assert!(!remaining.is_empty(), "send_oracle called but no remaining oracle specs");
+		debug_assert_eq!(buffer.log_len(), remaining[0].log_msg_len);
+
+		// Copy the data into a buffer this channel owns.
+		//
+		// The caller's buffer is only borrowed for this call.
+		// Its round may not commit until a later challenge sample.
+		self.pending
+			.push(FieldBuffer::from_view_in(&self.alloc, buffer));
+		self.records.push(Record {
+			log_msg_len: buffer.log_len(),
+			mapping: None,
+		});
+		MergeOracle {
+			index: self.records.len() - 1,
+		}
+	}
+
+	fn prove_oracle_relation(
+		&mut self,
+		oracle: Self::Oracle,
+		transparent: FieldVec<P, A>,
+		claim: P::Scalar,
+	) {
+		// Every oracle must be sent before any oracle is opened.
+		// So this oracle's round is already committed by now.
+		//
+		// Flush anyway, in case no challenge was sampled in between.
+		self.flush();
+
+		let record = &self.records[oracle.index];
+		let n_i = record.log_msg_len;
+		assert_eq!(
+			transparent.log_len(),
+			n_i,
+			"transparent log_len mismatch: expected {n_i}, got {}",
+			transparent.log_len()
+		);
+		let Mapping {
+			group,
+			block_index,
+			combined_log_len,
+		} = record.mapping.expect("flushed above");
+
+		// Place the constituent's transparent polynomial into a zero buffer.
+		// Use the width of the combined oracle, at this oracle's own block.
+		//
+		// Everywhere outside that block reads as zero.
+		// So the produced inner product equals the original claim exactly.
+		let mut padded = FieldBuffer::zeros_in(&self.alloc, combined_log_len);
+		place_block(&mut padded, transparent.as_view(), block_index);
+
+		let outer = self.groups[group].outer.clone();
+		self.inner.prove_oracle_relation(outer, padded, claim);
+	}
+
+	fn finalize_oracle(&mut self, oracle: Self::Oracle, _buffer: FieldVec<P, A>) {
+		// The buffer handed back here must equal the one already sent.
+		// This channel already copied that data at commit time.
+		// So the copy handed back now is simply discarded.
+		self.flush();
+
+		let record = &self.records[oracle.index];
+		let group_index = record.mapping.expect("flushed above").group;
+
+		// Once every constituent is handed back, the round is done.
+		// Its combined buffer can now reach the underlying channel.
+		let group = &mut self.groups[group_index];
+		group.n_finalized += 1;
+		if group.n_finalized == group.n_members {
+			let combined_buffer = group
+				.buffer
+				.take()
+				.expect("group buffer present until every constituent is finalized");
+			let outer = group.outer.clone();
+			self.inner.finalize_oracle(outer, combined_buffer);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter;
+
+	use binius_compute::GlobalAllocator;
+	use binius_field::{
+		BinaryField, Field, Ghash128b, PackedBinaryGhash1x128b, PackedBinaryGhash4x128b,
+		PackedField,
+	};
+	use binius_hash::StdDigest;
+	use binius_iop::channel::{
+		IOPVerifierChannel, OracleSpec, merge::MergeVerifierChannel, naive::NaiveVerifierChannel,
+	};
+	use binius_ip::channel::IPVerifierChannel;
+	use binius_ip_prover::channel::IPProverChannel;
+	use binius_math::{
+		FieldBuffer,
+		multilinear::{Multilinear, hypercube::Hypercube},
+		test_utils::{random_field_buffer, random_scalars},
+	};
+	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
+	use proptest::prelude::*;
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::{IOPProverChannel, MergeProverChannel};
+	use crate::channel::naive::NaiveProverChannel;
+
+	type StdChallenger = HasherChallenger<StdDigest>;
+
+	/// Generates a random buffer of a given size.
+	///
+	/// Also returns an independent transparent polynomial.
+	/// And the claim their inner product produces.
+	fn generate_oracle_data<F, P, R: Rng>(
+		rng: &mut R,
+		n_vars: usize,
+	) -> (FieldBuffer<P>, FieldBuffer<P>, F)
+	where
+		F: BinaryField,
+		P: PackedField<Scalar = F>,
+	{
+		let buffer = random_field_buffer::<P>(&mut *rng, n_vars);
+		let point = random_scalars::<F>(&mut *rng, n_vars);
+		let transparent = Hypercube::One.expand(&point).build::<P>();
+		let claim = buffer.inner_product(&transparent);
+		(buffer, transparent, claim)
+	}
+
+	/// Runs a full prove-then-verify round trip over oracles grouped into rounds.
+	///
+	/// Each inner slice of `rounds` lists one round's oracle sizes, in log2.
+	/// Every one is sent, or received, before one challenge is sampled.
+	///
+	/// If `tamper` is set, the first oracle's claim is corrupted.
+	/// Verification must then reject the whole round trip.
+	fn run_merge_round_trip<P>(rounds: &[&[usize]], tamper: bool)
+	where
+		P: PackedField<Scalar = Ghash128b>,
+	{
+		type F = Ghash128b;
+
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Flatten the rounds into one flat list of sizes, in order.
+		// Both sides' bookkeeping expects that same list.
+		// Generate independent witness data for each one.
+		let fine_sizes: Vec<usize> = rounds
+			.iter()
+			.flat_map(|round| round.iter().copied())
+			.collect();
+		let fine_specs: Vec<OracleSpec> = fine_sizes.iter().map(|&n| OracleSpec::new(n)).collect();
+		let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = fine_sizes
+			.iter()
+			.map(|&n| generate_oracle_data::<F, P, _>(&mut rng, n))
+			.collect();
+
+		// The expected result of merging.
+		//
+		// One combined oracle per round.
+		// Sized to the smallest power of two that fits the total.
+		let coarse_specs: Vec<OracleSpec> = rounds
+			.iter()
+			.map(|sizes| {
+				let total: usize = sizes.iter().map(|&n| 1usize << n).sum();
+				OracleSpec::new(log2_ceil_usize(total))
+			})
+			.collect();
+
+		// Prover side.
+		//
+		// Send every oracle round by round.
+		// Sample a challenge between rounds.
+		// Each round commits as it goes.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let naive_prover = NaiveProverChannel::new(&mut prover_transcript, coarse_specs.clone());
+		let mut merge_prover = MergeProverChannel::new(naive_prover, &fine_specs, GlobalAllocator);
+
+		let mut oracles = Vec::new();
+		let mut index = 0;
+		for sizes in rounds {
+			for _ in *sizes {
+				let (buffer, _, _) = &data[index];
+				oracles.push(merge_prover.send_oracle(buffer.as_view()));
+				index += 1;
+			}
+			IPProverChannel::sample(&mut merge_prover);
+		}
+		// Prove every oracle's claim first.
+		// Then hand back every oracle's own witness data.
+		// That matches the order a real prover would follow.
+		for (&oracle, (_, transparent, claim)) in iter::zip(&oracles, &data) {
+			merge_prover.prove_oracle_relation(oracle, transparent.clone(), *claim);
+		}
+		for (&oracle, (buffer, _, _)) in iter::zip(&oracles, &data) {
+			merge_prover.finalize_oracle(oracle, buffer.clone());
+		}
+		merge_prover.into_inner().finish();
+
+		// Verifier side.
+		//
+		// Mirror the exact same round boundaries.
+		// Both sides then sample from the same transcript positions.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let naive_verifier = NaiveVerifierChannel::new(&mut verifier_transcript, &coarse_specs);
+		let mut merge_verifier = MergeVerifierChannel::new(naive_verifier, &fine_specs);
+
+		let mut v_oracles = Vec::new();
+		for sizes in rounds {
+			for &n in *sizes {
+				v_oracles.push(merge_verifier.recv_oracle(n, true).unwrap());
+			}
+			IPVerifierChannel::sample(&mut merge_verifier);
+		}
+		for (position, (&oracle, (_, transparent, claim))) in
+			iter::zip(&v_oracles, &data).enumerate()
+		{
+			let transparent = transparent.clone();
+			// Corrupt only the first oracle's claim.
+			// Only do this when tampering is requested.
+			// Every other claim is left untouched.
+			let claim = if tamper && position == 0 {
+				*claim + F::ONE
+			} else {
+				*claim
+			};
+			merge_verifier
+				.verify_oracle_relation(
+					oracle,
+					Box::new(move |point: &[F]| {
+						let eq = Hypercube::One.expand(point).build::<P>();
+						transparent.inner_product(&eq)
+					}),
+					claim,
+				)
+				.expect("verification only ever queues a relation, it does not check it here");
+		}
+		merge_verifier.into_inner().unwrap().finish();
+	}
+
+	#[test]
+	fn single_oracle_round_trip() {
+		// A single round holding a single oracle.
+		// The degenerate case, where merging has nothing to do.
+		run_merge_round_trip::<PackedBinaryGhash1x128b>(&[&[6]], false);
+	}
+
+	#[test]
+	fn multi_round_round_trip() {
+		// Three rounds, each a different shape.
+		//
+		// Round 1: two equal-size oracles.
+		// An exact power-of-two total.
+		//
+		// Round 2: three unequal oracles.
+		// A non-power-of-two total, so padding is required.
+		//
+		// Round 3: a single oracle, the degenerate case.
+		run_merge_round_trip::<PackedBinaryGhash1x128b>(&[&[3, 3], &[4, 2, 2], &[1]], false);
+	}
+
+	#[test]
+	fn multi_round_round_trip_narrow_packing() {
+		// The same three rounds, under a wider packing width.
+		//
+		// Some oracles are narrower than one packed field element.
+		// Placement then writes into part of one, not a whole chunk.
+		const {
+			assert!(
+				PackedBinaryGhash4x128b::LOG_WIDTH > 0,
+				"the fixture needs sub-packed-width oracle sizes to appear"
+			)
+		};
+		run_merge_round_trip::<PackedBinaryGhash4x128b>(&[&[3, 3], &[4, 2, 2], &[1]], false);
+	}
+
+	#[test]
+	fn zero_variable_oracle_round_trip() {
+		// A round mixing two single-scalar oracles with a larger one.
+		// The smallest possible oracle size.
+		run_merge_round_trip::<PackedBinaryGhash1x128b>(&[&[0, 0, 3]], false);
+	}
+
+	#[test]
+	#[should_panic(expected = "NaiveVerifierChannel: inner product verification failed")]
+	fn tampered_claim_is_rejected() {
+		// Corrupting one oracle's claim must fail the whole round trip.
+		// It must not be silently absorbed by the merge.
+		run_merge_round_trip::<PackedBinaryGhash1x128b>(&[&[3, 3], &[4, 2, 2]], true);
+	}
+
+	#[test]
+	fn multiple_relations_on_merged_oracle() {
+		type F = Ghash128b;
+		type P = PackedBinaryGhash1x128b;
+
+		// Two oracles, merged into a single round.
+		// Each carries two independent claims, rather than just one.
+		let mut rng = StdRng::seed_from_u64(0);
+		let fine_specs = vec![OracleSpec::new(4), OracleSpec::new(3)];
+		let (buffer_1, _, _) = generate_oracle_data::<F, P, _>(&mut rng, 4);
+		let (buffer_2, _, _) = generate_oracle_data::<F, P, _>(&mut rng, 3);
+
+		let relations_1: Vec<(FieldBuffer<P>, F)> = (0..2)
+			.map(|_| {
+				let point = random_scalars::<F>(&mut rng, 4);
+				let transparent = Hypercube::One.expand(&point).build::<P>();
+				let claim = buffer_1.inner_product(&transparent);
+				(transparent, claim)
+			})
+			.collect();
+		let relations_2: Vec<(FieldBuffer<P>, F)> = (0..2)
+			.map(|_| {
+				let point = random_scalars::<F>(&mut rng, 3);
+				let transparent = Hypercube::One.expand(&point).build::<P>();
+				let claim = buffer_2.inner_product(&transparent);
+				(transparent, claim)
+			})
+			.collect();
+
+		// One round, sized to fit both oracles.
+		// 2^4 + 2^3 = 24, rounded up to 2^5.
+		let total: usize = (1usize << 4) + (1usize << 3);
+		let coarse_specs = vec![OracleSpec::new(log2_ceil_usize(total))];
+
+		// Prover side.
+		//
+		// Both oracles arrive in the same round.
+		// All four claims are proved before either oracle is finalized.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let naive_prover = NaiveProverChannel::new(&mut prover_transcript, coarse_specs.clone());
+		let mut merge_prover = MergeProverChannel::new(naive_prover, &fine_specs, GlobalAllocator);
+
+		let oracle_1 = merge_prover.send_oracle(buffer_1.as_view());
+		let oracle_2 = merge_prover.send_oracle(buffer_2.as_view());
+		for (transparent, claim) in &relations_1 {
+			merge_prover.prove_oracle_relation(oracle_1, transparent.clone(), *claim);
+		}
+		for (transparent, claim) in &relations_2 {
+			merge_prover.prove_oracle_relation(oracle_2, transparent.clone(), *claim);
+		}
+		merge_prover.finalize_oracle(oracle_1, buffer_1);
+		merge_prover.finalize_oracle(oracle_2, buffer_2);
+		merge_prover.into_inner().finish();
+
+		// Verifier side.
+		//
+		// The same two oracles, each checked against its own two claims.
+		// In the same order the prover produced them.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let naive_verifier = NaiveVerifierChannel::new(&mut verifier_transcript, &coarse_specs);
+		let mut merge_verifier = MergeVerifierChannel::new(naive_verifier, &fine_specs);
+
+		let v_oracle_1 = merge_verifier.recv_oracle(4, true).unwrap();
+		let v_oracle_2 = merge_verifier.recv_oracle(3, true).unwrap();
+		for (transparent, claim) in relations_1 {
+			merge_verifier
+				.verify_oracle_relation(
+					v_oracle_1,
+					Box::new(move |point: &[F]| {
+						let eq = Hypercube::One.expand(point).build::<P>();
+						transparent.inner_product(&eq)
+					}),
+					claim,
+				)
+				.unwrap();
+		}
+		for (transparent, claim) in relations_2 {
+			merge_verifier
+				.verify_oracle_relation(
+					v_oracle_2,
+					Box::new(move |point: &[F]| {
+						let eq = Hypercube::One.expand(point).build::<P>();
+						transparent.inner_product(&eq)
+					}),
+					claim,
+				)
+				.unwrap();
+		}
+		merge_verifier.into_inner().unwrap().finish();
+	}
+
+	proptest! {
+		#[test]
+		fn round_trip_proptest(
+			rounds in prop::collection::vec(prop::collection::vec(0usize..5, 1..5), 1..5),
+		) {
+			// Random round shapes.
+			//
+			// 1 to 4 rounds, each holding 1 to 4 oracles sized 2^0 to 2^4.
+			//
+			// This goes far beyond the hand-picked shapes above.
+			// It stress-tests the alignment argument the merge relies on.
+			let round_refs: Vec<&[usize]> = rounds.iter().map(Vec::as_slice).collect();
+			run_merge_round_trip::<PackedBinaryGhash1x128b>(&round_refs, false);
+		}
+	}
+}

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -3,6 +3,7 @@
 //! Channel abstraction for interactive oracle protocol (IOP) provers.
 
 pub mod grinding;
+pub mod merge;
 pub mod naive;
 
 use binius_compute::Allocator;

--- a/crates/iop/src/channel/merge.rs
+++ b/crates/iop/src/channel/merge.rs
@@ -1,0 +1,550 @@
+// Copyright 2026 The Binius Developers
+
+//! A channel decorator that merges oracles committed within the same interaction round.
+
+use std::cmp::Reverse;
+
+use binius_core::word::Word;
+use binius_field::{BinaryField, Field, field::FieldOps};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
+use binius_math::multilinear::hypercube::Hypercube;
+use binius_utils::checked_arithmetics::log2_ceil_usize;
+
+use crate::channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn};
+
+/// A handle to an oracle received through the merging decorator.
+#[derive(Debug, Clone, Copy)]
+pub struct MergeOracle {
+	index: usize,
+}
+
+/// Records where one constituent oracle lives inside its round's combined oracle.
+#[derive(Clone)]
+struct Mapping<Oracle> {
+	/// The handle the underlying channel returned for the combined oracle.
+	outer: Oracle,
+
+	/// The constituent's position among its round-mates, as a block index.
+	///
+	/// Its own `2^n` scalars begin at scalar `block_index * 2^n`.
+	block_index: usize,
+
+	/// The base-2 logarithm of the combined oracle's length.
+	combined_log_len: usize,
+}
+
+/// Tracks one oracle from the moment it is received until its round is flushed.
+struct Record<Oracle> {
+	/// The base-2 logarithm of the oracle's own length.
+	log_msg_len: usize,
+
+	/// Whether the oracle's contents depend on the witness.
+	///
+	/// Declared by the caller when the oracle is received.
+	is_witness_dependent: bool,
+
+	/// Where this oracle ends up inside its round's combined oracle.
+	///
+	/// Filled in once that round is flushed.
+	mapping: Option<Mapping<Oracle>>,
+}
+
+/// A verifier channel decorator that merges one round's oracles into one combined oracle.
+///
+/// # Overview
+///
+/// An interaction round is the run of oracle receipts between two challenge samples.
+///
+/// Committing each oracle separately costs one commitment per oracle.
+/// One Merkle tree per oracle, for example.
+///
+/// This decorator buffers a round's oracles instead.
+/// It commits them together as one larger oracle.
+/// That cuts the cost to one commitment per round.
+///
+/// # Merging
+///
+/// A round's oracles are sorted from largest to smallest.
+/// They are laid out end to end.
+///
+/// Every oracle's size is a power of two.
+/// Write the sizes as `2^n_1, 2^n_2, ..., 2^n_k`.
+/// Sort them so `n_1 >= n_2 >= ... >= n_k`.
+///
+/// The combined oracle's size is `2^N`.
+/// `N` is the smallest exponent that covers the total.
+///
+/// ```text
+/// combined oracle, size 2^N:
+///
+///     [ oracle 1 (2^n_1) | oracle 2 (2^n_2) | ... | oracle k (2^n_k) | unused padding ]
+///       offset 0           offset 2^n_1                                total size 2^N
+/// ```
+///
+/// Sorting largest to smallest makes this layout exact.
+///
+/// Every earlier oracle is at least as large as the current one.
+/// So their combined space is a whole multiple of the current oracle's size.
+/// The current oracle therefore starts on a boundary of its own size.
+/// Its position is then a whole number of its-own-size blocks.
+/// That whole number is its block index.
+///
+/// A round of a single oracle needs no combining.
+/// It is forwarded unchanged, at zero cost.
+///
+/// Every oracle in a round must declare the same witness-dependence.
+///
+/// A commitment is masked as a whole, never partly.
+/// So mixing witness-carrying and structural oracles in one round is not supported.
+///
+/// # Timing
+///
+/// A round's oracles are committed the moment a challenge is sampled.
+/// Not the moment they arrive.
+///
+/// A real Fiat-Shamir transcript works the same way.
+/// A challenge can only be derived after its commitments are absorbed.
+/// So committing cannot wait past the sample that follows a round.
+///
+/// # Opening
+///
+/// A constituent oracle's claim is an inner product.
+/// It pairs the oracle's data with a transparent polynomial.
+///
+/// That claim becomes a claim about the combined oracle too.
+/// Extend the transparent polynomial with an equality check.
+/// The check is one over the constituent's own block, zero elsewhere.
+///
+/// ```text
+/// extended transparent(x) = original transparent(low bits of x) * is_this_block(high bits of x)
+/// ```
+///
+/// The check is zero outside the constituent's own block.
+/// So the combined inner product only ever sees this oracle's own data.
+/// It equals the original claim exactly.
+pub struct MergeVerifierChannel<'a, F, C>
+where
+	F: Field,
+	C: IOPVerifierChannel<F>,
+{
+	/// The underlying channel every oracle and challenge passes through.
+	inner: C,
+
+	/// Fine-grained specs, one per oracle this channel's caller will receive.
+	///
+	/// Not the coarser, one-per-round specs the underlying channel uses.
+	oracle_specs: &'a [OracleSpec],
+
+	/// Every oracle received so far, in arrival order.
+	records: Vec<Record<C::Oracle>>,
+
+	/// How many entries have already been flushed to the underlying channel.
+	///
+	/// Every later entry belongs to the current, still-open round.
+	flushed: usize,
+}
+
+impl<'a, F, C> MergeVerifierChannel<'a, F, C>
+where
+	F: Field,
+	C: IOPVerifierChannel<F>,
+{
+	/// Creates a new merging verifier channel over an underlying channel.
+	///
+	/// # Arguments
+	///
+	/// * `inner` — the channel every combined oracle is committed to, already configured with the
+	///   coarser, one-per-round spec list this decorator will produce.
+	/// * `oracle_specs` — the fine-grained specs for every oracle this channel's caller will pass
+	///   through, in arrival order.
+	pub const fn new(inner: C, oracle_specs: &'a [OracleSpec]) -> Self {
+		Self {
+			inner,
+			oracle_specs,
+			records: Vec::new(),
+			flushed: 0,
+		}
+	}
+
+	/// Commits the current round's queued oracles as one combined oracle.
+	///
+	/// Does nothing if every received oracle is already committed.
+	///
+	/// # Panics
+	///
+	/// Panics if the queued oracles do not all share one witness-dependence.
+	fn flush(&mut self) -> Result<(), Error> {
+		// Nothing new has arrived since the last flush.
+		if self.flushed == self.records.len() {
+			return Ok(());
+		}
+
+		// Order this round largest to smallest.
+		//
+		// This lets every position be a whole number of block sizes.
+		// That holds once every earlier oracle is at least as large.
+		let mut order: Vec<usize> = (self.flushed..self.records.len()).collect();
+		order.sort_by_key(|&i| Reverse(self.records[i].log_msg_len));
+
+		// One commitment is masked as a whole, never partly.
+		//
+		// Every oracle in the round must agree on its witness-dependence.
+		let is_witness_dependent = self.records[order[0]].is_witness_dependent;
+		assert!(
+			order
+				.iter()
+				.all(|&i| self.records[i].is_witness_dependent == is_witness_dependent),
+			"MergeVerifierChannel: every oracle merged into one round must share \
+			 is_witness_dependent"
+		);
+
+		// Size the combined oracle to fit every oracle end to end.
+		let total_len: usize = order
+			.iter()
+			.map(|&i| 1usize << self.records[i].log_msg_len)
+			.sum();
+		let combined_log_len = log2_ceil_usize(total_len);
+
+		// Commit the whole round as one oracle on the underlying channel.
+		let outer = self
+			.inner
+			.recv_oracle(combined_log_len, is_witness_dependent)?;
+
+		// Walk the sorted order again.
+		// Record where each oracle actually landed.
+		//
+		// Every step adds a whole multiple of the next block's size.
+		// So each offset divides evenly by that oracle's own size.
+		let mut offset = 0usize;
+		for &i in &order {
+			let n_i = self.records[i].log_msg_len;
+			self.records[i].mapping = Some(Mapping {
+				outer: outer.clone(),
+				block_index: offset >> n_i,
+				combined_log_len,
+			});
+			offset += 1 << n_i;
+		}
+
+		self.flushed = self.records.len();
+		Ok(())
+	}
+
+	/// Commits any oracles still queued and returns the underlying channel.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the final round fails to commit.
+	///
+	/// # Panics
+	///
+	/// Panics if any declared oracle has not yet been received.
+	pub fn into_inner(mut self) -> Result<C, Error> {
+		self.flush()?;
+		let n_remaining = self.oracle_specs.len() - self.records.len();
+		assert!(n_remaining == 0, "into_inner called but {n_remaining} oracle specs remaining",);
+		Ok(self.inner)
+	}
+}
+
+impl<F, C> IPVerifierChannel<F> for MergeVerifierChannel<'_, F, C>
+where
+	F: Field,
+	C: IOPVerifierChannel<F>,
+{
+	type Elem = C::Elem;
+
+	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+		self.inner.recv_one()
+	}
+
+	fn recv_many(&mut self, n: usize) -> Result<Vec<Self::Elem>, binius_ip::channel::Error> {
+		self.inner.recv_many(n)
+	}
+
+	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], binius_ip::channel::Error> {
+		self.inner.recv_array()
+	}
+
+	fn recv_public_claim(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+		self.inner.recv_public_claim()
+	}
+
+	fn sample(&mut self) -> Self::Elem {
+		// Commit this round before deriving its challenge.
+		//
+		// Sampling cannot return an error.
+		// A flush failure here has nowhere to go.
+		// It stays queued for the next call that can return one.
+		let _ = self.flush();
+		self.inner.sample()
+	}
+
+	fn observe_one(&mut self, val: F) -> Self::Elem {
+		self.inner.observe_one(val)
+	}
+
+	fn observe_many(&mut self, vals: &[F]) -> Vec<Self::Elem> {
+		self.inner.observe_many(vals)
+	}
+
+	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
+		self.inner.assert_zero(val)
+	}
+}
+
+impl<F, C> WordIPVerifierChannel<F> for MergeVerifierChannel<'_, F, C>
+where
+	F: BinaryField,
+	C: IOPVerifierChannel<F> + WordIPVerifierChannel<F>,
+{
+	type Word = C::Word;
+
+	fn observe_words(&mut self, words: &[Word]) -> Vec<Self::Word> {
+		self.inner.observe_words(words)
+	}
+
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		self.inner.subset_sum(elems, word)
+	}
+
+	fn select(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		self.inner.select(elems, word)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Self::Word {
+		self.inner.sample_bits(bits)
+	}
+
+	fn pack_words(&mut self, words: &[Self::Word]) -> Vec<Self::Elem> {
+		self.inner.pack_words(words)
+	}
+}
+
+impl<'a, F, C> IOPVerifierChannel<F> for MergeVerifierChannel<'a, F, C>
+where
+	F: Field,
+	C: IOPVerifierChannel<F>,
+{
+	type Oracle = MergeOracle;
+
+	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
+		&self.oracle_specs[self.records.len()..]
+	}
+
+	fn recv_oracle(
+		&mut self,
+		log_msg_len: usize,
+		is_witness_dependent: bool,
+	) -> Result<Self::Oracle, Error> {
+		// Every oracle this channel will receive is declared up front.
+		//
+		// Reject anything past that count.
+		// Do not silently accept an undeclared oracle.
+		let remaining = self.remaining_oracle_specs();
+		assert!(!remaining.is_empty(), "recv_oracle called but no remaining oracle specs");
+		debug_assert_eq!(log_msg_len, remaining[0].log_msg_len);
+
+		// Queue the oracle without touching the underlying channel yet.
+		//
+		// It only becomes a real commitment once its round flushes.
+		self.records.push(Record {
+			log_msg_len,
+			is_witness_dependent,
+			mapping: None,
+		});
+		Ok(MergeOracle {
+			index: self.records.len() - 1,
+		})
+	}
+
+	fn verify_oracle_relation(
+		&mut self,
+		oracle: Self::Oracle,
+		transparent: TransparentEvalFn<Self::Elem>,
+		claim: Self::Elem,
+	) -> Result<(), Error> {
+		// Every oracle must be received before any oracle is opened.
+		// So this oracle's round is already committed by now.
+		//
+		// Flush anyway, in case no challenge was sampled in between.
+		self.flush()?;
+
+		let record = &self.records[oracle.index];
+		let n_i = record.log_msg_len;
+		let Mapping {
+			outer,
+			block_index,
+			combined_log_len,
+		} = record.mapping.clone().expect("flushed above");
+
+		// Build the fixed 0/1 pattern for this oracle's own block.
+		// One bit per high coordinate of the combined opening point.
+		//
+		// A round of one oracle has no high coordinates at all.
+		// The pattern is then empty, and the check below is always one.
+		let padding_len = combined_log_len - n_i;
+		let block_pattern: Vec<Self::Elem> = (0..padding_len)
+			.map(|bit| {
+				if (block_index >> bit) & 1 == 1 {
+					Self::Elem::one()
+				} else {
+					Self::Elem::zero()
+				}
+			})
+			.collect();
+
+		// Extend the transparent polynomial with that equality check.
+		//
+		// The result is zero outside this oracle's own block.
+		// Inside it, the result is the original transparent polynomial.
+		let padded_transparent: TransparentEvalFn<Self::Elem> = Box::new(move |point| {
+			let (low, high) = point.split_at(n_i);
+			Hypercube::One.eq_ind(high, &block_pattern) * transparent(low)
+		});
+
+		// The claim itself is unchanged.
+		//
+		// The combined oracle agrees with this one on that block.
+		// So the same inner product holds there.
+		self.inner
+			.verify_oracle_relation(outer, padded_transparent, claim)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::Ghash128b;
+
+	use super::*;
+	use crate::channel::oracle_setup::OracleSetupChannel;
+
+	type F = Ghash128b;
+
+	/// Runs the given rounds through the merging decorator.
+	///
+	/// Returns the round-shaped spec list its underlying channel recorded.
+	/// Each inner list is one round.
+	/// A round is flushed once a challenge is sampled after it.
+	fn record_rounds(rounds: &[&[usize]], is_zk: bool) -> Vec<OracleSpec> {
+		// Flatten the rounds into one flat list of sizes, in order.
+		let fine_sizes: Vec<usize> = rounds
+			.iter()
+			.flat_map(|round| round.iter().copied())
+			.collect();
+		let fine_specs: Vec<OracleSpec> = fine_sizes
+			.iter()
+			.map(|&n| {
+				if is_zk {
+					OracleSpec::new_zk(n)
+				} else {
+					OracleSpec::new(n)
+				}
+			})
+			.collect();
+
+		// A recording-only channel stands in for a real one here.
+		// It never checks a proof.
+		// It only remembers the shape of every oracle it receives.
+		let mut channel = MergeVerifierChannel::new(OracleSetupChannel::new(is_zk), &fine_specs);
+		for sizes in rounds {
+			for &n in *sizes {
+				channel.recv_oracle(n, true).unwrap();
+			}
+			// Crossing a round boundary flushes it as one combined oracle.
+			IPVerifierChannel::<F>::sample(&mut channel);
+		}
+		channel.into_inner().unwrap().into_oracle_specs()
+	}
+
+	#[test]
+	fn merges_oracles_within_a_round() {
+		// Three rounds, each a different shape.
+		//
+		// Round 1: two same-size oracles.
+		// 2^3 + 2^3 = 2^4, an exact power of two.
+		//
+		// Round 2: three unequal oracles.
+		// 2^4 + 2^2 + 2^2 = 24, not a power of two.
+		// One extra bit is needed: 2^5 = 32.
+		//
+		// Round 3: a single oracle.
+		// It needs no combining.
+		let coarse = record_rounds(&[&[3, 3], &[4, 2, 2], &[1]], true);
+
+		// One combined oracle per round.
+		//
+		// Every one is still marked zero-knowledge.
+		// Every constituent declared itself zero-knowledge too.
+		assert_eq!(
+			coarse,
+			vec![
+				OracleSpec::new_zk(4),
+				OracleSpec::new_zk(5),
+				OracleSpec::new_zk(1)
+			]
+		);
+	}
+
+	#[test]
+	fn ties_keep_arrival_order() {
+		// Three equal-size oracles.
+		// 2^2 + 2^2 + 2^2 = 12, rounded up to 2^4 = 16.
+		//
+		// Equal sizes keep the alignment property either way.
+		// This only checks the combined size comes out right.
+		let coarse = record_rounds(&[&[2, 2, 2]], false);
+		assert_eq!(coarse, vec![OracleSpec::new(log2_ceil_usize(3 << 2))]);
+	}
+
+	#[test]
+	fn non_zk_round_records_non_zk_combined_spec() {
+		// Neither constituent depends on the witness.
+		// The combined oracle must not be zero-knowledge either.
+		let coarse = record_rounds(&[&[5, 3]], false);
+		assert_eq!(coarse, vec![OracleSpec::new(6)]);
+	}
+
+	#[test]
+	#[should_panic(expected = "must share is_witness_dependent")]
+	fn heterogeneous_witness_dependence_panics() {
+		// One oracle depends on the witness.
+		// The other does not.
+		//
+		// One commitment cannot be masked for one and not the other.
+		// Mixing the two in a round must be rejected.
+		let fine_specs = [OracleSpec::new(2), OracleSpec::new(2)];
+		let mut channel = MergeVerifierChannel::new(OracleSetupChannel::new(true), &fine_specs);
+		channel.recv_oracle(2, true).unwrap();
+		channel.recv_oracle(2, false).unwrap();
+		let _ = IPVerifierChannel::<F>::sample(&mut channel);
+	}
+
+	#[test]
+	#[should_panic(expected = "recv_oracle called but no remaining oracle specs")]
+	fn recv_oracle_past_remaining_specs_panics() {
+		// Only one oracle was declared up front.
+		//
+		// Receiving a second must be rejected.
+		// It must not be silently accepted.
+		let fine_specs = [OracleSpec::new(2)];
+		let mut channel =
+			MergeVerifierChannel::<F, _>::new(OracleSetupChannel::new(false), &fine_specs);
+		channel.recv_oracle(2, true).unwrap();
+		channel.recv_oracle(2, true).unwrap();
+	}
+
+	#[test]
+	#[should_panic(expected = "into_inner called but 1 oracle specs remaining")]
+	fn into_inner_before_all_specs_received_panics() {
+		// Two oracles were declared up front.
+		// Only one ever arrives.
+		//
+		// One oracle spec is still outstanding at teardown.
+		let fine_specs = [OracleSpec::new(2), OracleSpec::new(2)];
+		let mut channel =
+			MergeVerifierChannel::<F, _>::new(OracleSetupChannel::new(false), &fine_specs);
+		channel.recv_oracle(2, true).unwrap();
+		let _ = channel.into_inner();
+	}
+}

--- a/crates/iop/src/channel/mod.rs
+++ b/crates/iop/src/channel/mod.rs
@@ -3,6 +3,7 @@
 //! Channel abstraction for interactive oracle protocol (IOP) verifiers.
 
 pub mod grinding;
+pub mod merge;
 pub mod naive;
 pub mod oracle_setup;
 pub mod size_tracking;


### PR DESCRIPTION
Closes [BINIUS-507](https://linear.app/jimpo/issue/BINIUS-507/iop-channel-wrapper-for-merging-same-round-commitments).

Adds a channel decorator that commits a round's oracles as one combined oracle instead of one commitment each.

### The problem

IOP verifier and prover channels commit oracles one at a time.
Several oracles often get committed in the same interaction round, before the same challenge is sampled.
Each one still pays for its own physical commitment (a Merkle tree, under BaseFold/FRI), even though they're about to be opened together right after.

### The idea

Buffer a round's oracles and commit them together, as one combined oracle, instead.

Sort largest to smallest before concatenating.
That ordering guarantees every oracle lands on a boundary aligned to its own size, which is exactly what lets it be recovered exactly at opening time.

On the verifier side, recovering one oracle's claim against the combined oracle means extending its transparent-polynomial check with an equality indicator that selects its own block.
On the prover side, which holds real buffers rather than formulas, the same idea is just zero-padded placement of the same data.

```
extended_transparent(x) = transparent(low bits of x) * is_this_block(high bits of x)
```

Flushing happens exactly when the next challenge is sampled — never later.
That matches how a real Fiat-Shamir transcript must work: a challenge can only be derived once every commitment it depends on has been absorbed.

Everything merged into one round must share the same witness-dependence.
A physical commitment is masked as a whole, never partly, so zero-knowledge and non-zero-knowledge oracles cannot share one round.

A round of a single oracle needs no combining at all — it is forwarded unchanged, at zero cost.

### The change

- `crates/iop/src/channel/merge.rs` — `MergeVerifierChannel`, the verifier-side decorator.
- `crates/iop-prover/src/channel/merge.rs` — `MergeProverChannel`, its prover-side mirror.

Both wrap any existing channel implementation, so they compose with the crate's naive test channel or the real BaseFold/FRI channel without changes to either.

### Scope

- **new:** the two decorator modules above, each with its own unit and round-trip tests
- **changed:** one `pub mod merge;` line added to each crate's `channel/mod.rs`
- **left untouched:** no existing channel, protocol, or call site — this is purely additive, nothing yet wires it into a real protocol driver

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-iop -p binius-iop-prover --all-targets --all-features` — clean
- nightly `cargo fmt --all -- --check` — clean
- `cargo test -p binius-iop -p binius-iop-prover` (default features and `--features rayon`) — 66 tests pass, including a proptest sweep over random round shapes

### Benchmark

Not shipped as code in this PR — a one-off script drove the real BaseFold/FRI channel with and without the decorator, over the same witness data, and verified both proofs:

| | commitments | proof size |
|---|---|---|
| without merging | 6 | 41840 bytes |
| with merging | 2 | 28320 bytes |

2 rounds of 3 oracles each, merging cuts proof size by 32.3% on this shape.

<details>
<summary>Reproduce this: drop into <code>crates/iop-prover/examples/</code> and run with <code>cargo run --release --example merge_channel_proof_size -p binius-iop-prover</code></summary>

```rust
// Copyright 2026 The Binius Developers

//! Compares real BaseFold/FRI proof size with and without same-round oracle merging.
//!
//! Both scenarios commit the exact same witness data over the exact same round shape.
//! The only difference is whether each round's oracles get one Merkle commitment each, or
//! one combined commitment per round.
//! Both proofs are also verified, so the size numbers below are for proofs that actually
//! check out.
//!
//! Run with: cargo run --release --example merge_channel_proof_size -p binius-iop-prover

use binius_compute::GlobalAllocator;
use binius_field::{BinaryField128bGhash, PackedBinaryGhash1x128b};
use binius_hash::{StdDigest, StdHashSuite};
use binius_iop::{
	basefold::compiler::BaseFoldVerifierCompiler,
	channel::{IOPVerifierChannel, OracleSpec, merge::MergeVerifierChannel},
	fri::MinProofSizeStrategy,
	merkle_tree::BinaryMerkleTreeScheme,
};
use binius_iop_prover::{
	basefold::compiler::BaseFoldProverCompiler,
	channel::{IOPProverChannel, merge::MergeProverChannel},
};
use binius_ip::channel::IPVerifierChannel;
use binius_ip_prover::channel::IPProverChannel;
use binius_math::{
	FieldBuffer,
	inner_product::inner_product_buffers,
	multilinear::eq::eq_ind_partial_eval,
	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
	test_utils::{random_field_buffer, random_scalars},
};
use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
use binius_utils::checked_arithmetics::log2_ceil_usize;
use rand::{SeedableRng, rngs::StdRng};

type F = BinaryField128bGhash;
type P = PackedBinaryGhash1x128b;
type StdChallenger = HasherChallenger<StdDigest>;

// A rate-1/2 code with 32 test queries, the same parameters the crate's own BaseFold tests
// use.
const LOG_INV_RATE: usize = 1;
const SECURITY_BITS: usize = 32;

const fn n_test_queries() -> usize {
	SECURITY_BITS.div_ceil(LOG_INV_RATE)
}

fn make_ntt(log_domain_size: usize) -> NeighborsLastSingleThread<GaoMateerOnTheFly<F>> {
	NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(log_domain_size))
}

fn make_merkle_scheme() -> BinaryMerkleTreeScheme<F, StdHashSuite> {
	BinaryMerkleTreeScheme::new()
}

/// A random witness for one oracle, together with a transparent polynomial and the claim
/// their inner product produces.
fn generate_oracle_data(rng: &mut StdRng, n_vars: usize) -> (FieldBuffer<P>, FieldBuffer<P>, F) {
	let buffer = random_field_buffer::<P>(&mut *rng, n_vars);
	let point = random_scalars::<F>(&mut *rng, n_vars);
	let transparent = eq_ind_partial_eval::<P>(&point);
	let claim = inner_product_buffers(&buffer, &transparent);
	(buffer, transparent, claim)
}

/// Commits, proves, and verifies every oracle in `rounds` as its own commitment.
///
/// Returns the finalized proof size in bytes.
fn run_unmerged(rounds: &[&[usize]]) -> usize {
	let mut rng = StdRng::seed_from_u64(0);
	let sizes: Vec<usize> = rounds
		.iter()
		.flat_map(|round| round.iter().copied())
		.collect();
	let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = sizes
		.iter()
		.map(|&n| generate_oracle_data(&mut rng, n))
		.collect();
	let oracle_specs: Vec<OracleSpec> = sizes.iter().map(|&n| OracleSpec::new_zk(n)).collect();

	let verifier_compiler = BaseFoldVerifierCompiler::new(
		&make_merkle_scheme(),
		oracle_specs,
		LOG_INV_RATE,
		n_test_queries(),
		&MinProofSizeStrategy,
	);
	let ntt = make_ntt(verifier_compiler.max_log_domain_size());
	let prover_compiler =
		BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);

	// Prover side: one commitment per oracle, in arrival order.
	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
	let mut prover_channel = prover_compiler
		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
			&mut prover_transcript,
			StdRng::seed_from_u64(1),
			GlobalAllocator,
		);

	let oracles: Vec<_> = data
		.iter()
		.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
		.collect();
	for (&oracle, (_, transparent, claim)) in oracles.iter().zip(&data) {
		prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
	}
	for (oracle, (buffer, _, _)) in oracles.iter().copied().zip(data.iter().cloned()) {
		prover_channel.finalize_oracle(oracle, buffer);
	}
	prover_channel.finish();
	let proof = prover_transcript.finalize();
	let proof_size = proof.len();

	// Verifier side: replay the exact same commitments and relations.
	let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
	let mut verifier_channel = verifier_compiler
		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(&mut verifier_transcript);

	let v_oracles: Vec<_> = sizes
		.iter()
		.map(|&n| verifier_channel.recv_oracle(n, true).unwrap())
		.collect();
	for (oracle, (_, transparent, claim)) in v_oracles.into_iter().zip(data) {
		verifier_channel
			.verify_oracle_relation(
				oracle,
				Box::new(move |point: &[F]| {
					let eq = eq_ind_partial_eval::<P>(point);
					inner_product_buffers(&transparent, &eq)
				}),
				claim,
			)
			.unwrap();
	}
	verifier_channel
		.finish()
		.expect("unmerged proof must verify");

	proof_size
}

/// Commits, proves, and verifies every round in `rounds` as one combined commitment.
///
/// Returns the finalized proof size in bytes.
fn run_merged(rounds: &[&[usize]]) -> usize {
	let mut rng = StdRng::seed_from_u64(0);
	let fine_sizes: Vec<usize> = rounds
		.iter()
		.flat_map(|round| round.iter().copied())
		.collect();
	let fine_specs: Vec<OracleSpec> = fine_sizes.iter().map(|&n| OracleSpec::new_zk(n)).collect();
	let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = fine_sizes
		.iter()
		.map(|&n| generate_oracle_data(&mut rng, n))
		.collect();

	// One coarse spec per round, sized to fit that round's total.
	let coarse_specs: Vec<OracleSpec> = rounds
		.iter()
		.map(|sizes| {
			let total: usize = sizes.iter().map(|&n| 1usize << n).sum();
			OracleSpec::new_zk(log2_ceil_usize(total))
		})
		.collect();

	let verifier_compiler = BaseFoldVerifierCompiler::new(
		&make_merkle_scheme(),
		coarse_specs,
		LOG_INV_RATE,
		n_test_queries(),
		&MinProofSizeStrategy,
	);
	let ntt = make_ntt(verifier_compiler.max_log_domain_size());
	let prover_compiler =
		BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);

	// Prover side: every round is sent, then sampled once, so the merging decorator commits
	// each round as a single oracle underneath.
	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
	let base_channel = prover_compiler
		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
			&mut prover_transcript,
			StdRng::seed_from_u64(1),
			GlobalAllocator,
		);
	let mut merge_channel = MergeProverChannel::new(base_channel, &fine_specs, GlobalAllocator);

	let mut oracles = Vec::new();
	let mut index = 0;
	for sizes in rounds {
		for _ in *sizes {
			let (buffer, _, _) = &data[index];
			oracles.push(merge_channel.send_oracle(buffer.to_ref()));
			index += 1;
		}
		merge_channel.sample();
	}
	for (&oracle, (_, transparent, claim)) in oracles.iter().zip(&data) {
		merge_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
	}
	for (oracle, (buffer, _, _)) in oracles.iter().copied().zip(data.iter().cloned()) {
		merge_channel.finalize_oracle(oracle, buffer);
	}
	merge_channel.into_inner().finish();
	let proof = prover_transcript.finalize();
	let proof_size = proof.len();

	// Verifier side: the same round boundaries, wrapped the same way.
	let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
	let base_verifier_channel = verifier_compiler
		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(&mut verifier_transcript);
	let mut merge_verifier_channel = MergeVerifierChannel::new(base_verifier_channel, &fine_specs);

	let mut v_oracles = Vec::new();
	for sizes in rounds {
		for &n in *sizes {
			v_oracles.push(merge_verifier_channel.recv_oracle(n, true).unwrap());
		}
		merge_verifier_channel.sample();
	}
	for (oracle, (_, transparent, claim)) in v_oracles.into_iter().zip(data) {
		merge_verifier_channel
			.verify_oracle_relation(
				oracle,
				Box::new(move |point: &[F]| {
					let eq = eq_ind_partial_eval::<P>(point);
					inner_product_buffers(&transparent, &eq)
				}),
				claim,
			)
			.unwrap();
	}
	merge_verifier_channel
		.into_inner()
		.expect("merged proof must verify")
		.finish()
		.expect("merged proof must verify");

	proof_size
}

fn main() {
	// Two rounds, three oracles each: sizes are log2 variable counts.
	let rounds: &[&[usize]] = &[&[8, 7, 7], &[9, 6, 6]];
	let n_oracles: usize = rounds.iter().map(|round| round.len()).sum();
	let n_rounds = rounds.len();

	let unmerged_bytes = run_unmerged(rounds);
	let merged_bytes = run_merged(rounds);

	let reduction = 100.0 * (1.0 - merged_bytes as f64 / unmerged_bytes as f64);

	println!("Same-round oracle merging: proof-size comparison");
	println!("Rounds (log2 oracle sizes): {rounds:?}");
	println!();
	println!("Without merging: {n_oracles} commitments -> {unmerged_bytes} bytes");
	println!("With merging:    {n_rounds} commitments -> {merged_bytes} bytes");
	println!("Reduction: {reduction:.1}% (both proofs verified)");
}
```

</details>

### Follow-ups

Rebased on `main`. The port to the current APIs is part of this branch: `eq_ind` / `eq_ind_partial_eval` are now `Hypercube::One` methods, `FieldBuffer::to_ref` is `as_view`, `clone_from_slice` is `from_view_in`, the indexed mutable chunk accessor is gone (`place_block` writes scalars directly), and `BinaryField128bGhash` is `Ghash128b`. The benchmark script in the collapsed section above predates those renames.

Left for follow-up PRs, per review:

- an `OracleSchedule` carrying the specs *and* their grouping into interaction rounds, so both decorators can map every placement up front instead of discovering rounds as they go
- surfacing a flush error rather than dropping it in `sample`
- flushing in `sample_bits`
- deriving the combined `is_witness_dependent` as the OR of the round's oracles instead of asserting they agree
- the prover-side buffer work: drop `zeros_in` in favour of `extend_from_slice`, drop the `send_oracle` copy, and batch the openings at this layer instead of proving each constituent against the combined oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

