### PR TITLE
BINIUS-510: Add FIPS 202 SHA3-256/384/512 circuit gadgets

### DIFF
--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -40,6 +40,7 @@ pub mod ripemd;
 pub mod rs256;
 pub mod secp256k1;
 pub mod sha256;
+pub mod sha3;
 pub mod sha512;
 pub mod shift;
 pub mod skein512;

--- a/crates/circuits/src/sha3/fixed_length.rs
+++ b/crates/circuits/src/sha3/fixed_length.rs
@@ -1,0 +1,284 @@
+// Copyright 2026 The Binius Developers
+
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire};
+
+use super::{
+	SHA3_256_DIGEST_WORDS, SHA3_256_RATE_BYTES, SHA3_384_DIGEST_WORDS, SHA3_384_RATE_BYTES,
+	SHA3_512_DIGEST_WORDS, SHA3_512_RATE_BYTES, SHA3_DELIMITER_BYTE,
+};
+use crate::keccak::{N_WORDS_PER_STATE, permutation::keccak_f1600};
+
+/// Computes a FIPS 202 SHA-3 digest of a fixed-length message.
+///
+/// This is the shared core for every SHA-3 variant in this module.
+///
+/// Only the rate and the digest length differ between them.
+///
+/// The message length is a compile-time constant, so the padded words are computed directly
+/// instead of derived with runtime multiplexers.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message as packed 64-bit words, 8 bytes per wire, little-endian.
+/// * `len_bytes` - The exact length of the message in bytes.
+/// * `rate_bytes` - The sponge rate for this hash variant, in bytes.
+/// * `digest_words` - The digest length for this hash variant, in 64-bit words.
+///
+/// # Panics
+/// * If the message wire count does not equal the message length divided into 64-bit words, rounded
+///   up.
+fn sha3_fixed(
+	builder: &CircuitBuilder,
+	message: &[Wire],
+	len_bytes: usize,
+	rate_bytes: usize,
+	digest_words: usize,
+) -> Vec<Wire> {
+	// The caller must supply exactly one wire per 8-byte word of the message.
+	assert_eq!(
+		message.len(),
+		len_bytes.div_ceil(8),
+		"message.len() ({}) must equal len_bytes.div_ceil(8) ({})",
+		message.len(),
+		len_bytes.div_ceil(8)
+	);
+
+	let n_words_per_block = rate_bytes / 8;
+	// A message that exactly fills whole blocks still needs one more block for the padding.
+	let n_blocks = (len_bytes + 1).div_ceil(rate_bytes);
+	let n_padded_words = n_blocks * n_words_per_block;
+
+	let mut padded_message = Vec::with_capacity(n_padded_words);
+
+	// FIPS 202 folds a two-bit domain suffix into the first padding byte.
+	//
+	// A byte-aligned message either ends exactly on a word boundary, in which case the suffix
+	// becomes a whole new word, or ends partway through a word, in which case the suffix is
+	// combined with the trailing message bytes in that same word.
+	if len_bytes.is_multiple_of(8) {
+		// Every message word is already complete, so the suffix becomes its own word.
+		padded_message.extend_from_slice(message);
+		padded_message.push(builder.add_constant(Word(SHA3_DELIMITER_BYTE)));
+	} else {
+		// Every word before the last one is complete message data.
+		padded_message.extend_from_slice(&message[..message.len() - 1]);
+
+		let last_idx = message.len() - 1;
+		let byte_in_word = len_bytes % 8;
+
+		// Keep only the valid low bytes of the trailing word.
+		let mask = (1u64 << (byte_in_word * 8)) - 1;
+		let masked_word = builder.band(message[last_idx], builder.add_constant(Word(mask)));
+
+		// Place the domain suffix right after the last valid message byte.
+		let padding_bit = SHA3_DELIMITER_BYTE << (byte_in_word * 8);
+		let boundary_word = builder.bxor(masked_word, builder.add_constant(Word(padding_bit)));
+		padded_message.push(boundary_word);
+	}
+
+	// Every word after the boundary word is zero padding, until the final byte set below.
+	let zero = builder.add_constant(Word::ZERO);
+	padded_message.resize(n_padded_words, zero);
+
+	// The padding rule always sets the top bit of the last byte of the last block.
+	//
+	// XOR combines it correctly even when the domain suffix already landed in that same word.
+	let last_byte_mask = 0x80u64 << 56;
+	let last_idx = n_padded_words - 1;
+	padded_message[last_idx] =
+		builder.bxor(padded_message[last_idx], builder.add_constant(Word(last_byte_mask)));
+
+	// Absorb one padded block at a time.
+	//
+	// XOR it into the front of the state, then permute the whole state.
+	let mut state = [zero; N_WORDS_PER_STATE];
+	for block in padded_message.chunks(n_words_per_block) {
+		for (i, &word) in block.iter().enumerate() {
+			state[i] = builder.bxor(state[i], word);
+		}
+		keccak_f1600(builder, &mut state);
+	}
+
+	// The digest length never exceeds the rate for any FIPS 202 hash function.
+	//
+	// So the digest can be read straight out of the state after the last permutation.
+	state[..digest_words].to_vec()
+}
+
+/// Computes the SHA3-256 digest of a fixed-length message.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message as packed 64-bit words, 8 bytes per wire, little-endian.
+/// * `len_bytes` - The exact length of the message in bytes.
+///
+/// # Returns
+/// The digest as 4 little-endian 64-bit words.
+///
+/// # Panics
+/// * If the message wire count does not equal the message length divided into 64-bit words, rounded
+///   up.
+pub fn sha3_256(
+	builder: &CircuitBuilder,
+	message: &[Wire],
+	len_bytes: usize,
+) -> [Wire; SHA3_256_DIGEST_WORDS] {
+	// Delegate to the shared core with this variant's rate and digest length.
+	sha3_fixed(builder, message, len_bytes, SHA3_256_RATE_BYTES, SHA3_256_DIGEST_WORDS)
+		.try_into()
+		.unwrap()
+}
+
+/// Computes the SHA3-384 digest of a fixed-length message.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message as packed 64-bit words, 8 bytes per wire, little-endian.
+/// * `len_bytes` - The exact length of the message in bytes.
+///
+/// # Returns
+/// The digest as 6 little-endian 64-bit words.
+///
+/// # Panics
+/// * If the message wire count does not equal the message length divided into 64-bit words, rounded
+///   up.
+pub fn sha3_384(
+	builder: &CircuitBuilder,
+	message: &[Wire],
+	len_bytes: usize,
+) -> [Wire; SHA3_384_DIGEST_WORDS] {
+	// Delegate to the shared core with this variant's rate and digest length.
+	sha3_fixed(builder, message, len_bytes, SHA3_384_RATE_BYTES, SHA3_384_DIGEST_WORDS)
+		.try_into()
+		.unwrap()
+}
+
+/// Computes the SHA3-512 digest of a fixed-length message.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message as packed 64-bit words, 8 bytes per wire, little-endian.
+/// * `len_bytes` - The exact length of the message in bytes.
+///
+/// # Returns
+/// The digest as 8 little-endian 64-bit words.
+///
+/// # Panics
+/// * If the message wire count does not equal the message length divided into 64-bit words, rounded
+///   up.
+pub fn sha3_512(
+	builder: &CircuitBuilder,
+	message: &[Wire],
+	len_bytes: usize,
+) -> [Wire; SHA3_512_DIGEST_WORDS] {
+	// Delegate to the shared core with this variant's rate and digest length.
+	sha3_fixed(builder, message, len_bytes, SHA3_512_RATE_BYTES, SHA3_512_DIGEST_WORDS)
+		.try_into()
+		.unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_frontend::CircuitBuilder;
+	use rand::prelude::*;
+	use rstest::rstest;
+	use sha3::Digest;
+
+	use super::*;
+
+	// Builds a circuit around one hash function, runs it on a random message of the given
+	// length, and checks the computed digest against a reference implementation.
+	fn test_fixed<const DIGEST_WORDS: usize>(
+		message_len_bytes: usize,
+		hash_fn: impl FnOnce(&CircuitBuilder, &[Wire], usize) -> [Wire; DIGEST_WORDS],
+		reference: impl FnOnce(&[u8]) -> Vec<u8>,
+	) {
+		// Deterministic random message, so every run of a given case is reproducible.
+		let seed = message_len_bytes as u64;
+		let mut rng = StdRng::seed_from_u64(seed);
+		let mut message = vec![0u8; message_len_bytes];
+		rng.fill_bytes(&mut message);
+
+		let expected_digest = reference(&message);
+		assert_eq!(expected_digest.len(), DIGEST_WORDS * 8);
+
+		let builder = CircuitBuilder::new();
+		let n_words = message_len_bytes.div_ceil(8);
+		let message_wires: Vec<_> = (0..n_words).map(|_| builder.add_witness()).collect();
+		let expected_digest_wires: [Wire; DIGEST_WORDS] =
+			std::array::from_fn(|_| builder.add_witness());
+
+		// Constrain the circuit's digest to equal the expected one, wire by wire.
+		let computed_digest = hash_fn(&builder, &message_wires, message_len_bytes);
+		for i in 0..DIGEST_WORDS {
+			builder.assert_eq(format!("digest[{i}]"), computed_digest[i], expected_digest_wires[i]);
+		}
+
+		let circuit = builder.build();
+		let cs = circuit.constraint_system();
+		let mut witness = circuit.new_witness_filler();
+
+		// Populate the message wires, 8 bytes per wire, little-endian.
+		for (i, chunk) in message.chunks(8).enumerate() {
+			let mut word_bytes = [0u8; 8];
+			word_bytes[..chunk.len()].copy_from_slice(chunk);
+			witness[message_wires[i]] = Word(u64::from_le_bytes(word_bytes));
+		}
+		// Populate the expected digest wires the same way.
+		for (i, chunk) in expected_digest.chunks(8).enumerate() {
+			witness[expected_digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
+		}
+
+		// Evaluating the circuit fills in every internal wire from the message and digest inputs.
+		circuit.populate_wire_witness(&mut witness).unwrap();
+		// Checking the constraint system confirms the computed digest equals the reference
+		// digest, not just that the witness filled in without panicking.
+		cs.verify(&witness.into_value_vec())
+			.expect("Circuit constraints should be satisfied");
+	}
+
+	#[rstest]
+	#[case(0)] // Empty message
+	#[case(1)] // Single byte
+	#[case(8)] // Exactly one word
+	#[case(135)] // One byte before the block boundary
+	#[case(136)] // Exactly one block
+	#[case(137)] // One byte over the block boundary
+	#[case(272)] // Exactly two blocks
+	#[case(500)] // Arbitrary larger message
+	fn test_sha3_256(#[case] message_len_bytes: usize) {
+		test_fixed(message_len_bytes, sha3_256, |m| sha3::Sha3_256::digest(m).to_vec());
+	}
+
+	#[rstest]
+	#[case(0)] // Empty message
+	#[case(1)] // Single byte
+	#[case(103)] // One byte before the block boundary
+	#[case(104)] // Exactly one block
+	#[case(105)] // One byte over the block boundary
+	#[case(500)] // Arbitrary larger message
+	fn test_sha3_384(#[case] message_len_bytes: usize) {
+		test_fixed(message_len_bytes, sha3_384, |m| sha3::Sha3_384::digest(m).to_vec());
+	}
+
+	#[rstest]
+	#[case(0)] // Empty message
+	#[case(1)] // Single byte
+	#[case(71)] // One byte before the block boundary
+	#[case(72)] // Exactly one block
+	#[case(73)] // One byte over the block boundary
+	#[case(500)] // Arbitrary larger message
+	fn test_sha3_512(#[case] message_len_bytes: usize) {
+		test_fixed(message_len_bytes, sha3_512, |m| sha3::Sha3_512::digest(m).to_vec());
+	}
+
+	#[test]
+	#[should_panic(expected = "message.len() (1) must equal len_bytes.div_ceil(8) (2)")]
+	fn test_sha3_256_wrong_wire_count() {
+		// One wire claims to hold 10 bytes, but 10 bytes needs 2 wires.
+		let builder = CircuitBuilder::new();
+		let message_wires = vec![builder.add_witness()];
+		sha3_256(&builder, &message_wires, 10);
+	}
+}

--- a/crates/circuits/src/sha3/mod.rs
+++ b/crates/circuits/src/sha3/mod.rs
@@ -1,0 +1,68 @@
+// Copyright 2026 The Binius Developers
+
+//! FIPS 202 SHA-3 hash functions: SHA3-256, SHA3-384, and SHA3-512.
+//!
+//! SHA-3 is built from the same 1600-bit Keccak permutation and multi-rate padding rule as the
+//! Ethereum-style Keccak hash already in this crate.
+//!
+//! The only difference is a two-bit domain-separation suffix that FIPS 202 appends to the message
+//! before padding.
+//!
+//! For a byte-aligned message this changes the first padding byte from `0x01` to `0x06`.
+//!
+//! SHA3-224 is intentionally not provided.
+//!
+//! Its 224-bit digest does not divide evenly into 64-bit words.
+//!
+//! This crate represents every digest as a whole number of 64-bit words.
+//!
+//! Each hash function fixes its own rate and capacity.
+//!
+//! The capacity is twice the digest length.
+//!
+//! The rate is whatever remains of the 1600-bit permutation width.
+//!
+//! The digest never exceeds the rate for any of these three hash functions.
+//!
+//! That means the digest is always read directly out of the state after the last block's
+//! permutation, with no extra squeezing permutation ever needed.
+//!
+//! | Function  | Rate (bytes) | Capacity (bits) | Digest (words) |
+//! |-----------|--------------|------------------|-----------------|
+//! | SHA3-256  | 136          | 512              | 4               |
+//! | SHA3-384  | 104          | 768              | 6               |
+//! | SHA3-512  | 72           | 1024             | 8               |
+
+pub mod fixed_length;
+pub mod varlen;
+
+/// The two-bit domain-separation suffix FIPS 202 appends to the message before padding.
+///
+/// For a byte-aligned message this folds into the first padding byte as `0x06`.
+///
+/// The original Keccak padding would place `0x01` in that same position instead.
+const SHA3_DELIMITER_BYTE: u64 = 0x06;
+
+/// Rate of SHA3-256, in bytes.
+///
+/// The 1600-bit permutation width minus twice the digest length, converted to bytes.
+pub const SHA3_256_RATE_BYTES: usize = 136;
+
+/// Rate of SHA3-384, in bytes.
+///
+/// The 1600-bit permutation width minus twice the digest length, converted to bytes.
+pub const SHA3_384_RATE_BYTES: usize = 104;
+
+/// Rate of SHA3-512, in bytes.
+///
+/// The 1600-bit permutation width minus twice the digest length, converted to bytes.
+pub const SHA3_512_RATE_BYTES: usize = 72;
+
+/// SHA3-256 digest length, in 64-bit words.
+pub const SHA3_256_DIGEST_WORDS: usize = 4;
+
+/// SHA3-384 digest length, in 64-bit words.
+pub const SHA3_384_DIGEST_WORDS: usize = 6;
+
+/// SHA3-512 digest length, in 64-bit words.
+pub const SHA3_512_DIGEST_WORDS: usize = 8;

--- a/crates/circuits/src/sha3/varlen.rs
+++ b/crates/circuits/src/sha3/varlen.rs
@@ -1,0 +1,326 @@
+// Copyright 2026 The Binius Developers
+
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire};
+
+use super::{
+	SHA3_256_DIGEST_WORDS, SHA3_256_RATE_BYTES, SHA3_384_DIGEST_WORDS, SHA3_384_RATE_BYTES,
+	SHA3_512_DIGEST_WORDS, SHA3_512_RATE_BYTES, SHA3_DELIMITER_BYTE,
+};
+use crate::{
+	fixed_byte_vec::ByteVec,
+	keccak::{N_WORDS_PER_STATE, permutation::keccak_f1600},
+	multiplexer::{multi_wire_multiplex, single_wire_multiplex},
+};
+
+/// Computes a FIPS 202 SHA-3 digest of a variable-length message.
+///
+/// This is the shared core for every SHA-3 variant in this module.
+///
+/// Only the rate and the digest length differ between them.
+///
+/// The message length is a runtime value bounded by a fixed maximum, so the padded words are
+/// derived with runtime multiplexers instead of computed directly.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message with a runtime length wire and a fixed maximum capacity.
+/// * `rate_bytes` - The sponge rate for this hash variant, in bytes.
+/// * `digest_words` - The digest length for this hash variant, in 64-bit words.
+fn sha3_varlen(
+	builder: &CircuitBuilder,
+	message: &ByteVec,
+	rate_bytes: usize,
+	digest_words: usize,
+) -> Vec<Wire> {
+	let len_bytes = message.len_bytes;
+	let data = &message.data;
+
+	let n_words_per_block = rate_bytes / 8;
+	let max_len_bytes = data.len() << 3;
+	// A message that exactly fills its blocks still needs one more block for the padding.
+	let n_blocks = (max_len_bytes + 1).div_ceil(rate_bytes);
+	let n_words = n_blocks * n_words_per_block;
+
+	// Reject any claimed length past the wire capacity before it drives any derivation below.
+	let too_long = builder.icmp_ugt(len_bytes, builder.add_constant_64(max_len_bytes as u64));
+	builder.assert_false("len_check", too_long);
+
+	let zero = builder.add_constant(Word::ZERO);
+	let msb_one = builder.add_constant(Word::MSB_ONE);
+
+	// Split the length into a word index and a byte offset within that word.
+	//
+	// The word at that index is where the padding's domain suffix belongs.
+	let w_bd = builder.shr(len_bytes, 3);
+	let len_mod_8 = builder.band(len_bytes, builder.add_constant_64(7));
+
+	// Find which block holds the padding, by scanning every block's byte range.
+	//
+	// The rate is not a power of two, so this cannot be found with a shift.
+	let mut end_block_index = zero;
+	for block_no in 0..n_blocks {
+		let block_start = builder.add_constant_64((block_no * rate_bytes) as u64);
+		let block_end = builder.add_constant_64(((block_no + 1) * rate_bytes) as u64);
+		let gte_start = builder.icmp_ule(block_start, len_bytes);
+		let lt_end = builder.icmp_ult(len_bytes, block_end);
+		let is_final_block = builder.band(gte_start, lt_end);
+		end_block_index = builder.select(
+			is_final_block,
+			builder.add_constant_64(block_no as u64),
+			end_block_index,
+		);
+	}
+
+	// Build every possible boundary word, one per byte offset the length could land on.
+	//
+	// Each candidate keeps the low message bytes up to that offset and places the domain
+	// suffix right after them.
+	//
+	// At offset zero the message contributes nothing, so the candidate is the suffix alone.
+	let boundary_message_word = single_wire_multiplex(builder, data, w_bd);
+	let candidates: Vec<Wire> = (0..8)
+		.map(|i| {
+			let mask = builder.add_constant_64(0x00FFFFFFFFFFFFFF >> ((7 - i) << 3));
+			let delimiter = builder.add_constant_64(SHA3_DELIMITER_BYTE << (i << 3));
+			let message_low = builder.band(boundary_message_word, mask);
+			builder.bxor(message_low, delimiter)
+		})
+		.collect();
+	// Select the one candidate that matches the actual byte offset.
+	let boundary_word = single_wire_multiplex(builder, &candidates, len_mod_8);
+
+	// Derive every padded word, one at a time, classified by its position relative to the
+	// boundary word and to the block holding the padding.
+	let padded_message: Vec<Wire> = (0..n_words)
+		.map(|word_index| {
+			let block_index = word_index / n_words_per_block;
+			let column_index = word_index % n_words_per_block;
+			let word_idx_wire = builder.add_constant_64(word_index as u64);
+
+			let is_message_word = builder.icmp_ult(word_idx_wire, w_bd);
+			let is_boundary_word = builder.icmp_eq(word_idx_wire, w_bd);
+			let is_end_block =
+				builder.icmp_eq(builder.add_constant_64(block_index as u64), end_block_index);
+
+			// A word strictly before the boundary is plain message data.
+			//
+			// This index is only ever selected when it is within the message capacity, so the
+			// zero fallback below it is never actually read.
+			let msg_word = if word_index < data.len() {
+				data[word_index]
+			} else {
+				zero
+			};
+
+			// The last word of the last block carries the padding rule's closing bit.
+			//
+			// It combines with the boundary word when the boundary falls there too, and
+			// otherwise stands alone as a plain padding word.
+			let delimiter = if column_index == n_words_per_block - 1 {
+				builder.select(is_end_block, msb_one, zero)
+			} else {
+				zero
+			};
+			let boundary_val = if column_index == n_words_per_block - 1 {
+				builder.bxor(boundary_word, delimiter)
+			} else {
+				boundary_word
+			};
+
+			let boundary_or_padding = builder.select(is_boundary_word, boundary_val, delimiter);
+			builder.select(is_message_word, msg_word, boundary_or_padding)
+		})
+		.collect();
+
+	// Absorb one padded block at a time.
+	//
+	// XOR it into the front of the state, then permute the whole state.
+	//
+	// Every intermediate state is kept, since the block holding the padding is only known at
+	// runtime.
+	let mut states: Vec<[Wire; N_WORDS_PER_STATE]> = Vec::with_capacity(n_blocks + 1);
+	states.push([zero; N_WORDS_PER_STATE]);
+	for block_no in 0..n_blocks {
+		let mut state = states[block_no];
+		for i in 0..n_words_per_block {
+			state[i] = builder.bxor(state[i], padded_message[block_no * n_words_per_block + i]);
+		}
+		keccak_f1600(builder, &mut state);
+		states.push(state);
+	}
+
+	// Select the digest out of the one state that followed the block holding the padding.
+	let inputs: Vec<&[Wire]> = states[1..].iter().map(|s| &s[..]).collect();
+	let digest_vec = multi_wire_multiplex(builder, &inputs, end_block_index);
+	digest_vec[..digest_words].to_vec()
+}
+
+/// Computes the SHA3-256 digest of a variable-length message.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message with a runtime length wire and a fixed maximum capacity.
+///
+/// # Returns
+/// The digest as 4 little-endian 64-bit words.
+pub fn sha3_256_varlen(
+	builder: &CircuitBuilder,
+	message: &ByteVec,
+) -> [Wire; SHA3_256_DIGEST_WORDS] {
+	sha3_varlen(builder, message, SHA3_256_RATE_BYTES, SHA3_256_DIGEST_WORDS)
+		.try_into()
+		.unwrap()
+}
+
+/// Computes the SHA3-384 digest of a variable-length message.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message with a runtime length wire and a fixed maximum capacity.
+///
+/// # Returns
+/// The digest as 6 little-endian 64-bit words.
+pub fn sha3_384_varlen(
+	builder: &CircuitBuilder,
+	message: &ByteVec,
+) -> [Wire; SHA3_384_DIGEST_WORDS] {
+	sha3_varlen(builder, message, SHA3_384_RATE_BYTES, SHA3_384_DIGEST_WORDS)
+		.try_into()
+		.unwrap()
+}
+
+/// Computes the SHA3-512 digest of a variable-length message.
+///
+/// # Arguments
+/// * `builder` - Circuit builder for constructing constraints.
+/// * `message` - Input message with a runtime length wire and a fixed maximum capacity.
+///
+/// # Returns
+/// The digest as 8 little-endian 64-bit words.
+pub fn sha3_512_varlen(
+	builder: &CircuitBuilder,
+	message: &ByteVec,
+) -> [Wire; SHA3_512_DIGEST_WORDS] {
+	sha3_varlen(builder, message, SHA3_512_RATE_BYTES, SHA3_512_DIGEST_WORDS)
+		.try_into()
+		.unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::Word;
+	use binius_frontend::{CircuitBuilder, Wire};
+	use rand::prelude::*;
+	use rstest::rstest;
+	use sha3::Digest;
+
+	use super::*;
+
+	// Builds a circuit with the given capacity, runs one hash function on a message that fits
+	// within it, and checks the computed digest against a reference implementation.
+	fn test_varlen<const DIGEST_WORDS: usize>(
+		message: &[u8],
+		max_message_len_bytes: usize,
+		hash_fn: impl FnOnce(&CircuitBuilder, &ByteVec) -> [Wire; DIGEST_WORDS],
+		reference: impl FnOnce(&[u8]) -> Vec<u8>,
+	) {
+		assert!(message.len() <= max_message_len_bytes);
+
+		let expected_digest = reference(message);
+		assert_eq!(expected_digest.len(), DIGEST_WORDS * 8);
+
+		let b = CircuitBuilder::new();
+		let max_len_words = max_message_len_bytes.div_ceil(8);
+		let input = ByteVec::new_inout(&b, max_len_words);
+		let expected_digest_wires: [Wire; DIGEST_WORDS] = std::array::from_fn(|_| b.add_witness());
+
+		// Constrain the circuit's digest to equal the expected one, wire by wire.
+		let computed_digest = hash_fn(&b, &input);
+		for i in 0..DIGEST_WORDS {
+			b.assert_eq(format!("digest[{i}]"), computed_digest[i], expected_digest_wires[i]);
+		}
+
+		let circuit = b.build();
+		let cs = circuit.constraint_system();
+		let mut witness = circuit.new_witness_filler();
+
+		// Populate the message below its capacity and record its true length.
+		input.populate_data(&mut witness, message);
+		input.populate_len_bytes(&mut witness, message.len());
+		// Populate the expected digest wires.
+		for (i, bytes) in expected_digest.chunks(8).enumerate() {
+			witness[expected_digest_wires[i]] = Word(u64::from_le_bytes(bytes.try_into().unwrap()));
+		}
+
+		// Evaluating the circuit fills in every internal wire from the message and digest inputs.
+		circuit
+			.populate_wire_witness(&mut witness)
+			.expect("Circuit should accept valid witness");
+		// Checking the constraint system confirms the computed digest equals the reference
+		// digest, not just that the witness filled in without panicking.
+		cs.verify(&witness.into_value_vec())
+			.expect("All constraints should be satisfied");
+	}
+
+	// Deterministic random message of the given length, seeded from both lengths so every
+	// combination of message length and capacity gets an independent, reproducible message.
+	fn random_message(message_len_bytes: usize, max_message_len_bytes: usize) -> Vec<u8> {
+		let seed = ((message_len_bytes as u64) << 32) | (max_message_len_bytes as u64);
+		let mut rng = StdRng::seed_from_u64(seed);
+		let mut message = vec![0u8; message_len_bytes];
+		rng.fill_bytes(&mut message);
+		message
+	}
+
+	#[rstest]
+	#[case(0, 100)] // Empty message
+	#[case(1, 100)] // Single byte, well below capacity
+	#[case(1, 144)] // Single byte, capacity spans two blocks
+	#[case(135, 136)] // One byte before the block boundary
+	#[case(136, 136)] // Exactly one block
+	#[case(137, 272)] // Crosses the block boundary
+	#[case(271, 272)] // One byte before two blocks
+	#[case(272, 272)] // Exactly two blocks
+	fn test_sha3_256_varlen(
+		#[case] message_len_bytes: usize,
+		#[case] max_message_len_bytes: usize,
+	) {
+		let message = random_message(message_len_bytes, max_message_len_bytes);
+		test_varlen(&message, max_message_len_bytes, sha3_256_varlen, |m| {
+			sha3::Sha3_256::digest(m).to_vec()
+		});
+	}
+
+	#[rstest]
+	#[case(0, 100)] // Empty message
+	#[case(1, 100)] // Single byte, well below capacity
+	#[case(103, 104)] // One byte before the block boundary
+	#[case(104, 104)] // Exactly one block
+	#[case(105, 208)] // Crosses the block boundary
+	fn test_sha3_384_varlen(
+		#[case] message_len_bytes: usize,
+		#[case] max_message_len_bytes: usize,
+	) {
+		let message = random_message(message_len_bytes, max_message_len_bytes);
+		test_varlen(&message, max_message_len_bytes, sha3_384_varlen, |m| {
+			sha3::Sha3_384::digest(m).to_vec()
+		});
+	}
+
+	#[rstest]
+	#[case(0, 100)] // Empty message
+	#[case(1, 100)] // Single byte, well below capacity
+	#[case(71, 72)] // One byte before the block boundary
+	#[case(72, 72)] // Exactly one block
+	#[case(73, 144)] // Crosses the block boundary
+	fn test_sha3_512_varlen(
+		#[case] message_len_bytes: usize,
+		#[case] max_message_len_bytes: usize,
+	) {
+		let message = random_message(message_len_bytes, max_message_len_bytes);
+		test_varlen(&message, max_message_len_bytes, sha3_512_varlen, |m| {
+			sha3::Sha3_512::digest(m).to_vec()
+		});
+	}
+}

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -83,6 +83,14 @@ harness = false
 name = "sha512"
 harness = false
 
