### PR TITLE
Remove verification error variants that can never be constructed

### DIFF
--- a/crates/ip/src/logup_star/error.rs
+++ b/crates/ip/src/logup_star/error.rs
@@ -20,8 +20,6 @@ pub enum VerificationError {
 	IncorrectXEvaluation,
 	#[error("the index evaluations do not combine to the leaf denominator")]
 	IncorrectIndexEvaluation,
-	#[error("the table-side leaf denominator is not the transparent J - c")]
-	IncorrectTableDenominator,
 	#[error("the pushforward reduction evaluation is incorrect")]
 	PushforwardMismatch,
 	#[error("the proof is truncated or empty")]

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -30,16 +30,6 @@ pub enum Error {
 	IncorrectPublicInputLength { expected: usize, actual: usize },
 	#[error("constraint system error: {0}")]
 	ConstraintSystem(#[from] ConstraintSystemError),
-	#[error("invalid proof: {0}")]
-	Verification(#[from] VerificationError),
 	#[error("shift reduction error: {0}")]
 	ShiftReduction(#[from] shift::Error),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
-	#[error("public input check failed")]
-	PublicInputCheckFailed,
-	#[error("final evaluation check of sumcheck and FRI reductions failed")]
-	EvaluationInconsistency,
 }

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -17,7 +17,7 @@
 //! - [`Verifier`] - Main verification interface; call [`Verifier::setup`] with a constraint system,
 //!   then [`Verifier::verify`] with a proof and public inputs
 //! - [`IOPVerifier`] - Core IOP verification logic, independent of the compilation strategy
-//! - [`VerificationError`] - Error type returned when proof verification fails
+//! - [`Error`] - Error type returned when proof verification fails
 //!
 //! # Design philosophy
 //!


### PR DESCRIPTION
Three error variants are unreachable. Each one names a check, so the point of the PR is that the checks are all enforced elsewhere — nothing here removes a guard.

### binius-verifier: the whole `VerificationError` enum

Neither `PublicInputCheckFailed` nor `EvaluationInconsistency` is ever constructed, and the only other mention of the type is a doc bullet. Removed along with the `Error::Verification` arm.

A wrong public input is rejected twice over:

- wrong length → `Error::IncorrectPublicInputLength` (`verify.rs:153`);
- wrong value, right length → `channel.assert_zero(packed_eval * rs_eq_eval - eval)` (`reduction.rs:396`), where `packed_eval` is computed by the verifier from the public words it holds, so nothing prover-supplied enters it.

Final sumcheck/FRI consistency is enforced in `basefold/channel.rs:224`, `fri/verify.rs:236` and `fri/verify.rs:266`, all reached because `verify` calls `channel.finish()`.

This was also checked empirically rather than only by reading: a 3-inout `band` circuit was proved honestly, then re-verified with one bit flipped in one public word (same length), and it was rejected with `Channel(InvalidAssert)`. That throwaway test is not part of the diff.

### binius-ip logUp\*: `IncorrectTableDenominator`

Unreachable by construction. Both inputs to the table denominator are verifier-derived — `c` is a Fiat-Shamir challenge from `sample_many`, and `point` is a suffix of the challenge-derived leaf point — so no prover value reaches `denominator_eval`, and there is nothing to reject. The denominator is still checked, by the interpolation assert at `verify.rs:296` under the sibling `IncorrectIndexEvaluation`.

Its three siblings are live and untouched.

### Note: this narrows a public error type

`binius_verifier::VerificationError` was re-exported via `pub use error::*`, and `Error` loses a variant plus its `From` impl. Nothing in the workspace matches on it.

The intmul `#[from]` arms (`SumcheckVerify`, `ProdcheckVerify`, `LogupVerify`) were also candidates and are **kept** — deleting them fails to compile, since `?` constructs each of them in `protocols/intmul/verify.rs`.

### Verification

- `cargo build/test/clippy -p binius-verifier -p binius-ip --all-targets` — clean.
- `cargo build -p binius-prover -p binius-ip-prover -p binius-recursion -p binius-m4-verifier --all-targets` — clean.
- `cargo test -p binius-prover` — the end-to-end `prove_verify` suite, which exercises the rejection paths, passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)