### PR TITLE
BINIUS-513: overlap Merkle leaf-hashing with the tail of the Reed-Solomon/NTT encode

### DIFF
--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{fmt, mem::MaybeUninit, slice};
+use std::{fmt, marker::PhantomData, mem::MaybeUninit, slice};
 
 use binius_compute::{Allocator, GlobalAllocator, VecLike};
 use binius_field::Field;
@@ -233,6 +233,113 @@ impl<N: ArraySize, A: Allocator> BinaryMerkleTree<Array<u8, N>, A> {
 			log_len,
 			inner_nodes,
 		}
+	}
+
+	/// Commits leaves written through a [`LeafRangeWriter`] instead of hashed from one
+	/// contiguous input all at once.
+	///
+	/// `populate` must write every leaf in `0..2^log_len` exactly once through the writer it is
+	/// handed, from any thread, in any order, before it returns.
+	/// That is what lets a caller start hashing an early leaf range while a later one is still
+	/// being produced, instead of waiting for all of it before hashing starts.
+	///
+	/// # Panics
+	///
+	/// Panics unless `log_len` is nonzero.
+	pub fn from_leaves_pipelined<F, H>(
+		log_len: usize,
+		n_items_per_input: usize,
+		alloc: &A,
+		populate: impl FnOnce(&LeafRangeWriter<'_, F, H>),
+	) -> Self
+	where
+		F: Field,
+		H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>,
+	{
+		assert!(log_len > 0, "a tree over a single leaf has no nodes to build");
+
+		let total_length = (1 << (log_len + 1)) - 1;
+		let mut inner_nodes = alloc.alloc::<Array<u8, N>>(total_length);
+
+		let (leaf_layer, remaining) = inner_nodes.spare_capacity_mut().split_at_mut(1 << log_len);
+
+		{
+			let _span = tracing::debug_span!("hash_leaves_pipelined").entered();
+			let writer = LeafRangeWriter {
+				leaves: SendPtr(leaf_layer.as_mut_ptr()),
+				n_items_per_input,
+				_marker: PhantomData,
+			};
+			populate(&writer);
+		}
+
+		let leaves: &[Array<u8, N>] = unsafe {
+			// SAFETY: `populate`'s contract guarantees every leaf was written before it returned.
+			leaf_layer.assume_init_ref()
+		};
+
+		let parallel_compression = H::ParCompression::default();
+		let ctx = BuildContext {
+			leaves,
+			log_len,
+			nodes: SendPtr(remaining.as_mut_ptr()),
+			compression: &parallel_compression,
+		};
+		ctx.build_node(0, log_len);
+
+		unsafe {
+			// SAFETY: the leaf layer is fully written by `populate`'s contract, and `build_node`
+			// just wrote every remaining node above it.
+			inner_nodes.set_len(total_length);
+		}
+		Self {
+			log_len,
+			inner_nodes,
+		}
+	}
+}
+
+/// Lets [`BinaryMerkleTree::from_leaves_pipelined`]'s caller write disjoint leaf ranges from any
+/// thread, in any order, instead of hashing the whole leaf layer from one contiguous input.
+///
+/// Every scalar range handed to [`Self::write_range`] must be disjoint from every other range
+/// written through the same writer.
+/// Together, the ranges must cover every leaf exactly once before the `populate` closure that
+/// received this writer returns — that return is the only signal
+/// [`BinaryMerkleTree::from_leaves_pipelined`] has that every leaf is ready to read.
+pub struct LeafRangeWriter<'a, F, H: HashSuite> {
+	leaves: SendPtr<MaybeUninit<Output<H::LeafHash>>>,
+	n_items_per_input: usize,
+	_marker: PhantomData<&'a [F]>,
+}
+
+impl<F: Field, H: HashSuite> LeafRangeWriter<'_, F, H> {
+	/// Hashes `scalars` into the leaves starting at `leaf_start`, `n_items_per_input` scalars
+	/// per leaf.
+	///
+	/// # Panics
+	///
+	/// Panics unless `scalars.len()` is a multiple of `n_items_per_input`.
+	pub fn write_range(&self, leaf_start: usize, scalars: &[F]) {
+		assert_eq!(
+			scalars.len() % self.n_items_per_input,
+			0,
+			"a leaf range must cover a whole number of leaves"
+		);
+		let n_leaves = scalars.len() / self.n_items_per_input;
+
+		let dst = unsafe {
+			// SAFETY: `Self`'s contract guarantees every range written through this writer is
+			// disjoint from every other one, so this range does not alias any other write.
+			slice::from_raw_parts_mut(self.leaves.0.add(leaf_start), n_leaves)
+		};
+		H::ParLeafHash::default().digest_with_const_len(
+			self.n_items_per_input,
+			scalars
+				.par_chunks(self.n_items_per_input)
+				.map(|chunk| chunk.iter().copied()),
+			dst,
+		);
 	}
 }
 

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -235,13 +235,16 @@ impl<N: ArraySize, A: Allocator> BinaryMerkleTree<Array<u8, N>, A> {
 		}
 	}
 
-	/// Commits leaves written through a [`LeafRangeWriter`] instead of hashed from one
-	/// contiguous input all at once.
+	/// Commits leaves written through a [`LeafRangeWriter`].
 	///
-	/// `populate` must write every leaf in `0..2^log_len` exactly once through the writer it is
-	/// handed, from any thread, in any order, before it returns.
-	/// That is what lets a caller start hashing an early leaf range while a later one is still
-	/// being produced, instead of waiting for all of it before hashing starts.
+	/// Unlike [`Self::from_leaves`], leaves don't come from one contiguous input all at once.
+	///
+	/// `populate` must write every leaf in `0..2^log_len` exactly once, through the writer.
+	/// It may write from any thread, in any order.
+	/// Every leaf must be written before `populate` returns.
+	///
+	/// That lets a caller start hashing an early leaf range while a later one is still produced.
+	/// Without this, hashing would have to wait for the whole leaf layer first.
 	///
 	/// # Panics
 	///
