### PR TITLE
BINIUS-521: Rename the free square_transpose to transpose_square_blocks

### DIFF
--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -52,5 +52,5 @@ pub use packed_ghash::*;
 pub use packed_ghash_sq::*;
 pub use random::Random;
 pub use sliced_packed_field::SlicedPackedField;
-pub use transpose::square_transpose;
+pub use transpose::transpose_square_blocks;
 pub use underlier::{Divisible, Maskable, UnderlierType, WithUnderlier};

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -22,7 +22,7 @@ use crate::{BinaryField, ExtensionField, PackedSubfield, WithUnderlier, cast_bas
 ///
 /// * `log_n` must be at most `P::LOG_WIDTH`.
 /// * `elems.len()` must be a power of two and at least `2^log_n`.
-pub fn square_transpose<P: PackedField>(log_n: usize, elems: &mut [P]) {
+pub fn transpose_square_blocks<P: PackedField>(log_n: usize, elems: &mut [P]) {
 	assert!(P::LOG_WIDTH >= log_n, "dimension n of square blocks must divide packing width");
 
 	let size = elems.len();
@@ -60,7 +60,7 @@ where
 	FE: PackedField<Scalar: ExtensionField<F>> + WithUnderlier,
 	PackedSubfield<FE, F>: PackedField<Scalar = F>,
 {
-	square_transpose(FE::Scalar::LOG_DEGREE, cast_bases_mut::<F, FE>(values))
+	transpose_square_blocks(FE::Scalar::LOG_DEGREE, cast_bases_mut::<F, FE>(values))
 }
 
 #[cfg(test)]
@@ -69,7 +69,7 @@ mod tests {
 	use crate::PackedBinaryField128x1b;
 
 	#[test]
-	fn test_square_transpose_128x1b() {
+	fn test_transpose_square_blocks_128x1b() {
 		let mut elems = [
 			PackedBinaryField128x1b::from(0x00000000000000000000000000000000u128),
 			PackedBinaryField128x1b::from(0x00000000000000000000000000000000u128),
@@ -80,7 +80,7 @@ mod tests {
 			PackedBinaryField128x1b::from(0xffffffffffffffffffffffffffffffffu128),
 			PackedBinaryField128x1b::from(0xffffffffffffffffffffffffffffffffu128),
 		];
-		square_transpose(3, &mut elems);
+		transpose_square_blocks(3, &mut elems);
 
 		let expected = [
 			PackedBinaryField128x1b::from(0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0u128),
@@ -96,7 +96,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_square_transpose_128x1b_multi_row() {
+	fn test_transpose_square_blocks_128x1b_multi_row() {
 		let mut elems = [
 			PackedBinaryField128x1b::from(0x00000000000000000000000000000000u128),
 			PackedBinaryField128x1b::from(0x00000000000000000000000000000000u128),
@@ -107,7 +107,7 @@ mod tests {
 			PackedBinaryField128x1b::from(0xffffffffffffffffffffffffffffffffu128),
 			PackedBinaryField128x1b::from(0xffffffffffffffffffffffffffffffffu128),
 		];
-		square_transpose(1, &mut elems);
+		transpose_square_blocks(1, &mut elems);
 
 		let expected = [
 			PackedBinaryField128x1b::from(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaau128),

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -2,7 +2,7 @@
 
 use std::ptr;
 
-use binius_field::{PackedField, square_transpose};
+use binius_field::{PackedField, transpose_square_blocks};
 use binius_utils::{
 	checked_arithmetics::checked_log_2,
 	rayon::{prelude::*, task_size::min_len_for_bytes},
@@ -226,7 +226,7 @@ fn transpose_tile<P: PackedField, const LOG_TILE_PACKED: usize>(tile: &mut [P], 
 	// A matrix one sub-block wide is already a single square of lanes.
 	// So it needs neither the mirror swaps nor the gather below.
 	if LOG_TILE_PACKED == 0 {
-		return square_transpose(P::LOG_WIDTH, tile);
+		return transpose_square_blocks(P::LOG_WIDTH, tile);
 	}
 
 	// Element holding lane row `a` of sub-block `(r, c)`.
@@ -253,7 +253,7 @@ fn transpose_tile<P: PackedField, const LOG_TILE_PACKED: usize>(tile: &mut [P], 
 				for (a, block_i) in block.iter_mut().enumerate() {
 					*block_i = tile[block_elem(r, a, c)];
 				}
-				square_transpose(P::LOG_WIDTH, block);
+				transpose_square_blocks(P::LOG_WIDTH, block);
 				for (a, &block_i) in block.iter().enumerate() {
 					tile[block_elem(r, a, c)] = block_i;
 				}


### PR DESCRIPTION
Closes [BINIUS-521](https://linear.app/jimpo/issue/BINIUS-521).

Pure rename — no signature change, no behaviour change.

### The problem

`binius-field` has three distinct things called `square_transpose`:

| Item | Signature | What it does |
|---|---|---|
| `transpose::square_transpose` | `(log_n: usize, elems: &mut [P])` | sweeps a slice of independent `2^log_n`-sided lane blocks |
| `ExtensionField::square_transpose` | `(values: &mut [Self])` | transposes one `DEGREE x DEGREE` coordinate matrix |
| `FieldOps::square_transpose::<FSub>` | `(elems: &mut [Self])` | the same, one layer up |

They are genuinely layered — `FieldOps` delegates to `ExtensionField` for scalars — but the shared name hides the layering rather than expressing it. The free function is also re-exported at the crate root (`lib.rs:55`), so it collides in every importer's namespace.

### The idea

Rename only the free function. Both trait methods keep their name; it is right for what they do.

The free function's own doc line already describes it better than its identifier did:

```
Transpose square blocks of elements within packed field elements in place.
```

Hence `transpose_square_blocks` — verb-first, reads like `std`, unmistakable against the trait methods.

### The change

- `crates/field/src/transpose.rs` — the definition, its one in-crate caller (`square_transforms_extension_field`), and its two unit tests (renamed too, so they no longer read as testing a trait method).
- `crates/field/src/lib.rs:55` — the crate-root re-export.
- `crates/math/src/bit_reverse.rs` — the import plus two call sites; the only caller outside `binius-field`.

### Scope — what was deliberately left alone

Every `square_transpose` hit was read, not just grepped. Untouched:

- Trait declarations and defaults: `extension.rs:82,113`, `field.rs:131,147,151`.
- Trait impls, each with its own butterfly or lane loop and none calling the free function: `arch/portable/packed.rs:427`, `binary_field.rs:577`, `sliced_packed_field.rs:475`, `iop/channel/oracle_setup.rs:119`, `recursion/symbolic/elem.rs`, `spartan-verifier/wrapper/circuit_elem.rs`.
- `spartan-verifier/wrapper/gadgets.rs` — the circuit *gadget* `gadgets::square_transpose`, a different item entirely.
- Trait-method callers and conformance tests: `math/tensor_algebra.rs:93`, `field/tests.rs`, `field/ghash_sq.rs`, `spartan-prover/wrapper/replay_channel.rs`.

Also out of scope, but worth flagging: `crates/prover/src/fold_word.rs` defines `square_transpose_const_size`, a separate const-generic copy of the same algorithm. It does not call the free function, so it needs no change here — but it is duplicated transpose logic.

### Verification

- `cargo clippy -p binius-field -p binius-math --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-field --lib` (229 pass) and `-p binius-math --lib` (144 pass), both also with `--features rayon`.
- `cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)