### PR TITLE
BINIUS-508: defer the GHASH reduction in ring-switch's sumcheck-claim inner product

### DIFF
--- a/crates/prover/benches/ring_switch.rs
+++ b/crates/prover/benches/ring_switch.rs
@@ -3,8 +3,9 @@
 use std::mem::size_of;
 
 use binius_compute::BufferPool;
-use binius_field::{ExtensionField, arch::OptimalPackedB128};
+use binius_field::{ExtensionField, Random, arch::OptimalPackedB128};
 use binius_math::{
+	inner_product::{inner_product_packed, inner_product_subfield},
 	multilinear::eq::eq_ind_partial_eval,
 	test_utils::{random_field_buffer, random_scalars},
 };
@@ -86,5 +87,47 @@ fn bench_suffix_tensor_pipeline(c: &mut Criterion) {
 	group.finish();
 }
 
-criterion_group!(ring_switch, bench_fold_1b_rows_split, bench_suffix_tensor_pipeline);
+/// The sumcheck-claim inner product at its one real shape: `N = 2^log_packing = 128` terms.
+///
+/// In-binary A/B: the naive per-term reduce (`inner_product_subfield`, what `ring_switch::prove`
+/// called before) against the deferred-reduce path (`inner_product_packed`, what it calls now).
+fn bench_sumcheck_claim_inner_product(c: &mut Criterion) {
+	let mut group = c.benchmark_group("ring_switch/sumcheck_claim_inner_product");
+
+	let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
+	let n = 1usize << log_packing;
+	group.throughput(Throughput::Elements(n as u64));
+
+	let mut rng = rand::rng();
+	let s_hat_u: Vec<B128> = (0..n).map(|_| B128::random(&mut rng)).collect();
+	let eq_r_double_prime: Vec<B128> = (0..n).map(|_| B128::random(&mut rng)).collect();
+
+	group.bench_function("naive_per_term_reduce", |b| {
+		b.iter(|| {
+			inner_product_subfield::<B128, B128>(
+				s_hat_u.iter().copied(),
+				eq_r_double_prime.iter().copied(),
+			)
+		});
+	});
+
+	group.bench_function("deferred_reduce", |b| {
+		b.iter(|| {
+			inner_product_packed::<B128, B128>(
+				log_packing,
+				s_hat_u.iter().copied(),
+				eq_r_double_prime.iter().copied(),
+			)
+		});
+	});
+
+	group.finish();
+}
+
+criterion_group!(
+	ring_switch,
+	bench_fold_1b_rows_split,
+	bench_suffix_tensor_pipeline,
+	bench_sumcheck_claim_inner_product
+);
 criterion_main!(ring_switch);

