### PR TITLE
Make keccak_f1600 a gadget, so a circuit can permute in a chip

### DIFF
--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -5,7 +5,7 @@ pub mod permutation;
 
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
-use permutation::keccak_f1600;
+pub use permutation::{KeccakF1600, keccak_f1600, ref_keccak_f1600};
 
 use crate::{
 	fixed_byte_vec::ByteVec,
@@ -161,7 +161,7 @@ pub fn keccak256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; N
 #[cfg(test)]
 mod tests {
 	use binius_core::Word;
-	use binius_frontend::{CircuitBuilder, Wire};
+	use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 	use rand::prelude::*;
 	use rstest::rstest;
 	use sha3::Digest;
@@ -230,5 +230,113 @@ mod tests {
 		rng.fill_bytes(&mut message);
 
 		test_keccak_varlen_with_input(&message, max_message_len_bytes);
+	}
+
+	/// Checks an M4 system built with [`KeccakF1600`] as a chip.
+	///
+	/// The digest wires are public and filled with the reference digest, so a disagreement fails
+	/// to populate. What the chip adds is checked twice over: the system has to hold one chip
+	/// serving exactly the `n_permutations` calls the sponge makes, and every one of those
+	/// instances has to recompute the lanes its call named, which is what `WitnessM4::verify`
+	/// reports on.
+	fn check_chip_serves(
+		b: CircuitBuilder,
+		computed_digest: [Wire; N_WORDS_PER_DIGEST],
+		expected: [u8; 32],
+		n_permutations: usize,
+		fill: impl FnOnce(&mut WitnessFiller<'_>),
+	) {
+		let digest_out: [Wire; N_WORDS_PER_DIGEST] = std::array::from_fn(|_| b.add_inout());
+		for i in 0..N_WORDS_PER_DIGEST {
+			b.assert_eq(format!("digest[{i}]"), computed_digest[i], digest_out[i]);
+		}
+
+		let circuit = b.build_m4();
+		circuit.validate().unwrap();
+		assert_eq!(circuit.chips.len(), 1, "the permutation is the system's only chip");
+		assert_eq!(
+			circuit.chips[0].1, n_permutations,
+			"every permutation the sponge runs has to reach the chip"
+		);
+
+		let cs = circuit.to_constraint_system();
+		cs.validate().unwrap();
+
+		let witness = circuit
+			.generate_witness(|w| {
+				fill(w);
+				for (i, bytes) in expected.chunks(8).enumerate() {
+					w[digest_out[i]] = Word(u64::from_le_bytes(bytes.try_into().unwrap()));
+				}
+			})
+			.unwrap();
+
+		witness.verify(&cs).unwrap();
+	}
+
+	// The block loop between `fixed_length::keccak256` and `keccak_f1600` is untouched by the
+	// chip: every block lands as a call because the builder holds the chip, not because anything
+	// in between was told. Lengths cover the empty message, one byte, and both sides of the one-
+	// and two-block boundaries. Every message permutes at least once, the empty one included,
+	// since `(len_bytes + 1).div_ceil(136)` is never zero, so unlike the paired SHA-256 gadget
+	// there is no length that leaves the chip uncalled.
+	#[test]
+	fn a_registered_chip_serves_every_fixed_length_permutation() {
+		for &len in &[0usize, 1, 135, 136, 137, 271, 272, 500] {
+			let message: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+
+			let b = CircuitBuilder::new();
+			b.register_chip(KeccakF1600, &[]);
+			let message_wires: Vec<Wire> = (0..len.div_ceil(8)).map(|_| b.add_witness()).collect();
+			let digest = fixed_length::keccak256(&b, &message_wires, len);
+
+			check_chip_serves(
+				b,
+				digest,
+				sha3::Keccak256::digest(&message).into(),
+				(len + 1).div_ceil(RATE_BYTES),
+				|w| {
+					for (wire, chunk) in std::iter::zip(&message_wires, message.chunks(8)) {
+						let mut bytes = [0u8; 8];
+						bytes[..chunk.len()].copy_from_slice(chunk);
+						w[*wire] = Word(u64::from_le_bytes(bytes));
+					}
+				},
+			);
+		}
+	}
+
+	// The variable-length sponge permutes every block its capacity allows rather than its
+	// message's, and the runtime length only picks which state the digest is read from. So the
+	// call count follows the `ByteVec`, not the message: 135 bytes reach the chip once through
+	// `fixed_length::keccak256` and twice through a 136-byte capacity.
+	#[test]
+	fn a_registered_chip_serves_every_variable_length_permutation() {
+		for &(len, max_len) in &[
+			(0usize, 100usize),
+			(1, 144),
+			(135, 136),
+			(137, 272),
+			(272, 272),
+		] {
+			let message: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+
+			let b = CircuitBuilder::new();
+			b.register_chip(KeccakF1600, &[]);
+			let max_len_words = max_len.div_ceil(8);
+			let input = ByteVec::new_witness(&b, max_len_words);
+			let digest = keccak256_varlen(&b, &input);
+
+			check_chip_serves(
+				b,
+				digest,
+				sha3::Keccak256::digest(&message).into(),
+				((max_len_words << 3) + 1).div_ceil(RATE_BYTES),
+				|w| {
+					input.populate_data(w, &message);
+					input.populate_len_bytes(w, message.len());
+				},
+			);
+		}
 	}
 }

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -1,8 +1,8 @@
 // Copyright 2025 Irreducible Inc.
-use std::array;
+use std::{array, iter};
 
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire};
 
 // ι round constants
 pub const RC: [u64; 24] = [
@@ -49,11 +49,56 @@ pub const fn idx(x: usize, y: usize) -> usize {
 
 /// Perform the Keccak f\[1600\] permutation in place on a 25-lane state.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `b` - The circuit builder to use.
 /// * `state` - The 25-word state to permute.
+///
+/// # Chips
+///
+/// This is a [`ChipGadget`]. A circuit that calls
+/// [`register_chip`](CircuitBuilder::register_chip) with [`KeccakF1600`] before building turns
+/// every permutation under it into a chip call, including the ones
+/// [`keccak256_varlen`](super::keccak256_varlen) and
+/// [`fixed_length::keccak256`](super::fixed_length::keccak256) reach.
 pub fn keccak_f1600(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	let outputs = b.build_gadget(KeccakF1600, &[], state);
+	state.copy_from_slice(&outputs);
+}
+
+/// [`keccak_f1600`] as a gadget, so that a circuit can make it a chip.
+///
+/// Its interface is the 25 input lanes and the 25 output lanes, both in lane order `x + 5 * y`.
+/// Every lane is a full 64-bit word; there is no lane packing.
+pub struct KeccakF1600;
+
+impl Hint for KeccakF1600 {
+	const NAME: &'static str = "binius.keccak_f1600";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(25, 25)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let mut state: [u64; 25] = array::from_fn(|i| inputs[i].as_u64());
+		ref_keccak_f1600(&mut state);
+
+		for (slot, lane) in iter::zip(outputs, state) {
+			*slot = Word(lane);
+		}
+	}
+}
+
+impl ChipGadget for KeccakF1600 {
+	fn build(&self, builder: &CircuitBuilder, _dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+		let mut state: [Wire; 25] = array::from_fn(|i| inputs[i]);
+		f1600_gates(builder, &mut state);
+		state.to_vec()
+	}
+}
+
+/// [`keccak_f1600`] in gates, whatever the building circuit does with the gadget.
+fn f1600_gates(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 	for round in 0..24 {
 		keccak_permutation_round(b, state, round);
 	}
@@ -125,84 +170,89 @@ fn rho_pi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 	*state = temp;
 }
 
+// --- Pure-Rust reference implementation of Keccak-f[1600] ---------------------------
+//
+// Shared by [`KeccakF1600`] (prover-side witness generation) and the tests. One function per
+// circuit step, so that each step can be checked against its gates alone.
+
+fn ref_theta(state: &mut [u64; 25]) {
+	let mut c = [0u64; 5];
+	for x in 0..5 {
+		c[x] = state[idx(x, 0)]
+			^ state[idx(x, 1)]
+			^ state[idx(x, 2)]
+			^ state[idx(x, 3)]
+			^ state[idx(x, 4)];
+	}
+	let d = [
+		c[4] ^ c[1].rotate_left(1),
+		c[0] ^ c[2].rotate_left(1),
+		c[1] ^ c[3].rotate_left(1),
+		c[2] ^ c[4].rotate_left(1),
+		c[3] ^ c[0].rotate_left(1),
+	];
+
+	for y in 0..5 {
+		for x in 0..5 {
+			state[idx(x, y)] ^= d[x];
+		}
+	}
+}
+
+fn ref_rho_pi(state: &mut [u64; 25]) {
+	let mut temp = [state[0]; 25];
+	for y in 0..5 {
+		for x in 0..5 {
+			temp[idx(y, (2 * x + 3 * y) % 5)] = state[idx(x, y)].rotate_left(R[idx(x, y)]);
+		}
+	}
+	*state = temp;
+}
+
+fn ref_chi(state: &mut [u64; 25]) {
+	for y in 0..5 {
+		let a0 = state[idx(0, y)];
+		let a1 = state[idx(1, y)];
+		let a2 = state[idx(2, y)];
+		let a3 = state[idx(3, y)];
+		let a4 = state[idx(4, y)];
+		state[idx(0, y)] = a0 ^ ((!a1) & a2);
+		state[idx(1, y)] = a1 ^ ((!a2) & a3);
+		state[idx(2, y)] = a2 ^ ((!a3) & a4);
+		state[idx(3, y)] = a3 ^ ((!a4) & a0);
+		state[idx(4, y)] = a4 ^ ((!a0) & a1);
+	}
+}
+
+const fn ref_iota(state: &mut [u64; 25], round: usize) {
+	state[0] ^= RC[round];
+}
+
+fn ref_keccak_permutation_round(state: &mut [u64; 25], round: usize) {
+	ref_theta(state);
+	ref_rho_pi(state);
+	ref_chi(state);
+	ref_iota(state, round);
+}
+
+/// Pure-Rust Keccak-f\[1600\] permutation of a 25-lane state, matching the in-circuit
+/// permutation exactly.
+///
+/// Used for prover-side witness generation and as the test reference.
+pub fn ref_keccak_f1600(state: &mut [u64; 25]) {
+	for round in 0..24 {
+		ref_keccak_permutation_round(state, round);
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_core::word::Word;
 	use binius_frontend::CircuitBuilder;
+	use proptest::prelude::*;
 	use rand::prelude::*;
 
 	use super::*;
-
-	mod reference {
-		use super::{R, RC, idx};
-
-		pub fn theta(state: &mut [u64; 25]) {
-			let mut c = [0u64; 5];
-			for x in 0..5 {
-				c[x] =
-					state[idx(x, 0)]
-						^ state[idx(x, 1)] ^ state[idx(x, 2)]
-						^ state[idx(x, 3)] ^ state[idx(x, 4)];
-			}
-			let d = [
-				c[4] ^ c[1].rotate_left(1),
-				c[0] ^ c[2].rotate_left(1),
-				c[1] ^ c[3].rotate_left(1),
-				c[2] ^ c[4].rotate_left(1),
-				c[3] ^ c[0].rotate_left(1),
-			];
-
-			for y in 0..5 {
-				for x in 0..5 {
-					state[idx(x, y)] ^= d[x];
-				}
-			}
-		}
-
-		#[inline(always)]
-		pub fn rho_pi(state: &mut [u64; 25]) {
-			let mut temp = [state[0]; 25];
-			for y in 0..5 {
-				for x in 0..5 {
-					temp[idx(y, (2 * x + 3 * y) % 5)] = state[idx(x, y)].rotate_left(R[idx(x, y)]);
-				}
-			}
-			*state = temp;
-		}
-
-		pub fn iota(state: &mut [u64; 25], round: usize) {
-			state[0] ^= RC[round];
-		}
-
-		#[inline(always)]
-		pub fn chi(state: &mut [u64; 25]) {
-			for y in 0..5 {
-				let a0 = state[idx(0, y)];
-				let a1 = state[idx(1, y)];
-				let a2 = state[idx(2, y)];
-				let a3 = state[idx(3, y)];
-				let a4 = state[idx(4, y)];
-				state[idx(0, y)] = a0 ^ ((!a1) & a2);
-				state[idx(1, y)] = a1 ^ ((!a2) & a3);
-				state[idx(2, y)] = a2 ^ ((!a3) & a4);
-				state[idx(3, y)] = a3 ^ ((!a4) & a0);
-				state[idx(4, y)] = a4 ^ ((!a0) & a1);
-			}
-		}
-
-		pub fn keccak_permutation_round(state: &mut [u64; 25], round: usize) {
-			theta(state);
-			rho_pi(state);
-			chi(state);
-			iota(state, round);
-		}
-
-		pub fn keccak_f1600(state: &mut [u64; 25]) {
-			for round in 0..24 {
-				keccak_permutation_round(state, round);
-			}
-		}
-	}
 
 	fn validate_circuit_component(
 		circuit_fn: impl FnOnce(&CircuitBuilder, &mut [Wire; 25]),
@@ -250,7 +300,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(keccak_f1600, reference::keccak_f1600, input_state);
+		validate_circuit_component(keccak_f1600, ref_keccak_f1600, input_state);
 	}
 
 	#[test]
@@ -260,7 +310,7 @@ mod tests {
 
 		validate_circuit_component(
 			|b, state| keccak_permutation_round(b, state, 0),
-			|state| reference::keccak_permutation_round(state, 0),
+			|state| ref_keccak_permutation_round(state, 0),
 			input_state,
 		);
 	}
@@ -270,7 +320,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(theta, reference::theta, input_state);
+		validate_circuit_component(theta, ref_theta, input_state);
 	}
 
 	#[test]
@@ -278,7 +328,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(rho_pi, reference::rho_pi, input_state);
+		validate_circuit_component(rho_pi, ref_rho_pi, input_state);
 	}
 
 	#[test]
@@ -294,10 +344,45 @@ mod tests {
 		validate_circuit_component(
 			|b, state| chi_iota(b, state, ROUND),
 			|state| {
-				reference::chi(state);
-				reference::iota(state, ROUND);
+				ref_chi(state);
+				ref_iota(state, ROUND);
 			},
 			input_state,
 		);
+	}
+
+	/// Runs [`keccak_f1600`] in gates over its flat lane interface.
+	fn run_f1600_words(inputs: [u64; 25]) -> [u64; 25] {
+		let builder = CircuitBuilder::new();
+		let wires: [Wire; 25] = std::array::from_fn(|_| builder.add_witness());
+		let mut out = wires;
+		f1600_gates(&builder, &mut out);
+		for wire in out {
+			builder.mark_inout(wire);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for (wire, word) in std::iter::zip(wires, inputs) {
+			w[wire] = Word(word);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		std::array::from_fn(|i| w[out[i]].as_u64())
+	}
+
+	proptest! {
+		// The chip path takes the outputs from `KeccakF1600::execute` and the chip recomputes them
+		// from its gates, so the two have to agree on every word a circuit can reach them with.
+		// Every lane is a full 64-bit value, so random words cover the whole interface.
+		#[test]
+		fn f1600_hint_matches_its_gates(words in prop::collection::vec(any::<u64>(), 25)) {
+			let inputs: [u64; 25] = std::array::from_fn(|i| words[i]);
+
+			let mut hinted = [Word::ZERO; 25];
+			KeccakF1600.execute(&[], &inputs.map(Word), &mut hinted);
+
+			prop_assert_eq!(hinted.map(|word| word.as_u64()), run_f1600_words(inputs));
+		}
 	}
 }


### PR DESCRIPTION
## What

Follows #2141, #2180 and #2181, which made the paired BLAKE3, SHA-256 and SHA-512 cores `ChipGadget`s. Keccak has the same shape and is simpler than any of them: its lanes are full 64-bit words with no packing, and both sponges reach the permutation through one function.

`keccak_f1600` becomes a `ChipGadget` and the sponges above it are left alone. Its gates move to a private `f1600_gates`; the public function calls `build_gadget`, which is where the choice is made. `KeccakF1600` supplies the hint the chip path needs through `ref_keccak_f1600`, the pure-Rust permutation the tests already carried, moved up beside the gates under the same banner BLAKE3's reference uses, since the hint now runs in production witness generation.

`fixed_length::keccak256` and `keccak256_varlen` are unchanged and permute through a chip when the circuit registers one:

```rust
let builder = CircuitBuilder::new();
builder.register_chip(KeccakF1600, &[]);
let digest = keccak256(&builder, &message, len_bytes);
let circuit = builder.build_m4();
```

## Numbers

Apple M2, rate 1/2, `ProverM4`, `fixed_length::keccak256`, median of 5 after a warmup, proof verified in every configuration. Committed counts are words used.

| message | calls | main AND | main committed | prove |
|---|---|---|---|---|
| 136 B | 2 | 1,179 -> 0 | 1,196 -> 69 | 1.49 -> 1.92 ms |
| 544 B | 5 | 2,979 -> 0 | 3,047 -> 246 | 2.02 -> 1.99 ms |
| 1 KiB | 8 | 4,779 -> 0 | 4,907 -> 441 | 3.25 -> 2.10 ms |
| 4 KiB | 31 | 18,579 -> 0 | 19,091 -> 1,784 | 10.65 -> 3.73 ms |
| 16 KiB | 121 | 72,579 -> 0 | 74,627 -> 7,106 | 40.79 -> 9.77 ms |
| 64 KiB | 482 | 289,179 -> 0 | 297,371 -> 28,419 | 163.47 -> 38.86 ms |

The chip system stays at 600 AND and 575 committed words whatever the instance count, and main keeps no permutation at all: with one permutation for every sponge, every block lands in the chip. The chip pays for itself from about five calls up; below that the second table's fixed cost wins, the same trade #2180 measures for the paired core.

## Testing

- `a_registered_chip_serves_every_fixed_length_permutation` hashes at eight lengths (empty, one byte, and both sides of the one- and two-block boundaries), and `a_registered_chip_serves_every_variable_length_permutation` does the same over five capacities, where the call count follows the `ByteVec`'s capacity rather than the message. Each builds its own M4 system, validates, generates a witness against the sha3 reference digest, and passes `WitnessM4::verify`. Each also asserts the chip's active instance count is exactly the block count the sponge implies, so a sponge that stopped reaching the gadget fails on the count rather than on a digest that still happens to match. The two sponges get a system each for the same reason: in one system either one could carry the chip for the other.
- `f1600_hint_matches_its_gates` holds `KeccakF1600::execute` to `f1600_gates` over random words. Every lane is a full 64-bit value, so random words cover the whole interface.
- There is no uncalled-chip case to pin, as there was none for SHA-512: `(len_bytes + 1).div_ceil(136)` is at least one, so every message permutes at least once, the empty one included.

## Costs

A call commits 50 words per instance (25 in, 25 out). The rate lanes each sponge XORs into the state before a permutation are handed to the gadget as words, so each costs a committed word and a ZERO constraint where a constraint operand would have fused it in for free, the same cost #2141 notes. The gates path is unchanged: the `keccak` and `ethsign` snapshots pass untouched.

### Why

We build a fresh Binius64 circuit for almost every Ethereum block, proving the block's receipts trie is fully indexed, so the circuit hashes every node of that trie: one keccak256 per node, on the order of a few thousand permutations for a typical mainnet block, and they are the largest single thing in it. That whole load is what a chip takes out of main here.

Happy to adjust the interface, the reference function's placement, or the test shapes to your preference.

### Checks

`cargo test -p binius-circuits -p binius-m4-prover`, `cargo clippy -p binius-circuits -p binius-m4-prover -p binius-examples --all-targets --all-features -- -D warnings`, `cargo doc -p binius-circuits --document-private-items --no-deps` with `RUSTDOCFLAGS=-D warnings`, `cargo fmt` on nightly-2026-07-01, and `check-snapshot` on the `keccak` and `ethsign` examples.
