### PR TITLE
BINIUS-516: Add the Ligerito parameter and cost model, and the soundness ceiling it must respect

### DIFF
--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -22,3 +22,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 binius-math = { path = "../math", features = ["test-utils"] }
+proptest.workspace = true

--- a/crates/iop/src/lib.rs
+++ b/crates/iop/src/lib.rs
@@ -15,6 +15,7 @@
 //!
 //! - [`basefold`] - BaseFold polynomial commitment scheme verification
 //! - [`fri`] - FRI (Fast Reed-Solomon Interactive Oracle Proof) verification
+//! - [`ligerito`] - Ligerito parameter selection and proof-size accounting
 //! - [`merkle_tree`] - Merkle tree commitment verification
 //! - [`channel`] - IOP verifier channel traits for abstracting oracle interactions
 //!
@@ -28,6 +29,8 @@
 pub mod basefold;
 pub mod channel;
 pub mod fri;
+pub mod ligerito;
 pub mod logup_star;
 pub mod merkle_channel;
 pub mod merkle_tree;
+pub mod soundness;

--- a/crates/iop/src/ligerito/common.rs
+++ b/crates/iop/src/ligerito/common.rs
@@ -1,0 +1,364 @@
+// Copyright 2026 The Binius Developers
+
+use binius_field::BinaryField;
+use getset::CopyGetters;
+
+use super::size_estimation;
+use crate::{merkle_tree::MerkleTreeScheme, soundness::SoundnessRegime};
+
+/// One committed level of the Ligerito recursion.
+///
+/// The level's message is a matrix of `2^log_lanes` interleaved lanes by `2^log_msg_cols` columns.
+/// Every lane is Reed–Solomon encoded to `2^(log_msg_cols + log_inv_rate)` positions.
+/// One Merkle leaf holds one codeword position across all lanes.
+/// So the tree has `2^(log_msg_cols + log_inv_rate)` leaves of `2^log_lanes` elements each.
+/// An opened row is therefore `2^log_lanes` field elements.
+///
+/// The `log_lanes` fold challenges of this level are also its sumcheck rounds.
+/// That is why the lane count and the fold amount are the same number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LigeritoLevel {
+	/// log2 the number of message columns this level's matrix has.
+	pub log_msg_cols: usize,
+	/// log2 the number of interleaved lanes, which is also this level's fold amount.
+	pub log_lanes: usize,
+	/// log2 the inverse Reed-Solomon rate this level is committed at.
+	pub log_inv_rate: usize,
+	/// Number of row queries opened against this level.
+	pub n_queries: usize,
+}
+
+impl LigeritoLevel {
+	/// A level whose query count is derived from `regime` at this level's own rate.
+	///
+	/// ## Preconditions
+	///
+	/// * Those of [`SoundnessRegime::n_queries`].
+	pub fn new(
+		log_msg_cols: usize,
+		log_lanes: usize,
+		log_inv_rate: usize,
+		regime: SoundnessRegime,
+		security_bits: usize,
+	) -> Self {
+		Self {
+			log_msg_cols,
+			log_lanes,
+			log_inv_rate,
+			n_queries: regime.n_queries(security_bits, log_inv_rate),
+		}
+	}
+
+	/// log2 the number of codeword positions, which is also the number of Merkle leaves.
+	pub const fn log_codeword_len(&self) -> usize {
+		self.log_msg_cols + self.log_inv_rate
+	}
+
+	/// log2 the total number of message elements this level commits.
+	pub const fn log_msg_len(&self) -> usize {
+		self.log_msg_cols + self.log_lanes
+	}
+
+	/// Whether this level has at least as many codeword positions as queries to open.
+	///
+	/// Queries are sampled without replacement.
+	/// A level with fewer positions than queries is not a protocol at all.
+	pub const fn is_feasible(&self) -> bool {
+		self.n_queries <= pow2_saturating(self.log_codeword_len())
+	}
+}
+
+/// Parameters for the Ligerito recursive matrix-commitment protocol.
+///
+/// ## Invariants
+///
+/// Level `i`'s fields are abbreviated `cols_i`, `lanes_i`, `inv_rate_i`, and `queries_i` below.
+/// [`Self::new`] enforces:
+///
+/// - `levels` is non-empty.
+/// - Column counts chain: `cols_{i+1} + lanes_{i+1} == cols_i`.
+/// - The rate falls down the ladder: `inv_rate_{i+1} > inv_rate_i`.
+/// - Every level is feasible: `2^(cols_i + inv_rate_i) >= queries_i`.
+///
+/// And derives, rather than taking on faith:
+///
+/// - `log_residual_dim == cols_last`.
+///
+/// That last relation is the whole recursion in one line.
+/// A level holds `2^(cols + lanes)` elements and folds `lanes` of them away, leaving `2^cols`.
+/// For an intermediate level that remainder is the next level's message, hence the chaining.
+/// For the last level there is no next level, so it is the residual sent in the clear.
+#[derive(Debug, Clone, CopyGetters)]
+pub struct LigeritoParams {
+	/// The committed levels, outermost first. Guaranteed non-empty.
+	levels: Vec<LigeritoLevel>,
+	/// log2 the number of field elements in the residual matrix sent in the clear.
+	#[getset(get_copy = "pub")]
+	log_residual_dim: usize,
+	/// The proximity-testing regime the per-level query counts were derived in.
+	#[getset(get_copy = "pub")]
+	regime: SoundnessRegime,
+	/// The target query-phase soundness, in bits.
+	#[getset(get_copy = "pub")]
+	security_bits: usize,
+}
+
+impl LigeritoParams {
+	/// Assembles parameters from an explicit ladder, checking every invariant.
+	///
+	/// ## Preconditions
+	///
+	/// * All the invariants listed on [`LigeritoParams`].
+	pub fn new(levels: Vec<LigeritoLevel>, regime: SoundnessRegime, security_bits: usize) -> Self {
+		assert!(!levels.is_empty(), "precondition: levels must be non-empty");
+
+		for (i, pair) in levels.windows(2).enumerate() {
+			let (prev, next) = (&pair[0], &pair[1]);
+
+			// Invariant: a level folds `log_lanes` of its dimensions away, and what remains is
+			// exactly the next level's message.
+			assert!(
+				next.log_msg_cols + next.log_lanes == prev.log_msg_cols,
+				"precondition: column counts must chain, but level {} has log_msg_cols {} + \
+				 log_lanes {} != level {i}'s log_msg_cols {}",
+				i + 1,
+				next.log_msg_cols,
+				next.log_lanes,
+				prev.log_msg_cols,
+			);
+
+			// Invariant: the rate strictly decreases down the ladder. This is the whole point of
+			// recommitting per level, so a flat or rising rate is a mis-specified ladder.
+			assert!(
+				next.log_inv_rate > prev.log_inv_rate,
+				"precondition: the rate ladder must be strictly increasing in log_inv_rate, but \
+				 level {} has {} and level {i} has {}",
+				i + 1,
+				next.log_inv_rate,
+				prev.log_inv_rate,
+			);
+		}
+
+		for (i, level) in levels.iter().enumerate() {
+			// Invariant: queries are sampled without replacement, so there must be at least as
+			// many codeword positions as queries.
+			assert!(
+				level.is_feasible(),
+				"precondition: level {i} is infeasible, it opens {} queries against a codeword of \
+				 2^{} positions",
+				level.n_queries,
+				level.log_codeword_len(),
+			);
+		}
+
+		let log_residual_dim = levels.last().expect("levels is non-empty").log_msg_cols;
+
+		Self {
+			levels,
+			log_residual_dim,
+			regime,
+			security_bits,
+		}
+	}
+
+	/// The committed levels, outermost first. Non-empty.
+	pub fn levels(&self) -> &[LigeritoLevel] {
+		&self.levels
+	}
+
+	/// The number of committed levels, which is also the number of Merkle roots sent.
+	pub const fn n_levels(&self) -> usize {
+		self.levels.len()
+	}
+
+	/// log2 the number of field elements in the committed message.
+	pub fn log_msg_len(&self) -> usize {
+		self.levels[0].log_msg_len()
+	}
+
+	/// The total number of sumcheck fold rounds, `sum_i log_lanes_i`.
+	pub fn n_fold_rounds(&self) -> usize {
+		self.levels.iter().map(|level| level.log_lanes).sum()
+	}
+
+	/// The ceiling the correlated-agreement term puts on this ladder, over a field of that size.
+	///
+	/// Every level is an independent proximity test, so the ladder is only as sound as its worst
+	/// one.
+	/// That is normally level 0, whose codeword is the longest.
+	///
+	/// No number of queries raises this.
+	/// See [`crate::soundness`] for why, and `PROXIMITY_GAPS.md` for where it falls in practice.
+	///
+	/// A level folding `2^log_lanes` interleaved lanes applies the underlying bound once per
+	/// lane-fold round, so it pays a row union that the single-step bound does not carry.
+	/// The two reference implementations disagree on the size of that union, charging a factor
+	/// `log_lanes` and `2^(log_lanes - 1)` respectively.
+	/// This charges the second, which is the pessimistic one.
+	pub fn correlated_agreement_bits(&self, log_field_size: usize) -> f64 {
+		self.levels
+			.iter()
+			.map(|level| {
+				let base = self.regime.correlated_agreement_bits(
+					level.log_msg_len(),
+					level.log_inv_rate,
+					log_field_size,
+				);
+				// The worst of the `log_lanes` fold rounds pays `2^(log_lanes - 1)`.
+				base - (level.log_lanes.saturating_sub(1)) as f64
+			})
+			.fold(f64::INFINITY, f64::min)
+	}
+
+	/// The security this ladder reaches over a field of that size, counting both terms.
+	///
+	/// This is the worse of [`Self::correlated_agreement_bits`] and the query-phase soundness.
+	/// It can fall below [`Self::security_bits`], which is the *target* the queries were sized to.
+	pub fn achieved_security_bits(&self, log_field_size: usize) -> f64 {
+		let queries = self
+			.levels
+			.iter()
+			.map(|level| level.n_queries as f64 * self.regime.bits_per_query(level.log_inv_rate))
+			.fold(f64::INFINITY, f64::min);
+		self.correlated_agreement_bits(log_field_size).min(queries)
+	}
+
+	/// The exact byte-size of a Ligerito proof at these parameters, without running the prover.
+	///
+	/// Counted on the message channel:
+	/// - one Merkle root per committed level.
+	///
+	/// Counted on the decommitment channel, per level:
+	/// - the opened rows, `n_queries * 2^log_lanes` field elements;
+	/// - one Merkle multi-proof over the level's codeword positions.
+	///
+	/// Plus the sumcheck transcript, two field elements per fold round, and the cleartext residual.
+	pub fn proof_size<F, VCS>(&self, vcs: &VCS) -> usize
+	where
+		F: BinaryField,
+		VCS: MerkleTreeScheme<F>,
+	{
+		size_estimation::proof_size(self, vcs)
+	}
+
+	/// The ladder minimizing [`Self::proof_size`], with level 0's rate pinned by the caller.
+	///
+	/// Level 0's rate is pinned because level 0's encoding dominates prover time.
+	/// A ladder only compares to today's FRI at the same L0 rate, where it does the same L0 work.
+	/// The deep levels are small, so they are free to drop the rate as far as the search likes.
+	///
+	/// Returns the parameters together with their [`Self::proof_size`] in bytes.
+	///
+	/// `None` means no ladder reaches `security_bits`, for either of two reasons.
+	/// A level must have at least as many codeword positions as it opens queries, which rules out
+	/// small `log_n`.
+	/// And a level's correlated-agreement term must itself clear the target, which rules out large
+	/// `log_n` over a field this size.
+	/// See [`crate::soundness`] for why the second one cannot be bought back with more queries.
+	///
+	/// ## Panics
+	///
+	/// Panics if `l0_log_inv_rate` is outside `1..=MAX_LOG_INV_RATE`, or `security_bits` is zero.
+	pub fn optimal_ladder<F, MerkleScheme>(
+		merkle_scheme: &MerkleScheme,
+		log_n: usize,
+		l0_log_inv_rate: usize,
+		regime: SoundnessRegime,
+		security_bits: usize,
+	) -> Option<(Self, usize)>
+	where
+		F: BinaryField,
+		MerkleScheme: MerkleTreeScheme<F>,
+	{
+		size_estimation::optimal_ladder(
+			merkle_scheme,
+			log_n,
+			l0_log_inv_rate,
+			regime,
+			security_bits,
+		)
+	}
+}
+
+/// `2^log`, saturating at `usize::MAX` rather than wrapping on an out-of-range exponent.
+const fn pow2_saturating(log: usize) -> usize {
+	if log < usize::BITS as usize {
+		1 << log
+	} else {
+		usize::MAX
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// A three-level ladder that satisfies every invariant, used as the base for the rejection
+	// tests below. Message 2^12, lanes 3/2/1, rates 1/2 -> 1/4 -> 1/8, residual 2^6.
+	fn valid_levels() -> Vec<LigeritoLevel> {
+		vec![
+			LigeritoLevel::new(9, 3, 1, SoundnessRegime::UniqueDecoding, 100),
+			LigeritoLevel::new(7, 2, 2, SoundnessRegime::UniqueDecoding, 100),
+			LigeritoLevel::new(6, 1, 3, SoundnessRegime::UniqueDecoding, 100),
+		]
+	}
+
+	#[test]
+	fn valid_ladder_is_accepted_and_residual_is_derived() {
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100);
+		assert_eq!(params.n_levels(), 3);
+		assert_eq!(params.log_msg_len(), 12);
+		// The residual is the last level's remaining columns.
+		assert_eq!(params.log_residual_dim(), 6);
+		// Every fold challenge is a sumcheck round: 3 + 2 + 1.
+		assert_eq!(params.n_fold_rounds(), 6);
+		assert_eq!(params.regime(), SoundnessRegime::UniqueDecoding);
+		assert_eq!(params.security_bits(), 100);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: levels must be non-empty")]
+	fn empty_ladder_is_rejected() {
+		LigeritoParams::new(Vec::new(), SoundnessRegime::UniqueDecoding, 100);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: column counts must chain")]
+	fn broken_column_chain_is_rejected() {
+		let mut levels = valid_levels();
+		// Level 1 should have 7 columns to absorb level 0's 9 minus its own 2 lanes.
+		levels[1].log_msg_cols = 8;
+		LigeritoParams::new(levels, SoundnessRegime::UniqueDecoding, 100);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: the rate ladder must be strictly increasing")]
+	fn flat_rate_ladder_is_rejected() {
+		let mut levels = valid_levels();
+		// Level 1 recommits at level 0's rate, so the recursion buys nothing.
+		levels[1].log_inv_rate = 1;
+		LigeritoParams::new(levels, SoundnessRegime::UniqueDecoding, 100);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: level 2 is infeasible")]
+	fn infeasible_level_is_rejected() {
+		let mut levels = valid_levels();
+		// 2^(6 + 3) = 512 positions cannot serve 513 distinct queries.
+		levels[2].n_queries = 513;
+		LigeritoParams::new(levels, SoundnessRegime::UniqueDecoding, 100);
+	}
+
+	#[test]
+	fn feasibility_is_exact_at_the_boundary() {
+		let mut level = LigeritoLevel {
+			log_msg_cols: 6,
+			log_lanes: 1,
+			log_inv_rate: 3,
+			n_queries: 512,
+		};
+		assert!(level.is_feasible());
+		level.n_queries = 513;
+		assert!(!level.is_feasible());
+	}
+}

--- a/crates/iop/src/ligerito/mod.rs
+++ b/crates/iop/src/ligerito/mod.rs
@@ -1,0 +1,34 @@
+// Copyright 2026 The Binius Developers
+
+//! Parameter selection and proof-size accounting for the Ligerito polynomial commitment scheme.
+//!
+//! Ligerito ([NA25]) is Ligero's interleaved matrix commitment, recursed.
+//! One *level* of that recursion does four things:
+//!
+//! - reshape its message into `2^log_lanes` interleaved lanes of `2^log_msg_cols` columns;
+//! - Reed–Solomon encode every lane at the level's own rate;
+//! - Merkle-commit one leaf per codeword position, holding that position across all lanes;
+//! - open `n_queries` rows, then fold the matrix by the level's `log_lanes` sumcheck challenges.
+//!
+//! The folded matrix becomes the next level's message, committed at a *strictly lower rate*.
+//! That is what makes the deep levels cheap, because a lower rate needs fewer queries.
+//! After the last level the residual matrix is sent in the clear.
+//!
+//! This module contains **no protocol code**.
+//! It holds only:
+//!
+//! - [`LigeritoParams`] and its invariants;
+//! - [`LigeritoParams::proof_size`], the byte-exact estimate;
+//! - [`LigeritoParams::optimal_ladder`], the search that minimizes it subject to a security target.
+//!
+//! The soundness regimes and the error terms live in [`crate::soundness`], because they describe
+//! Reed-Solomon proximity testing rather than Ligerito.
+//! `PROXIMITY_GAPS.md` at the repository root records which of them this field can support.
+//!
+//! [NA25]: <https://eprint.iacr.org/2025/1187>
+
+mod common;
+mod size_estimation;
+
+pub use common::*;
+pub use size_estimation::{MAX_LOG_INV_RATE, MAX_LOG_LANES};

--- a/crates/iop/src/ligerito/size_estimation.rs
+++ b/crates/iop/src/ligerito/size_estimation.rs
@@ -1,0 +1,783 @@
+// Copyright 2026 The Binius Developers
+
+use std::marker::PhantomData;
+
+use binius_field::BinaryField;
+
+use super::common::{LigeritoLevel, LigeritoParams};
+use crate::{merkle_tree::MerkleTreeScheme, soundness::SoundnessRegime};
+
+/// The largest `log_lanes` the ladder search considers.
+///
+/// An opened row costs `2^log_lanes` field elements, so its cost doubles with every extra lane.
+/// The Merkle branch that lane saves shortens by only one hash.
+/// Past 7 the rows dominate at every size and rate this repo commits at.
+/// So the cap sits far outside the optimum rather than binding on it.
+pub const MAX_LOG_LANES: usize = 7;
+
+/// The largest `log_inv_rate` the ladder search considers.
+///
+/// Query counts flatten out as the rate falls.
+/// At 100-bit security the unique-decoding count moves from 105 to 101 between 1/32 and 1/256.
+/// Each extra `log_inv_rate`, meanwhile, doubles the level's encoding work and Merkle tree.
+/// Nothing is gained past 8.
+pub const MAX_LOG_INV_RATE: usize = 8;
+
+/// Serialized byte sizes of the two atoms a proof is built from.
+struct ByteSizes {
+	/// Byte-size of one Merkle digest.
+	digest: usize,
+	/// Byte-size of one serialized field element.
+	value: usize,
+}
+
+impl ByteSizes {
+	fn new<F, VCS>() -> Self
+	where
+		F: BinaryField,
+		VCS: MerkleTreeScheme<F>,
+	{
+		let mut buf = Vec::new();
+		F::default()
+			.serialize(&mut buf)
+			.expect("default element can be serialized to a resizable buffer");
+		Self {
+			digest: std::mem::size_of::<VCS::Digest>(),
+			value: buf.len(),
+		}
+	}
+}
+
+/// The proof bytes one committed level contributes.
+///
+/// Per formula (19) of [NA25], a level sends:
+///
+/// ```text
+///     root        one digest
+///     rows        n_queries * 2^log_lanes field elements
+///     branches    one Merkle multi-proof over 2^(log_msg_cols + log_inv_rate) leaves
+///     sumcheck    2 field elements per fold round, and there are log_lanes of them
+/// ```
+///
+/// A round message is `(u_0, u_2)` only.
+/// The degree-2 round polynomial's middle coefficient is `u_1 = T_r + u_2` in characteristic 2.
+/// The verifier recovers it, so it is never sent.
+///
+/// The Merkle tree is indexed by codeword position, one leaf per position across all lanes.
+/// So it is `log_lanes` levels shorter than the level's element count.
+/// Sizing it by the element count would charge `log_lanes` extra hashes per branch.
+/// The search would then minimize a proof size no prover produces.
+///
+/// [NA25]: <https://eprint.iacr.org/2025/1187>
+fn level_size<F, VCS>(level: &LigeritoLevel, vcs: &VCS, sizes: &ByteSizes) -> usize
+where
+	F: BinaryField,
+	VCS: MerkleTreeScheme<F>,
+{
+	let log_n_leaves = level.log_codeword_len();
+	let layer_depth = vcs.optimal_verify_layer(level.n_queries, log_n_leaves);
+	let merkle_size = vcs.proof_size(1 << log_n_leaves, level.n_queries, layer_depth);
+
+	let rows_size = level.n_queries * (1 << level.log_lanes) * sizes.value;
+	let sumcheck_size = 2 * level.log_lanes * sizes.value;
+
+	sizes.digest + rows_size + merkle_size + sumcheck_size
+}
+
+/// Computes the exact byte-size of a Ligerito proof without running the prover.
+///
+/// This accounts for:
+///
+/// - **Message channel**: one Merkle root per committed level (digests observed by Fiat-Shamir).
+/// - **Decommitment channel**: per level, the opened rows and one Merkle multi-proof.
+/// - **Sumcheck transcript**: two field elements per fold round, over `sum_i log_lanes_i` rounds.
+/// - **Residual**: `2^log_residual_dim` field elements of the last fold, sent in the clear.
+pub(super) fn proof_size<F, VCS>(params: &LigeritoParams, vcs: &VCS) -> usize
+where
+	F: BinaryField,
+	VCS: MerkleTreeScheme<F>,
+{
+	let sizes = ByteSizes::new::<F, VCS>();
+
+	let levels_size = params
+		.levels()
+		.iter()
+		.map(|level| level_size(level, vcs, &sizes))
+		.sum::<usize>();
+	let residual_size = (1 << params.log_residual_dim()) * sizes.value;
+
+	levels_size + residual_size
+}
+
+/// One entry of the ladder search: the best continuation from a subproblem, and its cost.
+#[derive(Debug, Clone, Copy)]
+struct Decision {
+	/// Total proof bytes of this level and everything after it, residual included.
+	cost: usize,
+	/// The lane count chosen for this level.
+	log_lanes: usize,
+	/// The inverse rate chosen for this level.
+	log_inv_rate: usize,
+	/// Whether a further committed level follows, rather than the residual terminating here.
+	recurse: bool,
+}
+
+/// Everything the ladder search needs that does not vary between subproblems.
+struct Search<'a, F, MerkleScheme> {
+	/// The Merkle scheme whose branch sizes price every level.
+	merkle_scheme: &'a MerkleScheme,
+	/// Serialized sizes of a digest and a field element.
+	sizes: ByteSizes,
+	/// Query count per `log_inv_rate`. Index 0 is unused: rate 1 is not a proximity test.
+	n_queries: Vec<usize>,
+	/// The regime the query counts and the soundness ceiling are derived in.
+	regime: SoundnessRegime,
+	/// The target every level must reach, in bits.
+	security_bits: usize,
+	/// Ties `F` to the Merkle scheme without storing a value of it.
+	_field: PhantomData<F>,
+}
+
+impl<F, MerkleScheme> Search<'_, F, MerkleScheme>
+where
+	F: BinaryField,
+	MerkleScheme: MerkleTreeScheme<F>,
+{
+	/// Whether a level can reach [`Self::security_bits`] at all.
+	///
+	/// Two independent ways to fail, and neither is fixable by opening more rows.
+	/// A level cannot sample more distinct positions than its codeword has.
+	/// And its correlated-agreement term is a ceiling set by the codeword length and the field.
+	fn reaches_target(&self, level: &LigeritoLevel) -> bool {
+		let base = self.regime.correlated_agreement_bits(
+			level.log_msg_len(),
+			level.log_inv_rate,
+			F::N_BITS,
+		);
+		// Same row union `LigeritoParams::correlated_agreement_bits` charges, so the search and
+		// the reported ceiling cannot disagree about which levels clear the target.
+		let algebra = base - (level.log_lanes.saturating_sub(1)) as f64;
+		level.is_feasible() && algebra >= self.security_bits as f64
+	}
+
+	/// The best level to commit next, given `log_total` message elements left and a rate floor.
+	///
+	/// `min_log_inv_rate ..= max_log_inv_rate` is the range of rates this level may commit at.
+	/// Level 0 gets a pinned singleton, and deeper levels get `previous + 1 ..= MAX_LOG_INV_RATE`.
+	///
+	/// `best` holds the already-solved subproblems, indexed by `[log_total][rate_floor]`.
+	/// Every subproblem read here has a smaller `log_total`, since a level folds at least one axis.
+	///
+	/// Returns `None` when no level reaches the target for this subproblem.
+	fn choose_level(
+		&self,
+		best: &[Vec<Option<Decision>>],
+		log_total: usize,
+		min_log_inv_rate: usize,
+		max_log_inv_rate: usize,
+	) -> Option<Decision> {
+		let mut chosen: Option<Decision> = None;
+		let mut consider = |candidate: Decision| {
+			if chosen.is_none_or(|current: Decision| candidate.cost < current.cost) {
+				chosen = Some(candidate);
+			}
+		};
+
+		for log_lanes in 1..=MAX_LOG_LANES.min(log_total) {
+			let log_msg_cols = log_total - log_lanes;
+			for log_inv_rate in min_log_inv_rate..=max_log_inv_rate {
+				let level = LigeritoLevel {
+					log_msg_cols,
+					log_lanes,
+					log_inv_rate,
+					n_queries: self.n_queries[log_inv_rate],
+				};
+				if !self.reaches_target(&level) {
+					continue;
+				}
+				let here = level_size(&level, self.merkle_scheme, &self.sizes);
+
+				// Terminate: fold this level and send the remaining columns in the clear.
+				consider(Decision {
+					cost: here + (1 << log_msg_cols) * self.sizes.value,
+					log_lanes,
+					log_inv_rate,
+					recurse: false,
+				});
+
+				// Or recurse: the remaining columns become the next level's message, committed at
+				// a strictly lower rate.
+				if let Some(next) = best[log_msg_cols][log_inv_rate + 1] {
+					consider(Decision {
+						cost: here + next.cost,
+						log_lanes,
+						log_inv_rate,
+						recurse: true,
+					});
+				}
+			}
+		}
+
+		chosen
+	}
+}
+
+/// Ladder minimizing the estimated proof size, with level 0's rate pinned by the caller.
+///
+/// Level 0's rate is pinned because level 0's encoding dominates prover time.
+/// A ladder only compares to today's FRI at the same L0 rate, where it does the same L0 work.
+/// The deep levels are small, so they are free to drop the rate as far as the search likes.
+///
+/// Returns the parameters together with the estimated proof size in bytes.
+/// That size is exactly [`LigeritoParams::proof_size`] of the returned parameters.
+///
+/// ## The search
+///
+/// This is a memoized dynamic program over `(log_total, rate_floor)`.
+/// The state is how many message elements are left, and the lowest rate the ladder still
+/// allows. It mirrors what `fri`'s `ReductionOptimizer` does for fold arities, with two
+/// differences.
+///
+/// The first difference is that the state carries a rate floor at all.
+/// A Ligerito level chooses its own rate, where an FRI round cannot.
+/// So an FRI round minimizes over arity alone.
+/// Each state here minimizes over a two-dimensional grid of `(log_lanes, log_inv_rate)`.
+///
+/// The second is that the minimization is exhaustive, not the early-exit `min_concave`
+/// performs. The `log_lanes` axis was measured monotone, so that early exit would in fact be
+/// sound on it. The measurement swept every state up to `log_n = 32`, both regimes, at 100 and
+/// 128 bits. It never found the objective turning back down after rising.
+/// The scan stays exhaustive anyway, for two reasons.
+/// The minimization is genuinely two-dimensional, where `min_concave` handles one axis.
+/// And a state's low rates are infeasible while its high ones are not, leaving a hole.
+/// An early-exit scan cannot walk over that hole unless it is handed a filtered range first.
+/// Meanwhile a state costs at most `MAX_LOG_LANES * MAX_LOG_INV_RATE` evaluations either way.
+/// A shape assumption buys nothing here, so this code does not make one.
+///
+/// The search caps `log_lanes` at [`MAX_LOG_LANES`] and `log_inv_rate` at [`MAX_LOG_INV_RATE`].
+/// See those constants for why neither cap binds.
+///
+/// Returns `None` when no ladder reaches `security_bits`, for either of two reasons.
+/// A level must have at least as many codeword positions as it opens queries, which rules out
+/// small `log_n`.
+/// And a level's correlated-agreement term must itself clear the target, which rules out large
+/// `log_n` over a field this size.
+/// [`crate::soundness`] explains why the second one cannot be bought back with more queries.
+///
+/// ## Panics
+///
+/// Panics if the preconditions below are violated.
+///
+/// ## Preconditions
+///
+/// * `l0_log_inv_rate` is in `1..=MAX_LOG_INV_RATE`.
+/// * `security_bits` is positive.
+pub(super) fn optimal_ladder<F, MerkleScheme>(
+	merkle_scheme: &MerkleScheme,
+	log_n: usize,
+	l0_log_inv_rate: usize,
+	regime: SoundnessRegime,
+	security_bits: usize,
+) -> Option<(LigeritoParams, usize)>
+where
+	F: BinaryField,
+	MerkleScheme: MerkleTreeScheme<F>,
+{
+	assert!(
+		(1..=MAX_LOG_INV_RATE).contains(&l0_log_inv_rate),
+		"precondition: l0_log_inv_rate must be in 1..={MAX_LOG_INV_RATE}, got {l0_log_inv_rate}"
+	);
+	assert!(security_bits > 0, "precondition: security_bits must be positive");
+
+	// Query counts depend only on the rate, so derive them once. Index 0 is unused: rate 1 is
+	// not a proximity test at all.
+	let search = Search::<F, MerkleScheme> {
+		merkle_scheme,
+		sizes: ByteSizes::new::<F, MerkleScheme>(),
+		n_queries: (0..=MAX_LOG_INV_RATE)
+			.map(|log_inv_rate| match log_inv_rate {
+				0 => 0,
+				_ => regime.n_queries(security_bits, log_inv_rate),
+			})
+			.collect(),
+		regime,
+		security_bits,
+		_field: PhantomData,
+	};
+
+	// `best[log_total][rate_floor]`. The rate floor runs to `MAX_LOG_INV_RATE + 1`, one past
+	// the last usable rate, so that a level committed at the last rate can look up "no level
+	// may follow" without a bounds check.
+	let mut best = vec![vec![None::<Decision>; MAX_LOG_INV_RATE + 2]; log_n + 1];
+	for log_total in 0..=log_n {
+		for rate_floor in 1..=MAX_LOG_INV_RATE {
+			best[log_total][rate_floor] =
+				search.choose_level(&best, log_total, rate_floor, MAX_LOG_INV_RATE);
+		}
+	}
+
+	// Level 0 is the same subproblem with its rate pinned to a single value.
+	let root = search.choose_level(&best, log_n, l0_log_inv_rate, l0_log_inv_rate)?;
+
+	let estimated_size = root.cost;
+
+	let mut levels = Vec::new();
+	let mut decision = root;
+	let mut log_total = log_n;
+	loop {
+		let log_msg_cols = log_total - decision.log_lanes;
+		levels.push(LigeritoLevel {
+			log_msg_cols,
+			log_lanes: decision.log_lanes,
+			log_inv_rate: decision.log_inv_rate,
+			n_queries: search.n_queries[decision.log_inv_rate],
+		});
+		if !decision.recurse {
+			break;
+		}
+		log_total = log_msg_cols;
+		decision = best[log_msg_cols][decision.log_inv_rate + 1]
+			.expect("a recursing decision was scored against a solved subproblem");
+	}
+
+	Some((LigeritoParams::new(levels, regime, security_bits), estimated_size))
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::Ghash128b as B128;
+	use binius_hash::StdHashSuite;
+	use proptest::prelude::*;
+
+	use super::*;
+	use crate::{channel::OracleSpec, fri::FRIParams, merkle_tree::BinaryMerkleTreeScheme};
+
+	type TestMerkleScheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
+
+	fn test_merkle_scheme() -> TestMerkleScheme {
+		BinaryMerkleTreeScheme::new()
+	}
+
+	const UDR: SoundnessRegime = SoundnessRegime::UniqueDecoding;
+	const JOHNSON: SoundnessRegime = SoundnessRegime::Johnson { eta: 0.02 };
+
+	/// The target `binius-verifier` ships, which the pinned tables below are sized to.
+	///
+	/// The plan document tabulates 100 bits instead. Over `B128` that target is out of reach for
+	/// the larger shapes, which the infeasibility test below pins.
+	const SECURITY_BITS: usize = 96;
+
+	// Re-checks the constructor's invariants from the outside, so a ladder the search produced is
+	// held to the same standard as one a caller wrote by hand.
+	fn assert_invariants(params: &LigeritoParams) {
+		let levels = params.levels();
+		assert!(!levels.is_empty());
+		for pair in levels.windows(2) {
+			let (prev, next) = (&pair[0], &pair[1]);
+			assert_eq!(next.log_msg_cols + next.log_lanes, prev.log_msg_cols);
+			assert!(next.log_inv_rate > prev.log_inv_rate);
+		}
+		for level in levels {
+			assert!(level.is_feasible());
+			assert!(level.log_lanes >= 1);
+			assert!(level.log_lanes <= MAX_LOG_LANES);
+			assert!(level.log_inv_rate <= MAX_LOG_INV_RATE);
+			assert_eq!(
+				level.n_queries,
+				params
+					.regime()
+					.n_queries(params.security_bits(), level.log_inv_rate)
+			);
+		}
+		assert_eq!(params.log_residual_dim(), levels.last().expect("non-empty").log_msg_cols);
+	}
+
+	#[test]
+	fn ladder_is_valid_and_its_estimate_is_exact() {
+		let merkle_scheme = test_merkle_scheme();
+		for regime in [SoundnessRegime::UniqueDecoding, JOHNSON] {
+			for log_n in [12, 17, 20, 24, 28, 30] {
+				for l0_log_inv_rate in [1, 2, 4] {
+					let Some((params, estimate)) = LigeritoParams::optimal_ladder::<B128, _>(
+						&merkle_scheme,
+						log_n,
+						l0_log_inv_rate,
+						regime,
+						SECURITY_BITS,
+					) else {
+						continue;
+					};
+					assert_invariants(&params);
+					// Level 0's rate is the caller's to pin, and the message is fully covered.
+					assert_eq!(params.levels()[0].log_inv_rate, l0_log_inv_rate);
+					assert_eq!(params.log_msg_len(), log_n);
+					// The search's own objective is the byte count, not an approximation of it.
+					assert_eq!(estimate, params.proof_size(&merkle_scheme));
+				}
+			}
+		}
+	}
+
+	// The plan document's table, priced by this repo's own Merkle scheme rather than by the
+	// document's simplified model. L0's rate is pinned to 1/2, so L0 encoding costs exactly what
+	// today's FRI costs and only the small deep levels drop the rate.
+	#[test]
+	fn pinned_ladder_sizes_at_l0_rate_one_half() {
+		let merkle_scheme = test_merkle_scheme();
+
+		// Level 0's lane count comes out at 3 or 4, matching the arity `fri`'s own optimizer picks.
+		let expected = [
+			(17, 161_504),
+			(20, 236_960),
+			(24, 348_288),
+			(28, 472_960),
+			(30, 542_816),
+		];
+		for (log_n, bytes) in expected {
+			let (_, size) = LigeritoParams::optimal_ladder::<B128, _>(
+				&merkle_scheme,
+				log_n,
+				1,
+				UDR,
+				SECURITY_BITS,
+			)
+			.expect("pinned shapes are feasible");
+			assert_eq!(size, bytes, "log_n={log_n}");
+		}
+	}
+
+	#[test]
+	fn the_johnson_regime_has_no_ladder_over_this_field() {
+		let merkle_scheme = test_merkle_scheme();
+
+		// The reference implementation's `eta = 0.02` puts `m = ceil(sqrt(rho)/eta)` at 36 at rate
+		// 1/2, and `m^5 * n / |F|` is then nowhere near the target. So there is no ladder at all.
+		for log_n in [17, 20, 24, 28, 30] {
+			let ladder = LigeritoParams::optimal_ladder::<B128, _>(
+				&merkle_scheme,
+				log_n,
+				1,
+				JOHNSON,
+				SECURITY_BITS,
+			);
+			assert!(ladder.is_none(), "log_n={log_n}");
+		}
+
+		// Sweeping `eta` barely rescues it. Past `log_n = 20` no slack clears the target at all,
+		// and at 20 the slack that does clear costs several times what unique decoding costs.
+		for log_n in [24, 28, 30] {
+			assert_eq!(SoundnessRegime::optimal_johnson(SECURITY_BITS, log_n, 1, 128), None);
+		}
+		let (_, swept) =
+			SoundnessRegime::optimal_johnson(SECURITY_BITS, 20, 1, 128).expect("20 clears, barely");
+		assert!(swept > 4 * UDR.n_queries(SECURITY_BITS, 1), "swept={swept}");
+	}
+
+	#[test]
+	fn lower_l0_rate_gives_a_smaller_proof() {
+		let merkle_scheme = test_merkle_scheme();
+		// Unique decoding only: the Johnson regime has no feasible ladder over this field, which
+		// the test above pins.
+		for regime in [UDR] {
+			for log_n in [17, 20, 24, 28] {
+				// The trend holds while the ladder still has rate room below L0 to recurse into.
+				let sizes = (1..=4)
+					.map(|l0_log_inv_rate| {
+						LigeritoParams::optimal_ladder::<B128, _>(
+							&merkle_scheme,
+							log_n,
+							l0_log_inv_rate,
+							regime,
+							SECURITY_BITS,
+						)
+						.expect("feasible")
+						.1
+					})
+					.collect::<Vec<_>>();
+				// Lowering L0's rate pays down to 1/8 at every size measured.
+				for pair in sizes[..3].windows(2) {
+					assert!(pair[1] <= pair[0], "regime={regime:?} log_n={log_n} sizes={sizes:?}");
+				}
+				assert!(sizes[2] < sizes[0], "regime={regime:?} log_n={log_n} sizes={sizes:?}");
+				// It stops paying at 1/16 for the largest shapes: the fold row union eats the
+				// headroom the extra rate step would have bought.
+				if log_n <= 24 {
+					assert!(sizes[3] <= sizes[2], "regime={regime:?} log_n={log_n} {sizes:?}");
+				}
+
+				// It reverses at the far end, and the reason is the rate cap rather than the rate.
+				// Pinning L0 at MAX_LOG_INV_RATE leaves no strictly lower rate for a second level,
+				// so the ladder is forced to one level and a huge cleartext residual.
+				let Some((capped, capped_size)) = LigeritoParams::optimal_ladder::<B128, _>(
+					&merkle_scheme,
+					log_n,
+					MAX_LOG_INV_RATE,
+					regime,
+					SECURITY_BITS,
+				) else {
+					continue;
+				};
+				assert_eq!(capped.n_levels(), 1);
+				assert!(capped_size > sizes[3], "regime={regime:?} log_n={log_n}");
+			}
+		}
+	}
+
+	#[test]
+	fn single_level_ladder_prices_the_residual_in_the_clear() {
+		let merkle_scheme = test_merkle_scheme();
+		// One level, 2^9 columns by 2^3 lanes, rate 1/2, residual 2^9 elements in the clear.
+		let level = LigeritoLevel::new(9, 3, 1, UDR, SECURITY_BITS);
+		let params = LigeritoParams::new(vec![level], UDR, SECURITY_BITS);
+		assert_eq!(params.log_residual_dim(), 9);
+
+		let value_size = size_of::<B128>();
+		let digest_size = size_of::<<TestMerkleScheme as MerkleTreeScheme<B128>>::Digest>();
+		let queries = UDR.n_queries(SECURITY_BITS, 1);
+		let layer_depth = merkle_scheme.optimal_verify_layer(queries, 10);
+		let expected = digest_size
+			+ queries * 8 * value_size
+			+ merkle_scheme.proof_size(1 << 10, queries, layer_depth)
+			+ 2 * 3 * value_size
+			+ (1 << 9) * value_size;
+		assert_eq!(params.proof_size(&merkle_scheme), expected);
+	}
+
+	#[test]
+	fn smallest_feasible_log_n() {
+		let merkle_scheme = test_merkle_scheme();
+		// At 96 bits and rate 1/2 the unique-decoding regime opens 232 queries, so a level needs
+		// 2^8 codeword positions. With one lane folded away that puts the floor at log_n = 8.
+		let (params, size) =
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 8, 1, UDR, SECURITY_BITS)
+				.expect("log_n = 8 is the smallest feasible shape");
+		assert_invariants(&params);
+		// The search stops at one level, not because a second is infeasible but because it costs
+		// more: the 2^7-element residual is cheaper than another root, rows, and multi-proof.
+		assert_eq!(params.n_levels(), 1);
+		assert_eq!(params.levels()[0].log_lanes, 1);
+		assert_eq!(params.log_residual_dim(), 7);
+		assert_eq!(size, params.proof_size(&merkle_scheme));
+	}
+
+	#[test]
+	fn log_n_below_the_feasibility_floor_has_no_ladder() {
+		// Every candidate level would open more rows than its codeword has positions.
+		let ladder = LigeritoParams::optimal_ladder::<B128, _>(
+			&test_merkle_scheme(),
+			7,
+			1,
+			UDR,
+			SECURITY_BITS,
+		);
+		assert!(ladder.is_none());
+	}
+
+	#[test]
+	fn the_correlated_agreement_ceiling_bounds_log_n_from_above() {
+		let merkle_scheme = test_merkle_scheme();
+
+		// Over B128 the ceiling falls one bit per doubling, so a target picks out a largest shape.
+		// At 96 bits and L0 rate 1/2 nothing past log_n = 32 has a ladder at all.
+		let ladder = |log_n, target| {
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, log_n, 1, UDR, target)
+				.is_some()
+		};
+		assert!(ladder(32, 96));
+		assert!(!ladder(33, 96));
+
+		// And the cutoff is not a cliff: the shape degenerates well before it. At log_n = 32 the
+		// only levels that still clear the target fold one lane at a time, so the search is forced
+		// into a huge cleartext residual rather than a ladder. Pinning that keeps a caller from
+		// reading the returned size as a usable configuration.
+		let (_, degenerate) =
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 32, 1, UDR, SECURITY_BITS)
+				.expect("log_n = 32 still has a ladder, of a sort");
+		let (_, sane) =
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 30, 1, UDR, SECURITY_BITS)
+				.expect("log_n = 30 has a real ladder");
+		assert!(degenerate > 100 * sane, "degenerate={degenerate} sane={sane}");
+
+		// Raising the target lowers that boundary, which is the whole point of tracking the term.
+		assert!(ladder(28, 100));
+		assert!(!ladder(29, 100));
+
+		// And 128 bits is out of reach at every size, as `crate::soundness` documents.
+		for log_n in [12, 20, 28] {
+			assert!(!ladder(log_n, 128), "log_n={log_n}");
+		}
+	}
+
+	// The full 2x2 of {FRI, Ligerito} x {unique decoding, Johnson}, all priced by this repo's own
+	// estimators. Run with `--nocapture` to read the table.
+	//
+	// The Johnson rows price the *query phase only*, which is what the plan document tabulates.
+	// Over this field that regime has no correlated-agreement headroom at all, so its Ligerito
+	// cell reads infeasible and its FRI cells are a lower bound on bytes rather than a shippable
+	// configuration. `crate::soundness` and `PROXIMITY_GAPS.md` carry the reason.
+	//
+	// The regime enters the FRI side only through the query count, so feeding it a Johnson count
+	// is the entire change needed to price FRI in that regime.
+	//
+	// Two things to read carefully in the output. Rows (2) and (4) lower the rate at L0 too, so
+	// they are not comparable on prover time to rows (1), (3), (5), or (6): L0 encoding scales
+	// with the codeword, and rate 1/8 measures ~3.75x rate 1/2. And row (4)'s winner sits at the
+	// top of the swept range, so that row is bounded by the sweep, not by an interior optimum.
+	//
+	// Byte counts are deliberately not pinned: six configurations by five sizes is a lot of
+	// literals to maintain, and each one would break on any retuning of either search. Only the
+	// orderings are asserted, and only the ones that hold at every size measured.
+	#[test]
+	fn fri_versus_ligerito_table() {
+		let merkle_scheme = test_merkle_scheme();
+
+		// FRI at one fixed rate, a single non-ZK oracle, its own proof-size-minimizing arities.
+		let fri_size = |log_n: usize, log_inv_rate: usize, regime: SoundnessRegime| {
+			let (params, _) = FRIParams::<B128>::optimal_for_batch(
+				&merkle_scheme,
+				&[OracleSpec::new(log_n)],
+				log_inv_rate,
+				regime.n_queries(100, log_inv_rate),
+			);
+			params.proof_size(&merkle_scheme)
+		};
+		// The best constant rate FRI can pick, paired with the rate that won it.
+		let fri_best = |log_n: usize, regime: SoundnessRegime| {
+			(1..=MAX_LOG_INV_RATE)
+				.map(|log_inv_rate| (fri_size(log_n, log_inv_rate, regime), log_inv_rate))
+				.min()
+				.expect("the rate range is non-empty")
+		};
+		// A ladder exists exactly when some level 0 is feasible, which is cheap to check up front.
+		// Checking it here keeps an infeasible cell a printed row rather than a panic.
+		let ladder_feasible = |log_n: usize, l0: usize, regime: SoundnessRegime| {
+			(1..=MAX_LOG_LANES.min(log_n)).any(|lanes| {
+				LigeritoLevel::new(log_n - lanes, lanes, l0, regime, 100).is_feasible()
+			})
+		};
+
+		println!();
+		println!(
+			"{:>5}  {:<31}  {:>9}  {:>7}  {:>7}",
+			"log_n", "configuration", "bytes", "KiB", "vs (1)"
+		);
+		for log_n in [17usize, 20, 24, 28, 30] {
+			let baseline = fri_size(log_n, 1, UDR);
+			let (best_udr, best_udr_rate) = fri_best(log_n, UDR);
+			let (best_john, best_john_rate) = fri_best(log_n, JOHNSON);
+			let ladder = |regime| {
+				ladder_feasible(log_n, 1, regime)
+					.then(|| {
+						LigeritoParams::optimal_ladder::<B128, _>(
+							&merkle_scheme,
+							log_n,
+							1,
+							regime,
+							SECURITY_BITS,
+						)
+					})
+					.flatten()
+					.map(|(_, size)| size)
+			};
+
+			let rows = [
+				("(1) FRI       UDR      rate 1/2".to_owned(), Some(baseline)),
+				(format!("(2) FRI       UDR      rate 1/{}", 1 << best_udr_rate), Some(best_udr)),
+				("(3) FRI       Johnson  rate 1/2".to_owned(), Some(fri_size(log_n, 1, JOHNSON))),
+				(format!("(4) FRI       Johnson  rate 1/{}", 1 << best_john_rate), Some(best_john)),
+				("(5) Ligerito  UDR      L0 1/2".to_owned(), ladder(UDR)),
+				("(6) Ligerito  Johnson  L0 1/2".to_owned(), ladder(JOHNSON)),
+			];
+			for (label, size) in &rows {
+				match size {
+					Some(bytes) => println!(
+						"{log_n:>5}  {label:<31}  {bytes:>9}  {:>7.1}  {:>6.2}x",
+						*bytes as f64 / 1024.0,
+						baseline as f64 / *bytes as f64,
+					),
+					None => println!("{log_n:>5}  {label:<31}  {:>9}", "infeasible"),
+				}
+			}
+
+			let lig_udr = ladder(UDR).expect("a unique-decoding ladder is feasible at these sizes");
+
+			// A ladder beats FRI at the same L0 rate, in the same regime. This is the honest
+			// comparison, since equal L0 rate means equal L0 encoding cost.
+			assert!(lig_udr < baseline, "log_n={log_n} lig={lig_udr} fri={baseline}");
+			// Rows (3), (4) and (6) price a regime this field cannot support. They are printed
+			// because the plan document tabulates them, and asserted only on their query counts.
+			assert!(fri_size(log_n, 1, JOHNSON) < baseline, "log_n={log_n}");
+			assert_eq!(ladder(JOHNSON), None, "log_n={log_n}");
+			// Rows (2) and (4) are deliberately NOT asserted against the ladder. They can and do
+			// beat it, by lowering the rate at L0 too, which is exactly where the encoding cost
+			// lives. Only their weak ordering against their own rate-1/2 row is a real invariant.
+			assert!(best_udr <= baseline, "log_n={log_n}");
+			assert!(best_john <= fri_size(log_n, 1, JOHNSON), "log_n={log_n}");
+		}
+	}
+
+	proptest! {
+		#[test]
+		fn ladder_always_satisfies_the_invariants(
+			log_n in 12usize..=32,
+			l0_log_inv_rate in 1usize..=4,
+			eta in 0.005f64..0.1,
+			use_johnson in any::<bool>(),
+			security_bits in 80usize..=128,
+		) {
+			let regime = if use_johnson {
+				SoundnessRegime::Johnson { eta }
+			} else {
+				SoundnessRegime::UniqueDecoding
+			};
+			let merkle_scheme = test_merkle_scheme();
+			let Some((params, estimate)) = LigeritoParams::optimal_ladder::<B128, _>(
+				&merkle_scheme,
+				log_n,
+				l0_log_inv_rate,
+				regime,
+				security_bits,
+			) else {
+				// Infeasible shapes are a documented outcome, not a failure to search.
+				return Ok(());
+			};
+			assert_invariants(&params);
+			prop_assert_eq!(params.log_msg_len(), log_n);
+			prop_assert_eq!(estimate, params.proof_size(&merkle_scheme));
+		}
+
+		#[test]
+		fn proof_size_is_positive_and_grows_with_queries(
+			log_msg_cols in 8usize..=20,
+			log_lanes in 1usize..=7,
+			log_inv_rate in 1usize..=4,
+			extra_queries in 1usize..=64,
+		) {
+			let merkle_scheme = test_merkle_scheme();
+			let base = LigeritoLevel {
+				log_msg_cols,
+				log_lanes,
+				log_inv_rate,
+				n_queries: 1,
+			};
+			let mut more = base;
+			more.n_queries = 1 + extra_queries;
+			// Both levels must fit their codeword, which 2^(8 + 1) positions comfortably do.
+			prop_assert!(more.is_feasible());
+
+			let small = LigeritoParams::new(
+				vec![base],
+				SoundnessRegime::UniqueDecoding,
+				SECURITY_BITS,
+			);
+			let large = LigeritoParams::new(
+				vec![more],
+				SoundnessRegime::UniqueDecoding,
+				SECURITY_BITS,
+			);
+			let small_size = small.proof_size(&merkle_scheme);
+			prop_assert!(small_size > 0);
+			prop_assert!(large.proof_size(&merkle_scheme) > small_size);
+		}
+	}
+}

