### PR TITLE
BINIUS-511: Pack BLAKE2s block compression into 2 lanes, halving its AND count

### DIFF
--- a/crates/circuits/src/blake2s/compress.rs
+++ b/crates/circuits/src/blake2s/compress.rs
@@ -1,0 +1,974 @@
+// Copyright 2026 The Binius Developers
+//! BLAKE2s compression primitive.
+//!
+//! A BLAKE2s block is 64 bytes: 16 32-bit words.
+//!
+//! The compression function mixes an 8-word chained state with a 16-word message block, a
+//! 64-bit byte counter split into two 32-bit halves, and a finalization flag.
+//!
+//! It produces an updated 8-word state.
+//!
+//! Every gate here is lane-agnostic.
+//!
+//! A 32-bit add, a 32-bit rotate, and a bitwise exclusive-or all act independently on each
+//! 32-bit half of a 64-bit wire.
+//!
+//! That lets one mixing core serve three shapes:
+//!
+//! - One compression, packed into the low 32 bits of each wire.
+//! - Two independent compressions, one per 32-bit lane.
+//! - Two sequential compressions, where the second's input state is the first's output.
+//!
+//! The sequential pair is packed into the same two lanes through a hint that breaks the
+//! circular dependency between them.
+
+use std::{array, iter};
+
+use binius_core::word::Word;
+use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire};
+
+use super::constants::{IV, SIGMA};
+use crate::util::clear_high_bits;
+
+/// BLAKE2s G mixing function.
+///
+/// Every operation here is a parallel-halves gate or a bitwise one.
+///
+/// A parallel-halves gate acts independently on each 32-bit half of a 64-bit wire.
+///
+/// So the same code mixes either one compression alone, or two compressions packed side by
+/// side.
+#[allow(clippy::too_many_arguments)]
+fn g(
+	builder: &CircuitBuilder,
+	v: &mut [Wire; 16],
+	a: usize,
+	b: usize,
+	c: usize,
+	d: usize,
+	x: Wire,
+	y: Wire,
+) {
+	// Mix the first message word into a, then rotate d by 16 bits.
+	v[a] = builder.iadd_32(builder.iadd_32(v[a], v[b]), x);
+	v[d] = builder.rotr32(builder.bxor(v[d], v[a]), 16);
+	// Fold d back into c, then rotate b by 12 bits.
+	v[c] = builder.iadd_32(v[c], v[d]);
+	v[b] = builder.rotr32(builder.bxor(v[b], v[c]), 12);
+	// Mix the second message word into a, then rotate d by 8 bits.
+	v[a] = builder.iadd_32(builder.iadd_32(v[a], v[b]), y);
+	v[d] = builder.rotr32(builder.bxor(v[d], v[a]), 8);
+	// Fold d back into c again, then rotate b by 7 bits.
+	v[c] = builder.iadd_32(v[c], v[d]);
+	v[b] = builder.rotr32(builder.bxor(v[b], v[c]), 7);
+}
+
+/// One mixing round.
+///
+/// Four column mixes, followed by four diagonal mixes, using the round's own message-word
+/// schedule.
+fn round(builder: &CircuitBuilder, v: &mut [Wire; 16], m: &[Wire; 16], round_idx: usize) {
+	let s = &SIGMA[round_idx];
+	// Mix the four columns: (0,4,8,12), (1,5,9,13), (2,6,10,14), (3,7,11,15).
+	g(builder, v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+	g(builder, v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+	g(builder, v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+	g(builder, v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+	// Mix the four diagonals: (0,5,10,15), (1,6,11,12), (2,7,8,13), (3,4,9,14).
+	g(builder, v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+	g(builder, v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+	g(builder, v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+	g(builder, v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+}
+
+/// The compression's initial 16-word working vector.
+///
+/// The chained state fills the low half.
+///
+/// The IV fills the high half.
+///
+/// The byte counter and the finalization flag are then folded into the last four words.
+///
+/// The `iv` argument carries one lane's worth of IV words for a single compression, or the
+/// same words replicated into both lanes for two packed compressions.
+///
+/// That replication is the only difference between those two shapes.
+fn init_v(
+	builder: &CircuitBuilder,
+	h: [Wire; 8],
+	iv: [Wire; 8],
+	t_lo: Wire,
+	t_hi: Wire,
+	last: Wire,
+) -> [Wire; 16] {
+	let mut v: [Wire; 16] = array::from_fn(|i| if i < 8 { h[i] } else { iv[i - 8] });
+	// Mix the low 32 bits of the byte counter into word 12.
+	v[12] = builder.bxor(v[12], t_lo);
+	// Mix the high 32 bits of the byte counter into word 13.
+	v[13] = builder.bxor(v[13], t_hi);
+	// Mix the finalization flag into word 14: an all-ones flag flips every bit of that word.
+	v[14] = builder.bxor(v[14], last);
+	v
+}
+
+/// Runs the ten mixing rounds, then folds the working vector's two halves back into the state.
+///
+/// Shared by every shape this module offers.
+///
+/// The state and the working vector are single-lane for one compression, or packed two per
+/// wire for a pair.
+///
+/// This code never needs to know which.
+fn compress_core(
+	builder: &CircuitBuilder,
+	h: [Wire; 8],
+	mut v: [Wire; 16],
+	m: [Wire; 16],
+) -> [Wire; 8] {
+	for round_idx in 0..10 {
+		round(builder, &mut v, &m, round_idx);
+	}
+	// Fold the vector's two halves back into the chained state.
+	array::from_fn(|i| builder.bxor(h[i], builder.bxor(v[i], v[i + 8])))
+}
+
+/// BLAKE2s compression function.
+///
+/// # Arguments
+/// * `builder` - Circuit builder.
+/// * `h` - The 8-word chained state, one 32-bit value per wire.
+/// * `m` - The 16-word message block, one 32-bit value per wire.
+/// * `t_lo` - Low 32 bits of the byte counter.
+/// * `t_hi` - High 32 bits of the byte counter.
+/// * `last` - The finalization flag.
+///
+/// All-ones for the final block, zero otherwise.
+///
+/// # Preconditions
+/// The high 32 bits of every input wire must be empty.
+///
+/// Ensuring this is the caller's responsibility.
+///
+/// Violating it leaves the gadget's behavior undefined, and unsafe to rely on.
+///
+/// # Returns
+/// The updated 8-word state.
+///
+/// Every wire's high 32 bits are empty.
+pub fn blake2s_compress(
+	builder: &CircuitBuilder,
+	h: [Wire; 8],
+	m: [Wire; 16],
+	t_lo: Wire,
+	t_hi: Wire,
+	last: Wire,
+) -> [Wire; 8] {
+	// The IV constant occupies only the low 32 bits of each wire, satisfying the precondition
+	// this compression relies on.
+	let iv: [Wire; 8] = array::from_fn(|i| builder.add_constant(Word(IV[i] as u64)));
+	let v = init_v(builder, h, iv, t_lo, t_hi, last);
+	compress_core(builder, h, v, m)
+}
+
+/// BLAKE2s compression function running two independent compressions in parallel.
+///
+/// Each 64-bit input wire packs two 32-bit lanes.
+///
+/// Bits 0 through 31 hold lane 0's word.
+///
+/// Bits 32 through 63 hold lane 1's word.
+///
+/// Every gate the mixing core uses already acts independently on each half.
+///
+/// So the ten mixing rounds compute both compressions for the gate cost of a single one.
+///
+/// # Arguments
+/// Every wire packs two lanes, as described above.
+///
+/// * `h` - The 8-word chained state.
+/// * `m` - The 16-word message block.
+/// * `t_lo` - Low 32 bits of the byte counter.
+/// * `t_hi` - High 32 bits of the byte counter.
+/// * `last` - The finalization flag.
+///
+/// # Returns
+/// The updated 8-word state.
+///
+/// Each wire packs both lanes' results.
+///
+/// # Chips
+/// This gadget can be registered as a chip.
+///
+/// Doing so turns every paired compression under it into a chip call, including the ones a
+/// sequential pairing and the fixed-length hasher reach.
+pub fn blake2s_compress_2x(
+	builder: &CircuitBuilder,
+	h: [Wire; 8],
+	m: [Wire; 16],
+	t_lo: Wire,
+	t_hi: Wire,
+	last: Wire,
+) -> [Wire; 8] {
+	let inputs: Vec<Wire> = h.into_iter().chain(m).chain([t_lo, t_hi, last]).collect();
+	let outputs = builder.build_gadget(Blake2sCompress2x, &[], &inputs);
+	array::from_fn(|i| outputs[i])
+}
+
+/// The two-lane compression above, in a form a circuit can register as a chip.
+///
+/// Its interface is the flat 27 input words: the 8-word state, the 16-word message block, the
+/// counter's low half, the counter's high half, and the finalization flag.
+///
+/// The 8 output words pack two lanes the same way the inputs do.
+pub struct Blake2sCompress2x;
+
+impl Hint for Blake2sCompress2x {
+	const NAME: &'static str = "binius.blake2s_compress_2x";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(27, 8)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		// Every input word packs one lane per 32-bit half, and the two halves never interact.
+		//
+		// Every add, rotate, and mix this core uses is either 32-bit or bitwise.
+		//
+		// So computing one lane is exactly a plain compression of that lane's own words.
+		let compress_lane = |i: usize| {
+			let lane = |word: Word| (word.as_u64() >> (32 * i)) as u32;
+			let h: [u32; 8] = array::from_fn(|j| lane(inputs[j]));
+			let m: [u32; 16] = array::from_fn(|j| lane(inputs[8 + j]));
+			ref_compress(h, m, lane(inputs[24]), lane(inputs[25]), lane(inputs[26]))
+		};
+
+		// Compute both lanes, then repack them into one word per output.
+		let (lane_0, lane_1) = (compress_lane(0), compress_lane(1));
+		for (slot, (low, high)) in iter::zip(outputs, iter::zip(lane_0, lane_1)) {
+			*slot = Word(low as u64 | ((high as u64) << 32));
+		}
+	}
+}
+
+impl ChipGadget for Blake2sCompress2x {
+	fn build(&self, builder: &CircuitBuilder, _dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
+		// Split the flat input list back into the state and the message block, then run the
+		// shared gate path a direct call would use.
+		let h: [Wire; 8] = array::from_fn(|i| inputs[i]);
+		let m: [Wire; 16] = array::from_fn(|i| inputs[8 + i]);
+		compress_2x_gates(builder, h, m, inputs[24], inputs[25], inputs[26]).to_vec()
+	}
+}
+
+/// The two-lane compression, expressed directly in gates.
+///
+/// Used both by a direct call and by the chip's gate path, so the two stay identical by
+/// construction.
+fn compress_2x_gates(
+	builder: &CircuitBuilder,
+	h: [Wire; 8],
+	m: [Wire; 16],
+	t_lo: Wire,
+	t_hi: Wire,
+	last: Wire,
+) -> [Wire; 8] {
+	// Replicate the IV into both 32-bit halves, so each lane mixes in its own copy.
+	let iv_2x: [Wire; 8] = array::from_fn(|i| {
+		let w = IV[i] as u64;
+		builder.add_constant(Word(w | (w << 32)))
+	});
+	let v = init_v(builder, h, iv_2x, t_lo, t_hi, last);
+	compress_core(builder, h, v, m)
+}
+
+/// Two sequential BLAKE2s block compressions, evaluated in one parallel core.
+///
+/// The second block's compression takes the first block's output state as its own input
+/// state.
+///
+/// Both compressions run as the two 32-bit lanes of a single parallel compression.
+///
+/// ```text
+///     high lane [32:64]:  S1 = compress(input state, first block)
+///     low  lane [0:32] :  S2 = compress(S1,          second block)
+/// ```
+///
+/// So two chained blocks cost one compression, instead of two.
+///
+/// The two lanes run at the same time.
+///
+/// Yet the low lane needs the high lane's *output* as its own input, before that output
+/// exists.
+///
+/// A hint breaks this circular dependency by computing that output off-circuit first.
+///
+/// The hinted value seeds the low lane's input.
+///
+/// It is then constrained two ways, so it cannot lie:
+///
+/// - Its high half must equal the real input state.
+/// - Its low half must equal what the first compression actually produces in-circuit.
+///
+/// # Arguments
+/// * `builder` - Circuit builder.
+/// * `h` - The 8-word input state for the first compression, one 32-bit value per wire.
+/// * `blocks` - The two 16-word message blocks.
+///
+/// The first feeds the first compression, the second feeds the second.
+///
+/// * `t_los` - Each compression's low 32 bits of its byte counter.
+/// * `t_his` - Each compression's high 32 bits of its byte counter.
+/// * `lasts` - Each compression's finalization flag.
+///
+/// # Preconditions
+/// Every input wire holds a valid 32-bit value in its low 32 bits.
+///
+/// High halves need not be empty:
+///
+/// - `h`'s high half is discarded by the shift that lifts it into the high lane.
+/// - The first block's words, and the first compression's counter and flag, are likewise only ever
+///   shifted, never read directly.
+/// - The second block's words, and the second compression's counter and flag, are masked before
+///   use.
+///
+/// # Returns
+/// 8 wires, each packing both output states.
+///
+/// - Low 32 bits: the second compression's output.
+/// - High 32 bits: the first compression's output.
+pub fn blake2s_compress_2x_seq(
+	builder: &CircuitBuilder,
+	h: [Wire; 8],
+	blocks: [[Wire; 16]; 2],
+	t_los: [Wire; 2],
+	t_his: [Wire; 2],
+	lasts: [Wire; 2],
+) -> [Wire; 8] {
+	// The hint returns the merged state directly, one word at a time:
+	//
+	//     low 32 bits : first compression's output  = second compression's input
+	//     high 32 bits: first compression's input state word
+	//
+	// Both halves are re-derived and constrained below, so the hint itself need not be
+	// trusted.
+	let mut hint_inputs = Vec::with_capacity(27);
+	hint_inputs.extend_from_slice(&h);
+	hint_inputs.extend_from_slice(&blocks[0]);
+	hint_inputs.push(t_los[0]);
+	hint_inputs.push(t_his[0]);
+	hint_inputs.push(lasts[0]);
+	let merged_vec = builder.call_hint(Blake2sCompressHint, &[], &hint_inputs);
+	let merged: [Wire; 8] = array::from_fn(|i| merged_vec[i]);
+
+	// Pack a lane pair into one wire: the low 32 bits hold lane 0, the high 32 bits hold
+	// lane 1.
+	//
+	// Shifting left by 32 already clears the shifted operand's own high bits.
+	//
+	// The operand placed in the low half is cleared explicitly, since nothing here guarantees
+	// its high bits start empty.
+	let pack = |lo: Wire, hi: Wire| builder.bxor(lo, builder.shl(hi, 32));
+	let clear = |w: Wire| clear_high_bits(builder, w, 32);
+
+	// Merge each pair of per-compression values into its own two-lane wire: the second
+	// compression's value in the low lane, the first's in the high lane.
+	let merged_block: [Wire; 16] = array::from_fn(|i| pack(clear(blocks[1][i]), blocks[0][i]));
+	let merged_t_lo = pack(clear(t_los[1]), t_los[0]);
+	let merged_t_hi = pack(clear(t_his[1]), t_his[0]);
+	let merged_last = pack(clear(lasts[1]), lasts[0]);
+
+	let out =
+		blake2s_compress_2x(builder, merged, merged_block, merged_t_lo, merged_t_hi, merged_last);
+
+	// Bind the hinted state, one 64-bit equality per word.
+	//
+	// A single equality pins both halves at once, since they never overlap.
+	//
+	//     hinted word:  [ high lane = input state | low lane = S1 output ]
+	//                          must equal                must equal
+	//                     input state << 32       ^     result >> 32
+	//
+	// Together these leave the hint no freedom:
+	//
+	// - The high lane provably compresses the caller's own input state.
+	// - The low lane provably chains from what the first compression really produced.
+	//
+	// Each side is one shift of an already-committed word, so nothing needs masking:
+	//
+	// - Shifting up discards the input's own high bits.
+	// - Shifting down discards the result's low bits.
+	for (m, (s, o)) in iter::zip(merged, iter::zip(h, out)) {
+		let expected = builder.bxor(builder.shl(s, 32), builder.shr(o, 32));
+		builder.assert_eq("blake2s_compress_2x_seq.merged_state", m, expected);
+	}
+
+	out
+}
+
+/// Precomputes the merged input state for the sequential two-lane compression above.
+///
+/// It runs the first compression off-circuit, then packs each output word to seed both
+/// lanes at once.
+///
+/// - Low 32 bits: the first compression's output, which is the second compression's input.
+/// - High 32 bits: the first compression's input state word.
+///
+/// Both halves are re-derived and constrained in-circuit, so this hint only needs to be
+/// honest, not trusted.
+///
+/// # Input layout
+/// 27 words, with the value in the low 32 bits of each.
+///
+/// - Words 0 through 7: the input state.
+/// - Words 8 through 23: the first message block.
+/// - Word 24: the first compression's low counter half.
+/// - Word 25: the first compression's high counter half.
+/// - Word 26: the first compression's finalization flag.
+struct Blake2sCompressHint;
+
+impl Hint for Blake2sCompressHint {
+	const NAME: &'static str = "binius.blake2s_compress";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(27, 8)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		// Read the first compression's inputs out of the flat 27-word layout.
+		let h: [u32; 8] = array::from_fn(|i| inputs[i].as_u64() as u32);
+		let m: [u32; 16] = array::from_fn(|i| inputs[8 + i].as_u64() as u32);
+		let t_lo = inputs[24].as_u64() as u32;
+		let t_hi = inputs[25].as_u64() as u32;
+		let last = inputs[26].as_u64() as u32;
+
+		// Pack each output word with the compression's result in the low half and the
+		// original input state word in the high half.
+		let out = ref_compress(h, m, t_lo, t_hi, last);
+		for (i, slot) in outputs.iter_mut().enumerate() {
+			*slot = Word(out[i] as u64 | ((h[i] as u64) << 32));
+		}
+	}
+}
+
+/// Pure-Rust BLAKE2s compression of a single 64-byte block.
+///
+/// Matches the in-circuit compression exactly, per RFC 7693 Section 3.2.
+///
+/// Used for prover-side witness generation, and as the test reference.
+///
+/// # Arguments
+/// * `h` - The 8-word input state.
+/// * `m` - The 16-word message block.
+/// * `t_lo` - Low 32 bits of the byte counter.
+/// * `t_hi` - High 32 bits of the byte counter.
+/// * `last` - The finalization flag.
+///
+/// All-ones for the final block, zero otherwise.
+///
+/// # Returns
+/// The updated 8-word state.
+pub fn ref_compress(h: [u32; 8], m: [u32; 16], t_lo: u32, t_hi: u32, last: u32) -> [u32; 8] {
+	const fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, x: u32, y: u32) {
+		// Mix the first message word into a, then rotate d by 16 bits.
+		v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
+		v[d] = (v[d] ^ v[a]).rotate_right(16);
+		// Fold d back into c, then rotate b by 12 bits.
+		v[c] = v[c].wrapping_add(v[d]);
+		v[b] = (v[b] ^ v[c]).rotate_right(12);
+		// Mix the second message word into a, then rotate d by 8 bits.
+		v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
+		v[d] = (v[d] ^ v[a]).rotate_right(8);
+		// Fold d back into c again, then rotate b by 7 bits.
+		v[c] = v[c].wrapping_add(v[d]);
+		v[b] = (v[b] ^ v[c]).rotate_right(7);
+	}
+
+	let mut v = [0u32; 16];
+	// The chained state fills the low half of the working vector, the IV the high half.
+	v[..8].copy_from_slice(&h);
+	v[8..].copy_from_slice(&IV);
+	// Mix the byte counter and the finalization flag into the last four words.
+	v[12] ^= t_lo;
+	v[13] ^= t_hi;
+	v[14] ^= last;
+
+	// Ten rounds: four column mixes, then four diagonal mixes, per round.
+	for s in &SIGMA {
+		ref_g(&mut v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+		ref_g(&mut v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+		ref_g(&mut v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+		ref_g(&mut v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+		ref_g(&mut v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+		ref_g(&mut v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+		ref_g(&mut v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+		ref_g(&mut v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+	}
+
+	// Fold the vector's two halves back into the chained state.
+	array::from_fn(|i| h[i] ^ v[i] ^ v[i + 8])
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_frontend::CircuitBuilder;
+	use hex_literal::hex;
+	use proptest::prelude::*;
+
+	use super::*;
+
+	// Circuit-level tests.
+
+	// Builds a circuit around the single-lane compression, populates the witness with the
+	// given values, and returns the evaluated 8-word output.
+	//
+	// Every input is fed in with an empty high half, satisfying the gadget's precondition.
+	fn run_compress(h: [u32; 8], m: [u32; 16], t_lo: u32, t_hi: u32, last: u32) -> [u32; 8] {
+		let builder = CircuitBuilder::new();
+		let h_wires: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let m_wires: [Wire; 16] = array::from_fn(|_| builder.add_witness());
+		let t_lo_w = builder.add_witness();
+		let t_hi_w = builder.add_witness();
+		let last_w = builder.add_witness();
+
+		// Wire the gadget under test, and pin its output to a public value the witness fills
+		// with the reference result: a disagreement then surfaces as a failure to populate.
+		let out = blake2s_compress(&builder, h_wires, m_wires, t_lo_w, t_hi_w, last_w);
+		let out_inout: [Wire; 8] = array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("out_match", out[i], out_inout[i]);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for i in 0..8 {
+			w[h_wires[i]] = Word(h[i] as u64);
+		}
+		for i in 0..16 {
+			w[m_wires[i]] = Word(m[i] as u64);
+		}
+		w[t_lo_w] = Word(t_lo as u64);
+		w[t_hi_w] = Word(t_hi as u64);
+		w[last_w] = Word(last as u64);
+
+		let expected = ref_compress(h, m, t_lo, t_hi, last);
+		for i in 0..8 {
+			w[out_inout[i]] = Word(expected[i] as u64);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+		array::from_fn(|i| w[out_inout[i]].0 as u32)
+	}
+
+	#[test]
+	fn rfc7693_appendix_b_trace_matches_spec() {
+		// Trace from RFC 7693 Appendix B: the unkeyed BLAKE2s-256 compression of "abc".
+		//
+		// A 3-byte message is one block.
+		//
+		// So the whole hash is a single compression, run from the parameter-mixed IV.
+		//
+		// This pins the compression against the specification text itself.
+		//
+		// It therefore holds even if the reference crate and this circuit were wrong
+		// together.
+
+		// h[0] carries the parameter block: unkeyed (key length 0), 32-byte digest.
+		let h: [u32; 8] = [
+			IV[0] ^ 0x0101_0020,
+			IV[1],
+			IV[2],
+			IV[3],
+			IV[4],
+			IV[5],
+			IV[6],
+			IV[7],
+		];
+		// "abc" packed little-endian into the first message word; the rest of the block is
+		// zero.
+		let mut m = [0u32; 16];
+		m[0] = 0x0063_6261;
+		// A single block carries the whole 3-byte length, and the finalization flag.
+		let (t_lo, t_hi, last) = (3u32, 0u32, 0xFFFF_FFFFu32);
+
+		let expected: [u32; 8] = [
+			0x8C5E_8C50,
+			0xE214_7C32,
+			0xA32B_A7E1,
+			0x2F45_EB4E,
+			0x208B_4537,
+			0x293A_D69E,
+			0x4C9B_994D,
+			0x8259_6786,
+		];
+		assert_eq!(ref_compress(h, m, t_lo, t_hi, last), expected);
+		assert_eq!(run_compress(h, m, t_lo, t_hi, last), expected);
+
+		// The published digest is these words read little-endian, byte for byte.
+		let digest_bytes: Vec<u8> = expected.iter().flat_map(|w| w.to_le_bytes()).collect();
+		assert_eq!(
+			digest_bytes,
+			hex!("508c5e8c327c14e2e1a72ba34eeb452f37458b209ed63a294d999b4c86675982")
+		);
+	}
+
+	// 2x SIMD tests.
+
+	fn pack2x(lo: u32, hi: u32) -> u64 {
+		(lo as u64) | ((hi as u64) << 32)
+	}
+
+	fn unpack2x(w: u64) -> (u32, u32) {
+		(w as u32, (w >> 32) as u32)
+	}
+
+	// Runs the two-lane compression with two independent per-lane inputs, and returns the two
+	// per-lane 8-word outputs.
+	fn run_compress_2x(
+		h: [[u32; 8]; 2],
+		m: [[u32; 16]; 2],
+		t_lo: [u32; 2],
+		t_hi: [u32; 2],
+		last: [u32; 2],
+	) -> [[u32; 8]; 2] {
+		let builder = CircuitBuilder::new();
+		let h_wires: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let m_wires: [Wire; 16] = array::from_fn(|_| builder.add_witness());
+		let t_lo_w = builder.add_witness();
+		let t_hi_w = builder.add_witness();
+		let last_w = builder.add_witness();
+
+		let out = blake2s_compress_2x(&builder, h_wires, m_wires, t_lo_w, t_hi_w, last_w);
+		let out_inout: [Wire; 8] = array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("out_match_2x", out[i], out_inout[i]);
+		}
+
+		// Pack each pair of per-lane values into its two-lane wire before populating.
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for i in 0..8 {
+			w[h_wires[i]] = Word(pack2x(h[0][i], h[1][i]));
+		}
+		for i in 0..16 {
+			w[m_wires[i]] = Word(pack2x(m[0][i], m[1][i]));
+		}
+		w[t_lo_w] = Word(pack2x(t_lo[0], t_lo[1]));
+		w[t_hi_w] = Word(pack2x(t_hi[0], t_hi[1]));
+		w[last_w] = Word(pack2x(last[0], last[1]));
+
+		let exp0 = ref_compress(h[0], m[0], t_lo[0], t_hi[0], last[0]);
+		let exp1 = ref_compress(h[1], m[1], t_lo[1], t_hi[1], last[1]);
+		for i in 0..8 {
+			w[out_inout[i]] = Word(pack2x(exp0[i], exp1[i]));
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		// Unpack the two lanes of the evaluated result back into separate per-lane arrays.
+		let mut actual = [[0u32; 8]; 2];
+		for i in 0..8 {
+			let (lo, hi) = unpack2x(w[out_inout[i]].0);
+			actual[0][i] = lo;
+			actual[1][i] = hi;
+		}
+		actual
+	}
+
+	#[test]
+	fn compress_2x_distinct_lanes() {
+		// Lane 0 reruns the RFC trace.
+		//
+		// Lane 1 runs a completely different chained-state and message-block pair.
+		//
+		// This confirms the lanes are independent: no bits cross the 32-bit boundary.
+		let h0: [u32; 8] = [
+			IV[0] ^ 0x0101_0020,
+			IV[1],
+			IV[2],
+			IV[3],
+			IV[4],
+			IV[5],
+			IV[6],
+			IV[7],
+		];
+		let mut m0 = [0u32; 16];
+		m0[0] = 0x0063_6261;
+
+		let h1: [u32; 8] = [
+			0xDEAD_BEEF,
+			0xCAFE_BABE,
+			0x1234_5678,
+			0x9ABC_DEF0,
+			0x0BAD_F00D,
+			0xFEED_FACE,
+			0x0123_4567,
+			0x89AB_CDEF,
+		];
+		let m1: [u32; 16] = array::from_fn(|i| (i as u32).wrapping_mul(0x0101_0101));
+
+		let actual = run_compress_2x([h0, h1], [m0, m1], [3, 64], [0, 0], [0xFFFF_FFFF, 0]);
+		assert_eq!(actual[0], ref_compress(h0, m0, 3, 0, 0xFFFF_FFFF));
+		assert_eq!(actual[1], ref_compress(h1, m1, 64, 0, 0));
+	}
+
+	#[test]
+	fn compress_2x_lane_independence() {
+		// Lane 0 is the RFC trace.
+		//
+		// Lane 1 is an all-zero block, compressed from the same parameter-mixed IV.
+		//
+		// Each lane must match its own reference.
+		//
+		// That proves the zero lane does not perturb the "abc" lane, and vice versa.
+		let h: [u32; 8] = [
+			IV[0] ^ 0x0101_0020,
+			IV[1],
+			IV[2],
+			IV[3],
+			IV[4],
+			IV[5],
+			IV[6],
+			IV[7],
+		];
+		let mut m = [0u32; 16];
+		m[0] = 0x0063_6261;
+		let actual =
+			run_compress_2x([h, h], [m, [0u32; 16]], [3, 0], [0, 0], [0xFFFF_FFFF, 0xFFFF_FFFF]);
+		assert_eq!(actual[0], ref_compress(h, m, 3, 0, 0xFFFF_FFFF));
+		assert_eq!(actual[1], ref_compress(h, [0u32; 16], 0, 0, 0xFFFF_FFFF));
+	}
+
+	// 2x sequential tests.
+
+	// Runs the sequential two-lane compression, and returns the second and first compression
+	// outputs, unpacked from the low and high lanes of the packed result.
+	#[allow(clippy::too_many_arguments)]
+	fn run_compress_2x_seq(
+		h: [u32; 8],
+		m1: [u32; 16],
+		m2: [u32; 16],
+		t_lo1: u32,
+		t_hi1: u32,
+		last1: u32,
+		t_lo2: u32,
+		t_hi2: u32,
+		last2: u32,
+	) -> ([u32; 8], [u32; 8]) {
+		let builder = CircuitBuilder::new();
+		let h_wires: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let m1_wires: [Wire; 16] = array::from_fn(|_| builder.add_witness());
+		let m2_wires: [Wire; 16] = array::from_fn(|_| builder.add_witness());
+		let t_lo1_w = builder.add_witness();
+		let t_hi1_w = builder.add_witness();
+		let last1_w = builder.add_witness();
+		let t_lo2_w = builder.add_witness();
+		let t_hi2_w = builder.add_witness();
+		let last2_w = builder.add_witness();
+
+		let out = blake2s_compress_2x_seq(
+			&builder,
+			h_wires,
+			[m1_wires, m2_wires],
+			[t_lo1_w, t_lo2_w],
+			[t_hi1_w, t_hi2_w],
+			[last1_w, last2_w],
+		);
+		let out_inout: [Wire; 8] = array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("out_match_2x_seq", out[i], out_inout[i]);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for i in 0..8 {
+			w[h_wires[i]] = Word(h[i] as u64);
+		}
+		for i in 0..16 {
+			w[m1_wires[i]] = Word(m1[i] as u64);
+			w[m2_wires[i]] = Word(m2[i] as u64);
+		}
+		w[t_lo1_w] = Word(t_lo1 as u64);
+		w[t_hi1_w] = Word(t_hi1 as u64);
+		w[last1_w] = Word(last1 as u64);
+		w[t_lo2_w] = Word(t_lo2 as u64);
+		w[t_hi2_w] = Word(t_hi2 as u64);
+		w[last2_w] = Word(last2 as u64);
+
+		// The expected result chains two plain compressions: the first compression's output
+		// becomes the second compression's input state.
+		let s1 = ref_compress(h, m1, t_lo1, t_hi1, last1);
+		let s2 = ref_compress(s1, m2, t_lo2, t_hi2, last2);
+		for i in 0..8 {
+			w[out_inout[i]] = Word(pack2x(s2[i], s1[i]));
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		let mut s2_out = [0u32; 8];
+		let mut s1_out = [0u32; 8];
+		for i in 0..8 {
+			let (lo, hi) = unpack2x(w[out_inout[i]].0);
+			s2_out[i] = lo;
+			s1_out[i] = hi;
+		}
+		(s2_out, s1_out)
+	}
+
+	#[test]
+	fn compress_2x_seq_chains_two_blocks() {
+		// A two-block message: the first block is not final, the second is.
+		let h: [u32; 8] = [
+			IV[0] ^ 0x0101_0020,
+			IV[1],
+			IV[2],
+			IV[3],
+			IV[4],
+			IV[5],
+			IV[6],
+			IV[7],
+		];
+		let m1 = [0u32; 16];
+		let m2: [u32; 16] = array::from_fn(|i| i as u32);
+		let (s2, s1) = run_compress_2x_seq(h, m1, m2, 64, 0, 0, 100, 0, 0xFFFF_FFFF);
+		let exp_s1 = ref_compress(h, m1, 64, 0, 0);
+		let exp_s2 = ref_compress(exp_s1, m2, 100, 0, 0xFFFF_FFFF);
+		assert_eq!(s1, exp_s1);
+		assert_eq!(s2, exp_s2);
+	}
+
+	#[test]
+	fn compress_2x_seq_distinct_params() {
+		// Invariant: the hinted first output is bound twice.
+		//
+		// Once as the second compression's input state.
+		//
+		// Once against the first compression's own in-circuit output.
+		//
+		// Fixture: a non-IV starting state and two unrelated blocks exercise the full lane
+		// packing.
+		let h: [u32; 8] = [
+			0xDEAD_BEEF,
+			0xCAFE_BABE,
+			0x1234_5678,
+			0x9ABC_DEF0,
+			0x0BAD_F00D,
+			0xFEED_FACE,
+			0x0123_4567,
+			0x89AB_CDEF,
+		];
+		let m1: [u32; 16] = array::from_fn(|i| (i as u32).wrapping_mul(0xDEAD_BEEF));
+		let m2: [u32; 16] = array::from_fn(|i| (i as u32).wrapping_mul(0x0101_0101));
+		let (s2, s1) = run_compress_2x_seq(h, m1, m2, 64, 0, 0, 40, 0, 0xFFFF_FFFF);
+		let exp_s1 = ref_compress(h, m1, 64, 0, 0);
+		let exp_s2 = ref_compress(exp_s1, m2, 40, 0, 0xFFFF_FFFF);
+		assert_eq!(s1, exp_s1);
+		assert_eq!(s2, exp_s2);
+	}
+
+	// Runs the two-lane compression's own gate path directly, over its flat packed-word
+	// interface, bypassing the chip machinery.
+	fn run_compress_2x_words(inputs: [u64; 27]) -> [u64; 8] {
+		let builder = CircuitBuilder::new();
+		let wires: [Wire; 27] = array::from_fn(|_| builder.add_witness());
+		let out = compress_2x_gates(
+			&builder,
+			array::from_fn(|i| wires[i]),
+			array::from_fn(|i| wires[8 + i]),
+			wires[24],
+			wires[25],
+			wires[26],
+		);
+		for wire in out {
+			builder.mark_inout(wire);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for (wire, word) in iter::zip(wires, inputs) {
+			w[wire] = Word(word);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		array::from_fn(|i| w[out[i]].as_u64())
+	}
+
+	// A 32-bit word, weighted towards the values that stress carry propagation.
+	//
+	// One case in four is drawn from the boundary set rather than uniformly.
+	//
+	// - Zero and one exercise the shortest carry chains.
+	// - All-ones makes every position carry.
+	// - The lone top bit and the all-ones-below-it value straddle the lane boundary.
+	fn word32() -> impl Strategy<Value = u32> {
+		prop_oneof![
+			3 => any::<u32>(),
+			1 => prop_oneof![Just(0), Just(1), Just(u32::MAX), Just(1 << 31), Just(u32::MAX >> 1)],
+		]
+	}
+
+	fn h8() -> impl Strategy<Value = [u32; 8]> {
+		prop::array::uniform8(word32())
+	}
+
+	fn block16() -> impl Strategy<Value = [u32; 16]> {
+		prop::array::uniform16(word32())
+	}
+
+	proptest! {
+		// Every case compiles and evaluates a whole compression circuit.
+		//
+		// So the sample stays small, and the boundary weighting above carries the coverage.
+		#![proptest_config(ProptestConfig::with_cases(16))]
+
+		#[test]
+		fn compress_matches_reference(
+			h in h8(), m in block16(), t_lo in any::<u32>(), t_hi in any::<u32>(), last in any::<u32>(),
+		) {
+			prop_assert_eq!(run_compress(h, m, t_lo, t_hi, last), ref_compress(h, m, t_lo, t_hi, last));
+		}
+
+		#[test]
+		fn compress_2x_lanes_are_independent(
+			h0 in h8(), h1 in h8(), m0 in block16(), m1 in block16(),
+			t0 in any::<u32>(), t1 in any::<u32>(), l0 in any::<u32>(), l1 in any::<u32>(),
+		) {
+			// Invariant: the two lanes share one core, but must not leak into each other.
+			//
+			// Every parameter differs per lane, so any carry or rotate crossing bit 32 shows
+			// up.
+			let actual = run_compress_2x([h0, h1], [m0, m1], [t0, t1], [0, 0], [l0, l1]);
+			prop_assert_eq!(actual[0], ref_compress(h0, m0, t0, 0, l0));
+			prop_assert_eq!(actual[1], ref_compress(h1, m1, t1, 0, l1));
+		}
+
+		#[test]
+		fn compress_2x_hint_matches_its_gates(words in prop::collection::vec(any::<u64>(), 27)) {
+			// Invariant: the chip's off-circuit computation and its in-circuit gate path
+			// must agree on every word a circuit can reach them with.
+			//
+			// A random 64-bit word is a valid lane pair here, so this covers the whole
+			// interface.
+			let inputs: [u64; 27] = array::from_fn(|i| words[i]);
+
+			let mut hinted = [Word::ZERO; 8];
+			Blake2sCompress2x.execute(&[], &inputs.map(Word), &mut hinted);
+
+			prop_assert_eq!(hinted.map(|word| word.as_u64()), run_compress_2x_words(inputs));
+		}
+
+		#[test]
+		fn compress_2x_seq_matches_two_chained_references(
+			h in h8(), m1 in block16(), m2 in block16(),
+			t1 in any::<u32>(), l1 in any::<u32>(), t2 in any::<u32>(), l2 in any::<u32>(),
+		) {
+			// Invariant: the two lanes run one after the other, not side by side.
+			//
+			// The second compression's input state is the first one's output.
+			//
+			//     h --block 1--> S1 --block 2--> S2
+			//
+			// The first output arrives through a hint, so this is what pins that hint honest.
+			let (s2, s1) = run_compress_2x_seq(h, m1, m2, t1, 0, l1, t2, 0, l2);
+			let exp_s1 = ref_compress(h, m1, t1, 0, l1);
+			prop_assert_eq!(s1, exp_s1);
+			prop_assert_eq!(s2, ref_compress(exp_s1, m2, t2, 0, l2));
+		}
+	}
+}

--- a/crates/circuits/src/blake2s/mod.rs
+++ b/crates/circuits/src/blake2s/mod.rs
@@ -1,295 +1,120 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-//! Blake2s hash function circuit implementation
+//! BLAKE2s hash function circuit.
 //!
-//! Blake2s is a cryptographic hash function optimized for 32-bit platforms,
-//! producing digests from 1 to 32 bytes. This implementation follows RFC 7693
-//! and supports variable-length messages with unkeyed hashing.
+//! BLAKE2s is a cryptographic hash function optimized for 32-bit platforms.
 //!
-//! ## RFC 7693 Compliance
+//! It produces digests from 1 to 32 bytes.
 //!
-//! This implementation is fully compliant with RFC 7693 for the core Blake2s-256
-//! hash function. It correctly implements the compression function, G mixing
-//! function, and message scheduling as specified.
+//! This implementation follows RFC 7693.
 //!
-//! ## Excluded Features
+//! It supports fixed-length messages with unkeyed hashing.
 //!
-//! This circuit implementation intentionally excludes the following optional
-//! features from RFC 7693:
+//! ## RFC 7693 compliance
 //!
-//! - **Keyed hashing (MAC mode)**: Not supported. Use for hash verification only.
-//! - **Salt parameter**: The 8-byte salt field is not implemented.
-//! - **Personalization parameter**: The 8-byte personalization field is not implemented.
-//! - **Tree hashing mode**: Only sequential mode is supported.
-//! - **Variable input length**: Message length is specified at instantiation time.
-//! - **Variable output length**: Fixed at 256 bits (32 bytes).
-//! - **Message size limitation**: Messages are limited to < 4GiB (2^32 bytes) as the high counter
-//!   word (t_hi) is always zero. This is sufficient for most ZK circuit applications.
+//! This implementation is fully compliant with RFC 7693 for the core BLAKE2s-256 hash function.
 //!
-//! These exclusions are appropriate for a ZK circuit focused on hash verification
-//! rather than general-purpose hashing.
+//! The compression function, the G mixing function, and the message scheduling all match the
+//! specification.
 //!
-//! # Algorithm Overview
+//! ## Excluded features
 //!
-//! Blake2s processes messages in 512-bit (64-byte) blocks using a compression
-//! function based on a modified ChaCha cipher. Each block undergoes 10 rounds
-//! of mixing operations, where each round applies 8 G-function calls that
-//! mix the internal state with message words.
+//! This circuit intentionally excludes the following optional features from RFC 7693:
 //!
-//! # Circuit Design
+//! - Keyed hashing, also called MAC mode: only unkeyed hash verification is supported.
+//! - The 8-byte salt field.
+//! - The 8-byte personalization field.
+//! - Tree hashing mode: only sequential mode is supported.
+//! - Runtime-variable message length: the length is fixed at circuit construction time instead.
+//! - Variable output length: the digest is fixed at 256 bits.
+//! - Messages of 4 GiB or more.
 //!
-//! This circuit verifies that a given message produces a specific Blake2s digest.
+//! The high half of the byte counter is always the zero constant, which caps the supported
+//! message length at just under 4 GiB.
+//!
+//! These exclusions suit a circuit whose job is hash verification, rather than
+//! general-purpose hashing.
+//!
+//! # Algorithm overview
+//!
+//! BLAKE2s processes a message in 64-byte blocks.
+//!
+//! Each block goes through a compression function built from a modified ChaCha cipher core.
+//!
+//! A compression runs ten mixing rounds, and each round mixes the internal state with the
+//! message block through eight calls to the G mixing function.
+//!
+//! # Circuit design
+//!
+//! This circuit verifies that a message of a fixed, compile-time-known length produces a
+//! specific BLAKE2s digest.
+//!
+//! Blocks chain sequentially: each one's input state is the previous one's output.
+//!
+//! So consecutive blocks are compressed two at a time, packing both compressions into the two
+//! 32-bit lanes of one parallel core.
+//!
+//! A trailing block with no partner runs through the same paired core with its second lane
+//! left dead, except when the whole message is a single block, which stays fully single-lane.
 
+mod compress;
 mod constants;
 #[cfg(test)]
 mod tests;
 
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-use constants::{IV, SIGMA};
+pub use compress::{
+	Blake2sCompress2x, blake2s_compress, blake2s_compress_2x, blake2s_compress_2x_seq, ref_compress,
+};
+use constants::IV;
 
 use crate::util::clear_high_bits;
 
-/// Blake2s G mixing function - the core cryptographic primitive.
-///
-/// The G function is the heart of Blake2s, providing confusion and diffusion
-/// through a series of additions, XORs, and rotations. It operates on four
-/// 32-bit state words (a, b, c, d) and two message words (x, y), mixing them
-/// together in a way that ensures every bit of input affects every bit of output.
-///
-/// # Algorithm (RFC 7693 Section 3.1)
-///
-/// The function performs 8 operations in 4 stages:
-/// 1. Mix a with b and first message word x, then rotate d
-/// 2. Mix c with the rotated d, then rotate b
-/// 3. Mix a with b and second message word y, then rotate d again
-/// 4. Mix c with the rotated d, then rotate b again
-///
-/// The rotation amounts (16, 12, 8, 7) are carefully chosen to provide
-/// good diffusion properties on 32-bit architectures.
-///
-/// # Constraint Cost
-/// - 4x 32-bit additions (iadd_32): 8 AND constraints
-/// - 4x 32-bit rotations (rotr_32): 4 AND constraints
-/// - 4x XOR operations (bxor): FREE (0 constraints)
-/// - **Total: 12 AND constraints per G-function call**
-///
-/// Since we call G 8 times per round and have 10 rounds, the total
-/// cost for all G operations is 8 × 10 × 12 = 960 AND constraints.
-pub fn g_function(
-	builder: &mut CircuitBuilder,
-	mut a: Wire,
-	mut b: Wire,
-	mut c: Wire,
-	mut d: Wire,
-	x: Wire,
-	y: Wire,
-) -> (Wire, Wire, Wire, Wire) {
-	// ---- Stage 1: First message word mixing
-	// a := a + b + x
-	// d := (d ⊕ a) >>> 16
-	a = builder.iadd_32(a, b);
-	a = builder.iadd_32(a, x);
-	d = builder.bxor(d, a); // XOR is free
-	d = builder.rotr32(d, 16);
-
-	// ---- Stage 2: First diagonal mixing
-	// c := c + d
-	// b := (b ⊕ c) >>> 12
-	c = builder.iadd_32(c, d);
-	b = builder.bxor(b, c); // XOR is free
-	b = builder.rotr32(b, 12);
-
-	// ---- Stage 3: Second message word mixing
-	// a := a + b + y
-	// d := (d ⊕ a) >>> 8
-	a = builder.iadd_32(a, b);
-	a = builder.iadd_32(a, y);
-	d = builder.bxor(d, a); // XOR is free
-	d = builder.rotr32(d, 8);
-
-	// ---- Stage 4: Second diagonal mixing
-	// c := c + d
-	// b := (b ⊕ c) >>> 7
-	c = builder.iadd_32(c, d);
-	b = builder.bxor(b, c); // XOR is free
-	b = builder.rotr32(b, 7);
-
-	(a, b, c, d)
+/// One message block's padded words, plus the counter and flag values its compression needs.
+struct BlockInput {
+	/// The 16-word padded message block, one 32-bit value per wire.
+	m: [Wire; 16],
+	/// The low 32 bits of the byte counter after absorbing this block.
+	t_lo: Wire,
+	/// The finalization flag: all-ones if this is the final block, zero otherwise.
+	last: Wire,
 }
 
-/// Blake2s compression function circuit.
+/// BLAKE2s hash function circuit for a fixed-length message.
 ///
-/// This implements the core compression function F that processes a single
-/// 64-byte message block and updates the internal hash state. The function
-/// takes the current hash state, message block, byte counter, and finalization
-/// flag as inputs.
+/// This struct is a complete circuit that verifies a message of a fixed, compile-time-known
+/// length produces a specific 256-bit digest.
 ///
-/// # Algorithm (RFC 7693 Section 3.2)
-///
-/// 1. **Initialize working vector**: Combine hash state h with IV constants
-/// 2. **Mix counter and flags**: XOR the counter t and finalization flag f into v[12..15]
-/// 3. **Apply rounds**: Perform 10 rounds of mixing using the G function
-/// 4. **Finalize**: XOR the working vector halves back into the hash state
-///
-/// # Circuit Design Notes
-///
-/// - All operations are performed on 32-bit words using Binius64 constraints
-/// - The counter `t` tracks total bytes processed (including current block)
-/// - The `last` flag indicates if this is the final block (sets f=-1)
-/// - Message padding is handled externally before calling this function
-///
-/// # Constraint Cost Analysis
-///
-/// - G function calls: 8 × 10 × 12 = 960 AND constraints
-/// - Counter operations: 2 AND constraints (for lo/hi counter mixing)
-/// - State finalization: 16 XOR operations (FREE)
-/// - **Total per compression: ~962 AND constraints**
-pub fn blake2s_compress(
-	builder: &mut CircuitBuilder,
-	h: &[Wire; 8],  // Current hash state
-	m: &[Wire; 16], // Message block (16 × 32-bit words = 64 bytes)
-	t_lo: Wire,     // Low 32 bits of byte counter
-	t_hi: Wire,     // High 32 bits of byte counter
-	last: Wire,     // Finalization flag (0 or 0xFFFFFFFF)
-) -> [Wire; 8] {
-	// Initialize working vector v[0..15]
-	let mut v = [builder.add_constant(Word(0)); 16];
-
-	// First half from state: v[0..7] = h[0..7]
-	v[0..8].copy_from_slice(h);
-
-	// Second half from IV: v[8..15] = IV[0..7]
-	for i in 0..8 {
-		v[8 + i] = builder.add_constant(Word(IV[i] as u64));
-	}
-
-	// Mix in the counter and finalization flag
-	// v[12] ^= t_lo (low 32 bits of byte counter)
-	// v[13] ^= t_hi (high 32 bits of byte counter)
-	// v[14] ^= f0 (first finalization word, always 0xFFFFFFFF if last block)
-	// v[15] ^= f1 (second finalization word, always 0 for Blake2s)
-	v[12] = builder.bxor(v[12], t_lo);
-	v[13] = builder.bxor(v[13], t_hi);
-	v[14] = builder.bxor(v[14], last); // last is 0xFFFFFFFF if final block
-
-	// 10 rounds of G function mixing
-	for round in 0..10 {
-		// Column step: Apply G to columns (indices 0,4,8,12), (1,5,9,13), etc.
-		let (v0, v4, v8, v12) =
-			g_function(builder, v[0], v[4], v[8], v[12], m[SIGMA[round][0]], m[SIGMA[round][1]]);
-		v[0] = v0;
-		v[4] = v4;
-		v[8] = v8;
-		v[12] = v12;
-
-		let (v1, v5, v9, v13) =
-			g_function(builder, v[1], v[5], v[9], v[13], m[SIGMA[round][2]], m[SIGMA[round][3]]);
-		v[1] = v1;
-		v[5] = v5;
-		v[9] = v9;
-		v[13] = v13;
-
-		let (v2, v6, v10, v14) =
-			g_function(builder, v[2], v[6], v[10], v[14], m[SIGMA[round][4]], m[SIGMA[round][5]]);
-		v[2] = v2;
-		v[6] = v6;
-		v[10] = v10;
-		v[14] = v14;
-
-		let (v3, v7, v11, v15) =
-			g_function(builder, v[3], v[7], v[11], v[15], m[SIGMA[round][6]], m[SIGMA[round][7]]);
-		v[3] = v3;
-		v[7] = v7;
-		v[11] = v11;
-		v[15] = v15;
-
-		// Diagonal step: Apply G to diagonals
-		let (v0, v5, v10, v15) =
-			g_function(builder, v[0], v[5], v[10], v[15], m[SIGMA[round][8]], m[SIGMA[round][9]]);
-		v[0] = v0;
-		v[5] = v5;
-		v[10] = v10;
-		v[15] = v15;
-
-		let (v1, v6, v11, v12) =
-			g_function(builder, v[1], v[6], v[11], v[12], m[SIGMA[round][10]], m[SIGMA[round][11]]);
-		v[1] = v1;
-		v[6] = v6;
-		v[11] = v11;
-		v[12] = v12;
-
-		let (v2, v7, v8, v13) =
-			g_function(builder, v[2], v[7], v[8], v[13], m[SIGMA[round][12]], m[SIGMA[round][13]]);
-		v[2] = v2;
-		v[7] = v7;
-		v[8] = v8;
-		v[13] = v13;
-
-		let (v3, v4, v9, v14) =
-			g_function(builder, v[3], v[4], v[9], v[14], m[SIGMA[round][14]], m[SIGMA[round][15]]);
-		v[3] = v3;
-		v[4] = v4;
-		v[9] = v9;
-		v[14] = v14;
-	}
-
-	// Finalization: h' = h ^ v[0..7] ^ v[8..15]
-	let mut h_new = [builder.add_constant(Word(0)); 8];
-	for i in 0..8 {
-		h_new[i] = builder.bxor(h[i], v[i]);
-		h_new[i] = builder.bxor(h_new[i], v[8 + i]);
-	}
-
-	h_new
-}
-
-/// Blake2s hash function circuit for variable-length messages.
-///
-/// This struct represents a complete Blake2s circuit that can verify
-/// that a message of predefined `length` produces a specific 256-bit digest.
-/// The circuit handles message padding and block processing according to RFC 7693.
-///
-/// # Circuit Structure
-///
-/// 1. **Message Input**: Fixed length byte array little-endian packed into 64-bit words.
-/// 4. **Output**: 256-bit digest (8 × 32-bit words)
-///
-/// # Design Decisions
-///
-/// - Pads messages to 64-byte blocks as per Blake2s specification
-/// - Optimized for messages up to a few hundred bytes
+/// The message bytes are packed little-endian into 64-bit words.
 pub struct Blake2s {
-	/// Message size in bytes this circuit supports
+	/// Message size in bytes this circuit supports.
 	pub length: usize,
-	/// Witness wires for the input message (encoded into little-endian 64-bit words)
+	/// Witness wires for the input message, packed little-endian into 64-bit words.
 	pub message: Vec<Wire>,
-	/// Witness wires for the expected 256-bit digest (8 × 32-bit words)
+	/// Witness wires for the expected 256-bit digest, as 8 32-bit words.
 	pub digest: [Wire; 8],
 }
 
 impl Blake2s {
-	/// Create a new Blake2s circuit with witness variables.
+	/// Creates a new BLAKE2s circuit with witness variables.
 	///
-	/// This creates a circuit that can verify messages up to `max_bytes` in length.
-	/// The actual message length is provided as a witness value at proving time.
+	/// The message length is fixed at circuit construction time, so it shapes the circuit
+	/// rather than being a witness value itself.
 	///
 	/// # Arguments
-	///
-	/// * `builder` - Circuit builder to add constraints to
-	/// * `length` - Fixed message size (in bytes) this circuit will support
+	/// * `builder` - Circuit builder to add constraints to.
+	/// * `length` - The exact message size, in bytes, this circuit will verify.
 	///
 	/// # Returns
-	///
-	/// A Blake2s struct with witness wires for message, length, and digest
+	/// A struct holding the witness wires for the message and the expected digest.
 	pub fn new_witness(builder: &mut CircuitBuilder, length: usize) -> Self {
-		// Create witness wires
+		// One witness wire per 8 bytes of the message.
 		let message: Vec<Wire> = (0..length.div_ceil(8))
 			.map(|_| builder.add_witness())
 			.collect();
 		let digest = std::array::from_fn(|_| builder.add_witness());
 
-		// Build the circuit
 		Self::build_circuit(builder, length, &message, digest);
 
 		Self {
@@ -299,27 +124,19 @@ impl Blake2s {
 		}
 	}
 
-	/// Build the Blake2s circuit constraints.
-	///
-	/// This constructs the circuit that verifies a variable-length message
-	/// produces the expected Blake2s digest. The circuit handles:
-	///
-	/// 1. Message padding to 64-byte blocks
-	/// 2. Conditional processing based on actual message length
-	/// 3. Proper counter management for multi-block messages
-	/// 4. Final block detection and processing
+	/// Builds the constraints that verify the message hashes to the expected digest.
 	fn build_circuit(
 		builder: &mut CircuitBuilder,
 		length: usize,
 		message: &[Wire],
 		expected_digest: [Wire; 8],
 	) {
-		// Calculate number of blocks needed for this length
+		// A message that exactly fills whole blocks still needs at least one block.
 		let num_blocks = length.div_ceil(64).max(1);
 		let zero = builder.add_constant(Word(0));
 
-		// Initialize hash state with Blake2s-256 parameters
-		// h[0] = IV[0] ^ 0x01010020 (param block: digest_length=32, fanout=1, depth=1)
+		// The BLAKE2s-256 parameter block folds into the first IV word: unkeyed (key length
+		// zero), 32-byte digest, sequential mode (fanout 1, depth 1).
 		let init_state = [
 			builder.add_constant_64((IV[0] ^ 0x01010020) as u64),
 			builder.add_constant_64(IV[1] as u64),
@@ -331,87 +148,164 @@ impl Blake2s {
 			builder.add_constant_64(IV[7] as u64),
 		];
 
-		// The final digest
-		let mut final_digest = [zero; 8];
+		// Every block's padded message words and counter/flag values, computed up front.
+		//
+		// That lets the compression chain below pair consecutive blocks without interleaving
+		// padding logic.
+		let blocks: Vec<BlockInput> = (0..num_blocks)
+			.map(|block_idx| Self::block_input(builder, message, length, block_idx, zero))
+			.collect();
 
-		// Process each block and accumulate the correct digest
+		// Consecutive blocks chain: each one's input state is the previous one's output.
+		//
+		// So a pair of blocks is compressed through one parallel core, at roughly half the AND
+		// cost of two single-lane compressions.
+		//
+		// The threaded state carries the pair's first compression in its high half.
+		//
+		// That half is left as it is, rather than masked off, since nothing downstream reads it
+		// before the final digest:
+		//
+		// - A compression never lets a carry or a rotate cross bit 32, so the halves stay apart.
+		// - The paired core takes an input state's low half only, through a left shift.
+		//
+		// So the low half of a result depends on the low halves of its inputs alone.
 		let mut h = init_state;
-
-		// Process each block - all blocks are processed but with appropriate padding
-		for block_idx in 0..num_blocks {
-			// Prepare message block with proper padding
-			let mut m = [builder.add_constant(Word(0)); 16];
-
-			// Fill message words from input qwords
-			for word_idx in 0..16 {
-				let message_qword = *message.get(block_idx << 3 | word_idx >> 1).unwrap_or(&zero);
-
-				// Select low or high dword from the qword
-				let message_dword = if word_idx % 2 == 0 {
-					clear_high_bits(builder, message_qword, 32)
-				} else {
-					builder.shr(message_qword, 32)
-				};
-
-				// Process padding for the last dword, if needed.
-				let first_byte_offset = block_idx * 64 + word_idx * 4;
-				let padded_message_dword = if first_byte_offset + 4 > length {
-					if first_byte_offset < length {
-						let nonzero_bytes = (length - first_byte_offset) as u32;
-						builder.band(
-							message_dword,
-							builder.add_constant(Word::ALL_ONE >> (64 - nonzero_bytes * 8)),
-						)
-					} else {
-						zero
-					}
-				} else {
-					message_dword
-				};
-
-				m[word_idx] = padded_message_dword;
-			}
-
-			// Determine if this block is in the valid range and if it's the final block
-			let block_start = (block_idx * 64) as u64;
-			let block_end = block_start + 64;
-			let is_final_block =
-				(block_idx == 0 || block_start < length as u64) && length as u64 <= block_end;
-
-			// t_lo is block end (length for the last block)
-			let t_lo = builder.add_constant_64(if is_final_block {
-				length as u64
+		let mut block_idx = 0;
+		while block_idx + 1 < num_blocks {
+			let sub =
+				builder.subcircuit(format!("blake2s_compress[{block_idx}..{}]", block_idx + 2));
+			let a = &blocks[block_idx];
+			let b = &blocks[block_idx + 1];
+			h = blake2s_compress_2x_seq(
+				&sub,
+				h,
+				[a.m, b.m],
+				[a.t_lo, b.t_lo],
+				[zero, zero],
+				[a.last, b.last],
+			);
+			block_idx += 2;
+		}
+		if block_idx < num_blocks {
+			let sub = builder.subcircuit(format!("blake2s_compress[{block_idx}]"));
+			let b = &blocks[block_idx];
+			h = if block_idx > 0 {
+				// The trailing odd block has no partner.
+				//
+				// It still runs through the paired core with its second lane dead, so a
+				// registered chip serves every compression uniformly.
+				//
+				// In gates the two cores emit the same circuit, so nothing changes without a
+				// chip.
+				blake2s_compress_2x(&sub, h, b.m, b.t_lo, zero, b.last)
 			} else {
-				block_end
-			});
-			// t_hi is always zero (see message size limitation in module documentation)
-			let t_hi = zero;
-
-			// Finalization flag: use select for conditional flag
-			let flag_value = builder.add_constant(Word(0xFFFFFFFF));
-			let last_flag = if is_final_block { flag_value } else { zero };
-
-			// Process the block
-			h = blake2s_compress(builder, &h, &m, t_lo, t_hi, last_flag);
-
-			// Assign this state into final digest if it's the final block
-			if is_final_block {
-				final_digest.copy_from_slice(&h);
-			}
+				// A single-block message keeps the single-lane core.
+				//
+				// Its empty high halves are what lets the digest skip the clearing below.
+				blake2s_compress(&sub, h, b.m, b.t_lo, zero, b.last)
+			};
 		}
 
-		// Assert that accumulated digest matches expected
+		// The escaping digest is the one place a clean high half is required.
+		//
+		// So clear it once here, rather than after every pair.
+		//
+		// A single-block message never enters the paired core, so its one-lane result already
+		// has an empty high half and needs no clearing.
+		let final_digest: [Wire; 8] = if num_blocks < 2 {
+			h
+		} else {
+			std::array::from_fn(|i| clear_high_bits(builder, h[i], 32))
+		};
+
 		for i in 0..8 {
 			builder.assert_eq("digest_match", final_digest[i], expected_digest[i]);
 		}
 	}
 
-	/// Populate the message witness data.
+	/// Builds one block's padded message words, and its counter and finalization-flag values.
+	///
+	/// The high half of the byte counter is not part of the returned value.
+	///
+	/// It is always the zero constant, per this module's 4 GiB message-size limit, so every
+	/// caller shares one wire for it.
+	fn block_input(
+		builder: &CircuitBuilder,
+		message: &[Wire],
+		length: usize,
+		block_idx: usize,
+		zero: Wire,
+	) -> BlockInput {
+		let mut m = [zero; 16];
+
+		for word_idx in 0..16 {
+			// The message is packed 8 bytes per wire, so two consecutive 32-bit words share
+			// one 64-bit wire.
+			let message_qword = *message.get(block_idx << 3 | word_idx >> 1).unwrap_or(&zero);
+
+			// Take the low or the high 32 bits of that wire, depending on which of the pair
+			// this word is.
+			let message_dword = if word_idx % 2 == 0 {
+				clear_high_bits(builder, message_qword, 32)
+			} else {
+				builder.shr(message_qword, 32)
+			};
+
+			// Mask off any bytes past the message's true length.
+			//
+			// A word entirely past the end becomes the zero constant.
+			//
+			// A word straddling the end keeps only its valid leading bytes.
+			let first_byte_offset = block_idx * 64 + word_idx * 4;
+			let padded_message_dword = if first_byte_offset + 4 > length {
+				if first_byte_offset < length {
+					let nonzero_bytes = (length - first_byte_offset) as u32;
+					builder.band(
+						message_dword,
+						builder.add_constant(Word::ALL_ONE >> (64 - nonzero_bytes * 8)),
+					)
+				} else {
+					zero
+				}
+			} else {
+				message_dword
+			};
+
+			m[word_idx] = padded_message_dword;
+		}
+
+		// The final block is the one whose byte range contains the message's true length.
+		//
+		// Block 0 always counts as in range, so a zero-length message still has one block.
+		let block_start = (block_idx * 64) as u64;
+		let block_end = block_start + 64;
+		let is_final_block =
+			(block_idx == 0 || block_start < length as u64) && length as u64 <= block_end;
+
+		// The byte counter after this block is the block's end offset, except on the final
+		// block, where it is the message's true length instead.
+		let t_lo = builder.add_constant_64(if is_final_block {
+			length as u64
+		} else {
+			block_end
+		});
+
+		// The finalization flag is all-ones on the final block, and zero otherwise.
+		let flag_value = builder.add_constant(Word(0xFFFFFFFF));
+		let last = if is_final_block { flag_value } else { zero };
+
+		BlockInput { m, t_lo, last }
+	}
+
+	/// Populates the message witness wires.
 	///
 	/// # Arguments
+	/// * `witness` - Witness filler to populate.
+	/// * `message` - The message bytes to hash.
 	///
-	/// * `witness` - Witness filler to populate
-	/// * `message` - The message bytes to hash
+	/// # Panics
+	/// * If `message.len()` does not equal the circuit's fixed message length.
 	pub fn populate_message(&self, witness: &mut WitnessFiller, message: &[u8]) {
 		assert!(
 			message.len() == self.length,
@@ -420,7 +314,6 @@ impl Blake2s {
 			message.len(),
 		);
 
-		// Set message bytes
 		for (i, bytes) in message.chunks(8).enumerate() {
 			let mut le_bytes = [0; 8];
 			le_bytes[..bytes.len()].copy_from_slice(bytes);
@@ -428,14 +321,12 @@ impl Blake2s {
 		}
 	}
 
-	/// Populate the expected digest witness data.
+	/// Populates the expected-digest witness wires.
 	///
 	/// # Arguments
-	///
-	/// * `witness` - Witness filler to populate
-	/// * `digest` - The expected 32-byte Blake2s digest
+	/// * `witness` - Witness filler to populate.
+	/// * `digest` - The expected 32-byte BLAKE2s digest.
 	pub fn populate_digest(&self, witness: &mut WitnessFiller, digest: &[u8; 32]) {
-		// Convert digest bytes to 8 × 32-bit words (little-endian)
 		for i in 0..8 {
 			let word_bytes = &digest[i * 4..(i + 1) * 4];
 			let word = u32::from_le_bytes(word_bytes.try_into().unwrap());

--- a/crates/circuits/src/blake2s/tests.rs
+++ b/crates/circuits/src/blake2s/tests.rs
@@ -1,11 +1,13 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
+use binius_core::word::Word;
 use binius_frontend::CircuitBuilder;
 use blake2::{Blake2s256, Digest};
 use rand::prelude::*;
 use rstest::rstest;
 
-use super::Blake2s;
+use super::{Blake2s, Blake2sCompress2x};
 
 #[rstest]
 #[case(0, 1)] // Empty message - edge case
@@ -53,4 +55,114 @@ fn test_blake2s_circuit(#[case] message_len_bytes: usize, #[case] max_message_le
 	let cs = circuit.constraint_system();
 	cs.verify(&witness.into_value_vec())
 		.expect("All constraints should be satisfied");
+}
+
+// Builds and checks a fixed-length BLAKE2s circuit for `message`, against the reference crate.
+//
+// Shared by the block-boundary sweep below, which needs message lengths beyond what a single
+// `#[case]` list conveniently expresses: every block count from one block up through several
+// pairs, in both parities.
+fn check(message: &[u8]) {
+	let expected: [u8; 32] = Blake2s256::digest(message).into();
+
+	let mut builder = CircuitBuilder::new();
+	let blake2s = Blake2s::new_witness(&mut builder, message.len());
+	let circuit = builder.build();
+
+	let mut witness = circuit.new_witness_filler();
+	blake2s.populate_message(&mut witness, message);
+	blake2s.populate_digest(&mut witness, &expected);
+
+	circuit
+		.populate_wire_witness(&mut witness)
+		.unwrap_or_else(|e| panic!("Blake2s digest disagreed for len={}: {e:?}", message.len()));
+	let cs = circuit.constraint_system();
+	cs.verify(&witness.into_value_vec()).unwrap();
+}
+
+#[test]
+fn block_boundaries() {
+	// Lengths chosen to cover 1 through 6 blocks, both parities, and the byte immediately
+	// either side of each block boundary.
+	//
+	// That sweep exercises every shape of the compression chain:
+	//
+	//     1 block     : the single-lane path, no pairing at all
+	//     2, 4 blocks : whole pairs, no trailing block
+	//     3, 5 blocks : whole pairs plus a trailing block through the dead-lane path
+	for &len in &[
+		0usize, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 257, 319, 320, 321,
+	] {
+		let message: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+		check(&message);
+	}
+}
+
+// Hashes `message` with the two-lane compression registered as a chip, and checks both the
+// digest and the resulting constraint system.
+//
+// The digest wires are populated with the reference digest, so a disagreement fails to
+// populate.
+//
+// What the chip adds is checked afterward: every compression the circuit makes has to be
+// served by a chip instance that recomputes the same words.
+fn check_with_compress_chip(message: &[u8]) {
+	let mut builder = CircuitBuilder::new();
+	builder.register_chip(Blake2sCompress2x, &[]);
+
+	let blake2s = Blake2s::new_witness(&mut builder, message.len());
+	let circuit = builder.build_m4();
+	circuit.validate().unwrap();
+	let cs = circuit.to_constraint_system();
+	cs.validate().unwrap();
+
+	let expected: [u8; 32] = Blake2s256::digest(message).into();
+
+	let witness = circuit
+		.generate_witness(|w| {
+			// Populate the message bytes, the same way the plain circuit does.
+			for (i, bytes) in message.chunks(8).enumerate() {
+				let mut le_bytes = [0u8; 8];
+				le_bytes[..bytes.len()].copy_from_slice(bytes);
+				w[blake2s.message[i]] = Word(u64::from_le_bytes(le_bytes));
+			}
+			// Populate the expected digest, the same way the plain circuit does.
+			for i in 0..8 {
+				let word = u32::from_le_bytes(expected[i * 4..(i + 1) * 4].try_into().unwrap());
+				w[blake2s.digest[i]] = Word(word as u64);
+			}
+		})
+		.unwrap_or_else(|e| panic!("Blake2s digest disagreed for len={}: {e:?}", message.len()));
+
+	witness.verify(&cs).unwrap();
+}
+
+// Every layer between the circuit's entry point and its two-lane compression is untouched by
+// the chip.
+//
+// Block pairs, and the trailing odd block riding the paired core with a dead lane, land as chip
+// calls because the builder holds the chip, not because anything in between was told to route
+// through it.
+//
+// Lengths cover one pair, a pair plus a trailing block, two pairs, and two pairs plus a
+// trailing block.
+#[test]
+fn a_registered_chip_serves_every_paired_compression() {
+	for &len in &[128usize, 192, 256, 300] {
+		let message: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+		check_with_compress_chip(&message);
+	}
+}
+
+// A single-block message compresses single-lane only, and never reaches the paired gadget.
+//
+// So its chip goes uncalled, and the constraint system that leaves cannot be populated.
+#[test]
+fn a_chip_no_paired_compression_reaches_leaves_an_uncalled_chip() {
+	let mut builder = CircuitBuilder::new();
+	builder.register_chip(Blake2sCompress2x, &[]);
+	Blake2s::new_witness(&mut builder, 4);
+
+	let error = builder.build_m4().validate().unwrap_err();
+	assert!(matches!(error, binius_frontend::CircuitM4Error::NeverCalled { .. }), "{error:?}");
 }

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -1,30 +1,30 @@
 blake2s circuit
 --
 Gates & Instructions
-├─ Number of gates: 18,568
-└─ Number of evaluation instructions: 18,568
+├─ Number of gates: 10,392
+└─ Number of evaluation instructions: 10,392
 
 Constraints
-├─ ZERO constraints: 3,460 used (84.5% of 2^12)
-│  [▓▓▓▓▓▓▓▓░░] spare: 636
-├─ AND constraints: 7,680 used (93.8% of 2^13)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 512
+├─ ZERO constraints: 2,069 used (50.5% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 2,027
+├─ AND constraints: 3,840 used (93.8% of 2^12)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 256
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 41,628
-   ├─ Distinct shifted value indices: 30,479
-   └─ Distinct unshifted value indices: 11,149
+└─ Distinct value indices: 21,375
+   ├─ Distinct shifted value indices: 15,462
+   └─ Distinct unshifted value indices: 5,913
 
 Value Vector
-├─ Public Section: 45 (not committed)
-│  ├─ Constants: 45
+├─ Public Section: 35 (not committed)
+│  ├─ Constants: 35
 │  └─ Inout: 0
-├─ Private Section: 11,268
+├─ Private Section: 6,037
 │  ├─ Witness: 136
-│  └─ Internal: 11,132
-├─ Committed Trace: 11,268 used (68.8% of 2^14)
-│  [▓▓▓▓▓▓░░░░] spare: 5,116
-└─ Scratch (uncommitted): 41 (peak live: 41)
+│  └─ Internal: 5,901
+├─ Committed Trace: 6,037 used (73.7% of 2^13)
+│  [▓▓▓▓▓▓▓░░░] spare: 2,155
+└─ Scratch (uncommitted): 132 (peak live: 132)
 


### PR DESCRIPTION
Closes [BINIUS-511](https://linear.app/jimpo/issue/BINIUS-511/pack-blake2s-block-compression-into-2-lanes-halving-its-and-count).

Packs two BLAKE2s block compressions into the two 32-bit lanes of one 64-bit-wide core, the same trick already applied to SHA-256 and BLAKE3.

### The problem

BLAKE2s ran single-lane on binius64's 32-bit-word gates.

Every gate here (a 32-bit add, a 32-bit rotate) costs the same 1 AND constraint whether it touches 32 bits or 64.

So a single-lane BLAKE2s compression was leaving half of every gate's width completely unused.

This is the exact same anomaly SHA-256 and BLAKE3 already had fixed, through a 2x-lane-packing trick that packs two block compressions into the two 32-bit halves of one 64-bit wire.

BLAKE2s just never got the same treatment.

### The idea

Two independent BLAKE2s compressions can run as the two 32-bit lanes of one parallel core, at the gate cost of a single compression, since every mixing gate already acts independently on each half of a 64-bit wire.

BLAKE2s blocks chain sequentially: each block's input state is the previous block's output.

So pairing two *sequential* blocks needs one more trick: the second block's input is the first block's not-yet-computed output, a circular dependency.

A hint breaks that circularity by computing the first block's output off-circuit, feeding it into the low lane, and constraining it two ways so it cannot lie:

- Its high half must equal the real input state.
- Its low half must equal what the first compression actually produces in-circuit.

This is the same hint-based construction already used for SHA-256 and BLAKE3's own sequential pairings.

### The change

Added a `compress.rs` module with three functions:

- The existing single-lane compression, unchanged in behavior.
- A two-independent-lanes compression, exposed as a chip so a registered circuit can batch every paired call.
- A two-sequential-lanes compression, using the hint described above.

Rewrote the block-processing loop to pair consecutive blocks through the sequential-lanes function, with a trailing odd block riding the same paired core with a dead second lane, and a single-block message staying fully single-lane.

The public API (building the circuit, and populating the message and digest witnesses) is unchanged.

### Per 1024-byte message

- **before:** 7,680 AND constraints, needing a 2^13 proving domain
- **after:** 3,840 AND constraints, needing a 2^12 proving domain

→ exactly halved, and the domain bucket now matches BLAKE3's.

### Soundness

The hint is untrusted: both halves of its output are re-derived and constrained in-circuit, so it can only ever be caught lying, never trusted blindly.

The two lanes never let a carry or a rotate cross the 32-bit boundary, since every gate here is either a 32-bit-parallel-halves gate or a bitwise one.

So packing two compressions into one wire changes nothing about what either one computes.

### Scope

- new: a compression module with the single-lane, two-independent-lane, and two-sequential-lane BLAKE2s primitives, each backed by a pure-Rust reference implementation
- changed: the block-processing loop, to pair blocks through the new sequential primitive
- changed: the blessed circuit-stat snapshot, to the new AND count
- left untouched: the public circuit-building API

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-circuits -p binius-examples --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- 17 tests: an RFC 7693 known-answer trace, lane-independence and sequential-chaining tests, three proptests (single compression vs. reference, the chip's hint vs. its own gates, two chained compressions vs. reference), a chip-registration pair, and a 17-length block-boundary sweep against the `blake2` reference crate — all passing

### Benchmark

| | AND constraints | Gates | Domain |
|---|---|---|---|
| Before | 7,680 | 18,568 | 2^13 |
| After | 3,840 | 10,392 | 2^12 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)