### PR TITLE
BINIUS-517: Validate Key and KeySegment deserialization against sibling lengths

### DIFF
--- a/crates/prover/src/protocols/shift/key_collection/key.rs
+++ b/crates/prover/src/protocols/shift/key_collection/key.rs
@@ -133,6 +133,11 @@ impl DeserializeBytes for Key {
 		let dense_shift_idx = u16::deserialize(&mut read_buf)?;
 		let start = u32::deserialize(&mut read_buf)?;
 		let end = u32::deserialize(&mut read_buf)?;
+		// `accumulate_wide` slices the segment's constraint list with this range.
+		// Only the ordering is checkable here; the upper bound needs the segment's own list.
+		if start > end {
+			return Err(SerializationError::InvalidConstruction { name: "Key::range" });
+		}
 		Ok(Key {
 			operation,
 			dense_shift_idx,
@@ -182,6 +187,41 @@ mod tests {
 
 	fn f(value: u128) -> F {
 		F::new(value)
+	}
+
+	// Serializes a key built raw, bypassing `KeySegment::build`, so a malformed range reaches the
+	// deserializer.
+	fn deserialize_raw(key: &Key) -> Result<Key, SerializationError> {
+		let mut buf = Vec::new();
+		key.serialize(&mut buf).unwrap();
+		Key::deserialize(buf.as_slice())
+	}
+
+	#[test]
+	fn key_rejects_a_reversed_range() {
+		// `accumulate_wide` slices `start..end`, which panics when start runs past end.
+		let reversed = Key {
+			operation: Operation::Zero,
+			dense_shift_idx: 0,
+			range: Range { start: 5, end: 3 },
+		};
+		match deserialize_raw(&reversed).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "Key::range");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
+
+	#[test]
+	fn key_accepts_an_empty_range() {
+		// A key covering no constraints is legitimate: `accumulate_wide` returns early on it.
+		let empty = Key {
+			operation: Operation::Zero,
+			dense_shift_idx: 0,
+			range: Range { start: 3, end: 3 },
+		};
+		assert_eq!(deserialize_raw(&empty).unwrap().range, Range { start: 3, end: 3 });
 	}
 
 	/// Reference oracle for the weighted accumulation above.

--- a/crates/prover/src/protocols/shift/key_collection/key_segment.rs
+++ b/crates/prover/src/protocols/shift/key_collection/key_segment.rs
@@ -126,11 +126,192 @@ impl DeserializeBytes for KeySegment {
 		let constraint_indices = Vec::<ConstraintIndex>::deserialize(&mut read_buf)?;
 		let dense_shift_enc = DenseShiftEncoding::deserialize(&mut read_buf)?;
 
+		// A key indexes its own segment's shift encoding and constraint list.
+		// Rejecting a bad index here beats panicking mid-proof in `build_g` or `word_scalar`.
+		let keys_index_siblings = keys.iter().all(|key| {
+			(key.dense_shift_idx as usize) < dense_shift_enc.len()
+				&& key.range.end as usize <= constraint_indices.len()
+		});
+		if !keys_index_siblings {
+			return Err(SerializationError::InvalidConstruction {
+				name: "KeySegment::keys",
+			});
+		}
+		// A word's range names its keys inside the flattened keys vector, which `word_keys` slices.
+		let key_ranges_index_keys = key_ranges
+			.iter()
+			.all(|range| range.start <= range.end && range.end as usize <= keys.len());
+		if !key_ranges_index_keys {
+			return Err(SerializationError::InvalidConstruction {
+				name: "KeySegment::key_ranges",
+			});
+		}
+
 		Ok(KeySegment {
 			keys,
 			key_ranges,
 			constraint_indices,
 			dense_shift_enc,
 		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::constraint_system::Shift;
+
+	use super::{super::operation::Operation, *};
+
+	// Serializes a segment built raw, bypassing `build`, so malformed indices reach the
+	// deserializer.
+	fn deserialize_raw(segment: &KeySegment) -> Result<KeySegment, SerializationError> {
+		let mut buf = Vec::new();
+		segment.serialize(&mut buf).unwrap();
+		KeySegment::deserialize(buf.as_slice())
+	}
+
+	#[test]
+	fn key_segment_round_trips_a_well_formed_segment() {
+		// Pins the checks against the shape `build` produces: word ranges tile the keys vector, and
+		// every index addresses a sibling long enough to hold it.
+		let segment = KeySegment {
+			keys: vec![
+				Key {
+					operation: Operation::Zero,
+					dense_shift_idx: 0,
+					range: Range { start: 0, end: 2 },
+				},
+				Key {
+					operation: Operation::Zero,
+					dense_shift_idx: 1,
+					range: Range { start: 2, end: 3 },
+				},
+			],
+			key_ranges: vec![Range { start: 0, end: 1 }, Range { start: 1, end: 2 }],
+			constraint_indices: (0..3)
+				.map(|constraint_index| ConstraintIndex {
+					operand_index: 0,
+					constraint_index,
+				})
+				.collect(),
+			dense_shift_enc: DenseShiftEncoding::new([
+				[Shift::srl(1), Shift::IDENTITY],
+				[Shift::srl(2), Shift::IDENTITY],
+			]),
+		};
+
+		let segment = deserialize_raw(&segment).expect("a well-formed segment deserializes");
+
+		assert_eq!(segment.n_words(), 2);
+		assert_eq!(segment.keys.len(), 2);
+		assert_eq!(segment.constraint_indices.len(), 3);
+		assert_eq!(segment.dense_shift_enc.len(), 2);
+		assert_eq!(segment.word_keys(0).len(), 1);
+		assert_eq!(segment.word_keys(1).len(), 1);
+	}
+
+	#[test]
+	fn key_segment_rejects_a_key_indexing_past_the_shift_encoding() {
+		// `build_g` scales this index by the row length to reach into the multilinears buffer.
+		// The encoding holds two sequences, so index 2 is one past its end.
+		let segment = KeySegment {
+			keys: vec![Key {
+				operation: Operation::Zero,
+				dense_shift_idx: 2,
+				range: Range { start: 0, end: 1 },
+			}],
+			key_ranges: vec![Range { start: 0, end: 1 }],
+			constraint_indices: vec![ConstraintIndex {
+				operand_index: 0,
+				constraint_index: 0,
+			}],
+			dense_shift_enc: DenseShiftEncoding::new([
+				[Shift::srl(1), Shift::IDENTITY],
+				[Shift::srl(2), Shift::IDENTITY],
+			]),
+		};
+
+		match deserialize_raw(&segment).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "KeySegment::keys");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
+
+	#[test]
+	fn key_segment_rejects_a_key_range_past_the_constraint_indices() {
+		// `accumulate_wide` slices the segment's flattened constraint list with this range, which
+		// holds one entry against the key's claim of four.
+		let segment = KeySegment {
+			keys: vec![Key {
+				operation: Operation::Zero,
+				dense_shift_idx: 0,
+				range: Range { start: 0, end: 4 },
+			}],
+			key_ranges: vec![Range { start: 0, end: 1 }],
+			constraint_indices: vec![ConstraintIndex {
+				operand_index: 0,
+				constraint_index: 0,
+			}],
+			dense_shift_enc: DenseShiftEncoding::new([[Shift::srl(1), Shift::IDENTITY]]),
+		};
+
+		match deserialize_raw(&segment).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "KeySegment::keys");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
+
+	#[test]
+	fn key_segment_rejects_a_word_range_past_the_keys() {
+		// `word_keys` slices the flattened keys vector, which holds one key against a range of two.
+		let segment = KeySegment {
+			keys: vec![Key {
+				operation: Operation::Zero,
+				dense_shift_idx: 0,
+				range: Range { start: 0, end: 1 },
+			}],
+			key_ranges: vec![Range { start: 0, end: 2 }],
+			constraint_indices: vec![ConstraintIndex {
+				operand_index: 0,
+				constraint_index: 0,
+			}],
+			dense_shift_enc: DenseShiftEncoding::new([[Shift::srl(1), Shift::IDENTITY]]),
+		};
+
+		match deserialize_raw(&segment).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "KeySegment::key_ranges");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
+	}
+
+	#[test]
+	fn key_segment_rejects_a_reversed_word_range() {
+		// Slicing `start..end` panics when start runs past end, in bounds or not.
+		let segment = KeySegment {
+			keys: vec![Key {
+				operation: Operation::Zero,
+				dense_shift_idx: 0,
+				range: Range { start: 0, end: 1 },
+			}],
+			key_ranges: vec![Range { start: 1, end: 0 }],
+			constraint_indices: vec![ConstraintIndex {
+				operand_index: 0,
+				constraint_index: 0,
+			}],
+			dense_shift_enc: DenseShiftEncoding::new([[Shift::srl(1), Shift::IDENTITY]]),
+		};
+
+		match deserialize_raw(&segment).unwrap_err() {
+			SerializationError::InvalidConstruction { name } => {
+				assert_eq!(name, "KeySegment::key_ranges");
+			}
+			other => panic!("Expected InvalidConstruction, got: {other:?}"),
+		}
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-517](https://linear.app/jimpo/issue/BINIUS-517).

Makes a corrupted key-collection cache fail `KeyCollection::deserialize` cleanly instead of panicking mid-proof. No format change, no computation change.

### The problem

`KeyCollection` deserialization trusts its own index fields.

`Key::deserialize` reads a `dense_shift_idx: u16` and a `range: Range<u32>` and checks neither.
`KeySegment::deserialize` builds `key_ranges` from raw `u32` pairs and checks neither.

So a corrupted cache file deserializes successfully, then panics at the first site that uses one of those indices:

- `build_g` (`phase_1.rs`) scales `dense_shift_idx` by the row length to reach into the multilinears buffer.
- `word_scalar` (`monster.rs`) scales the same index by the operation's arity to reach into the scalars buffer.
- `accumulate_wide` (`key.rs`) slices the segment's flattened constraint list with `range`.
- `word_keys` (`key_segment.rs`) slices the flattened keys vector with a `key_ranges` entry.

Every one is ordinary checked slice indexing, so the failure mode is a panic, never an out-of-bounds read.

`DenseShiftEncoding::deserialize`, the sibling in the same module, already does this properly — sortedness, distinctness, in-range amounts, the `u16` length cap, all returning `SerializationError::InvalidConstruction`. `Key` and `KeySegment` are the two types that never got the same treatment.

`build_g` even carries a `debug_assert!` for exactly the `dense_shift_idx` invariant, so the constraint was already documented — just not enforced in release.

### The idea

Check every index against the sibling it addresses, at load time, and put each check where the information to make it actually lives.

- `Key` sees only its own fields, so it validates `start <= end`.
- `KeySegment` owns all four fields, so it validates each key and each word range against the sibling that has to hold it.

### The change

```
Key::deserialize
+ start > end                                              -> "Key::range"

KeySegment::deserialize
+ any key with dense_shift_idx >= dense_shift_enc.len()    -> "KeySegment::keys"
+ any key with range.end > constraint_indices.len()        -> "KeySegment::keys"
+ any key_ranges entry with start > end                    -> "KeySegment::key_ranges"
+ any key_ranges entry with end > keys.len()               -> "KeySegment::key_ranges"
```

Two distinct error names rather than one, so a test can tell which invariant tripped.

### Trust boundary — why this is hardening, not a vulnerability fix

`KeyCollection` bytes arrive only as part of a prover's own persisted setup cache, through `ZKProver::deserialize`.
They never travel over the interactive transcript between prover and verifier.

So this is not reachable by a malicious verifier, nor by a malicious prover trying to fool a verifier.
The exposure is whoever supplies the cache file to their own prover — a downloaded precomputed key collection for a public circuit, say.

### Soundness

Unaffected. Nothing about the serialized format, the in-memory representation, or any proving computation moves. The new code only rejects byte strings that previously produced a panic.

### Scope

- **changed:** `Key::deserialize` and `KeySegment::deserialize` — 24 lines of validation.
- **new:** 7 tests, using the `deserialize_raw` round-trip pattern the neighbouring `dense_shift_encoding.rs` tests already established.
- **left untouched:** the serialized format, every indexing site, and `build`'s construction path.

One deliberate omission: word ranges are checked for being *in bounds*, not for *tiling* the keys vector contiguously the way `build` emits them. Bounds is what prevents the panics; contiguity is a stronger invariant no consumer relies on, and enforcing it would risk rejecting data a future builder legitimately writes.

### Verification

- `cargo test -p binius-prover` — 67 + 17 + 1 pass, 0 fail. Same with `--features rayon`.
- `cargo clippy -p binius-prover --all-targets` — zero warnings.
- `cargo +nightly fmt --check -p binius-prover` — exit 0.

Gates are scoped to the touched crate; `binius-prover` has no in-workspace dependents, and the change is confined to one private module's `DeserializeBytes` impls.

The 5 rejection tests were each shown to be non-vacuous: stubbing all three conditions to `if false` fails exactly those 5 while both positive tests (`key_accepts_an_empty_range`, `key_segment_round_trips_a_well_formed_segment`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)