--- a/crates/iop/src/soundness.rs
+++ b/crates/iop/src/soundness.rs
@@ -1,0 +1,671 @@
+// Copyright 2026 The Binius Developers
+
+//! Soundness accounting for Reed-Solomon proximity tests.
+//!
+//! A proximity test bounds the chance that a word far from the code survives.
+//! Two independent terms bound it, and the protocol's security is the worse of the two.
+//!
+//! ```text
+//!     bits    = min(algebra, queries)
+//!
+//!     algebra = -log2(eps_ca)                  <- fixed by the code and the field
+//!     queries = -n_queries * log2(1 - delta)   <- bought one query at a time
+//! ```
+//!
+//! The right-hand term is the one everybody counts.
+//! Sampling `n_queries` positions catches a `delta`-far word all but `(1 - delta)^n_queries` of the
+//! time, so more queries always buy more bits.
+//!
+//! The left-hand term is the *correlated-agreement error*.
+//! It says how often a random linear combination of two far words lands close to the code anyway.
+//! It grows with the codeword length and shrinks with the field size, and **no number of queries
+//! affects it**.
+//! It is a ceiling, and `PROXIMITY_GAPS.md` at the repository root tabulates where that ceiling
+//! falls for the shapes this repo commits at.
+//!
+//! # Which property a protocol needs
+//!
+//! Three properties form a chain, each stronger than the last.
+//!
+//! - *Proximity gap*: either almost none of the line is close to the code, or all of it is.
+//! - *Correlated agreement* (CA): all the words agree with codewords on one shared set.
+//! - *Mutual correlated agreement* (MCA): they agree on *every* set that witnesses closeness.
+//!
+//! FRI needs CA, because it only ever concludes that the folded word is close to the code.
+//! BaseFold, WHIR and Ligerito need MCA, because they conclude things about the *message* the
+//! nearby codeword encodes.
+//! [`SoundnessRegime::correlated_agreement_bits`] returns the MCA bound, which upper-bounds the CA
+//! one, so a caller that only needs CA is charged conservatively.
+//!
+//! # Scope
+//!
+//! Every bound here is quoted from a theorem, not fitted or extrapolated.
+//! Three scope questions decide whether a quoted theorem covers this repository.
+//!
+//! *Which field?*
+//! [BCHKS25] Cor. 1.4 and Theorem 4.6 are stated for `RS[F_q, D, k]` over any finite field.
+//! Neither assumes a characteristic.
+//! So both cover the binary field this repo draws challenges from.
+//!
+//! *Which evaluation domain?*
+//! Both are stated for an arbitrary domain of definition `D`.
+//! That matters, because this repo's `D` is an `F_2`-affine subspace, not a multiplicative
+//! subgroup, and several results in the literature assume the latter.
+//! In particular [KKH26]'s limitation is proven for smooth multiplicative domains, so it does not
+//! transfer here as stated.
+//!
+//! *Which randomness?*
+//! Both theorems bound a line `u_0 + z * u_1` or a power curve `sum_i z^i * u_i`.
+//! The FRI fold draws one challenge per layer and is a line, so it is covered.
+//! Oracle batching instead uses the tensor randomness of [DP24], via `eq_ind_partial_eval`.
+//! A tensor is not a power curve, so the bounds here transfer to the batching step only through
+//! [DP24]'s own analysis, and only in the unique-decoding regime.
+//! Read the [`SoundnessRegime::Johnson`] numbers as a bound on the fold, not on the batch.
+//!
+//! # What this module does not count
+//!
+//! Two terms belong in a whole-protocol budget and are not here.
+//! Both reference Ligerito implementations carry them, so the numbers here are a floor on the
+//! work, not a complete accounting.
+//!
+//! *Out-of-domain binding.* Past the unique-decoding radius the prover is near a *list* of
+//! codewords, not one.
+//! Binding it to a single element costs a term of roughly `binom(L, 2) * (mu/|F|)^s` for `s`
+//! out-of-domain samples on a `mu`-variate multilinear.
+//! Without it the query term pays a factor `L` instead.
+//! Only the Johnson regime needs this, and this repo cannot afford that regime anyway.
+//!
+//! *The fold row union.* These bounds are stated for one fold step.
+//! A level that folds `2^l` interleaved lanes pays the bound once per lane-fold round, and the two
+//! reference implementations disagree on how much: one charges a factor `l`, the other `2^(l-1)`.
+//! [`crate::ligerito::LigeritoParams::correlated_agreement_bits`] charges the pessimistic one.
+//!
+//! Proof-of-work grinding is also absent, and it is what both references use to close the last
+//! few bits.
+//! Grinding is a transcript-level device rather than a property of the code, so it belongs to
+//! whichever protocol adopts it.
+//!
+//! One warning is *stronger* in characteristic 2 than elsewhere.
+//! [BCHKS25] Theorem 1.6 and Cor. 1.7 show proximity gaps past the Johnson radius fail, and they
+//! prove it *for all fields of characteristic 2*, using an `F_2`-subspace domain.
+//! Their counterexamples need `n` near `sqrt(q)`, far past any size this repo commits at.
+//! But they do rule out a general theorem past Johnson in exactly this setting.
+//! [BCHKS25] leaves open whether well-chosen characteristic-2 domains escape it.
+//!
+//! # References
+//!
+//! - [BCHKS25] Cor. 1.4 is the unique-decoding error, and is optimal on its range.
+//! - [BCHKS25] Theorem 4.6 is mutual correlated agreement up to the Johnson bound.
+//! - [DG25] §1.5 is the query floor no conjecture can undercut, over all characteristics.
+//! - [ABF26] surveys all of the above.
+//!
+//! [BCHKS25]: <https://eprint.iacr.org/2025/2055>
+//! [DG25]: <https://eprint.iacr.org/2025/2010>
+//! [KKH26]: <https://eprint.iacr.org/2026/782>
+//! [DP24]: <https://eprint.iacr.org/2024/504>
+//! [ABF26]: <https://eprint.iacr.org/2026/680>
+
+use crate::fri::calculate_n_test_queries;
+
+/// Which proximity-testing regime a code's parameters are derived in.
+///
+/// The variants differ only in how far out the proximity parameter `delta` is pushed.
+/// Pushing it out buys query-phase soundness and costs correlated-agreement soundness.
+/// Neither variant rests on a conjecture; both are theorems.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum SoundnessRegime {
+	/// The unique-decoding radius, `delta = (1 - rho)/2`.
+	///
+	/// A word that far from the code has at most one codeword near it.
+	/// The correlated-agreement error is then `(delta * n + 1)/|F|`, per [BCHKS25] Cor. 1.4.
+	/// That bound is tight, so nothing better exists on this range.
+	/// The resulting query count is exactly what FRI uses today.
+	///
+	/// [BCHKS25]: <https://eprint.iacr.org/2025/2055>
+	#[default]
+	UniqueDecoding,
+	/// The unique-decoding radius held back by a constant, `delta = (1 - rho)/2 - loss`.
+	///
+	/// Giving up an arbitrarily small constant of distance buys an exceptional set that does not
+	/// grow with the codeword: [BCHKS25] Theorem 1.3 gives
+	///
+	/// ```text
+	///     a >= max( (d/g - 1) / (d - 2g) , 1 + g/loss )     d = 1 - rho,  g = d/2 - loss
+	/// ```
+	///
+	/// with **no `n` in it**.
+	/// [`Self::UniqueDecoding`]'s bound is tight but carries a factor `n`, so its ceiling falls one
+	/// bit per doubling of the witness.
+	/// This one does not move at all.
+	/// The price is a slightly smaller `delta`, so slightly more queries.
+	///
+	/// Both reference Ligerito implementations use this variant rather than the lossless one for
+	/// their conjecture-free profile.
+	///
+	/// [BCHKS25]: <https://eprint.iacr.org/2025/2055>
+	UniqueDecodingWithLoss {
+		/// The distance `loss > 0` given up below the unique-decoding radius.
+		///
+		/// Smaller values keep more distance, so fewer queries, but drive `a` up as `1/loss`.
+		/// [`Self::optimal_unique_decoding`] picks the value that balances the two.
+		loss: f64,
+	},
+	/// The Johnson list-decoding bound, `delta = 1 - sqrt(rho) - eta`.
+	///
+	/// Past the unique-decoding radius the list of nearby codewords is no longer a singleton.
+	/// Soundness then needs *mutual* correlated agreement, which [BCHKS25] Theorem 4.6 proves holds
+	/// up to the Johnson bound with error `O_rho(n / (eta^5 * |F|))`.
+	///
+	/// This variant is **not** conjecture-gated.
+	/// It is gated on having enough field: the `eta^5` makes it expensive.
+	/// Check [`SoundnessRegime::correlated_agreement_bits`] before choosing it.
+	///
+	/// [BCHKS25]: <https://eprint.iacr.org/2025/2055>
+	Johnson {
+		/// The slack `eta > 0` held back from the Johnson radius, in units of relative distance.
+		///
+		/// Smaller values push `delta` further out, so each query rules out more.
+		/// They also drive the correlated-agreement error up as `eta^-5`.
+		/// [`SoundnessRegime::optimal_johnson`] picks the value that balances the two.
+		eta: f64,
+	},
+}
+
+impl SoundnessRegime {
+	/// The proximity parameter `delta` this regime tests at, for a code of the given rate.
+	///
+	/// # Panics
+	/// Panics if `log_inv_rate` is zero, since at rate 1 there is nothing to test.
+	/// Panics if a [`Self::Johnson`] slack is not in `(0, 1 - sqrt(rho))`.
+	pub fn proximity_parameter(self, log_inv_rate: usize) -> f64 {
+		assert!(log_inv_rate >= 1, "precondition: log_inv_rate must be at least 1");
+		let rho = rate(log_inv_rate);
+		match self {
+			Self::UniqueDecoding => (1.0 - rho) / 2.0,
+			Self::UniqueDecodingWithLoss { loss } => {
+				assert!(loss > 0.0, "precondition: loss must be positive");
+				let delta = (1.0 - rho) / 2.0 - loss;
+				assert!(delta > 0.0, "precondition: loss must be less than (1 - rho)/2");
+				delta
+			}
+			Self::Johnson { eta } => {
+				assert!(eta > 0.0, "precondition: eta must be positive");
+				let delta = 1.0 - rho.sqrt() - eta;
+				assert!(delta > 0.0, "precondition: eta must be less than 1 - sqrt(rho)");
+				delta
+			}
+		}
+	}
+
+	/// Bits of query-phase soundness one row query rules out, at the given rate.
+	///
+	/// This is `-log2(1 - delta)`, the chance a single sampled position misses the disagreement.
+	///
+	/// # Panics
+	/// Those of [`Self::proximity_parameter`].
+	pub fn bits_per_query(self, log_inv_rate: usize) -> f64 {
+		-(1.0 - self.proximity_parameter(log_inv_rate)).log2()
+	}
+
+	/// Row queries needed for `security_bits` bits of *query-phase* soundness.
+	///
+	/// This is `ceil(security_bits / bits_per_query)`, and accounts for the query phase alone.
+	/// It says nothing about whether the correlated-agreement term also clears the target.
+	/// Use [`Self::plan_queries`] to get a count that clears both.
+	///
+	/// For [`Self::UniqueDecoding`] this delegates to [`calculate_n_test_queries`].
+	/// A Ligerito level in that regime therefore costs exactly as many queries as an FRI round.
+	///
+	/// # Panics
+	/// Those of [`Self::proximity_parameter`].
+	pub fn n_queries(self, security_bits: usize, log_inv_rate: usize) -> usize {
+		match self {
+			Self::UniqueDecoding => {
+				assert!(log_inv_rate >= 1, "precondition: log_inv_rate must be at least 1");
+				calculate_n_test_queries(security_bits, log_inv_rate)
+			}
+			Self::UniqueDecodingWithLoss { .. } | Self::Johnson { .. } => {
+				(security_bits as f64 / self.bits_per_query(log_inv_rate)).ceil() as usize
+			}
+		}
+	}
+
+	/// Bits of soundness the correlated-agreement term alone allows, whatever the query count.
+	///
+	/// `log_msg_len` and `log_inv_rate` fix the codeword length `n = 2^(log_msg_len +
+	/// log_inv_rate)`, and `log_field_size` is `log2|F|` of the field challenges are drawn from.
+	///
+	/// In [`Self::UniqueDecoding`] the error is `(delta * n + 1)/|F|`, per [BCHKS25] Cor. 1.4.
+	/// That corollary is stated for `delta` a hair inside the radius, short of it by
+	/// `3/((1 - rho) * n)` of relative distance.
+	/// Evaluating at the radius itself moves the bound by far less than a bit.
+	///
+	/// In [`Self::Johnson`] the error is [BCHKS25] Theorem 4.6 at `M = 1`, plus the Johnson list
+	/// size over the field.
+	/// The list term is what [ABF26] §6.4 adds alongside the MCA term when accounting a round.
+	///
+	/// # Panics
+	/// Those of [`Self::proximity_parameter`].
+	///
+	/// [BCHKS25]: <https://eprint.iacr.org/2025/2055>
+	/// [ABF26]: <https://eprint.iacr.org/2026/680>
+	pub fn correlated_agreement_bits(
+		self,
+		log_msg_len: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+	) -> f64 {
+		let rho = rate(log_inv_rate);
+		let n = 2.0f64.powi((log_msg_len + log_inv_rate) as i32);
+		let delta = self.proximity_parameter(log_inv_rate);
+
+		let exceptional = match self {
+			// Cor. 1.4: the exceptional set has size `delta * n + 1`, and that is tight.
+			Self::UniqueDecoding => delta * n + 1.0,
+			// Theorem 1.3, and the `n` is gone. `delta` here is already the held-back radius.
+			Self::UniqueDecodingWithLoss { loss } => {
+				let code_distance = 1.0 - rho;
+				let interpolation = (code_distance / delta - 1.0) / (code_distance - 2.0 * delta);
+				interpolation.max(1.0 + delta / loss)
+			}
+			Self::Johnson { eta } => {
+				// Theorem 4.6 at M = 1. The `m^5` is why small `eta` is expensive.
+				let m = (rho.sqrt() / eta).ceil().max(3.0) + 0.5;
+				let leading = (2.0 * m.powi(5) + 3.0 * m * delta * rho) / (3.0 * rho.powf(1.5));
+				// The Johnson list size `1/(2 * eta * sqrt(rho))` rides along in the same round.
+				leading * n + m / rho.sqrt() + 1.0 / (2.0 * eta * rho.sqrt())
+			}
+		};
+
+		log_field_size as f64 - exceptional.log2()
+	}
+
+	/// The security a configuration actually reaches: the worse of its two terms.
+	///
+	/// See the module documentation for what the two terms are, and why only one of them responds
+	/// to `n_queries`.
+	///
+	/// # Panics
+	/// Those of [`Self::proximity_parameter`].
+	pub fn achieved_security_bits(
+		self,
+		log_msg_len: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+		n_queries: usize,
+	) -> f64 {
+		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size);
+		let queries = n_queries as f64 * self.bits_per_query(log_inv_rate);
+		algebra.min(queries)
+	}
+
+	/// The smallest query count reaching `security_bits`, or `None` if the algebra caps below it.
+	///
+	/// A `None` is not a parameter that needs more queries.
+	/// It is a configuration that cannot reach the target at all, because
+	/// [`Self::correlated_agreement_bits`] is already under it.
+	/// Widen the field, grind, or lower the target.
+	///
+	/// # Panics
+	/// Those of [`Self::proximity_parameter`].
+	pub fn plan_queries(
+		self,
+		security_bits: usize,
+		log_msg_len: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+	) -> Option<usize> {
+		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size);
+		if algebra < security_bits as f64 {
+			return None;
+		}
+		Some(self.n_queries(security_bits, log_inv_rate))
+	}
+
+	/// The [`Self::Johnson`] slack minimizing queries at `security_bits`, with the count it
+	/// reaches.
+	///
+	/// Sweeps `eta` over `(0, 1 - sqrt(rho))`.
+	/// Small `eta` pushes `delta` out and cuts queries, but drives the `eta^-5` error term up.
+	/// Large `eta` does the reverse, until `delta` falls back inside the unique-decoding radius and
+	/// the regime stops paying for itself.
+	///
+	/// Returns `None` when no slack reaches the target, which over a field this size is the common
+	/// case rather than the exception.
+	///
+	/// # Panics
+	/// Panics if `log_inv_rate` is zero.
+	pub fn optimal_johnson(
+		security_bits: usize,
+		log_msg_len: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+	) -> Option<(Self, usize)> {
+		assert!(log_inv_rate >= 1, "precondition: log_inv_rate must be at least 1");
+		let span = 1.0 - rate(log_inv_rate).sqrt();
+
+		// A fixed grid keeps the answer reproducible across platforms, which a solver would not.
+		const STEPS: usize = 4096;
+		(1..STEPS)
+			.map(|i| Self::Johnson {
+				eta: span * i as f64 / STEPS as f64,
+			})
+			.filter_map(|regime| {
+				let queries = regime.plan_queries(
+					security_bits,
+					log_msg_len,
+					log_inv_rate,
+					log_field_size,
+				)?;
+				Some((regime, queries))
+			})
+			.min_by_key(|&(_, queries)| queries)
+	}
+
+	/// The unique-decoding loss minimizing queries at `security_bits`, with the count it reaches.
+	///
+	/// Sweeps `loss` over `(0, (1 - rho)/2)`.
+	/// Small `loss` keeps more distance, so fewer queries, but drives the error up as `1/loss`.
+	/// Large `loss` does the reverse.
+	///
+	/// Unlike [`Self::optimal_johnson`] this reaches high targets over a 128-bit field, because
+	/// [`Self::UniqueDecodingWithLoss`]'s error does not grow with the codeword.
+	///
+	/// Returns `None` when no loss reaches the target.
+	///
+	/// # Panics
+	/// Panics if `log_inv_rate` is zero.
+	pub fn optimal_unique_decoding(
+		security_bits: usize,
+		log_msg_len: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+	) -> Option<(Self, usize)> {
+		assert!(log_inv_rate >= 1, "precondition: log_inv_rate must be at least 1");
+		let span = (1.0 - rate(log_inv_rate)) / 2.0;
+
+		// A fixed grid keeps the answer reproducible across platforms, which a solver would not.
+		const STEPS: usize = 4096;
+		(1..STEPS)
+			.map(|i| Self::UniqueDecodingWithLoss {
+				loss: span * i as f64 / STEPS as f64,
+			})
+			.chain(std::iter::once(Self::UniqueDecoding))
+			.filter_map(|regime| {
+				let queries = regime.plan_queries(
+					security_bits,
+					log_msg_len,
+					log_inv_rate,
+					log_field_size,
+				)?;
+				Some((regime, queries))
+			})
+			.min_by_key(|&(_, queries)| queries)
+	}
+
+	/// The query count no conjecture can undercut, from [DG25] §1.5.
+	///
+	/// Regime-independent: this is a floor every variant of [`Self`] must clear.
+	///
+	/// Once the radius-`z` Hamming balls around codewords fill the space, a random word is close to
+	/// the code by accident and proximity testing cannot work at all.
+	/// That happens within
+	///
+	/// ```text
+	///     eta_min ~ log2(e / rho) * rho / log2(q)
+	/// ```
+	///
+	/// of capacity, so any regime must keep `delta` below `1 - rho - eta_min`, which floors the
+	/// query count at `security_bits / -log2(rho + eta_min)`.
+	///
+	/// [DG25]'s own advice is to stay above this line rather than at it.
+	/// Both regimes here sit well clear of it; the function exists so that a future
+	/// conjecture-gated regime cannot silently sink below a proven impossibility.
+	///
+	/// # Panics
+	/// Panics if `log_inv_rate` is zero.
+	///
+	/// [DG25]: <https://eprint.iacr.org/2025/2010>
+	pub fn random_word_query_floor(
+		security_bits: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+	) -> usize {
+		assert!(log_inv_rate >= 1, "precondition: log_inv_rate must be at least 1");
+		let rho = rate(log_inv_rate);
+		let eta_min = (std::f64::consts::E / rho).log2() * rho / log_field_size as f64;
+		(security_bits as f64 / -(rho + eta_min).log2()).ceil() as usize
+	}
+}
+
+/// The code rate `2^-log_inv_rate`.
+fn rate(log_inv_rate: usize) -> f64 {
+	2.0f64.powi(-(log_inv_rate as i32))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// binius64's own target, and the field its challenges are drawn from.
+	const B128: usize = 128;
+
+	#[test]
+	fn unique_decoding_query_counts_agree_with_fri() {
+		for security_bits in [96, 100, 128] {
+			for log_inv_rate in 1..=8 {
+				assert_eq!(
+					SoundnessRegime::UniqueDecoding.n_queries(security_bits, log_inv_rate),
+					calculate_n_test_queries(security_bits, log_inv_rate),
+					"security_bits={security_bits} log_inv_rate={log_inv_rate}"
+				);
+			}
+		}
+	}
+
+	#[test]
+	fn unique_decoding_query_counts_at_100_bits() {
+		// The table in `LIGERITO_PLAN.md`: rates 1/2 through 1/32 at 100-bit security.
+		let counts = (1..=5)
+			.map(|log_inv_rate| SoundnessRegime::UniqueDecoding.n_queries(100, log_inv_rate))
+			.collect::<Vec<_>>();
+		assert_eq!(counts, vec![241, 148, 121, 110, 105]);
+	}
+
+	#[test]
+	fn johnson_needs_fewer_queries_than_unique_decoding() {
+		let johnson = SoundnessRegime::Johnson { eta: 0.02 };
+		for log_inv_rate in 1..=8 {
+			let udr = SoundnessRegime::UniqueDecoding.n_queries(100, log_inv_rate);
+			assert!(johnson.n_queries(100, log_inv_rate) < udr, "log_inv_rate={log_inv_rate}");
+		}
+	}
+
+	#[test]
+	fn the_correlated_agreement_ceiling_falls_one_bit_per_doubling() {
+		// Unique decoding, rate 1/2, over B128. The exceptional set is linear in the codeword
+		// length, so every extra message bit costs one bit of headroom, up to the additive one.
+		let bits = |log_msg_len| {
+			SoundnessRegime::UniqueDecoding.correlated_agreement_bits(log_msg_len, 1, B128)
+		};
+		for log_msg_len in 20..32 {
+			let step = bits(log_msg_len) - bits(log_msg_len + 1);
+			assert!((step - 1.0).abs() < 1e-4, "log_msg_len={log_msg_len} step={step}");
+		}
+	}
+
+	#[test]
+	fn binius64_reaches_its_own_target_but_not_by_much() {
+		// The shipped configuration: 96 bits, rate 1/2, unique decoding, B128 challenges.
+		for (log_msg_len, expected) in [(20, 109.0), (24, 105.0), (28, 101.0), (32, 97.0)] {
+			let ceiling =
+				SoundnessRegime::UniqueDecoding.correlated_agreement_bits(log_msg_len, 1, B128);
+			assert!((ceiling - expected).abs() < 0.01, "log_msg_len={log_msg_len} {ceiling}");
+
+			// The query count clears the target, and the algebra clears it too, so 96 holds.
+			let queries = SoundnessRegime::UniqueDecoding.plan_queries(96, log_msg_len, 1, B128);
+			assert_eq!(queries, Some(232));
+			let achieved =
+				SoundnessRegime::UniqueDecoding.achieved_security_bits(log_msg_len, 1, B128, 232);
+			assert!(achieved >= 96.0, "log_msg_len={log_msg_len} achieved={achieved}");
+		}
+	}
+
+	#[test]
+	fn the_lossless_bound_decays_with_size_and_the_lossy_one_does_not() {
+		// Cor. 1.4 is tight but carries a factor `n`, so its ceiling slides.
+		// Theorem 1.3 gives up a constant of distance and buys an `n`-free exceptional set.
+		let lossless = |log_msg_len| {
+			SoundnessRegime::UniqueDecoding.correlated_agreement_bits(log_msg_len, 1, B128)
+		};
+		let lossy = |log_msg_len| {
+			SoundnessRegime::UniqueDecodingWithLoss { loss: 1e-3 }.correlated_agreement_bits(
+				log_msg_len,
+				1,
+				B128,
+			)
+		};
+		for (log_msg_len, expected) in [(20, 109.0), (24, 105.0), (28, 101.0), (32, 97.0)] {
+			assert!((lossless(log_msg_len) - expected).abs() < 0.01);
+			// The lossy bound does not move at all across the same range.
+			assert!((lossy(log_msg_len) - lossy(20)).abs() < 1e-9, "log_msg_len={log_msg_len}");
+		}
+	}
+
+	#[test]
+	fn a_constant_of_distance_buys_one_hundred_and_twenty_eight_bits_over_b128() {
+		// The lossless bound cannot reach 128 bits at any size, and neither can Johnson.
+		for log_msg_len in [20, 24, 28] {
+			for log_inv_rate in 1..=8 {
+				assert_eq!(
+					SoundnessRegime::UniqueDecoding.plan_queries(
+						128,
+						log_msg_len,
+						log_inv_rate,
+						B128
+					),
+					None,
+				);
+				assert_eq!(
+					SoundnessRegime::optimal_johnson(128, log_msg_len, log_inv_rate, B128),
+					None
+				);
+			}
+		}
+
+		// Giving up a constant of distance does not reach 128 either, but it comes far closer and
+		// it stops sliding: over B128 at rate 1/2 the ceiling is a flat 124.5 bits at every size.
+		// A handful of proof-of-work bits closes that fixed gap, where no amount of grinding keeps
+		// up with a ceiling that falls one bit per doubling.
+		for log_msg_len in [20, 24, 28, 32] {
+			assert_eq!(SoundnessRegime::optimal_unique_decoding(128, log_msg_len, 1, B128), None);
+
+			let ceiling = (1..4096)
+				.map(|i| SoundnessRegime::UniqueDecodingWithLoss {
+					loss: 0.25 * f64::from(i) / 4096.0,
+				})
+				.map(|regime| regime.correlated_agreement_bits(log_msg_len, 1, B128))
+				.fold(f64::NEG_INFINITY, f64::max);
+			assert!((ceiling - 124.46).abs() < 0.01, "log_msg_len={log_msg_len} {ceiling}");
+		}
+
+		// 120 bits is reachable, at 292 queries, independent of the witness size. That is the
+		// target and regime the reference Ligerito implementation ships for its own
+		// conjecture-free profile, which is a useful outside check on this arithmetic.
+		for log_msg_len in [20, 24, 28, 32] {
+			let (regime, queries) =
+				SoundnessRegime::optimal_unique_decoding(120, log_msg_len, 1, B128)
+					.expect("120 bits is reachable with a constant loss");
+			assert!(matches!(regime, SoundnessRegime::UniqueDecodingWithLoss { .. }));
+			assert_eq!(queries, 292);
+		}
+	}
+
+	#[test]
+	fn the_johnson_regime_is_out_of_reach_over_b128_at_the_shipped_target() {
+		// At 96 bits the Johnson regime needs more field than B128 has, at every size this repo
+		// commits at. Only the smallest shape clears it, and it costs more queries than unique
+		// decoding rather than fewer.
+		for log_inv_rate in 1..=4 {
+			for log_msg_len in [24, 28, 30] {
+				assert_eq!(
+					SoundnessRegime::optimal_johnson(96, log_msg_len, log_inv_rate, B128),
+					None
+				);
+			}
+		}
+		let (_, johnson) = SoundnessRegime::optimal_johnson(96, 20, 1, B128)
+			.expect("the smallest shape clears it");
+		let udr = SoundnessRegime::UniqueDecoding.n_queries(96, 1);
+		assert!(johnson > udr, "johnson={johnson} udr={udr}");
+	}
+
+	#[test]
+	fn a_wider_field_puts_both_regimes_back_in_reach() {
+		// A degree-2 extension of B128 lifts the ceiling past every target considered here.
+		for log_msg_len in [24, 28, 30] {
+			assert!(
+				SoundnessRegime::UniqueDecoding
+					.plan_queries(128, log_msg_len, 1, 256)
+					.is_some()
+			);
+			assert!(SoundnessRegime::optimal_johnson(128, log_msg_len, 1, 256).is_some());
+		}
+	}
+
+	#[test]
+	fn the_johnson_optimum_reproduces_the_published_instantiation() {
+		// [ABF26] section 6.4 instantiates a rate-1/2 interleaved Reed-Solomon code over a sextic
+		// extension of the Koala Bear prime, so log2|F| is about 186, and reports that 128-bit
+		// knowledge soundness needs 259 queries at eta near 2^-8.6.
+		//
+		// That instantiation is a prime field over a smooth domain, where this repo is binary over
+		// an affine subspace. The theorems being evaluated hold for both, so reproducing their
+		// number cross-checks this arithmetic rather than claiming their setting.
+		//
+		// This model is the more conservative of the two. [ABF26] restates the error with the
+		// `m = ceil(sqrt(rho) / (2 * eta))` of [BCHKS25] Theorem 1.5, which bounds *correlated*
+		// agreement. Theorem 4.6, which bounds the *mutual* variant this repo needs, carries
+		// `m = ceil(sqrt(rho) / eta)` instead. So a few more queries is the expected direction.
+		let (regime, queries) =
+			SoundnessRegime::optimal_johnson(128, 20, 1, 186).expect("reachable over 2^186");
+		assert!((259..=265).contains(&queries), "queries={queries}");
+		let SoundnessRegime::Johnson { eta } = regime else {
+			panic!("optimal_johnson returns a Johnson regime");
+		};
+		// The `m` above is twice [ABF26]'s, so the balance point sits about one bit higher.
+		assert!((-8.6..=-7.0).contains(&eta.log2()), "log2(eta)={}", eta.log2());
+	}
+
+	#[test]
+	fn every_shipped_configuration_clears_the_random_word_floor() {
+		// [DG25]'s floor is a proven impossibility, so a regime that dips below it is unsound
+		// whatever else is assumed.
+		for log_inv_rate in 1..=8 {
+			let floor = SoundnessRegime::random_word_query_floor(96, log_inv_rate, B128);
+			let udr = SoundnessRegime::UniqueDecoding.n_queries(96, log_inv_rate);
+			assert!(udr > floor, "log_inv_rate={log_inv_rate} udr={udr} floor={floor}");
+		}
+	}
+
+	#[test]
+	fn the_random_word_floor_matches_the_published_table() {
+		// [DG25] Table 1, at 100 bits over a 128-bit field: 102.80, 50.98, 33.89, 25.38, 20.29.
+		let floors = (1..=5)
+			.map(|log_inv_rate| SoundnessRegime::random_word_query_floor(100, log_inv_rate, B128))
+			.collect::<Vec<_>>();
+		assert_eq!(floors, vec![103, 51, 34, 26, 21]);
+	}
+
+	#[test]
+	#[should_panic(expected = "log_inv_rate must be at least 1")]
+	fn rate_one_is_not_a_proximity_test() {
+		SoundnessRegime::UniqueDecoding.bits_per_query(0);
+	}
+
+	#[test]
+	#[should_panic(expected = "eta must be less than 1 - sqrt(rho)")]
+	fn a_slack_past_the_johnson_radius_is_rejected() {
+		SoundnessRegime::Johnson { eta: 0.5 }.bits_per_query(1);
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-516](https://linear.app/jimpo/issue/BINIUS-516).

### In one line

Ligerito's parameters, a byte-exact proof-size estimator, a search that picks the cheapest parameters — and the soundness term that decides whether those parameters mean anything.

### The problem, part one: choosing badly is expensive

Ligerito commits a matrix, folds it, and re-commits the smaller matrix **at a lower code rate**, recursing until a small residual is sent in the clear.

Its whole economics live in that ladder: how many lanes each level folds, and what rate each level is committed at.

The one existing implementation, `succinctlabs/flock`, pins its top-level lane count for compatibility with its own upstream packing rather than to minimize proofs. Priced honestly, its shipped `m24` config is worse than binius64's current FRI. So writing protocol code first risks building the right protocol against parameters that do not pay.

### The problem, part two: query counts are only half the budget

This is the part that changed how the PR ended up.

Everyone counts queries. A word that differs from every codeword in a `delta` fraction of positions survives one random sample with probability `1 - delta`, so `t` samples catch it all but `(1 - delta)^t` of the time. Pick `t` big enough and the query phase is as sound as you like.

But there is a second, independent way to cheat, and **more queries do nothing about it**.

The verifier does not test one word. It tests a random *combination* of words — that is what folding is. A cheating prover can pick two words that are both far from the code, but whose combination happens to land close to it. The chance of that is the **correlated-agreement error**, and it depends on exactly three things: how long the codeword is, how far out you push `delta`, and how big the field the combining challenge comes from.

Not the query count. It is a ceiling.

### Walk through the ceiling

Take binius64's shipped setting: a message of `2^24` field elements, rate 1/2, challenges from the 128-bit GHASH field, testing at the unique-decoding radius `delta = (1 - rho)/2 = 1/4`.

The codeword has `2^25` positions. The theorem ([BCHKS25] Cor. 1.4) says the number of bad challenges is at most

```
    delta * n + 1  =  0.25 * 2^25  =  2^23
```

out of the `2^128` available. So the error is `2^23 / 2^128 = 2^-105`:

```
    query phase       232 queries        ->   96 bits
    correlated agr.   2^23 / 2^128       ->  105 bits
                                              ----
    actual security   min of the two     ->   96 bits   OK
```

96 bits holds. Now double the message. The codeword doubles, so the numerator doubles, so the ceiling drops by exactly one bit. At `2^32` elements it is 97 bits — one bit of headroom left over the target.

### The bound that stops sliding

A sliding ceiling would be bad news, and it turns out to be avoidable. The same paper has a second theorem for the same radius.

Test not *at* the unique-decoding radius but a constant `loss` inside it. [BCHKS25] Theorem 1.3 then bounds the bad challenges by

```
    max( (d/g - 1)/(d - 2g) ,  1 + g/loss )        d = 1 - rho,  g = d/2 - loss
```

There is no `n` in that expression. Over `B128` at rate 1/2 the ceiling becomes **a flat 124.5 bits at every witness size**:

| target | queries | reachable over `B128`? |
|---|---|---|
| 110 | 266 | yes, at any size |
| 120 | 292 | yes, at any size |
| 124 | 375 | yes, at any size |
| 125+ | — | no |

The price is a slightly smaller radius, so slightly more queries: 292 against 232 for 120 bits. 128 bits is 3.5 bits short — a *fixed* gap that proof-of-work closes, unlike one that grows with the witness.

Both reference implementations use this variant for their conjecture-free profile, and one of them ships exactly a 120-bit unique-decoding configuration over a 128-bit field. Reproducing that number is the outside check on this arithmetic.

So the module carries both bounds. `UniqueDecoding` is the tight-but-sliding one; `UniqueDecodingWithLoss` is the flat one; `optimal_unique_decoding` sweeps the loss and picks the winner.

### What that does to the Johnson regime

The other regime pushes `delta` further out, to `1 - sqrt(rho) - eta`, so each query rules out more and you need fewer of them. That is real, and it is a theorem now rather than a conjecture: [BCHKS25] Theorem 4.6 proves *mutual* correlated agreement — the strong form Ligerito and WHIR actually need — up to the Johnson bound.

The catch is what the error costs. The bound carries a factor `m^5` where `m` is about `sqrt(rho)/eta`. Push `delta` close to the bound and `eta` is small, so `m` is large, so `m^5` is enormous. Keep the error acceptable and `eta` must stay large — which pushes `delta` back down to, or below, the unique-decoding radius, where the regime buys nothing.

Measured over this field, at 96 bits: **no slack works** past `log_n = 20`. At `log_n = 20` exactly one range of slack clears the target, and it needs **1130 queries against unique decoding's 232**.

So the Johnson regime is not conjecture-blocked here. It is field-blocked, and that is confirmed outside this repo: leanVM-b targets 128-bit round-by-round soundness in exactly this regime, and its config declares "128-bit round-by-round soundness over F192" with `ANALYSIS_LOG_Q = 192.0`. An independent implementation reached the same conclusion and moved to a 192-bit field. This model's own answer is `|F| >= 2^167`, so their 192 has margin.

`flock`'s `eta = 0.02` reproduces their query counts but is nowhere near any target once the error term is priced.

### The change

New `crates/iop/src/soundness.rs` — *not* under `ligerito`, because it describes Reed–Solomon proximity testing and FRI needs the same terms:

```
SoundnessRegime { UniqueDecoding,                        // Cor 1.4: tight, slides with n
                  UniqueDecodingWithLoss { loss },       // Thm 1.3: flat, no n
                  Johnson { eta } }                      // Thm 4.6: needs more field
    .proximity_parameter / .bits_per_query / .n_queries
    .correlated_agreement_bits                <- the ceiling
    .achieved_security_bits(..)               <- min of the two terms
    .plan_queries(..) -> Option<usize>        <- None when the ceiling is under the target
    ::optimal_unique_decoding(..)             <- sweeps loss; reaches 120 bits over B128
    ::optimal_johnson(..)                     <- sweeps eta; None over B128
    ::random_word_query_floor(..)             <- a floor no conjecture can undercut
```

and `crates/iop/src/ligerito/`, mirroring the neighbouring `fri/` module:

```
LigeritoLevel  { log_msg_cols, log_lanes, log_inv_rate, n_queries }
LigeritoParams { levels, log_residual_dim, regime, security_bits }
    .correlated_agreement_bits(log_field_size)
    .achieved_security_bits(log_field_size)
    .proof_size(vcs)                          <- mirrors FRIParams::proof_size
    ::optimal_ladder(..) -> Option<(Self, usize)>  <- mirrors ::optimal_for_batch
```

Everything public is an associated item on the type it belongs to, not a free function taking it as the first argument. The workspace warns on `multiple_inherent_impl`, so the DP machinery stays private in `size_estimation.rs` and `common.rs` keeps the one impl block that is the API — which is also where `FRIParams::proof_size` lives.

`optimal_ladder` returns `Option` because infeasibility is a normal answer, not a bug. A level fails for either of two reasons, and neither is fixable with more rows: it cannot sample more distinct positions than its codeword has, and its correlated-agreement term is a ceiling. A shape whose algebra is already under the target has no ladder, rather than a cheap one that does not hold.

`LigeritoParams::new` makes bad ladders unrepresentable rather than merely asserted: column counts must chain, the rate ladder must strictly fall, and every level must be feasible. The residual dimension is *derived* from the last level, so there is nothing a caller can pass to violate it.

### Does any of this apply to a binary field?

Worth asking, because binius64 is unusual twice over: challenges in a binary field, and an evaluation domain that is an `F_2`-affine subspace rather than a smooth multiplicative subgroup. Much of the literature assumes one or the other.

The two bounds used here are stated for `RS[F_q, D, k]` with an arbitrary field and an arbitrary domain, and their proofs run through decoding over `F_q(Z)`, which does not care. So they transfer.

Some negative results transfer too, and one is *stronger* here: [BCHKS25] Theorem 1.6 proves proximity gaps past the Johnson radius fail **for every field of characteristic 2**, using an `F_2`-subspace domain. Others do not transfer — [KKH26] and [Kam26] are prime-field, and [KKH26]'s domain is multiplicative.

One gap is about randomness rather than fields, and the module records it: these bounds are for a line or a power curve, while oracle batching here uses the tensor randomness of [DP24]. The FRI fold is a line and is covered; the batch is not, except through [DP24]'s own analysis.

### What this deliberately does not count

Two terms belong in a whole-protocol budget and are named as absent rather than quietly skipped, because both reference implementations carry them.

**Out-of-domain binding.** Past the unique-decoding radius the prover sits near a *list*, not one codeword. Binding it to a single element costs roughly `binom(L, 2) * (mu/|F|)^s`. Only the Johnson regime needs it, and this field cannot afford that regime anyway.

**Grinding.** Both references grind (16 and 17 bits). It is a transcript device rather than a property of the code, so it belongs to whichever protocol adopts it — plan PR 11 here.

There is also a live disagreement worth flagging. These bounds are stated for one fold step, and a level folding `2^l` lanes pays the bound once per lane-fold round. flock charges a factor `l`; leanVM-b charges `2^(l-1)`. That is an exponential gap between two careful implementations, so this charges the pessimistic one and says so. It is what makes the ladder degenerate at `log_n = 32` rather than merely get expensive — pinned by a test, so nobody reads that size's output as a usable configuration.

### Benchmark

Ladder sizes at the shipped 96-bit target with level 0's rate pinned to 1/2:

| `log_n` | proof |
|---|---|
| 17 | 157.7 KiB |
| 20 | 231.4 KiB |
| 24 | 340.1 KiB |
| 28 | 461.9 KiB |
| 30 | 530.1 KiB |

A representative ladder at `log_n = 24` folds 3 lanes at rate 1/2, then 4 at 1/16, then 4 at 1/32, then 3 at 1/64, leaving a `2^10` residual — and reaches 96.3 bits, both terms counted. Level 0's lane count comes out at 3 or 4, independently agreeing with the arity the repo's own FRI optimizer picks.

**What this does not claim.** At its own best constant rate, FRI beats a Ligerito ladder on bytes at every size — it buys that by lowering the rate at level 0, which is exactly the prover cost the pinned comparison holds fixed. Ligerito's case is bytes at equal prover cost, not dominance, and prover time is not yet measured.

### Soundness

Nothing here changes any protocol, so nothing here can weaken one. Three things matter for later:

- `UniqueDecoding` is `Default`, so nothing is adopted by omission, and it is the pessimistic of the two unique-decoding bounds. Do **not** add a capacity variant: [DG25] disproves the conjecture it would rest on, over all characteristics.
- Round-by-round soundness for Ligerito is still not proved, but the gap narrowed twice. [BCHKS25] Theorem 4.6 covers the base code up to Johnson, and [Jo26] shows interleaving costs nothing in mutual-correlated-agreement error. What remains is the tensor randomness.
- The [Proximity Prize](https://proximityprize.org/) puts $1M on pushing past Johnson. Nothing here needs to.

### Scope

- **new:** `crates/iop/src/soundness.rs`, `crates/iop/src/ligerito/{mod,common,size_estimation}.rs`
- **changed:** two `pub mod` lines in `crates/iop/src/lib.rs`, and `proptest` added to dev-dependencies
- no protocol code, no existing signature touched, no caller migrated
- `fri::common::min_concave` visibility is deliberately **not** widened; the ladder search uses a plain exhaustive min, and its doc records why the early exit is not exploited

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-iop --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all --check`, `prek run typos`, `prek run copyright` — clean
- `cargo test -p binius-iop` — 36 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean

Tests reproduce [ABF26] §6.4's published instantiation to within a few queries, pin [DG25] Table 1's query floor, pin the shipped configuration's true security at each size, pin that the lossless bound slides while the lossy one does not, pin the flat 124.5-bit ceiling and the 120-bit/292-query point the reference implementation independently ships, and pin the size at which the ladder first degenerates and then disappears.

Rebased on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
