### PR TITLE
Remove two unused dependencies

### DIFF
--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -29,7 +29,6 @@ digest.workspace = true
 # Enabled by the `test-circuits` feature only.
 k256 = { workspace = true, features = ["arithmetic"], optional = true }
 rand = { workspace = true, optional = true }
-thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/m4-verifier/Cargo.toml
+++ b/crates/m4-verifier/Cargo.toml
@@ -13,7 +13,6 @@ binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-iop = { path = "../iop" }
 binius-ip = { path = "../ip" }
-binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }


### PR DESCRIPTION
Removes two dependency declarations that have no source reference in their crate.

- `binius-m4-verifier` → `binius-math`: no `binius_math` path anywhere in the crate.
- `binius-m4-prover` → `thiserror`: no `thiserror::` path and no `derive(Error)`.

`cargo machete` is clean workspace-wide afterwards.

### Verification

- `cargo build/test/clippy -p binius-m4-verifier -p binius-m4-prover --all-targets` — clean, 48 tests pass, also with `--features rayon`.
- `cargo tree -e features` diffed before and after: the only change is the two removed feature edges, so no sibling crate silently lost a feature it was relying on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)