### PR TITLE
BINIUS-523: Give packed_extension.rs the trait it is named after

### DIFF
--- a/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
@@ -15,7 +15,7 @@ use bytemuck::TransparentWrapper;
 
 use crate::{
 	BinaryField128bGhash, Divisible, PackedBinaryGhash2x128b, PackedGhashSq1x256b, WideMul,
-	cast_base, packed_ghash_sq::ghash_sq_from_coords,
+	packed_extension::PackedExtension, packed_ghash_sq::ghash_sq_from_coords,
 };
 
 /// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.
@@ -96,8 +96,8 @@ impl WideMul for GhashSqHybridWideMul<PackedGhashSq1x256b> {
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
 		// The GHASH² coordinates already sit in the two 128-bit lanes of the 256-bit value, so
 		// viewing an operand as a packed GHASH pair is a free reinterpretation.
-		let a = cast_base::<BinaryField128bGhash, _>(Self::peel(a));
-		let b = cast_base::<BinaryField128bGhash, _>(Self::peel(b));
+		let a = PackedExtension::<BinaryField128bGhash>::cast_base(Self::peel(a));
+		let b = PackedExtension::<BinaryField128bGhash>::cast_base(Self::peel(b));
 
 		WideGhashSqProduct {
 			// Diagonal `[a·e, b·f]` as one two-lane packed widening multiply.

--- a/crates/field/src/packed_extension.rs
+++ b/crates/field/src/packed_extension.rs
@@ -5,55 +5,66 @@ use crate::{
 	BinaryField, ExtensionField, PackedField, arch::PackedPrimitiveType, underlier::WithUnderlier,
 };
 
-/// The packed subfield type sharing the same underlier as the packed extension field type `P`.
+/// A packed extension field that can also be read as a packing of its subfield `FSub`.
 ///
-/// `P` and `PackedSubfield<P, FSub>` have the same in-memory representation, differing only in the
-/// scalar type and preserving the order of the smaller elements. This is what makes the reinterpret
-/// casts ([`cast_bases_mut`], [`cast_base_mut`], [`cast_ext`]) sound: the `FSub` scalars of
-/// `cast_bases_mut(exts)` are exactly the scalars yielded by
-/// `exts.iter().flat_map(|ext| ext.iter_bases())`.
-pub type PackedSubfield<P, FSub> = PackedPrimitiveType<<P as WithUnderlier>::Underlier, FSub>;
-
-/// Reinterpret a mutable slice of packed extension field elements as a mutable slice of the
-/// corresponding packed subfield elements.
+/// `Self` and [`Self::PackedSubfield`] cover the same bits in the same order.
+/// They differ only in how wide a scalar those bits are cut into.
+/// That is what makes all four casts free reinterpretations rather than conversions.
 ///
-/// The two slices share the same memory; `PackedSubfield<P, FSub>` has the same underlier as `P`.
-pub fn cast_bases_mut<FSub, P>(packed: &mut [P]) -> &mut [PackedSubfield<P, FSub>]
-where
-	FSub: BinaryField,
-	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
-	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
+/// The subfield scalars come out in [`ExtensionField`] basis order:
+///
+/// ```text
+/// P::cast_bases_mut(exts)  ==  exts.iter().flat_map(|ext| ext.iter_bases())
+/// ```
+pub trait PackedExtension<FSub: BinaryField>:
+	PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier
 {
-	PackedSubfield::<P, FSub>::from_underliers_ref_mut(P::to_underliers_ref_mut(packed))
+	/// The packing of `FSub` covering the same bits as `Self`.
+	type PackedSubfield: PackedField<Scalar = FSub>;
+
+	/// Reads a packed extension field element as a packed subfield element.
+	fn cast_base(self) -> Self::PackedSubfield;
+
+	/// Reads a packed extension field element in place as a packed subfield element.
+	fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield;
+
+	/// Reads a packed subfield element as a packed extension field element.
+	fn cast_ext(base: Self::PackedSubfield) -> Self;
+
+	/// Reads a slice of packed extension field elements in place as packed subfield elements.
+	fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield];
 }
 
-/// Reinterpret a mutable reference to a packed extension field element as a mutable reference to
-/// the corresponding packed subfield element.
-pub fn cast_base_mut<FSub, P>(packed: &mut P) -> &mut PackedSubfield<P, FSub>
-where
-	FSub: BinaryField,
-	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
-	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
-{
-	PackedSubfield::<P, FSub>::from_underlier_ref_mut(packed.to_underlier_ref_mut())
-}
+/// A shorthand for [`PackedExtension::PackedSubfield`].
+pub type PackedSubfield<P, FSub> = <P as PackedExtension<FSub>>::PackedSubfield;
 
-/// Reinterpret a packed extension field element as the corresponding packed subfield element.
-pub fn cast_base<FSub, P>(ext: P) -> PackedSubfield<P, FSub>
+/// A transparent wrapper over an underlier holds one contiguous bit string.
+/// Cutting that same string into `FSub` scalars is exactly a [`PackedPrimitiveType`].
+impl<FSub, P> PackedExtension<FSub> for P
 where
 	FSub: BinaryField,
 	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
-	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
+	PackedPrimitiveType<P::Underlier, FSub>: PackedField<Scalar = FSub>,
 {
-	PackedSubfield::<P, FSub>::from_underlier(ext.to_underlier())
-}
+	type PackedSubfield = PackedPrimitiveType<P::Underlier, FSub>;
 
-/// Reinterpret a packed subfield element as the corresponding packed extension field element.
-pub fn cast_ext<FSub, P>(base: PackedSubfield<P, FSub>) -> P
-where
-	FSub: BinaryField,
-	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
-	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
-{
-	P::from_underlier(base.to_underlier())
+	#[inline]
+	fn cast_base(self) -> Self::PackedSubfield {
+		Self::PackedSubfield::from_underlier(self.to_underlier())
+	}
+
+	#[inline]
+	fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
+		Self::PackedSubfield::from_underlier_ref_mut(self.to_underlier_ref_mut())
+	}
+
+	#[inline]
+	fn cast_ext(base: Self::PackedSubfield) -> Self {
+		Self::from_underlier(base.to_underlier())
+	}
+
+	#[inline]
+	fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
+		Self::PackedSubfield::from_underliers_ref_mut(Self::to_underliers_ref_mut(packed))
+	}
 }

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -38,7 +38,7 @@ use crate::{
 		portable::packed_macros::{portable_macros::*, *},
 	},
 	arithmetic_traits::{InvertOrZero, Square},
