### PR TITLE
Remove the unused GFNI squaring helper

### DIFF
--- a/crates/arith-bench/src/rijndael/gfni.rs
+++ b/crates/arith-bench/src/rijndael/gfni.rs
@@ -6,10 +6,6 @@ pub fn mul<U: Underlier + OpsGfni>(a: U, b: U) -> U {
 	OpsGfni::gf2p8mul(a, b)
 }
 
-pub fn sqr<U: Underlier + OpsGfni>(x: U) -> U {
-	OpsGfni::gf2p8mul(x, x)
-}
-
 pub fn inv<U: Underlier + OpsGfni + PackedUnderlier<u64>>(x: U) -> U {
 	#[rustfmt::skip]
 	pub const IDENTITY_MAP: u64 = u64::from_le_bytes([


### PR DESCRIPTION
`gfni::sqr` has no caller anywhere in the workspace. Every import of that module is explicit and singular (`use ...rijndael::gfni::mul;`), no glob import of `gfni` or `rijndael` exists, and no macro in the crate builds an identifier from a fragment.

It also carries no content: the body is `gf2p8mul(x, x)`, bit-identical to `mul(x, x)`. It maps to no distinct instruction, so benchmarking it would only re-measure `gf2p8mul`.

`gfni::inv` is unreferenced by the same evidence and is deliberately **kept** — it wraps `gf2p8affineinv` with an identity map, a genuinely distinct instruction and the crate's only GF(2^8) inversion wrapper. If everything in this benchmark surface should be bench-reachable, the fix for `inv` is to add a bench, not to delete it.

### Verification

This is x86-only code behind `#[cfg(target_feature = "gfni")]`, so a plain cross-check is blind to it. That was established rather than assumed: injecting a deliberate type error into the gated block was *not* caught by `cargo check --target x86_64-apple-darwin`, and *was* caught once `gfni` was enabled.

- `RUSTFLAGS="-C target-feature=+gfni,+sse2,..." cargo check -p binius-arith-bench --target x86_64-apple-darwin --all-targets` — clean. This is the gate that actually compiles the code.
- `cargo build/test/clippy -p binius-arith-bench --all-targets` — clean, 87 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)