+[[bench]]
+name = "sha3"
+harness = false
+
+[[bench]]
+name = "sha3_512"
+harness = false
+
 [features]
 default = []
 perfetto = ["tracing-profile/perfetto"]

--- a/crates/examples/benches/sha3.rs
+++ b/crates/examples/benches/sha3.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 The Binius Developers
+
+mod utils;
+
+use std::alloc::System;
+
+use binius_examples::circuits::{
+	sha3::Sha3Example,
+	utils::{HasherInstance, HasherParams},
+};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use peakmem_alloc::PeakMemAlloc;
+use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
+
+// Global allocator that tracks peak memory usage
+#[global_allocator]
+static SHA3_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
+
+struct Sha3Benchmark {
+	config: HashBenchConfig,
+}
+
+impl Sha3Benchmark {
+	fn new() -> Self {
+		let config = HashBenchConfig::from_env();
+		Self { config }
+	}
+}
+
+impl ExampleBenchmark for Sha3Benchmark {
+	type Params = HasherParams;
+	type Instance = HasherInstance;
+	type Example = Sha3Example;
+
+	fn create_params(&self) -> Self::Params {
+		HasherParams {
+			message_len: Some(self.config.max_bytes),
+			max_message_len: None,
+		}
+	}
+
+	fn create_instance(&self) -> Self::Instance {
+		HasherInstance {
+			random_message: false,
+			random_message_len: None,
+			message: None,
+		}
+	}
+
+	fn bench_name(&self) -> String {
+		format!("message_bytes_{}", self.config.max_bytes)
+	}
+
+	fn throughput(&self) -> Throughput {
+		Throughput::Bytes(self.config.max_bytes as u64)
+	}
+
+	fn proof_description(&self) -> String {
+		format!("{} bytes message", self.config.max_bytes)
+	}
+
+	fn log_inv_rate(&self) -> usize {
+		self.config.log_inv_rate
+	}
+
+	fn print_params(&self) {
+		const SHA3_256_RATE: usize = 136;
+		let n_permutations = self.config.max_bytes.div_ceil(SHA3_256_RATE);
+		let params = vec![
+			("Message size".to_string(), format!("{} bytes", self.config.max_bytes)),
+			(
+				"Permutations required".to_string(),
+				format!(
+					"{} (for {} bytes at {} bytes/permutation)",
+					n_permutations, self.config.max_bytes, SHA3_256_RATE
+				),
+			),
+			("Log inverse rate".to_string(), self.config.log_inv_rate.to_string()),
+		];
+		print_benchmark_header("SHA3-256", &params);
+	}
+}
+
+fn bench_sha3(c: &mut Criterion) {
+	let benchmark = Sha3Benchmark::new();
+	run_cs_benchmark(c, &benchmark, "sha3", &SHA3_PEAK_ALLOC);
+}
+
+criterion_group!(sha3, bench_sha3);
+criterion_main!(sha3);

