### PR TITLE
BINIUS-520: Fix the mislabelled multiplication trace in mul_by_binary_field_1b

### DIFF
--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -398,7 +398,7 @@ macro_rules! mul_by_binary_field_1b {
 			fn mul(self, rhs: BinaryField1b) -> Self::Output {
 				use $crate::underlier::{UnderlierType, WithUnderlier};
 
-				$crate::tracing::trace_multiplication!(BinaryField128b, BinaryField1b);
+				$crate::tracing::trace_multiplication!($name, BinaryField1b);
 
 				Self(self.0 & <$name as WithUnderlier>::Underlier::fill_with_bit(u8::from(rhs.0)))
 			}

--- a/crates/field/src/tracing.rs
+++ b/crates/field/src/tracing.rs
@@ -48,17 +48,25 @@ cfg_if! {
 
 		macro_rules! trace_multiplication {
 			($name: ty) => {
-				let _guard = $crate::tracing::TraceGuard::new(stringify!($name), stringify!($name));
+				$crate::tracing::trace_multiplication!($name, $name);
 			};
 			($lhs: ty, $rhs: ty) => {
+				// `stringify!` never resolves its argument, so also name both types where the
+				// compiler must resolve them, or a bogus label silently mislabels the trace.
+				const _: ::std::marker::PhantomData<($lhs, $rhs)> = ::std::marker::PhantomData;
 				let _guard = $crate::tracing::TraceGuard::new(stringify!($lhs), stringify!($rhs));
 			};
 		}
 
 	} else {
 		macro_rules! trace_multiplication {
-			($name: ty) => {};
-			($lhs: ty, $rhs: ty) => {};
+			($name: ty) => {
+				$crate::tracing::trace_multiplication!($name, $name);
+			};
+			($lhs: ty, $rhs: ty) => {
+				// Resolve the types even with tracing off, so a bogus label fails a plain build.
+				const _: ::std::marker::PhantomData<($lhs, $rhs)> = ::std::marker::PhantomData;
+			};
 		}
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-520](https://linear.app/jimpo/issue/BINIUS-520).

One token, plus a compile-time guard so the same mistake cannot come back. Diagnostic-only — no arithmetic changes.

### The problem

`crates/field/src/binary_field.rs:401`, inside `mul_by_binary_field_1b!`, hardcodes a type name:

```
trace_multiplication!(BinaryField128b, BinaryField1b);
```

The macro is invoked for three different types — `BinaryField128bGhash` (`ghash.rs:97`), `AESTowerField8b` (`aes_field.rs:102`), `GhashSq256b` (`ghash_sq.rs:80`). All three were attributed to `BinaryField128b`.

And `BinaryField128b` is not a type in this crate. It occurred exactly once in the whole crate, on that line:

```
$ grep -rn "BinaryField128b\b" crates/field/src | grep -v BinaryField128bGhash
crates/field/src/binary_field.rs:401:  trace_multiplication!(BinaryField128b, BinaryField1b);
```

### Why nothing caught it

Three things lined up:

- `trace_multiplication!` only does `stringify!($lhs)`, and `stringify!` never resolves its argument — so a nonexistent name compiles fine.
- The tracing arm is behind `--features trace_multiplications`, which nothing routinely enables.
- The `cfg_if` arm with tracing *off* expanded to nothing at all, so the names appeared in exactly one place, and that place never type-checked them.

No compiler, test, or lint could see it. Not even CI's `--all-features` build, since `stringify!` still doesn't resolve.

### The change

```
- trace_multiplication!(BinaryField128b, BinaryField1b);
+ trace_multiplication!($name, BinaryField1b);
```

Plus a guard in `tracing.rs`, in **both** `cfg_if` arms:

```
const _: ::std::marker::PhantomData<($lhs, $rhs)> = ::std::marker::PhantomData;
```

Putting it in the *disabled* arm is the point — that is where the names were invisible, so a bogus label now fails an ordinary default-feature build. It is an anonymous `const` item: no runtime code, no binary size.

The 1-argument arm now forwards to the 2-argument one, so the guard lives in one place per arm instead of four copies.

### Scope

- **changed:** the hardcoded name, and `trace_multiplication!`'s two arms.
- **left untouched:** the `mul_by_binary_field_1b!` macro itself, which is legitimate — it generates `impl Mul<BinaryField1b> for $name`, and coherence forbids a blanket impl.
- The crate's other two `trace_multiplication!` sites (`binary_field.rs:341`, `arithmetic_traits.rs:83`) were audited and are correct: both are same-type `Mul`, so `lhs == rhs` is right.

### Verification

- Guard proven effective by a negative control: reintroducing the hardcoded name fails a plain `cargo build` with 3 errors, one per invocation site (`cannot find type BinaryField128b in this scope`). Then reverted.
- `cargo clippy -p binius-field --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-field --lib` — 229 pass.
- `cargo test -p binius-field --lib --features trace_multiplications` — 229 pass; the feature that was never exercised now is.
- `cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)