### PR TITLE
Remove six accessor methods with no callers

### DIFF
--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -149,11 +149,6 @@ where
 		self.params.n_fold_rounds()
 	}
 
-	/// Number of times `execute_fold_round` has been called.
-	pub const fn n_rounds_remaining(&self) -> usize {
-		self.n_rounds() - self.curr_round
-	}
-
 	fn is_commitment_round(&self) -> bool {
 		self.next_commit_round
 			.is_some_and(|round| round == self.curr_round)

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -235,13 +235,6 @@ where
 		Ok(commitment)
 	}
 
-	/// Reports whether the round about to be processed carries a commitment.
-	pub fn needs_commitment(&self) -> bool {
-		// A commitment is due only when the schedule names this exact round.
-		self.next_commitment()
-			.is_some_and(|expected| expected.round == self.curr_round)
-	}
-
 	/// Reports whether every fold round has been processed.
 	pub const fn is_complete(&self) -> bool {
 		self.curr_round == self.n_rounds()
@@ -261,11 +254,6 @@ where
 		);
 
 		self.round_commitments
-	}
-
-	/// The round about to be processed, counted from zero.
-	pub const fn current_round(&self) -> usize {
-		self.curr_round
 	}
 
 	/// Number of rounds the fold phase runs.

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -3,7 +3,6 @@
 use std::{
 	iter::Sum,
 	marker::PhantomData,
-	mem,
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
@@ -58,11 +57,6 @@ where
 			elems,
 			_marker: PhantomData,
 		}
-	}
-
-	/// Returns a slice of the vertical subfield elements composing the tensor algebra element.
-	pub fn vertical_elems(&self) -> &[FE] {
-		&self.elems
 	}
 
 	/// Constructs a [`TensorAlgebra`] in the vertical subring.
@@ -128,11 +122,6 @@ where
 	F: Field,
 	FE: ExtensionField<F>,
 {
-	/// Returns the byte size of an element.
-	pub const fn byte_size() -> usize {
-		mem::size_of::<FE>() << FE::LOG_DEGREE
-	}
-
 	/// Tensor product of a vertical subring element and a horizontal subring element.
 	pub fn tensor(vertical: FE, horizontal: FE) -> Self {
 		let elems = horizontal

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -487,11 +487,6 @@ impl<F: Field> WitnessLayout<F> {
 		self.log_private
 	}
 
-	/// Returns the first index of the inout
-	pub const fn inout_offset(&self) -> WitnessIndex {
-		WitnessIndex::public(self.constants.len() as u32)
-	}
-
 	pub fn get(&self, wire: &ConstraintWire) -> Option<WitnessIndex> {
 		match wire.kind {
 			WireKind::Constant => {


### PR DESCRIPTION
Six accessors with no caller anywhere in the workspace, including tests and benches.

### The change

FRI fold state loses `needs_commitment`, `current_round` (`crates/iop/src/fri/fold.rs`) and `n_rounds_remaining` (`crates/iop-prover/src/fri/fold.rs`).

- The commitment decision `needs_commitment` reported is already computed inline in `process_round`'s match guard, and `process_round` returns `Result<Option<C>>`, so a caller learns from the return value whether the round committed.
- Both types keep `n_rounds()` and their drive methods, and the verifier keeps `is_complete()`, so the prover/verifier mirror ends up more symmetric, not less.
- `n_rounds_remaining`'s doc comment was also wrong — it described "number of times `execute_fold_round` has been called" for `n_rounds() - curr_round`.

`TensorAlgebra` loses `vertical_elems`, a literal `&self.elems` duplicate of an already-`pub` field, and `byte_size`. There is no `horizontal_elems` counterpart to leave unbalanced — the horizontal side is reached via `transpose()`.

`WitnessLayout` loses `inout_offset`, the only `*_offset` accessor in spartan-frontend/prover/verifier, whose body is inlined in `get`'s `WireKind::InOut` arm.

### Not included

`ReedSolomonCode::inv_rate` was in scope but is left alone: `dim`, `len` and `inv_rate` are *all* unreferenced, forming a systematic log/non-log family where `len()` carries a deliberate `#[allow(clippy::len_without_is_empty)]`. Removing one of the three would leave a lopsided remainder, so that family is better decided as a unit.

### Verification

- `cargo build/test/clippy` on `binius-iop`, `binius-iop-prover`, `binius-math`, `binius-spartan-frontend` `--all-targets` — clean, all suites pass, and with `--features rayon` where the crate has one.
- `cargo build -p binius-prover -p binius-verifier -p binius-recursion -p binius-spartan-prover --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)