### PR TITLE
Remove a redundant constant and a zero-caller reference wrapper

### DIFF
--- a/crates/circuits/src/blake2b/constants.rs
+++ b/crates/circuits/src/blake2b/constants.rs
@@ -39,5 +39,4 @@ pub const R4: u32 = 63;
 /// Algorithm parameters
 pub const ROUNDS: usize = 12;
 pub const BLOCK_BYTES: usize = 128;
-pub const STATE_WORDS: usize = 8;
 pub const MAX_OUTPUT_BYTES: usize = 64;

--- a/crates/circuits/src/blake2b/reference.rs
+++ b/crates/circuits/src/blake2b/reference.rs
@@ -146,16 +146,6 @@ pub fn blake2b_256(data: &[u8]) -> [u8; 32] {
 	result
 }
 
-/// BLAKE2b-512: Fixed 512-bit (64-byte) output variant
-///
-/// This is a convenience function for the maximum 512-bit output case
-pub fn blake2b_512(data: &[u8]) -> [u8; 64] {
-	let hash = blake2b(data, 64);
-	let mut result = [0u8; 64];
-	result.copy_from_slice(&hash);
-	result
-}
-
 #[cfg(test)]
 mod tests {
 	use blake2::digest::{Update, VariableOutput};


### PR DESCRIPTION
Two zero-reference items in `binius-circuits`.

- `blake2b::constants::STATE_WORDS` — RFC 7693's tunable BLAKE2b parameters are `b`, `r` and `nn`, all present as `BLOCK_BYTES` / `ROUNDS` / `MAX_OUTPUT_BYTES` and all used. The 8-word state is not tunable; it is fixed by the word size and already stated by the types (`h: &mut [u64; 8]`, `IV: [u64; 8]`). There is no companion `WORK_VECTOR_WORDS = 16` for the 16-word working vector, so it was never a systematic family — just a restatement of a type.
- `blake2b::reference::blake2b_512` — a convenience shim with no caller. The 512-bit reference path stays covered, more strongly, by `test_variable_output_lengths`, which pins `blake2b(msg, outlen)` against the `blake2` crate for every `outlen` in `1..=64`. The circuit tests already call `reference::blake2b(message, 64)` directly.

### Not included

`blake3::DERIVE_KEY_CONTEXT` and `blake3::DERIVE_KEY_MATERIAL` were also zero-reference but are deliberately **kept**. They are bits 5 and 6 of BLAKE3's domain-separation flag word, transcribed contiguously from the spec alongside five live siblings. The soundness of domain separation rests on those seven modes being mutually exclusive bits, so a reader needs to check the whole transcription against the spec at a glance; punching holes at `1 << 5` and `1 << 6` would turn a verifiable table into a partial one for no saving.

### Verification

- `cargo build/test/clippy -p binius-circuits --all-targets` — clean, 396 + 3 tests pass.
- `cargo build -p binius-examples --all-targets` and `cargo build -p binius-m4-prover --all-targets --features test-circuits` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)