### PR TITLE
Drop the unused scope facility from the no-rayon shim

### DIFF
--- a/crates/utils/src/rayon/mod.rs
+++ b/crates/utils/src/rayon/mod.rs
@@ -15,8 +15,6 @@
 
 cfg_if::cfg_if! {
 	if #[cfg(any(not(feature = "rayon"), all(target_arch="wasm32", not(target_feature = "atomics"))))] {
-		use std::marker::PhantomData;
-
 		pub mod iter;
 		pub mod slice;
 
@@ -89,32 +87,6 @@ cfg_if::cfg_if! {
 			RB: Send,
 		{
 			(oper_a(), oper_b())
-		}
-
-		pub struct Scope<'scope> {
-			#[allow(clippy::type_complexity)]
-			marker: PhantomData<Box<dyn FnOnce(&Scope<'scope>) + Send + Sync + 'scope>>,
-		}
-
-		impl<'scope> Scope<'scope> {
-			#[inline(always)]
-			pub fn spawn<BODY>(&self, body: BODY)
-			where
-				BODY: FnOnce(&Self) + Send + 'scope,
-			{
-				body(self)
-			}
-		}
-
-		#[inline(always)]
-		pub fn scope<'scope, OP, R>(op: OP) -> R
-		where
-			OP: for<'s> FnOnce(&'s Scope<'scope>) -> R + 'scope + Send,
-			R: Send,
-		{
-			op(&Scope {
-				marker: PhantomData,
-			})
 		}
 	} else {
 		pub use rayon::*;


### PR DESCRIPTION
`binius-utils`' no-rayon shim carries a `Scope` struct, `Scope::spawn` and `scope()` that nothing calls.

Parallel sites in this workspace use `join`, the prelude iterators, or `tracing`'s unrelated `Span::in_scope`. No crate glob-imports `binius_utils::rayon`, and the prelude only re-exports `iter::*` and `slice::*`, so the shim's `scope` could not be reached by accident either. Its `#[allow(clippy::type_complexity)]` existed only to keep the unused `PhantomData` marker field compiling.

Only the shim branch of the `cfg_if!` changes — under `--features rayon` the real `rayon::scope` is still there.

If a caller ever needs `scope`, the honest shim for it is sequential execution with the exact lifetime and `Send` bounds that caller requires, written against a real call site with a test. What was here was validated by nothing, and a subtly wrong `spawn` bound that compiles single-threaded but breaks under `--features rayon` is the failure mode this shim exists to prevent.

### Verification

Both feature configurations, since this shim is load-bearing for the whole workspace:

- `cargo build/test/clippy -p binius-utils --all-targets`, default and `--features rayon` — clean. (41 vs 28 tests is expected: the shim branch compiles its own `iter`/`slice` unit tests, which vanish under real rayon.)
- `cargo build -p binius-prover -p binius-frontend -p binius-hash -p binius-iop-prover --all-targets`, default and `--features rayon` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)