@@ -288,8 +291,8 @@ impl<N: ArraySize, A: Allocator> BinaryMerkleTree<Array<u8, N>, A> {
 		ctx.build_node(0, log_len);
 
 		unsafe {
-			// SAFETY: the leaf layer is fully written by `populate`'s contract, and `build_node`
-			// just wrote every remaining node above it.
+			// SAFETY: the leaf layer is fully written, by `populate`'s contract.
+			// `build_node` just wrote every remaining node above it.
 			inner_nodes.set_len(total_length);
 		}
 		Self {
@@ -299,14 +302,15 @@ impl<N: ArraySize, A: Allocator> BinaryMerkleTree<Array<u8, N>, A> {
 	}
 }
 
-/// Lets [`BinaryMerkleTree::from_leaves_pipelined`]'s caller write disjoint leaf ranges from any
-/// thread, in any order, instead of hashing the whole leaf layer from one contiguous input.
+/// Lets [`BinaryMerkleTree::from_leaves_pipelined`]'s caller write disjoint leaf ranges.
 ///
-/// Every scalar range handed to [`Self::write_range`] must be disjoint from every other range
-/// written through the same writer.
-/// Together, the ranges must cover every leaf exactly once before the `populate` closure that
-/// received this writer returns — that return is the only signal
-/// [`BinaryMerkleTree::from_leaves_pipelined`] has that every leaf is ready to read.
+/// A caller may write from any thread, in any order.
+/// That replaces hashing the whole leaf layer from one contiguous input.
+///
+/// Every range handed to [`Self::write_range`] must be disjoint from every other range.
+/// Together, the ranges must cover every leaf exactly once.
+/// That must happen before the `populate` closure holding this writer returns.
+/// That return is the only signal the tree builder has that every leaf is ready.
 pub struct LeafRangeWriter<'a, F, H: HashSuite> {
 	leaves: SendPtr<MaybeUninit<Output<H::LeafHash>>>,
 	n_items_per_input: usize,
@@ -316,19 +320,21 @@ pub struct LeafRangeWriter<'a, F, H: HashSuite> {
 impl<F: Field, H: HashSuite> LeafRangeWriter<'_, F, H> {
 	/// Hashes `leaves` into the tree's leaf layer starting at `leaf_start`.
 	///
-	/// `leaves` yields one iterator per leaf, each yielding exactly
-	/// [`n_items_per_input`](Self::write_range) scalars — the same shape
-	/// [`BinaryMerkleTree::from_leaves`] itself consumes, so a caller can hand this a zero-copy
-	/// view over packed data (e.g. `binius_math::FieldSlice::par_chunk_scalars`) instead of
-	/// first flattening it into an owned buffer.
+	/// `leaves` yields one iterator per leaf, each yielding exactly `n_items_per_input` scalars.
+	/// That's the same shape [`BinaryMerkleTree::from_leaves`] itself consumes.
+	///
+	/// So a caller can hand this a zero-copy view over packed data, such as
+	/// `binius_math::FieldSlice::par_chunk_scalars`.
+	/// That avoids first flattening the data into an owned buffer.
 	pub fn write_range<ParIter>(&self, leaf_start: usize, leaves: ParIter)
 	where
 		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 	{
 		let n_leaves = leaves.len();
 		let dst = unsafe {
-			// SAFETY: `Self`'s contract guarantees every range written through this writer is
-			// disjoint from every other one, so this range does not alias any other write.
+			// SAFETY: `Self`'s contract guarantees every range written through this writer
+			// is disjoint from every other one.
+			// So this range does not alias any other write.
 			slice::from_raw_parts_mut(self.leaves.0.add(leaf_start), n_leaves)
 		};
 		H::ParLeafHash::default().digest_with_const_len(self.n_items_per_input, leaves, dst);

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -314,32 +314,24 @@ pub struct LeafRangeWriter<'a, F, H: HashSuite> {
 }
 
 impl<F: Field, H: HashSuite> LeafRangeWriter<'_, F, H> {
-	/// Hashes `scalars` into the leaves starting at `leaf_start`, `n_items_per_input` scalars
-	/// per leaf.
+	/// Hashes `leaves` into the tree's leaf layer starting at `leaf_start`.
 	///
-	/// # Panics
-	///
-	/// Panics unless `scalars.len()` is a multiple of `n_items_per_input`.
-	pub fn write_range(&self, leaf_start: usize, scalars: &[F]) {
-		assert_eq!(
-			scalars.len() % self.n_items_per_input,
-			0,
-			"a leaf range must cover a whole number of leaves"
-		);
-		let n_leaves = scalars.len() / self.n_items_per_input;
-
+	/// `leaves` yields one iterator per leaf, each yielding exactly
+	/// [`n_items_per_input`](Self::write_range) scalars — the same shape
+	/// [`BinaryMerkleTree::from_leaves`] itself consumes, so a caller can hand this a zero-copy
+	/// view over packed data (e.g. `binius_math::FieldSlice::par_chunk_scalars`) instead of
+	/// first flattening it into an owned buffer.
+	pub fn write_range<ParIter>(&self, leaf_start: usize, leaves: ParIter)
+	where
+		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
+	{
+		let n_leaves = leaves.len();
 		let dst = unsafe {
 			// SAFETY: `Self`'s contract guarantees every range written through this writer is
 			// disjoint from every other one, so this range does not alias any other write.
 			slice::from_raw_parts_mut(self.leaves.0.add(leaf_start), n_leaves)
 		};
-		H::ParLeafHash::default().digest_with_const_len(
-			self.n_items_per_input,
-			scalars
-				.par_chunks(self.n_items_per_input)
-				.map(|chunk| chunk.iter().copied()),
-			dst,
-		);
+		H::ParLeafHash::default().digest_with_const_len(self.n_items_per_input, leaves, dst);
 	}
 }
 

--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -92,17 +92,20 @@ fn bench_blake3_merkle_tree(c: &mut Criterion) {
 
 /// Base-2 log of the message dimension the RS-encode+commit bench encodes from.
 ///
-/// Matches `LOG_LEAVES + LOG_ELEMS_IN_LEAF` at `LOG_INV_RATE = 1`, so the resulting codeword is
-/// the same `2^(LOG_LEAVES + LOG_ELEMS_IN_LEAF)`-scalar shape [`bench_binary_merkle_tree`] commits.
+/// Matches `LOG_LEAVES + LOG_ELEMS_IN_LEAF` at `LOG_INV_RATE = 1`.
+/// So the codeword here is the same shape [`bench_binary_merkle_tree`] commits.
 const LOG_DIM: usize = LOG_LEAVES + LOG_ELEMS_IN_LEAF - 1;
 const LOG_INV_RATE: usize = 1;
 
 /// Benchmarks the full commit phase — RS-encode then Merkle-commit — two ways.
 ///
-/// "sequential" runs [`ReedSolomonCode::encode_batch`] to completion, then commits the finished
-/// codeword, exactly as every prover call site does today.
-/// "pipelined" runs [`encode_and_commit_pipelined`], which hashes each independent NTT chunk's
-/// leaves the instant that chunk finishes, instead of waiting for the whole codeword.
+/// "sequential" runs [`ReedSolomonCode::encode_batch`] to completion, then commits the result.
+/// That's exactly what every prover call site does today.
+///
+/// "pipelined" runs [`encode_and_commit_pipelined`] instead.
+/// It hashes each independent NTT chunk's leaves the instant that chunk finishes.
+/// It does not wait for the whole codeword first.
+///
 /// Both arms are timed in one binary, back to back, so they meet identical machine conditions.
 fn bench_commit_pipeline(c: &mut Criterion) {
 	let mut rng = rand::rng();

--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -110,8 +110,9 @@ fn bench_commit_pipeline(c: &mut Criterion) {
 
 	let rs_code = ReedSolomonCode::<B128>::new(LOG_DIM, LOG_INV_RATE);
 	let domain_context = GaoMateerOnTheFly::<B128>::generate(rs_code.log_len());
-	let log_num_shares =
-		binius_utils::checked_arithmetics::log2_ceil_usize(binius_utils::rayon::current_num_threads());
+	let log_num_shares = binius_utils::checked_arithmetics::log2_ceil_usize(
+		binius_utils::rayon::current_num_threads(),
+	);
 	let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
 	let mut group = c.benchmark_group("slow/commit_pipeline/SHA-256");

--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -1,13 +1,20 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::BufferPool;
+use binius_compute::{BufferPool, GlobalAllocator};
 use binius_field::{BinaryField128bGhash as B128, PackedField, arch::OptimalPackedB128};
 use binius_hash::{
 	binary_merkle_tree::HashSuite, blake3::Blake3HashSuite, sha256::Sha256HashSuite,
 };
-use binius_iop_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
-use binius_math::test_utils::random_field_buffer;
+use binius_iop_prover::{
+	commit_pipeline::encode_and_commit_pipelined,
+	merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver},
+};
+use binius_math::{
+	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerOnTheFly},
+	reed_solomon::ReedSolomonCode,
+	test_utils::random_field_buffer,
+};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 const LOG_LEAVES: usize = 17;
@@ -83,5 +90,64 @@ fn bench_blake3_merkle_tree(c: &mut Criterion) {
 	);
 }
 
-criterion_group!(binary_merkle_tree, bench_sha256_merkle_tree, bench_blake3_merkle_tree);
+/// Base-2 log of the message dimension the RS-encode+commit bench encodes from.
+///
+/// Matches `LOG_LEAVES + LOG_ELEMS_IN_LEAF` at `LOG_INV_RATE = 1`, so the resulting codeword is
+/// the same `2^(LOG_LEAVES + LOG_ELEMS_IN_LEAF)`-scalar shape [`bench_binary_merkle_tree`] commits.
+const LOG_DIM: usize = LOG_LEAVES + LOG_ELEMS_IN_LEAF - 1;
+const LOG_INV_RATE: usize = 1;
+
+/// Benchmarks the full commit phase — RS-encode then Merkle-commit — two ways.
+///
+/// "sequential" runs [`ReedSolomonCode::encode_batch`] to completion, then commits the finished
+/// codeword, exactly as every prover call site does today.
+/// "pipelined" runs [`encode_and_commit_pipelined`], which hashes each independent NTT chunk's
+/// leaves the instant that chunk finishes, instead of waiting for the whole codeword.
+/// Both arms are timed in one binary, back to back, so they meet identical machine conditions.
+fn bench_commit_pipeline(c: &mut Criterion) {
+	let mut rng = rand::rng();
+	let message = random_field_buffer::<OptimalPackedB128>(&mut rng, LOG_DIM);
+
+	let rs_code = ReedSolomonCode::<B128>::new(LOG_DIM, LOG_INV_RATE);
+	let domain_context = GaoMateerOnTheFly::<B128>::generate(rs_code.log_len());
+	let log_num_shares =
+		binius_utils::checked_arithmetics::log2_ceil_usize(binius_utils::rayon::current_num_threads());
+	let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
+
+	let mut group = c.benchmark_group("slow/commit_pipeline/SHA-256");
+	group.throughput(Throughput::Bytes(
+		((1 << (LOG_LEAVES + LOG_ELEMS_IN_LEAF)) * std::mem::size_of::<B128>()) as u64,
+	));
+	group.sample_size(10);
+
+	group.bench_function("sequential", |b| {
+		b.iter(|| {
+			let codeword = rs_code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+			BinaryMerkleTreeProver::<B128, Sha256HashSuite>::new()
+				.commit_field_buffer(codeword.to_ref(), LOG_ELEMS_IN_LEAF)
+		});
+	});
+
+	group.bench_function("pipelined", |b| {
+		b.iter(|| {
+			encode_and_commit_pipelined::<B128, OptimalPackedB128, _, Sha256HashSuite, _, _>(
+				&rs_code,
+				&ntt,
+				message.to_ref(),
+				0,
+				LOG_ELEMS_IN_LEAF,
+				&GlobalAllocator,
+			)
+		});
+	});
+
+	group.finish();
+}
+
+criterion_group!(
+	binary_merkle_tree,
+	bench_sha256_merkle_tree,
+	bench_blake3_merkle_tree,
+	bench_commit_pipeline
+);
 criterion_main!(binary_merkle_tree);

--- a/crates/iop-prover/src/commit_pipeline.rs
+++ b/crates/iop-prover/src/commit_pipeline.rs
@@ -1,0 +1,165 @@
+// Copyright 2026 The Binius Developers
+
+//! Encode-and-commit a Reed-Solomon codeword with the Merkle leaf-hash overlapped against the
+//! additive NTT, instead of run strictly after it finishes.
+//!
+//! [`ReedSolomonCode::encode_batch`] splits its NTT into disjoint chunks, one per thread.
+//! Each chunk finishes independently of its siblings, well before the whole codeword is done.
+//! [`encode_and_commit_pipelined`] hashes a chunk's leaves the instant that chunk finishes,
+//! concurrently with the NTT still transforming the remaining chunks.
+
+use binius_compute::Allocator;
+use binius_field::{BinaryField, PackedField};
+use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
+use binius_math::{
+	FieldBuffer, FieldSlice,
+	ntt::{DomainContext, NeighborsLastMultiThread},
+	reed_solomon::ReedSolomonCode,
+};
+use digest::{Output, OutputSizeUser, array::ArraySize};
+
+/// The codeword and Merkle tree [`encode_and_commit_pipelined`] returns.
+pub type PipelinedCommit<P, H, A> = (
+	FieldBuffer<P, <A as Allocator>::Vec<P>>,
+	BinaryMerkleTree<Output<<H as HashSuite>::LeafHash>, A>,
+);
+
+/// Encodes `message` with `rs_code` and commits the resulting codeword.
+///
+/// Hashes each independent NTT chunk's leaves the instant that chunk finishes transforming,
+/// rather than waiting for the whole codeword before hashing any of it.
+///
+/// The returned codeword and Merkle tree are byte-identical to encoding with
+/// [`ReedSolomonCode::encode_batch`] and then committing with
+/// [`BinaryMerkleTree::from_leaves`](binius_hash::binary_merkle_tree::BinaryMerkleTree::from_leaves) —
+/// only the scheduling of leaf-hashing relative to the NTT changes, not any hashed or transformed
+/// value.
+///
+/// ## Preconditions
+///
+/// * Same as [`ReedSolomonCode::encode_batch`].
+/// * `log_leaf_len` must be at most the codeword's log length.
+/// * Every independent NTT chunk (see
+///   [`NeighborsLastMultiThread::forward_transform_with_callback`]) must span at least one whole
+///   leaf. This holds unless `log_leaf_len` is unusually large relative to `ntt.log_num_shares`,
+///   and is checked by an assertion inside the leaf writer.
+pub fn encode_and_commit_pipelined<F, P, DC, H, N, A>(
+	rs_code: &ReedSolomonCode<F>,
+	ntt: &NeighborsLastMultiThread<DC>,
+	message: FieldSlice<P>,
+	log_batch_size: usize,
+	log_leaf_len: usize,
+	alloc: &A,
+) -> PipelinedCommit<P, H, A>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	DC: DomainContext<Field = F> + Sync,
+	H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>,
+	N: ArraySize,
+	A: Allocator,
+{
+	let leaf_scalars = 1usize << log_leaf_len;
+	let log_output_len = rs_code.log_dim() + log_batch_size + rs_code.log_inv_rate();
+	assert!(log_leaf_len <= log_output_len, "precondition: log_leaf_len <= codeword log length");
+	let log_n_leaves = log_output_len - log_leaf_len;
+
+	// `from_leaves_pipelined`'s `populate` closure runs exactly once, so this is written exactly
+	// once before being read back below.
+	let mut codeword_slot: Option<FieldBuffer<P, A::Vec<P>>> = None;
+
+	let tree = BinaryMerkleTree::from_leaves_pipelined::<F, H>(
+		log_n_leaves,
+		leaf_scalars,
+		alloc,
+		|writer| {
+			let codeword = rs_code.encode_batch_with_callback(
+				ntt,
+				message,
+				log_batch_size,
+				alloc,
+				|block, chunk: &[P]| {
+					// A leaf is `leaf_scalars` scalars, and every chunk this NTT split produces
+					// is the same size, so the chunk index alone gives its scalar offset.
+					let scalars: Vec<F> = chunk.iter().flat_map(PackedField::iter).collect();
+					let leaf_start = block * scalars.len() / leaf_scalars;
+					writer.write_range(leaf_start, &scalars);
+				},
+			);
+			codeword_slot = Some(codeword);
+		},
+	);
+
+	let codeword =
+		codeword_slot.expect("`populate` above always runs exactly once and always sets this slot");
+	(codeword, tree)
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_compute::GlobalAllocator;
+	use binius_field::{
+		BinaryField128bGhash as B128, PackedBinaryGhash4x128b, arch::OptimalPackedB128,
+	};
+	use binius_hash::sha256::Sha256HashSuite;
+	use binius_math::{ntt::domain_context::GaoMateerOnTheFly, test_utils::random_field_buffer};
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	/// Pins [`encode_and_commit_pipelined`] to the sequential encode-then-commit path it
+	/// overlaps: same codeword, same committed root.
+	fn check<P: PackedField<Scalar = B128>>(
+		log_dim: usize,
+		log_inv_rate: usize,
+		log_num_shares: usize,
+	) {
+		let mut rng = StdRng::seed_from_u64(0);
+		let message = random_field_buffer::<P>(&mut rng, log_dim);
+
+		let rs_code = ReedSolomonCode::<B128>::new(log_dim, log_inv_rate);
+		let domain_context = GaoMateerOnTheFly::<B128>::generate(rs_code.log_len());
+		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
+
+		let log_leaf_len = 4.min(rs_code.log_len());
+
+		let (pipelined_codeword, pipelined_tree) =
+			encode_and_commit_pipelined::<B128, P, _, Sha256HashSuite, _, _>(
+				&rs_code,
+				&ntt,
+				message.to_ref(),
+				0,
+				log_leaf_len,
+				&GlobalAllocator,
+			);
+
+		let sequential_codeword = rs_code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+		let sequential_tree = BinaryMerkleTree::<_, GlobalAllocator>::new::<B128, Sha256HashSuite>(
+			&sequential_codeword.iter_scalars().collect::<Vec<_>>(),
+			1 << log_leaf_len,
+			&GlobalAllocator,
+		)
+		.unwrap();
+
+		assert_eq!(pipelined_codeword.as_ref(), sequential_codeword.as_ref());
+		assert_eq!(pipelined_tree.root(), sequential_tree.root());
+		for depth in 0..=pipelined_tree.log_len {
+			assert_eq!(
+				pipelined_tree.layer(depth).unwrap(),
+				sequential_tree.layer(depth).unwrap(),
+				"layer {depth} differs"
+			);
+		}
+	}
+
+	#[test]
+	fn test_matches_sequential_encode_then_commit() {
+		// Every case below spans 1 to 8 independent NTT chunks (log_num_shares 0..=3), each
+		// spanning several leaves, so the leaf-range split exercises more than one chunk.
+		for log_num_shares in 0..=3 {
+			check::<OptimalPackedB128>(10, 2, log_num_shares);
+		}
+		// A wider packing width, to exercise the scalar-unpacking path with `P::WIDTH > 1`.
+		check::<PackedBinaryGhash4x128b>(10, 2, 2);
+	}
+}

--- a/crates/iop-prover/src/commit_pipeline.rs
+++ b/crates/iop-prover/src/commit_pipeline.rs
@@ -1,12 +1,13 @@
 // Copyright 2026 The Binius Developers
 
-//! Encode-and-commit a Reed-Solomon codeword with the Merkle leaf-hash overlapped against the
-//! additive NTT, instead of run strictly after it finishes.
+//! Encode-and-commit a Reed-Solomon codeword, overlapping Merkle leaf-hashing against the NTT.
+//!
+//! The sequential path runs the leaf-hash strictly after the whole NTT finishes.
 //!
 //! [`ReedSolomonCode::encode_batch`] splits its NTT into disjoint chunks, one per thread.
 //! Each chunk finishes independently of its siblings, well before the whole codeword is done.
-//! [`encode_and_commit_pipelined`] hashes a chunk's leaves the instant that chunk finishes,
-//! concurrently with the NTT still transforming the remaining chunks.
+//! [`encode_and_commit_pipelined`] hashes a chunk's leaves the instant that chunk finishes.
+//! That runs concurrently with the NTT still transforming the remaining chunks.
 
 use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
@@ -26,14 +27,14 @@ pub type PipelinedCommit<P, H, A> = (
 
 /// Encodes `message` with `rs_code` and commits the resulting codeword.
 ///
-/// Hashes each independent NTT chunk's leaves the instant that chunk finishes transforming,
-/// rather than waiting for the whole codeword before hashing any of it.
+/// Hashes each independent NTT chunk's leaves the instant that chunk finishes transforming.
+/// That's instead of waiting for the whole codeword before hashing any of it.
 ///
-/// The returned codeword and Merkle tree are byte-identical to encoding with
-/// [`ReedSolomonCode::encode_batch`] and then committing with
-/// [`BinaryMerkleTree::from_leaves`](binius_hash::binary_merkle_tree::BinaryMerkleTree::from_leaves) —
-/// only the scheduling of leaf-hashing relative to the NTT changes, not any hashed or transformed
-/// value.
+/// The returned codeword and Merkle tree are byte-identical to the sequential path:
+/// [`ReedSolomonCode::encode_batch`], then
+/// [`BinaryMerkleTree::from_leaves`](binius_hash::binary_merkle_tree::BinaryMerkleTree::from_leaves).
+/// Only the scheduling of leaf-hashing relative to the NTT changes.
+/// No hashed or transformed value differs.
 ///
 /// ## Preconditions
 ///
@@ -41,8 +42,9 @@ pub type PipelinedCommit<P, H, A> = (
 /// * `log_leaf_len` must be at most the codeword's log length.
 /// * Every independent NTT chunk (see
 ///   [`NeighborsLastMultiThread::forward_transform_with_callback`]) must span at least one whole
-///   leaf. This holds unless `log_leaf_len` is unusually large relative to `ntt.log_num_shares`,
-///   and is checked by an assertion inside the leaf writer.
+///   leaf.
+/// * That holds unless `log_leaf_len` is unusually large relative to `ntt.log_num_shares`, in which
+///   case an assertion inside the leaf writer catches it.
 pub fn encode_and_commit_pipelined<F, P, DC, H, N, A>(
 	rs_code: &ReedSolomonCode<F>,
 	ntt: &NeighborsLastMultiThread<DC>,
@@ -64,8 +66,8 @@ where
 	assert!(log_leaf_len <= log_output_len, "precondition: log_leaf_len <= codeword log length");
 	let log_n_leaves = log_output_len - log_leaf_len;
 
-	// `from_leaves_pipelined`'s `populate` closure runs exactly once, so this is written exactly
-	// once before being read back below.
+	// `from_leaves_pipelined`'s `populate` closure runs exactly once.
+	// So this is written exactly once before being read back below.
 	let mut codeword_slot: Option<FieldBuffer<P, A::Vec<P>>> = None;
 
 	let tree = BinaryMerkleTree::from_leaves_pipelined::<F, H>(
@@ -79,14 +81,15 @@ where
 				log_batch_size,
 				alloc,
 				|block, chunk: &[P]| {
-					// A leaf is `leaf_scalars` scalars, and every chunk this NTT split produces
-					// is the same size, so the chunk index alone gives its leaf offset.
+					// A leaf is `leaf_scalars` scalars.
+					// Every chunk this NTT split produces is the same size.
+					// So the chunk index alone gives its leaf offset.
 					let chunk_log_len = chunk.len().ilog2() as usize + P::LOG_WIDTH;
 					let n_leaves_per_chunk = (1usize << chunk_log_len) / leaf_scalars;
 					let leaf_start = block * n_leaves_per_chunk;
 
-					// Zero-copy: reads scalars straight out of the packed chunk, so a finished
-					// chunk's leaves hash without first flattening it into an owned buffer.
+					// Zero-copy: reads scalars straight out of the packed chunk.
+					// So a finished chunk's leaves hash without first flattening into a buffer.
 					let chunk_view = FieldSlice::from_slice(chunk_log_len, chunk);
 					writer.write_range(leaf_start, chunk_view.par_chunk_scalars(log_leaf_len));
 				},
@@ -112,8 +115,8 @@ mod tests {
 
 	use super::*;
 
-	/// Pins [`encode_and_commit_pipelined`] to the sequential encode-then-commit path it
-	/// overlaps: same codeword, same committed root.
+	/// Pins [`encode_and_commit_pipelined`] against the sequential encode-then-commit path.
+	/// Same codeword, same committed root.
 	fn check<P: PackedField<Scalar = B128>>(
 		log_dim: usize,
 		log_inv_rate: usize,
@@ -159,8 +162,8 @@ mod tests {
 
 	#[test]
 	fn test_matches_sequential_encode_then_commit() {
-		// Every case below spans 1 to 8 independent NTT chunks (log_num_shares 0..=3), each
-		// spanning several leaves, so the leaf-range split exercises more than one chunk.
+		// Every case below spans 1 to 8 independent NTT chunks (log_num_shares 0..=3).
+		// Each chunk spans several leaves, so the leaf-range split exercises more than one.
 		for log_num_shares in 0..=3 {
 			check::<OptimalPackedB128>(10, 2, log_num_shares);
 		}

--- a/crates/iop-prover/src/commit_pipeline.rs
+++ b/crates/iop-prover/src/commit_pipeline.rs
@@ -80,10 +80,15 @@ where
 				alloc,
 				|block, chunk: &[P]| {
 					// A leaf is `leaf_scalars` scalars, and every chunk this NTT split produces
-					// is the same size, so the chunk index alone gives its scalar offset.
-					let scalars: Vec<F> = chunk.iter().flat_map(PackedField::iter).collect();
-					let leaf_start = block * scalars.len() / leaf_scalars;
-					writer.write_range(leaf_start, &scalars);
+					// is the same size, so the chunk index alone gives its leaf offset.
+					let chunk_log_len = chunk.len().ilog2() as usize + P::LOG_WIDTH;
+					let n_leaves_per_chunk = (1usize << chunk_log_len) / leaf_scalars;
+					let leaf_start = block * n_leaves_per_chunk;
+
+					// Zero-copy: reads scalars straight out of the packed chunk, so a finished
+					// chunk's leaves hash without first flattening it into an owned buffer.
+					let chunk_view = FieldSlice::from_slice(chunk_log_len, chunk);
+					writer.write_range(leaf_start, chunk_view.par_chunk_scalars(log_leaf_len));
 				},
 			);
 			codeword_slot = Some(codeword);

--- a/crates/iop-prover/src/lib.rs
+++ b/crates/iop-prover/src/lib.rs
@@ -27,6 +27,7 @@
 
 pub mod basefold;
 pub mod channel;
+pub mod commit_pipeline;
 pub mod fri;
 pub mod logup_star;
 pub mod merkle_channel;

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -458,21 +458,39 @@ impl<DC> NeighborsLastMultiThread<DC> {
 	}
 }
 
-impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
-	type Field = DC::Field;
-
-	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
+impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
+	/// Same transform as [`AdditiveNTT::forward_transform`], but invokes `on_chunk_ready` the
+	/// instant each independent post-shared-layer chunk finishes, instead of only after the whole
+	/// buffer is done.
+	///
+	/// The independent chunks this splits into are disjoint memory ranges, one per
+	/// [`Self::log_num_shares`] share.
+	/// Each one is fully transformed the moment its own [`forward_depth_first`] call returns.
+	/// A caller that wants to start downstream work on a finished region, without waiting for
+	/// every sibling region to finish too, hooks in here instead of after
+	/// [`AdditiveNTT::forward_transform`] returns.
+	///
+	/// `on_chunk_ready` runs on whichever worker thread finished that chunk, concurrently with
+	/// the other chunks' own transforms, so it must be `Sync` and safe to run from any thread.
+	///
+	/// When the input is too small to split (the fallback path below
+	/// [`PackedField::LOG_WIDTH`]), the whole buffer is one chunk, and `on_chunk_ready` runs once
+	/// for block 0 after the fallback transform completes.
+	pub fn forward_transform_with_callback<P: PackedField<Scalar = DC::Field>>(
 		&self,
 		mut data: FieldSliceMut<P>,
 		skip_early: usize,
 		skip_late: usize,
+		on_chunk_ready: impl Fn(usize, &[P]) + Sync,
 	) {
 		let log_d = data.log_len();
 		if log_d <= P::LOG_WIDTH {
 			let fallback_ntt = NeighborsLastReference {
 				domain_context: &self.domain_context,
 			};
-			return fallback_ntt.forward_transform(data, skip_early, skip_late);
+			fallback_ntt.forward_transform(data.to_mut(), skip_early, skip_late);
+			on_chunk_ready(0, data.as_ref());
+			return;
 		}
 
 		input_check(&self.domain_context, log_d, skip_early, skip_late);
@@ -522,7 +540,21 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 					independent_layers.clone(),
 					self.log_base_len,
 				);
+				on_chunk_ready(block, chunk);
 			});
+	}
+}
+
+impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
+	type Field = DC::Field;
+
+	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
+		&self,
+		data: FieldSliceMut<P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.forward_transform_with_callback(data, skip_early, skip_late, |_block, _chunk| {});
 	}
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -459,23 +459,22 @@ impl<DC> NeighborsLastMultiThread<DC> {
 }
 
 impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
-	/// Same transform as [`AdditiveNTT::forward_transform`], but invokes `on_chunk_ready` the
-	/// instant each independent post-shared-layer chunk finishes, instead of only after the whole
-	/// buffer is done.
+	/// Same transform as [`AdditiveNTT::forward_transform`].
 	///
-	/// The independent chunks this splits into are disjoint memory ranges, one per
-	/// [`Self::log_num_shares`] share.
-	/// Each one is fully transformed the moment its own [`forward_depth_first`] call returns.
-	/// A caller that wants to start downstream work on a finished region, without waiting for
-	/// every sibling region to finish too, hooks in here instead of after
-	/// [`AdditiveNTT::forward_transform`] returns.
+	/// Invokes `on_chunk_ready` as soon as each independent post-shared-layer chunk finishes.
+	/// [`AdditiveNTT::forward_transform`] instead waits for the whole buffer to finish.
 	///
-	/// `on_chunk_ready` runs on whichever worker thread finished that chunk, concurrently with
-	/// the other chunks' own transforms, so it must be `Sync` and safe to run from any thread.
+	/// The independent chunks are disjoint memory ranges, one per [`Self::log_num_shares`] share.
+	/// Each chunk is fully transformed the moment its own [`forward_depth_first`] call returns.
 	///
-	/// When the input is too small to split (the fallback path below
-	/// [`PackedField::LOG_WIDTH`]), the whole buffer is one chunk, and `on_chunk_ready` runs once
-	/// for block 0 after the fallback transform completes.
+	/// Use this to start downstream work on a finished region without waiting on its siblings.
+	///
+	/// `on_chunk_ready` runs on whichever worker thread finished that chunk.
+	/// Other chunks' transforms may still be running concurrently on other threads.
+	/// So the callback must be `Sync` and safe to call from any thread.
+	///
+	/// Below [`PackedField::LOG_WIDTH`] the fallback path treats the whole buffer as one chunk.
+	/// There, `on_chunk_ready` runs once for block 0, after the fallback transform completes.
 	pub fn forward_transform_with_callback<P: PackedField<Scalar = DC::Field>>(
 		&self,
 		mut data: FieldSliceMut<P>,

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -465,7 +465,7 @@ impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
 	/// [`AdditiveNTT::forward_transform`] instead waits for the whole buffer to finish.
 	///
 	/// The independent chunks are disjoint memory ranges, one per [`Self::log_num_shares`] share.
-	/// Each chunk is fully transformed the moment its own [`forward_depth_first`] call returns.
+	/// Each chunk is fully transformed the moment its own `forward_depth_first` call returns.
 	///
 	/// Use this to start downstream work on a finished region without waiting on its siblings.
 	///

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -170,13 +170,14 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		output
 	}
 
-	/// Same encoding as [`Self::encode_batch`], but invokes `on_chunk_ready` the instant each
-	/// independent post-shared-layer chunk of the codeword finishes transforming.
+	/// Same encoding as [`Self::encode_batch`].
 	///
-	/// A caller that wants to start downstream work on a finished region of the codeword, without
-	/// waiting for the whole encode to complete, hooks in here.
-	/// See [`NeighborsLastMultiThread::forward_transform_with_callback`] for the chunking this
-	/// callback rides on.
+	/// Invokes `on_chunk_ready` as each independent post-shared-layer chunk finishes.
+	/// [`Self::encode_batch`] instead waits for the whole codeword to finish.
+	///
+	/// Use this to start downstream work on a finished region of the codeword.
+	/// That avoids waiting for the whole encode to complete.
+	/// See [`NeighborsLastMultiThread::forward_transform_with_callback`] for the chunking.
 	///
 	/// ## Preconditions
 	///

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{
 	bit_reverse::{bit_reverse_indices, bit_reverse_packed},
-	ntt::{DomainContext, domain_context::GaoMateerOnTheFly},
+	ntt::{DomainContext, NeighborsLastMultiThread, domain_context::GaoMateerOnTheFly},
 };
 
 /// [Reed–Solomon] codes over binary fields.
@@ -167,6 +167,78 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		let mut output = FieldBuffer::new(log_output_len, output_data);
 
 		ntt.forward_transform(output.to_mut(), self.log_inv_rate, log_batch_size);
+		output
+	}
+
+	/// Same encoding as [`Self::encode_batch`], but invokes `on_chunk_ready` the instant each
+	/// independent post-shared-layer chunk of the codeword finishes transforming.
+	///
+	/// A caller that wants to start downstream work on a finished region of the codeword, without
+	/// waiting for the whole encode to complete, hooks in here.
+	/// See [`NeighborsLastMultiThread::forward_transform_with_callback`] for the chunking this
+	/// callback rides on.
+	///
+	/// ## Preconditions
+	///
+	/// Same as [`Self::encode_batch`].
+	pub fn encode_batch_with_callback<P, DC, A>(
+		&self,
+		ntt: &NeighborsLastMultiThread<DC>,
+		data: FieldSlice<P>,
+		log_batch_size: usize,
+		alloc: &A,
+		on_chunk_ready: impl Fn(usize, &[P]) + Sync,
+	) -> FieldBuffer<P, A::Vec<P>>
+	where
+		P: PackedField<Scalar = F>,
+		DC: DomainContext<Field = F> + Sync,
+		A: Allocator,
+	{
+		assert_eq!(
+			ntt.subspace(self.log_len()),
+			self.subspace(),
+			"precondition: NTT subspace must match code subspace"
+		);
+		assert_eq!(
+			data.log_len(),
+			self.log_dim() + log_batch_size,
+			"precondition: data.log_len() must equal log_dim() + log_batch_size"
+		);
+
+		let _scope = tracing::trace_span!(
+			"Reed-Solomon encode (pipelined)",
+			log_len = self.log_len(),
+			log_batch_size = log_batch_size,
+			symbol_bits = F::N_BITS,
+		)
+		.entered();
+
+		let log_output_len = self.log_dim() + log_batch_size + self.log_inv_rate;
+		let output_data = if data.log_len() < P::LOG_WIDTH {
+			let mut scalars = data.iter_scalars().collect::<Vec<_>>();
+			bit_reverse_indices(&mut scalars);
+			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
+			let len = 1 << log_output_len.saturating_sub(P::LOG_WIDTH);
+			let mut output = alloc.alloc::<P>(len);
+			output.resize(len, elem_0);
+			on_chunk_ready(0, &output);
+			return FieldBuffer::new(log_output_len, output);
+		} else {
+			let output_packed_len = 1 << (log_output_len - P::LOG_WIDTH);
+			let run = data
+				.as_ref()
+				.len()
+				.min(task_chunk_len::<P>().next_power_of_two());
+			repeated_message_buffer(data, output_packed_len, run, alloc)
+		};
+		let mut output = FieldBuffer::new(log_output_len, output_data);
+
+		ntt.forward_transform_with_callback(
+			output.to_mut(),
+			self.log_inv_rate,
+			log_batch_size,
+			on_chunk_ready,
+		);
 		output
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-513](https://linear.app/jimpo/issue/BINIUS-513/overlap-merkle-leaf-hashing-with-the-tail-of-the-reed-solomonntt).

### The problem

Committing to an encoded codeword is two strict, sequential steps today: transform the entire codeword with the additive NTT, and only once that is fully done, start hashing leaves into the Merkle tree.
But `ReedSolomonCode::encode_batch`'s NTT already splits into `2^log_num_shares` independent chunks, one per thread — each one finishes well before its siblings, and well before the whole codeword is done.
Measured on a real commit: the encode and the leaf-hash are both a substantial fraction of the combined phase (roughly two-thirds/one-third), so overlapping them is a real, not marginal, opportunity.

### The idea

Hash each independent NTT chunk's leaves the instant that chunk finishes transforming, concurrently with the NTT still transforming the remaining chunks, instead of waiting for the whole codeword.

```
sequential: [-------- encode (all chunks) --------][-- hash all leaves --]
pipelined:  [chunk 0][chunk 1][chunk 2][chunk 3]
                [hash 0][hash 1] [hash 2] [hash 3]
```

Each independent chunk is large enough, at realistic `log_num_shares`, to keep the existing SIMD-batched leaf hasher fully saturated — this matters, because folding Merkle parents in small increments instead of one contiguous sweep per finished region would fragment large batched hash calls into many small underfilled ones and quietly give the win back.

### The change

- `NeighborsLastMultiThread::forward_transform_with_callback` — same transform as `forward_transform`, but invokes a callback the instant each independent chunk finishes; `forward_transform` now delegates to it with a no-op callback.
- `ReedSolomonCode::encode_batch_with_callback` — threads that callback through the encode.
- `BinaryMerkleTree::from_leaves_pipelined` + `LeafRangeWriter` — lets a caller hash disjoint leaf ranges as they become ready, from any thread, in any order, instead of hashing the whole leaf layer from one contiguous input.
- `commit_pipeline::encode_and_commit_pipelined` — wires the two together, hashing each finished NTT chunk via a zero-copy `FieldSlice::par_chunk_scalars` view straight over the packed codeword.

The zero-copy step matters on its own: an earlier version of this change materialized each chunk into an owned `Vec<F>` before hashing it, and that copy — running serially on the very thread that had just finished the chunk's NTT work — was enough overhead to turn the whole thing into a **9% regression**. Hashing straight from the zero-copy view instead is what makes the overlap a net win.

### Soundness

The result is byte-identical to the sequential path: same codeword, same committed Merkle root, same bytes at every tree layer.
Only the scheduling of leaf-hashing relative to the NTT changes — no hashed or transformed value differs.
A dedicated equivalence test proves this directly (not just "should be" — it asserts codeword, root, and every layer's bytes match), across every `log_num_shares` from 0 to 3 and two packing widths.
It caught one real bug while it was being written: an early draft passed the codeword's scalar log-length to the tree builder instead of the leaf-count log-length, and the root mismatch caught it immediately.

### Scope

- **new:** `crates/iop-prover/src/commit_pipeline.rs` (`encode_and_commit_pipelined`, `PipelinedCommit`, equivalence test)
- **new:** `BinaryMerkleTree::from_leaves_pipelined`, `LeafRangeWriter` in `crates/hash/src/binary_merkle_tree.rs`
- **new:** `NeighborsLastMultiThread::forward_transform_with_callback` in `crates/math/src/ntt/neighbors_last.rs` (existing `forward_transform` now a thin wrapper over it)
- **new:** `ReedSolomonCode::encode_batch_with_callback` in `crates/math/src/reed_solomon.rs` (existing `encode_batch` untouched)
- **new:** a permanent `sequential` vs `pipelined` bench group added to the existing `crates/iop-prover/benches/binary_merkle_tree.rs`, timed in one binary so both arms meet identical machine conditions

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-math -p binius-hash -p binius-iop-prover --all-targets` — clean
- `cargo +nightly fmt` on the touched crates — clean
- `cargo test --lib` on all three touched crates, with and without `--features rayon` — 144 + 29 + 46 passed every way, including the new equivalence test

### Benchmark

Full commit phase, 2^21 B128 scalars, in-binary A/B (both arms in one criterion binary, alternated) — 5 back-to-back runs on a quiet machine:

| run | sequential | pipelined | delta |
|---|---|---|---|
| 1 | 10.869 ms | 11.598 ms | −6.7% |
| 2 | 11.685 ms | 10.945 ms | +6.3% |
| 3 | 11.454 ms | 10.833 ms | +5.4% |
| 4 | 11.429 ms | 10.864 ms | +4.9% |
| 5 | 12.453 ms | 12.147 ms | +2.5% |

Pipelined faster in 4 of 5 runs; median delta ≈ **+4.9%**.
Reported as measured — the one slower run is included, not dropped.

### Context

Surfaced while mining `Layr-Labs/flock-challenge-multi` (a new x86-only Flock speed-challenge repo) for portable optimization ideas — see the "Round 2" section of `FLOCK_MULTI_X86_IDEAS.md` at the repo root. A prior session on this same question (worktree `merkle-ntt-pipeline`, not pushed) confirmed the encode/hash split was real but declined to build the pipelining under contended machine conditions; this is the follow-up that actually builds and verifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)