### PR TITLE
fix(frontend): lower a zero-amount shift to the canonical identity

### DIFF
--- a/crates/frontend/src/gates/shift.rs
+++ b/crates/frontend/src/gates/shift.rs
@@ -57,7 +57,16 @@ const fn variant_of(imm: u32) -> ShiftVariant {
 }
 
 /// Builds the shifted-operand term for the given variant and amount.
+///
+/// A zero amount is the identity in every variant, and the identity has one canonical
+/// spelling ([`Shift::IDENTITY`](binius_core::constraint_system::Shift::IDENTITY), i.e. `Sll 0`)
+/// — see [`Shift::is_canonical`](binius_core::constraint_system::Shift::is_canonical). Emitting
+/// `Slr 0` or `Sar 0` here would put a non-canonical shift in an operand, which
+/// `ConstraintSystem::validate` rejects.
 const fn shifted_term(variant: ShiftVariant, x: Wire, n: u32) -> WireExprTerm {
+	if n == 0 {
+		return WireExprTerm::Wire(x);
+	}
 	match variant {
 		ShiftVariant::Sll => expr::sll(x, n),
 		ShiftVariant::Slr => expr::srl(x, n),
@@ -67,5 +76,51 @@ const fn shifted_term(variant: ShiftVariant, x: Wire, n: u32) -> WireExprTerm {
 		ShiftVariant::Srl32 => expr::srl32(x, n),
 		ShiftVariant::Sra32 => expr::sra32(x, n),
 		ShiftVariant::Rotr32 => expr::rotr32(x, n),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::{Word, constraint_system::ShiftVariant};
+
+	use crate::{CircuitBuilder, Options};
+
+	/// A shift by zero is the identity in every variant, and the constraint system carries
+	/// only the canonical spelling of it. Gate fusion used to hide a non-canonical one by
+	/// rebuilding the operand at the consumer, so this builds with fusion off.
+	#[test]
+	fn a_zero_amount_shift_lowers_to_the_canonical_identity() {
+		for variant in [
+			ShiftVariant::Sll,
+			ShiftVariant::Slr,
+			ShiftVariant::Sar,
+			ShiftVariant::Rotr,
+			ShiftVariant::Sll32,
+			ShiftVariant::Srl32,
+			ShiftVariant::Sra32,
+			ShiftVariant::Rotr32,
+		] {
+			let opts = Options {
+				enable_gate_fusion: false,
+				..Options::default()
+			};
+			let b = CircuitBuilder::with_opts(opts);
+			let x = b.add_witness();
+			let shifted = match variant {
+				ShiftVariant::Sll => b.shl(x, 0),
+				ShiftVariant::Slr => b.shr(x, 0),
+				ShiftVariant::Sar => b.sar(x, 0),
+				ShiftVariant::Rotr => b.rotr(x, 0),
+				ShiftVariant::Sll32 => b.sll32(x, 0),
+				ShiftVariant::Srl32 => b.srl32(x, 0),
+				ShiftVariant::Sra32 => b.sra32(x, 0),
+				ShiftVariant::Rotr32 => b.rotr32(x, 0),
+			};
+			b.assert_eq("shifted", shifted, b.add_constant(Word::ZERO));
+			let circuit = b.build();
+			circuit.constraint_system().validate().unwrap_or_else(|e| {
+				panic!("{variant:?} by 0 lowered to a non-canonical shift: {e:?}")
+			});
+		}
 	}
 }


### PR DESCRIPTION
`shifted_term` spells a shift with whatever variant the gate carried, including at amount zero. A shift by zero is the identity in every variant, and `Shift::is_canonical` says the identity has one spelling (`Shift::IDENTITY`, i.e. `Sll 0`), so `b.shr(x, 0)` and `b.sar(x, 0)` reach an operand as `Slr 0` / `Sar 0` and `ConstraintSystem::validate` rejects the system:

```
ConstraintOperand { constraint_kind: Zero, constraint_index: 0, operand_name: "val", source: NonCanonicalShift }
```

Repro (this is the added test, one variant of it):

```rust
let opts = Options { enable_gate_fusion: false, ..Options::default() };
let b = CircuitBuilder::with_opts(opts);
let x = b.add_witness();
let z = b.shr(x, 0);                       // or b.sar(x, 0)
b.assert_eq("v", z, b.add_constant(Word::ZERO));
b.build().constraint_system().validate().unwrap();   // NonCanonicalShift
```

Gate fusion usually hides it: a fused operand is rebuilt at the consumer and canonicalised on the way, so this shows with `enable_gate_fusion = false`. It is not exotic to hit — byte packing shifts byte `i` by `8*i`, so the first byte is a shift by zero, and every circuit of ours that packs bytes fails to validate with fusion off.

The fix returns the plain wire term when the amount is zero. The test builds one circuit per variant with fusion off and validates. Before the change it fails on `Slr`, `Sar`, `Sll32`, `Srl32` and `Sra32` — `Sll 0` is already the canonical spelling, and `rotr`/`rotr32` return the input wire in the builder before reaching this gate.

### Why we were building with fusion off
We prove a fresh circuit per Ethereum block, so we were measuring what fusion costs us. On our leaf circuit it is a 2.2x difference in operand terms — 10,161,703 with fusion against 4,658,716 without, for identical AND (383,193) and BMUL (20,616) counts — and operand terms are what the prover's key collection and our sumcheck tables are sized by. Whether that trade is worth taking is our problem, not this PR's, but the knob should produce a valid constraint system either way.

`cargo test -p binius-frontend` (259 + integration, green), `cargo fmt` on nightly-2026-07-01.