-	cast_base, cast_ext,
+	packed_extension::PackedExtension,
 	sliced_packed_field::SlicedPackedField,
 	underlier::{UnderlierType, WithUnderlier},
 };
@@ -237,14 +237,14 @@ where
 /// reinterpretation followed by two lane reads.
 #[inline]
 pub(crate) fn ghash_sq_coords(elem: PackedGhashSq1x256b) -> [BinaryField128bGhash; 2] {
-	let coords = cast_base::<BinaryField128bGhash, _>(elem);
+	let coords = PackedExtension::<BinaryField128bGhash>::cast_base(elem);
 	[coords.get(0), coords.get(1)]
 }
 
 /// Assembles a width-one GHASH² element `a + b·Y` from its GHASH coordinates `[a, b]`.
 #[inline]
 pub(crate) fn ghash_sq_from_coords(coords: [BinaryField128bGhash; 2]) -> PackedGhashSq1x256b {
-	cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars(coords))
+	PackedExtension::<BinaryField128bGhash>::cast_ext(PackedBinaryGhash2x128b::from_scalars(coords))
 }
 
 /// [`Square`] strategy for [`PackedGhashSq1x256b`].
@@ -256,7 +256,8 @@ impl Square for GhashSqSquare<PackedGhashSq1x256b> {
 	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two.
 	#[inline]
 	fn square(self) -> Self {
-		let sq = Square::square(cast_base::<BinaryField128bGhash, _>(Self::peel(self)));
+		let sq =
+			Square::square(PackedExtension::<BinaryField128bGhash>::cast_base(Self::peel(self)));
 
 		let x_t2 = sq.get(1).mul_x();
 		Self::wrap(ghash_sq_from_coords([sq.get(0) + x_t2, x_t2]))

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -4,7 +4,7 @@
 use binius_utils::checked_arithmetics::checked_log_2;
 
 use super::packed::PackedField;
-use crate::{BinaryField, ExtensionField, PackedSubfield, WithUnderlier, cast_bases_mut};
+use crate::{BinaryField, ExtensionField, PackedExtension};
 
 /// Transpose square blocks of elements within packed field elements in place.
 ///
@@ -57,10 +57,9 @@ pub fn transpose_square_blocks<P: PackedField>(log_n: usize, elems: &mut [P]) {
 pub fn square_transforms_extension_field<F, FE>(values: &mut [FE])
 where
 	F: BinaryField,
-	FE: PackedField<Scalar: ExtensionField<F>> + WithUnderlier,
-	PackedSubfield<FE, F>: PackedField<Scalar = F>,
+	FE: PackedExtension<F>,
 {
-	transpose_square_blocks(FE::Scalar::LOG_DEGREE, cast_bases_mut::<F, FE>(values))
+	transpose_square_blocks(FE::Scalar::LOG_DEGREE, FE::cast_bases_mut(values))
 }
 
 #[cfg(test)]

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -6,7 +6,7 @@ use std::{iter, ops::Deref};
 use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{
-	ExtensionField, Field, PackedBinaryField128x1b, PackedField, cast_base,
+	ExtensionField, Field, PackedBinaryField128x1b, PackedExtension, PackedField,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, InputWrappingTransformationFactory,
 		LinearTransformationFactory, OutputWrappingTransformationFactory, Transformation,
@@ -144,7 +144,7 @@ where
 					// so each view is free.
 					let mut group = [PackedBinaryField128x1b::default(); ROW_GROUP];
 					iter::zip(&mut group, &mut rows)
-						.for_each(|(dst, src)| *dst = cast_base::<B1, _>(src));
+						.for_each(|(dst, src)| *dst = PackedExtension::<B1>::cast_base(src));
 
 					fold_row_group(&group, table, &mut columns);
 				}
@@ -402,7 +402,7 @@ mod test {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField128bGhash, ExtensionField, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
-		PackedField, PackedSubfield, cast_ext,
+		PackedExtension, PackedField, PackedSubfield,
 	};
 	use binius_math::{
 		FieldBuffer,
@@ -600,7 +600,7 @@ mod test {
 			bit_matrix
 				.as_ref()
 				.iter()
-				.map(|&bits_packed| cast_ext::<B1, P>(bits_packed))
+				.map(|&bits_packed| <P as PackedExtension<B1>>::cast_ext(bits_packed))
 				.collect(),
 		);
 		let (eq_lo, eq_hi) = expand_tensor_factors(suffix);


### PR DESCRIPTION
Closes [BINIUS-523](https://linear.app/jimpo/issue/BINIUS-523).

Turns four free `cast_*` functions into a `PackedExtension` trait with an associated subfield type. Pure refactor — no behaviour change.

**Read "What this does not buy" before reviewing.** This is the weakest of the four `binius-field` cleanups and I would not argue hard for it.

### The problem

`crates/field/src/packed_extension.rs` is named after a trait that does not exist. Four free functions — `cast_bases_mut`, `cast_base_mut`, `cast_base`, `cast_ext` — each repeat the same bound verbatim:

```
FSub: BinaryField,
P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
```

The third line is the interesting one. It must be restated at every call site because `PackedSubfield` is a *type alias*, and an alias cannot carry its own bound:

```
pub type PackedSubfield<P, FSub> = PackedPrimitiveType<<P as WithUnderlier>::Underlier, FSub>;
```

That alias also hardcodes into the contract that every packed extension's subfield packing is a `PackedPrimitiveType`.

### The idea

```
pub trait PackedExtension<FSub: BinaryField>:
    PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier
{
    type PackedSubfield: PackedField<Scalar = FSub>;

    fn cast_base(self) -> Self::PackedSubfield;
    fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield;
    fn cast_ext(base: Self::PackedSubfield) -> Self;
    fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield];
}
```

Bound declared once, and `PackedPrimitiveType` leaves the contract.

Methods are **required, not defaulted**. A default body would need `Self::PackedSubfield: WithUnderlier<Underlier = Self::Underlier>` on the associated type, re-hardcoding "same underlier" into the contract — the exact thing the associated type exists to remove.

### What this does not buy

**No ergonomic win.** Method syntax cannot name `FSub` — it is a trait parameter, not a method parameter, and inference cannot recover it, because resolving `Self::PackedSubfield` requires selecting the impl first. So call sites read `PackedExtension::<FSub>::cast_base(x)`, the same width as the old `cast_base::<FSub, _>(x)`.

**The flexibility is latent.** With one blanket impl, `Self::PackedSubfield` is always `PackedPrimitiveType<Underlier, FSub>` — exactly what the alias hardcoded. Getting a genuinely different subfield packing means deleting the blanket impl and adding per-family impls first. Mechanical, but a follow-up.

So the honest win is narrow: one bound instead of four, and `PackedPrimitiveType` out of the contract.

### Why a blanket impl rather than per-family

- `ring_switch.rs:147` calls `cast_base` on a **scalar** `B128`, and scalar binary fields get `WithUnderlier` + `PackedField` from the `binary_field!` macro. An impl on `PackedPrimitiveType` alone would regress that call site, so per-family means one generic impl *plus* a macro arm — more code, no gain.
- The blanket impl forecloses per-type impls, but forecloses nothing real. `SlicedPackedField` is `([PSub; N], PhantomData<F>)`, so its bits are N separate registers and it can never be `WithUnderlier`. Even without that supertrait, `type PackedSubfield = PSub` would be a lie — the cast is layout-valid but yields sliced order, not the `flat_map(iter_bases)` order the trait documents. That family already meets the need via its own `FieldOps::square_transpose`.

### Scope

- **new:** the trait plus one blanket impl. No new `unsafe` — the casts go through the existing `WithUnderlier` conversions.
- **kept:** `PackedSubfield` as a projection, `pub type PackedSubfield<P, FSub> = <P as PackedExtension<FSub>>::PackedSubfield;`. It has two live uses in type position (`arch/arch_optimal.rs:29`, `prover/ring_switch.rs:584`) where the full projection is pure noise.
- **deleted:** all four free functions, no wrappers. All 13 call sites converted.
- `transpose.rs`'s three-line where-clause collapses to `FE: PackedExtension<F>`.

**Open question:** `cast_base_mut` has zero call sites anywhere in the repo, before this change and after. It completes the surface, but could reasonably be dropped — say the word and I will.

### Verification

- `cargo clippy -p binius-field -p binius-prover --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-field --lib` (229 pass) and `-p binius-prover --lib` (67 pass, also with `--features rayon`).
- `cargo doc -p binius-field --no-deps` — no warnings, intra-doc links resolve.
- `cargo +nightly fmt --check` — clean.

The x86_64 GFNI call sites sit behind `#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2"))]`, so a plain cross-check compiles nothing there. Proven with a `compile_error!` probe: a plain `--target x86_64-apple-darwin` check does **not** compile the file, while `RUSTFLAGS="-C target-feature=+avx2,+vpclmulqdq"` does. That flagged command is what actually type-checks it, and it is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)