### PR TITLE
Fix the recv_openings doc comment claiming the Merkle query-index bound is still open

### DIFF
--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -342,9 +342,13 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 	/// The opened values stay circuit inputs, since they are proof data.
 	/// They stop being *free*: each leaf is hashed and climbed to a layer the root fixes.
 	///
-	/// The index is a wire, so no range check is possible while the circuit is built.
-	/// An opening is verified at the index reduced modulo the leaf count.
-	/// Masking the sampled index so that reduction is a no-op is BINIUS-470.
+	/// Only the low index bits spanning the tree depth are ever read while climbing.
+	/// A caller must therefore supply an index already bounded below the leaf count.
+	///
+	/// The channel's own query indices satisfy this by construction.
+	/// They are drawn through a gadget that masks the raw sampled bytes with a real gate, so
+	/// the drawn value provably lies below the tree's width before it is ever used as an
+	/// index.
 	fn recv_openings(
 		&mut self,
 		commitment: &Commitment,


### PR DESCRIPTION
Fixes a doc comment in the recursive verifier's Merkle-opening channel that describes a soundness gap as still open, when the fix already landed elsewhere in the crate.
Pure doc change — no behavior change.

### The problem

The channel that turns a Merkle-opening verification into circuit gates only ever reads the low bits of a query-index wire spanning the tree depth.
Its doc comment said that made the opening "verified at the index reduced modulo the leaf count," and pointed at `BINIUS-470` as the still-open fix for that.

`BINIUS-470` already landed, and Linear lists it done.
The comment was never updated afterward, so it kept describing the old, unfixed state.

### The idea

The actual fix lives in the challenger's bit-sampling gadget, not in this file.
It masks every drawn value below its requested width with a real gate, so a query index is provably in range from the moment it is sampled — the low-bit read downstream is then a genuine no-op, not an unchecked reduction.

Every real caller derives a Merkle query index either directly from that gadget, or by right-shifting an index that was, which preserves the bound at each smaller commitment.
So the state the old comment warned about never actually occurs on the path the protocol takes.

### The change

```
- The index is a wire, so no range check is possible while the circuit is built.
- An opening is verified at the index reduced modulo the leaf count.
- Masking the sampled index so that reduction is a no-op is BINIUS-470.
+ Only the low index bits spanning the tree depth are ever read while climbing.
+ A caller must therefore supply an index already bounded below the leaf count.
+
+ The channel's own query indices satisfy this by construction.
+ They are drawn through a gadget that masks the raw sampled bytes with a real gate, so
+ the drawn value provably lies below the tree's width before it is ever used as an
+ index.
```

### Scope

- **changed:** one doc comment in `crates/recursion/src/channel.rs`, nothing else
- no code, no test, and no behavior changed

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p binius-recursion` — 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)