### PR TITLE
Remove dead code and a dead feature flag from binius-field

### DIFF
--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -29,7 +29,6 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 
 [features]
 default = []
-benchmark_alternative_strategies = []
 trace_multiplications = ["dep:tracing"]
 
 [lib]

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -44,11 +44,6 @@ impl M128 {
 	pub const fn from_u128(value: u128) -> Self {
 		Self(unsafe { std::mem::transmute::<u128, uint64x2_t>(value) })
 	}
-
-	#[inline]
-	pub fn shuffle_u8(self, src: [u8; 16]) -> Self {
-		unsafe { vqtbl1q_u8(self.into(), Self::from_le_bytes(src).into()).into() }
-	}
 }
 
 impl Default for M128 {

--- a/crates/field/src/arch/strategies.rs
+++ b/crates/field/src/arch/strategies.rs
@@ -17,9 +17,6 @@ use crate::{
 	underlier::{Divisible, UnderlierType},
 };
 
-/// Pairwise strategy. Apply the result of the operation to each packed element independently.
-pub struct PairwiseStrategy;
-
 /// Strategy that splits the underlier into `SubU`-sized lanes, applies the sub-packing
 /// `PackedPrimitiveType<SubU, F>`'s op to each lane, and recombines — a generic fallback for
 /// packings that lack a specialized full-width [`Square`], [`InvertOrZero`], or [`WideMul`]. The

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -33,16 +33,6 @@ impl M128 {
 	pub(super) const fn from_u128(value: u128) -> Self {
 		Self(u64x2(value as u64, (value >> 64) as u64))
 	}
-
-	#[inline]
-	pub fn from_lanes_u64(lo: u64, hi: u64) -> Self {
-		Self(u64x2(lo, hi))
-	}
-
-	#[inline]
-	pub fn split_lanes_u64(self) -> (u64, u64) {
-		(u64x2_extract_lane::<0>(self.0), u64x2_extract_lane::<1>(self.0))
-	}
 }
 
 impl Default for M128 {


### PR DESCRIPTION
Every item here had exactly one occurrence in the workspace: its own definition.

- `benchmark_alternative_strategies` — a declared feature that no `cfg` ever gated on.
- `PairwiseStrategy` — a 2024-vintage leftover; `Divide`, `LaneWideProduct` and `MulFromWideMul` are the live strategies.
- `M128::shuffle_u8` (aarch64), `M128::from_lanes_u64` and `M128::split_lanes_u64` (wasm32).

Deletion only, 19 lines. Nothing fell dead as a consequence — all three files' imports come from arch globs still used by surviving code.

### Verification

- `cargo build/test/clippy -p binius-field --all-targets` — clean, 229 tests pass.
- `cargo build -p binius-field --target wasm32-unknown-unknown` — clean.
- No crate enables the removed feature: `grep -rn "benchmark_alternative_strategies" crates/*/Cargo.toml` is empty.

One thing worth flagging separately: `crates/field/src/arch/wasm32/mod.rs` gates `mod m128;` behind `#[cfg(target_feature = "simd128")]`, and CI's wasm job passes no `simd128`, so that file is never compiled in CI. The plain wasm build above would have passed even if this change broke it, so it was also verified with `-C target-feature=+simd128`, which does compile the file, and that passes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)