### PR TITLE
BINIUS-518: Move powers from a free function onto FieldOps

### DIFF
--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -4,7 +4,7 @@
 use std::{
 	fmt::Display,
 	hash::Hash,
-	iter::{Product, Sum},
+	iter::{self, Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -117,6 +117,12 @@ pub trait FieldOps:
 
 	/// Returns the one element (multiplicative identity).
 	fn one() -> Self;
+
+	/// Iterate the powers of this value, beginning with 1 (the 0'th power).
+	fn powers(&self) -> impl Iterator<Item = Self> {
+		let val = self.clone();
+		iter::successors(Some(Self::one()), move |power| Some(power.clone() * val.clone()))
+	}
 
 	/// Transpose the subfield elements in a slice of field elements.
 	///

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -117,6 +117,17 @@ generate_spread_tests_small! {
 	spread_equals_basic_spread_64x1, PackedBinaryField64x1b, BinaryField1b, SmallU<1>, 64;
 }
 
+#[test]
+fn test_field_ops_powers() {
+	// The iterator starts at the 0'th power, so entry i must equal the base raised to i.
+	let generator = BinaryField128bGhash::MULTIPLICATIVE_GENERATOR;
+	let power_values: Vec<_> = generator.powers().take(10).collect();
+
+	for (i, power) in power_values.iter().enumerate() {
+		assert_eq!(*power, generator.pow(i as u64));
+	}
+}
+
 fn check_field_ops_square_transpose<FSub, F>()
 where
 	FSub: Field,

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -28,11 +28,6 @@ pub trait FieldFn<F: Field> {
 	}
 }
 
-/// Iterate the powers of a given value, beginning with 1 (the 0'th power).
-pub fn powers<F: FieldOps>(val: F) -> impl Iterator<Item = F> {
-	iter::successors(Some(F::one()), move |power| Some(power.clone() * val.clone()))
-}
-
 /// Expands an array of field elements into all possible subset sums.
 ///
 /// For an input array `[a, b, c]`, this computes all possible sums of subsets:
@@ -145,16 +140,6 @@ mod tests {
 
 	use super::*;
 	use crate::{BinaryField128bGhash, Random};
-
-	#[test]
-	fn test_powers_against_pow() {
-		let generator = BinaryField128bGhash::MULTIPLICATIVE_GENERATOR;
-		let power_values: Vec<_> = powers(generator).take(10).collect();
-
-		for i in 0..10 {
-			assert_eq!(power_values[i], generator.pow(i as u64));
-		}
-	}
 
 	type F = BinaryField128bGhash;
 

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -375,7 +375,7 @@ mod tests {
 	use binius_field::{
 		BinaryField1b, ExtensionField, Field,
 		arch::{OptimalB128, OptimalPackedB128},
-		util::powers,
+		field::FieldOps,
 	};
 	use binius_ip::{channel::IPVerifierChannel, logup_star};
 	use binius_math::{
@@ -531,7 +531,7 @@ mod tests {
 			// gamma^i within the table — the same power series serves every table — scattered onto
 			// its cube.
 			let mut pushforward = vec![F::ZERO; 1usize << m];
-			for (looker, power) in iter::zip(&table.lookers, powers(gamma)) {
+			for (looker, power) in iter::zip(&table.lookers, gamma.powers()) {
 				for (&j, &eq) in iter::zip(&looker.index, &looker.eq_r) {
 					pushforward[j] += power * eq;
 				}

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -12,7 +12,7 @@
 use std::iter;
 
 use binius_compute::{Allocator, VecLike};
-use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
+use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec, multilinear::eq::scaled_eq_ind_partial_eval_into,
 };
@@ -99,7 +99,7 @@ where
 		.map(|table| table.lookers.len())
 		.max()
 		.expect("tables is non-empty");
-	let scales = powers(gamma).take(max_table_lookers).collect::<Vec<_>>();
+	let scales = gamma.powers().take(max_table_lookers).collect::<Vec<_>>();
 	let flat = tables
 		.iter()
 		.flat_map(|table| iter::zip(&table.lookers, &scales))

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -11,7 +11,7 @@
 use std::{iter, ops::Deref};
 
 use binius_compute::Allocator;
-use binius_field::{Field, PackedField, util::powers};
+use binius_field::{Field, PackedField, field::FieldOps};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_math::{
 	FieldVec, field_buffer::FieldBuffer, line::extrapolate_line, univariate::evaluate_univariate,
@@ -73,7 +73,7 @@ pub fn expand_libra_eval<A: Allocator, P: PackedField>(
 
 	for (j, &r_j) in challenge_point.iter().enumerate() {
 		let base_idx = j * row_stride;
-		for (k, power) in powers(r_j).take(degree + 1).enumerate() {
+		for (k, power) in r_j.powers().take(degree + 1).enumerate() {
 			buffer.set(base_idx + k, power);
 		}
 	}

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -4,7 +4,7 @@
 
 use std::{iter, slice};
 
-use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps, util::powers};
+use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps};
 use binius_math::{
 	multilinear::{
 		eq::{eq_ind, eq_ind_zero},
@@ -179,9 +179,7 @@ where
 		.map(|table| table.lookers.len())
 		.max()
 		.expect("tables is non-empty");
-	let looker_powers = powers(gamma.clone())
-		.take(max_table_lookers)
-		.collect::<Vec<_>>();
+	let looker_powers = gamma.powers().take(max_table_lookers).collect::<Vec<_>>();
 
 	// Sample one logUp challenge per table. Distinct challenges are what make the single root check
 	// certify every table separately: a table's contribution to the root fraction is a rational

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_field::{Field, field::FieldOps, util::powers};
+use binius_field::{Field, field::FieldOps};
 use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
 
 use crate::{
@@ -243,7 +243,7 @@ pub fn libra_eval<F: FieldOps>(
 		.map(|(eq_j_val, r_j)| {
 			eq_k.iter()
 				.take(degree + 1)
-				.zip(powers(r_j.clone()))
+				.zip(r_j.powers())
 				.map(|(eq_k_val, r_j_power)| eq_j_val.clone() * eq_k_val.clone() * r_j_power)
 				.sum::<F>()
 		})

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -264,7 +264,7 @@ fn compute_barycentric_weights<F: Field>(points: &[F]) -> Vec<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128bGhash, Field, Random, util::powers};
+	use binius_field::{BinaryField128bGhash, Field, Random};
 	use rand::prelude::*;
 
 	use super::*;
@@ -276,7 +276,7 @@ mod tests {
 	};
 
 	fn evaluate_univariate_with_powers<F: Field>(coeffs: &[F], x: F) -> F {
-		inner_product(coeffs.iter().copied(), powers(x).take(coeffs.len()))
+		inner_product(coeffs.iter().copied(), x.powers().take(coeffs.len()))
 	}
 
 	type F = BinaryField128bGhash;

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -3,7 +3,7 @@
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, PackedField, util::powers};
+use binius_field::{BinaryField, Field, PackedField};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product,
@@ -117,7 +117,7 @@ impl<F: Field> PreparedOperatorData<F> {
 			r_x_prime,
 		} = operator_data;
 		let r_x_prime_tensor = eq_ind_partial_eval::<F>(&r_x_prime);
-		let lambda_powers: Vec<F> = powers(lambda).skip(1).take(ARITY).collect();
+		let lambda_powers: Vec<F> = lambda.powers().skip(1).take(ARITY).collect();
 		Self {
 			batched_eval: inner_product(evals, lambda_powers.iter().copied()),
 			r_zhat_prime,

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -307,7 +307,7 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let x_val = B128::random(&mut rng);
-		let expected_vals = binius_field::util::powers(x_val)
+		let expected_vals = binius_field::field::FieldOps::powers(&x_val)
 			.skip(1)
 			.take(4)
 			.collect::<Vec<_>>();

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -4,10 +4,7 @@
 use std::iter;
 
 use binius_core::constraint_system::Operand;
-use binius_field::{
-	BinaryField, FieldOps, WideMul,
-	util::{FieldFn, powers},
-};
+use binius_field::{BinaryField, FieldOps, WideMul, util::FieldFn};
 use binius_math::multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars};
 use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
@@ -156,8 +153,7 @@ where
 		let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
 		// The batching coefficients fan into the inner table only, holding it to
 		// `SHIFT_COUNT * arity`; the outer weight multiplies in per term.
-		let operand_shift_scalars =
-			operand_shift_scalar_table(shift_scalars.inner, lambda.clone(), ARITY);
+		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, lambda, ARITY);
 
 		// One contribution per constraint.
 		// Each term is weighted by its two slots' shift scalars and its word-index tensor entry.
@@ -197,7 +193,7 @@ where
 		// The packed expansion threads the tensor's multiplications.
 		// It applies over the base field, which is its own single-element packing.
 		let r_x_prime_tensor = eq_ind_partial_eval::<F>(r_x_prime);
-		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, *lambda, ARITY);
+		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, lambda, ARITY);
 
 		// One unreduced wide product per constraint. The constraints partition cleanly across
 		// rayon: each produces a single wide element and they are summed, so there is no large
@@ -270,10 +266,10 @@ pub fn encode_operation_input<E: Clone>(
 /// So the table is `SHIFT_COUNT * arity` entries rather than `SHIFT_COUNT^2 * arity`.
 fn operand_shift_scalar_table<E: FieldOps>(
 	shift_scalars: &[E; SHIFT_COUNT],
-	lambda: E,
+	lambda: &E,
 	arity: usize,
 ) -> Vec<E> {
-	let lambda_powers = powers(lambda).skip(1).take(arity).collect::<Vec<_>>();
+	let lambda_powers = lambda.powers().skip(1).take(arity).collect::<Vec<_>>();
 	let mut table = Vec::with_capacity(shift_scalars.len() * arity);
 	for shift_scalar in shift_scalars {
 		for lambda_power in &lambda_powers {


### PR DESCRIPTION
Closes [BINIUS-518](https://linear.app/jimpo/issue/BINIUS-518).

Makes `powers` a provided method on `FieldOps` instead of a free function in `util`. Pure refactor — same iterator, same values, same order.

### The problem

`powers` lives in `binius-field`'s `util` module even though it is pure `FieldOps` behaviour:

```
pub fn powers<F: FieldOps>(val: F) -> impl Iterator<Item = F>
```

So every caller imports `binius_field::util::powers` next to the field trait it is already using, and writes `powers(gamma)` where `gamma.powers()` says the same thing.

The free function also takes its argument by value, so two callers clone just to hand it over: `powers(gamma.clone())` and `powers(r_j.clone())`.

### Why it was like this

Historical, not deliberate. The file is dated 2024, and return-position `impl Trait` in traits only stabilized in Rust 1.75 (Dec 2023) — so a trait method returning `impl Iterator` was unavailable or brand new when this was written. Plonky3 has the same shape for the same reason, working around it with a concrete `Powers<F>` struct.

The two reasons that would normally justify a free function both fail here:

- **Object safety is moot.** `FieldOps` already declares the generic method `square_transpose<FSub>`, so the trait is not `dyn`-compatible, and there is no `dyn FieldOps` anywhere in the workspace.
- **External implementors are not a concern.** All six impls are in-tree, and adding a *provided* method is non-breaking regardless.

No extra bound is needed either: `FieldOps: Clone` already implies `Self: Sized`.

### The change

```
FieldOps:
+ fn powers(&self) -> impl Iterator<Item = Self> {
+     let val = self.clone();
+     iter::successors(Some(Self::one()), move |power| Some(power.clone() * val.clone()))
+ }

util.rs:
- pub fn powers<F: FieldOps>(val: F) -> impl Iterator<Item = F>
```

At the call sites:

```
- powers(gamma.clone())   ->  gamma.powers()
- powers(r_j.clone())     ->  r_j.powers()
- powers(lambda)          ->  lambda.powers()
```

The `&self` receiver is what removes the callers' clones — the clone moves inside the method, where it was already happening.

### Scope

- **changed:** `crates/field/src/field.rs` gains the provided method; `util.rs` loses the free function.
- **changed:** the `powers` test moves to `crates/field/src/tests.rs` as `test_field_ops_powers`, joining the `square_transpose` tests — the crate's existing home for `FieldOps` behaviour.
- **changed:** nine call sites across `binius-math`, `binius-ip`, `binius-ip-prover`, `binius-prover`, `binius-verifier` and `binius-spartan-frontend`, each also dropping its `util::powers` import.
- **left untouched:** `spartan_frontend::circuits::powers` is a different function — it builds power *wires* in a circuit and takes a builder, so it cannot move onto `FieldOps`.

### Verification

- `cargo check --all-targets` on the seven touched crates — clean, zero warnings.
- `cargo test --lib` on all seven — 229 + 144 + 13 + 95 + 60 + 27 + 10 pass, 0 fail.
- `cargo clippy --all-targets` on all seven — clean.
- `cargo +nightly fmt --all` — applied.

All six `FieldOps` implementors compile, including the symbolic ones (`SymbolicElem` in `binius-recursion`, `CircuitElem` in `binius-spartan-verifier`), which was the one case worth checking for a provided method returning `impl Iterator<Item = Self>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)