--- a/crates/examples/benches/sha3_512.rs
+++ b/crates/examples/benches/sha3_512.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 The Binius Developers
+
+mod utils;
+
+use std::alloc::System;
+
+use binius_examples::circuits::{
+	sha3_512::Sha3_512Example,
+	utils::{HasherInstance, HasherParams},
+};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use peakmem_alloc::PeakMemAlloc;
+use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
+
+// Global allocator that tracks peak memory usage
+#[global_allocator]
+static SHA3_512_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
+
+struct Sha3_512Benchmark {
+	config: HashBenchConfig,
+}
+
+impl Sha3_512Benchmark {
+	fn new() -> Self {
+		let config = HashBenchConfig::from_env();
+		Self { config }
+	}
+}
+
+impl ExampleBenchmark for Sha3_512Benchmark {
+	type Params = HasherParams;
+	type Instance = HasherInstance;
+	type Example = Sha3_512Example;
+
+	fn create_params(&self) -> Self::Params {
+		HasherParams {
+			message_len: Some(self.config.max_bytes),
+			max_message_len: None,
+		}
+	}
+
+	fn create_instance(&self) -> Self::Instance {
+		HasherInstance {
+			random_message: false,
+			random_message_len: None,
+			message: None,
+		}
+	}
+
+	fn bench_name(&self) -> String {
+		format!("message_bytes_{}", self.config.max_bytes)
+	}
+
+	fn throughput(&self) -> Throughput {
+		Throughput::Bytes(self.config.max_bytes as u64)
+	}
+
+	fn proof_description(&self) -> String {
+		format!("{} bytes message", self.config.max_bytes)
+	}
+
+	fn log_inv_rate(&self) -> usize {
+		self.config.log_inv_rate
+	}
+
+	fn print_params(&self) {
+		const SHA3_512_RATE: usize = 72;
+		let n_permutations = self.config.max_bytes.div_ceil(SHA3_512_RATE);
+		let params = vec![
+			("Message size".to_string(), format!("{} bytes", self.config.max_bytes)),
+			(
+				"Permutations required".to_string(),
+				format!(
+					"{} (for {} bytes at {} bytes/permutation)",
+					n_permutations, self.config.max_bytes, SHA3_512_RATE
+				),
+			),
+			("Log inverse rate".to_string(), self.config.log_inv_rate.to_string()),
+		];
+		print_benchmark_header("SHA3-512", &params);
+	}
+}
+
+fn bench_sha3_512(c: &mut Criterion) {
+	let benchmark = Sha3_512Benchmark::new();
+	run_cs_benchmark(c, &benchmark, "sha3_512", &SHA3_512_PEAK_ALLOC);
+}
+
+criterion_group!(sha3_512, bench_sha3_512);
+criterion_main!(sha3_512);