--- a/crates/prover/benches/ring_switch.rs
+++ b/crates/prover/benches/ring_switch.rs
@@ -89,8 +89,8 @@ fn bench_suffix_tensor_pipeline(c: &mut Criterion) {
 
 /// The sumcheck-claim inner product at its one real shape: `N = 2^log_packing = 128` terms.
 ///
-/// In-binary A/B: the naive per-term reduce (`inner_product_subfield`, what `ring_switch::prove`
-/// called before) against the deferred-reduce path (`inner_product_packed`, what it calls now).
+/// In-binary A/B against `inner_product_subfield` (naive per-term reduce).
+/// `inner_product_packed` (deferred reduce) is the path `ring_switch::prove` uses in production.
 fn bench_sumcheck_claim_inner_product(c: &mut Criterion) {
 	let mut group = c.benchmark_group("ring_switch/sumcheck_claim_inner_product");
 

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -17,7 +17,7 @@ use binius_ip_prover::{
 	sumcheck::{bivariate_product_prover, prove_single},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice, FieldVec, inner_product::inner_product,
+	FieldBuffer, FieldSlice, FieldVec, inner_product::inner_product_packed,
 	multilinear::eq::eq_ind_partial_eval, tensor_algebra::TensorAlgebra,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -323,8 +323,12 @@ where
 	let r_double_prime = channel.sample_many(log_packing);
 	let eq_r_double_prime = eq_ind_partial_eval::<B128>(&r_double_prime);
 
-	// Compute sumcheck claim
-	let sumcheck_claim = inner_product(s_hat_u, eq_r_double_prime.as_ref().iter().copied());
+	// Defers the reduction across all `log_packing` products instead of reducing each one eagerly.
+	let sumcheck_claim = inner_product_packed::<B128, B128>(
+		log_packing,
+		s_hat_u.into_iter(),
+		eq_r_double_prime.as_ref().iter().copied(),
+	);
 
 	// Compute ring-switching equality indicator (transparent poly)
 	let rs_eq_ind = tracing::debug_span!("Compute ring-switching equality indicator")

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -323,7 +323,8 @@ where
 	let r_double_prime = channel.sample_many(log_packing);
 	let eq_r_double_prime = eq_ind_partial_eval::<B128>(&r_double_prime);
 
-	// Defers the reduction across all `log_packing` products instead of reducing each one eagerly.
+	// GF(2^128) reduction is F2-linear, so it commutes with XOR.
+	// Summing 128 wide products then reducing once matches reducing each term first.
 	let sumcheck_claim = inner_product_packed::<B128, B128>(
 		log_packing,
 		s_hat_u.into_iter(),


### PR DESCRIPTION
Closes [BINIUS-508](https://linear.app/jimpo/issue/BINIUS-508/defer-the-ghash-reduction-in-ring-switchs-sumcheck-claim-inner-product).

Sums 128 wide products before reducing, instead of reducing each one and then summing. Output is bit-identical — pure reassociation, no protocol change.

### The problem

Ring-switching computes a sumcheck claim as an inner product of two 128-element $\mathbb{F}_{2^{128}}$ sequences.
The naive way multiplies each pair, reduces the wide product immediately, then XORs 128 already-reduced values.
That's 128 reduce operations to produce one scalar.

### The idea

GF(2^128)'s reduction map is linear over $\mathbb{F}_2$.
So `reduce(a) XOR reduce(b)` equals `reduce(a XOR b)`.

```
naive:     reduce(a1*b1) ^ reduce(a2*b2) ^ ... ^ reduce(a128*b128)   // 128 reduces
deferred:  reduce( (a1*b1) ^ (a2*b2) ^ ... ^ (a128*b128) )           // 1 reduce
```

Sum all 128 wide (unreduced) products first, then reduce once at the end.

### Per call

- **before:** 128 reduces
- **after:** 1 reduce

→ the reduce step is amortized 128x, though the multiplies still dominate total cost.

### The change

```diff
- inner_product(s_hat_u, eq_r_double_prime.as_ref().iter().copied())
+ inner_product_packed::<B128, B128>(
+     log_packing,
+     s_hat_u.into_iter(),
+     eq_r_double_prime.as_ref().iter().copied(),
+ )
```

One call site, in `crates/prover/src/ring_switch.rs`.

### How this relates / what it is not

- binius64 already has this deferred pattern for buffer-shaped inputs (`inner_product_par`, `inner_product_buffers`), proven sound there by the same linearity argument.
- This wires ring-switch's specific inner product onto the existing `inner_product_packed` machinery — no new kernel.
- Distinct from the deferred-reduce family already measured dead for block-local row folds (`fold_word::accumulate_word_chunk`, `ring_switch::fold_1b_rows_for_b128_split`): those fold exactly one multiply per output column, so there's nothing to defer within a chunk. This call collapses 128 terms into one scalar — a genuinely different shape, where deferring pays off.
- Verifier-side call sites with the same N-terms-to-one-scalar shape (`binmul.rs`, `reduction.rs`) were considered and declined: they're generic over `FieldOps`, a trait deliberately weaker than `WideMul` so it can also represent symbolic constraint-system field types. Adding the bound there would break that generality for a tiny, non-hot-loop win.

### Soundness

Pure reassociation of an XOR sum, justified by linearity of the reduction map.
No protocol change, no new soundness assumption, output is bit-identical by construction.
The verifier independently recomputes this exact claim, so a wrong value would fail every proof rather than silently diverging.

### Scope

- **changed:** one call site in `crates/prover/src/ring_switch.rs`
- **new:** an in-binary A/B bench group in `crates/prover/benches/ring_switch.rs`

### Verification

- `cargo check -p binius-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets` — clean
- `cargo +nightly fmt -p binius-prover -- --check` — clean
- `cargo test -p binius-prover --lib` — 60 passed
- `cargo test -p binius-prover --test '*'` — 17 + 1 passed (full prove/verify round trips)

### Benchmark

| variant | time | throughput |
|---|---|---|
| naive per-term reduce | 153.46 ns | 834 Melem/s |
| deferred reduce | 112.08 ns | 1.14 Gelem/s |

1.37x faster at N=128, the shape this call always runs at. Measured in-binary (both paths in one criterion binary) on a quiet machine via `cargo bench -p binius-prover --bench ring_switch -- sumcheck_claim_inner_product`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)