### PR TITLE
Fix the channel_builds smoke test's stale module doc comment

### DIFF
--- a/crates/recursion/tests/channel_builds.rs
+++ b/crates/recursion/tests/channel_builds.rs
@@ -1,9 +1,6 @@
 // Copyright 2026 The Binius Developers
 
 //! A smoke test that the channel records arithmetic into a circuit that compiles.
-//!
-//! This exercises the paths the skeleton implements — receiving elements, multiplying them, and
-//! asserting — and deliberately avoids the ones it does not, which panic with `todo!()`.
 
 use binius_field::BinaryField128bGhash as B128;
 use binius_frontend::CircuitStat;


### PR DESCRIPTION
Fixes a module doc comment on a recursion-crate smoke test that describes behavior the code no longer has.
Pure doc change — no behavior change.

### The problem

This file's module doc comment said the test "exercises the paths the [channel] implements" and "deliberately avoids the ones it does not, which panic with `todo!()`."
That described the channel back when it was a skeleton with some operations still unimplemented.

The channel now fully implements every operation the verifier traits require, and none of them panic with `todo!()` anymore.
The comment was never updated after that, so it kept describing a channel that no longer exists.

### The change

```
- This exercises the paths the skeleton implements — receiving elements, multiplying them, and
- asserting — and deliberately avoids the ones it does not, which panic with `todo!()`.
```

Dropped entirely, leaving the one line that is still accurate: this is a smoke test that the channel records arithmetic into a circuit that compiles.

### Scope

- **changed:** one module doc comment in `crates/recursion/tests/channel_builds.rs`, nothing else
- no code, no test, and no behavior changed

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p binius-recursion` — 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)