--- a/crates/examples/examples/sha3.rs
+++ b/crates/examples/examples/sha3.rs
@@ -1,0 +1,9 @@
+// Copyright 2026 The Binius Developers
+use anyhow::Result;
+use binius_examples::{Cli, circuits::sha3::Sha3Example};
+
+fn main() -> Result<()> {
+	Cli::<Sha3Example>::new("sha3")
+		.about("SHA3-256 hash function circuit example")
+		.run()
+}

--- a/crates/examples/examples/sha3_512.rs
+++ b/crates/examples/examples/sha3_512.rs
@@ -1,0 +1,9 @@
+// Copyright 2026 The Binius Developers
+use anyhow::Result;
+use binius_examples::{Cli, circuits::sha3_512::Sha3_512Example};
+
+fn main() -> Result<()> {
+	Cli::<Sha3_512Example>::new("sha3_512")
+		.about("SHA3-512 hash function circuit example")
+		.run()
+}

--- a/crates/examples/snapshots/sha3.snap
+++ b/crates/examples/snapshots/sha3.snap
@@ -1,0 +1,30 @@
+sha3 circuit
+--
+Gates & Instructions
+├─ Number of gates: 22,189
+└─ Number of evaluation instructions: 22,189
+
+Constraints
+├─ ZERO constraints: 4 used (100.0% of 2^2)
+│  [▓▓▓▓▓▓▓▓▓▓] spare: 0
+├─ AND constraints: 4,779 used (58.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,413
+├─ IMUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
+├─ BMUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
+└─ Distinct value indices: 57,197
+   ├─ Distinct shifted value indices: 52,360
+   └─ Distinct unshifted value indices: 4,837
+
+Value Vector
+├─ Public Section: 158 (not committed)
+│  ├─ Constants: 26
+│  └─ Inout: 132
+├─ Private Section: 4,779
+│  ├─ Witness: 0
+│  └─ Internal: 4,779
+├─ Committed Trace: 4,779 used (58.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,413
+└─ Scratch (uncommitted): 27 (peak live: 27)
+

--- a/crates/examples/snapshots/sha3_512.snap
+++ b/crates/examples/snapshots/sha3_512.snap
@@ -1,0 +1,30 @@
+sha3_512 circuit
+--
+Gates & Instructions
+├─ Number of gates: 41,513
+└─ Number of evaluation instructions: 41,513
+
+Constraints
+├─ ZERO constraints: 8 used (100.0% of 2^3)
+│  [▓▓▓▓▓▓▓▓▓▓] spare: 0
+├─ AND constraints: 8,983 used (54.8% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,401
+├─ IMUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
+├─ BMUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
+└─ Distinct value indices: 106,477
+   ├─ Distinct shifted value indices: 97,434
+   └─ Distinct unshifted value indices: 9,043
+
+Value Vector
+├─ Public Section: 162 (not committed)
+│  ├─ Constants: 26
+│  └─ Inout: 136
+├─ Private Section: 8,983
+│  ├─ Witness: 0
+│  └─ Internal: 8,983
+├─ Committed Trace: 8,983 used (54.8% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,401
+└─ Scratch (uncommitted): 27 (peak live: 27)
+

--- a/crates/examples/src/circuits/mod.rs
+++ b/crates/examples/src/circuits/mod.rs
@@ -14,6 +14,8 @@ pub mod hashsign;
 pub mod independent_hashes;
 pub mod keccak;
 pub mod sha256;
+pub mod sha3;
+pub mod sha3_512;
 pub mod sha512;
 pub mod subset_sum;
 pub mod utils;

--- a/crates/examples/src/circuits/sha3.rs
+++ b/crates/examples/src/circuits/sha3.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 The Binius Developers
+use std::array;
+
+use anyhow::Result;
+use binius_circuits::{
+	fixed_byte_vec::ByteVec,
+	sha3::{SHA3_256_DIGEST_WORDS, fixed_length::sha3_256, varlen::sha3_256_varlen},
+};
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use sha3::Digest;
+
+use super::utils::{self, HasherInstance, HasherMode, HasherParams};
+use crate::ExampleCircuit;
+
+/// SHA3-256 hash circuit example.
+pub struct Sha3Example {
+	circuit: Sha3Circuit,
+	mode: HasherMode,
+}
+
+/// Either the fixed-length (default) or variable-length SHA3-256 circuit.
+enum Sha3Circuit {
+	/// Fixed-length gadget: message length is a compile-time constant.
+	Fixed {
+		message: Vec<Wire>,
+		digest: [Wire; SHA3_256_DIGEST_WORDS],
+	},
+	/// Variable-length gadget: message length is a runtime witness.
+	Variable {
+		message: ByteVec,
+		digest: [Wire; SHA3_256_DIGEST_WORDS],
+	},
+}
+
+impl ExampleCircuit for Sha3Example {
+	type Params = HasherParams;
+	type Instance = HasherInstance;
+
+	fn build(params: HasherParams, builder: &mut CircuitBuilder) -> Result<Self> {
+		let mode = utils::resolve_hasher_mode(&params, "SHA3-256", true)?;
+
+		let circuit = match mode {
+			// Fixed-length (default): message length is a compile-time constant.
+			HasherMode::Fixed { len_bytes } => {
+				let n_words = len_bytes.div_ceil(8);
+				let message: Vec<Wire> = (0..n_words).map(|_| builder.add_inout()).collect();
+				let computed_digest = sha3_256(builder, &message, len_bytes);
+				let digest: [Wire; SHA3_256_DIGEST_WORDS] = array::from_fn(|_| builder.add_inout());
+				for i in 0..SHA3_256_DIGEST_WORDS {
+					builder.assert_eq(format!("digest[{i}]"), computed_digest[i], digest[i]);
+				}
+				Sha3Circuit::Fixed { message, digest }
+			}
+			// Variable-length: message length is a runtime witness.
+			HasherMode::Variable { max_len_bytes } => {
+				let n_words = max_len_bytes.div_ceil(8);
+				let len_bytes = builder.add_witness();
+				let data = (0..n_words).map(|_| builder.add_inout()).collect();
+				let message = ByteVec::new(data, len_bytes);
+				let digest: [Wire; SHA3_256_DIGEST_WORDS] = array::from_fn(|_| builder.add_inout());
+				let computed_digest = sha3_256_varlen(builder, &message);
+				for i in 0..SHA3_256_DIGEST_WORDS {
+					builder.assert_eq(format!("digest[{i}]"), computed_digest[i], digest[i]);
+				}
+				Sha3Circuit::Variable { message, digest }
+			}
+		};
+
+		Ok(Self { circuit, mode })
+	}
+
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
+		let digest: [u8; 32] = sha3::Sha3_256::digest(&message).into();
+
+		match &self.circuit {
+			Sha3Circuit::Fixed {
+				message: message_wires,
+				digest: digest_wires,
+			} => {
+				// Message: 64-bit little-endian words, 8 bytes per wire.
+				for (wire, word) in message_wires
+					.iter()
+					.zip(utils::pack_bytes_u64words(&message, false))
+				{
+					w[*wire] = word;
+				}
+				// Digest: 4 x 64-bit little-endian words.
+				for (i, chunk) in digest.chunks(8).enumerate() {
+					w[digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
+				}
+			}
+			Sha3Circuit::Variable {
+				message: byte_vec,
+				digest: digest_wires,
+			} => {
+				byte_vec.populate_data(w, &message);
+				byte_vec.populate_len_bytes(w, message.len());
+				for (i, chunk) in digest.chunks(8).enumerate() {
+					w[digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		utils::hasher_param_summary(params)
+	}
+}

--- a/crates/examples/src/circuits/sha3_512.rs
+++ b/crates/examples/src/circuits/sha3_512.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 The Binius Developers
+use std::array;
+
+use anyhow::Result;
+use binius_circuits::{
+	fixed_byte_vec::ByteVec,
+	sha3::{SHA3_512_DIGEST_WORDS, fixed_length::sha3_512, varlen::sha3_512_varlen},
+};
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use sha3::Digest;
+
+use super::utils::{self, HasherInstance, HasherMode, HasherParams};
+use crate::ExampleCircuit;
+
+/// SHA3-512 hash circuit example.
+pub struct Sha3_512Example {
+	circuit: Sha3_512Circuit,
+	mode: HasherMode,
+}
+
+/// Either the fixed-length (default) or variable-length SHA3-512 circuit.
+enum Sha3_512Circuit {
+	/// Fixed-length gadget: message length is a compile-time constant.
+	Fixed {
+		message: Vec<Wire>,
+		digest: [Wire; SHA3_512_DIGEST_WORDS],
+	},
+	/// Variable-length gadget: message length is a runtime witness.
+	Variable {
+		message: ByteVec,
+		digest: [Wire; SHA3_512_DIGEST_WORDS],
+	},
+}
+
+impl ExampleCircuit for Sha3_512Example {
+	type Params = HasherParams;
+	type Instance = HasherInstance;
+
+	fn build(params: HasherParams, builder: &mut CircuitBuilder) -> Result<Self> {
+		let mode = utils::resolve_hasher_mode(&params, "SHA3-512", true)?;
+
+		let circuit = match mode {
+			// Fixed-length (default): message length is a compile-time constant.
+			HasherMode::Fixed { len_bytes } => {
+				let n_words = len_bytes.div_ceil(8);
+				let message: Vec<Wire> = (0..n_words).map(|_| builder.add_inout()).collect();
+				let computed_digest = sha3_512(builder, &message, len_bytes);
+				let digest: [Wire; SHA3_512_DIGEST_WORDS] = array::from_fn(|_| builder.add_inout());
+				for i in 0..SHA3_512_DIGEST_WORDS {
+					builder.assert_eq(format!("digest[{i}]"), computed_digest[i], digest[i]);
+				}
+				Sha3_512Circuit::Fixed { message, digest }
+			}
+			// Variable-length: message length is a runtime witness.
+			HasherMode::Variable { max_len_bytes } => {
+				let n_words = max_len_bytes.div_ceil(8);
+				let len_bytes = builder.add_witness();
+				let data = (0..n_words).map(|_| builder.add_inout()).collect();
+				let message = ByteVec::new(data, len_bytes);
+				let digest: [Wire; SHA3_512_DIGEST_WORDS] = array::from_fn(|_| builder.add_inout());
+				let computed_digest = sha3_512_varlen(builder, &message);
+				for i in 0..SHA3_512_DIGEST_WORDS {
+					builder.assert_eq(format!("digest[{i}]"), computed_digest[i], digest[i]);
+				}
+				Sha3_512Circuit::Variable { message, digest }
+			}
+		};
+
+		Ok(Self { circuit, mode })
+	}
+
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
+		let digest: [u8; 64] = sha3::Sha3_512::digest(&message).into();
+
+		match &self.circuit {
+			Sha3_512Circuit::Fixed {
+				message: message_wires,
+				digest: digest_wires,
+			} => {
+				// Message: 64-bit little-endian words, 8 bytes per wire.
+				for (wire, word) in message_wires
+					.iter()
+					.zip(utils::pack_bytes_u64words(&message, false))
+				{
+					w[*wire] = word;
+				}
+				// Digest: 8 x 64-bit little-endian words.
+				for (i, chunk) in digest.chunks(8).enumerate() {
+					w[digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
+				}
+			}
+			Sha3_512Circuit::Variable {
+				message: byte_vec,
+				digest: digest_wires,
+			} => {
+				byte_vec.populate_data(w, &message);
+				byte_vec.populate_len_bytes(w, message.len());
+				for (i, chunk) in digest.chunks(8).enumerate() {
+					w[digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		utils::hasher_param_summary(params)
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-510](https://linear.app/jimpo/issue/BINIUS-510/add-fips-202-sha3-256384512-circuit-gadgets).

Adds real FIPS 202 SHA-3 circuits (SHA3-256/384/512) — this crate previously only had Ethereum's Keccak-256.

### The problem

This crate already has a circuit for Ethereum's Keccak-256, but not the actual NIST SHA-3 hash functions.

A teammate asked how much slower SHA-3 should be expected to run in-circuit compared to SHA-2 and BLAKE.

There was no direct way to measure that, since the real SHA-3 padding rule was missing — only the Ethereum variant existed.

### The idea

SHA-3 and Keccak-256 share the exact same 1600-bit permutation and multi-rate padding rule.

The only difference is a two-bit domain-separation suffix that FIPS 202 appends to the message before padding.

For a byte-aligned message, that turns the first padding byte from Keccak's `0x01` into `0x06`.

So SHA3-256/384/512 gadgets can reuse the existing permutation gadget completely unchanged.

They only need to derive the padded words with the different suffix, and use each variant's own rate/capacity split.

### The change

New module with fixed-length and variable-length gadgets for SHA3-256, SHA3-384, and SHA3-512, built on top of the existing Keccak permutation gadget.

SHA3-224 is intentionally left out.

Its 224-bit digest does not divide evenly into 64-bit words, and this crate represents every digest as a whole number of 64-bit words.

Added matching examples, criterion benches, and blessed circuit-stat snapshots, mirroring the existing hash examples exactly — same default message size — so the new gadgets are directly comparable to the ones already in the repo.

### Benchmark

AND constraints for a 1024-byte fixed-length message, the shared default across every hash example in this crate:

| Hash | Digest | AND constraints | Domain |
|---|---|---|---|
| BLAKE3 | 256-bit | 2,688 | 2^12 |
| BLAKE2b | 512-bit | 4,608 | 2^13 |
| SHA3-256 / Keccak-256 | 256-bit | 4,779 | 2^13 |
| SHA-256 | 256-bit | 6,503 | 2^13 |
| BLAKE2s | 256-bit | 7,680 | 2^13 |
| SHA-512 | 512-bit | 8,262 | 2^14 |
| SHA3-512 | 512-bit | 8,983 | 2^14 |

SHA3-256 costs about the same as SHA-256 (fewer AND constraints, same domain bucket) — nowhere near the order-of-magnitude penalty Keccak usually pays in prime-field SNARKs, because every gate here costs the same regardless of bit width and Keccak's lanes are already 64 bits wide.

SHA3-512 is the one real outlier: its smaller rate means more permutation calls per byte than SHA-512, and wall-clock proving measured ~1.8x slower despite only a 9% higher AND count.

### Scope

- new: three files for the SHA3-256/384/512 gadgets, plus matching examples, benches, and snapshots
- changed: module registration in the circuits crate, example registration and Cargo.toml bench entries in the examples crate
- left untouched: the existing Keccak-256 gadget and its underlying permutation, reused as-is

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-circuits -p binius-examples --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-circuits sha3::` — 39 passed, checked against the `sha3` crate's reference digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)