### PR TITLE
BINIUS-524: Tune task granularity in the shift protocol's monster-segment fill

### DIFF
--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -7,7 +7,13 @@ use binius_compute::{Allocator, VecLike};
 use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
-use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_utils::{
+	checked_arithmetics::log2_ceil_usize,
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
+};
 use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 use tracing::instrument;
 
@@ -349,6 +355,7 @@ where
 		values.spare_capacity_mut()[..n_full]
 			.par_iter_mut()
 			.enumerate()
+			.with_min_task(WorkPerItem::FieldMuls)
 			.for_each(|(chunk_index, slot)| {
 				let start = chunk_index * P::WIDTH;
 				slot.write(P::from_scalars(


### PR DESCRIPTION
Closes [BINIUS-524](https://linear.app/jimpo/issue/BINIUS-524/tune-task-granularity-in-the-shift-protocols-monster-segment-fill).

Adds a task-size hint to one parallel loop that was missing it. Pure scheduling change — no behavior change.

### The problem

The shift protocol builds two multilinears in parallel: the witness-and-batching one in `phase_1.rs`, and the constraint-matrix one (informally "the monster") in `monster.rs`.

Both loops do the same shape of work: one small per-element computation, fanned out over every word of a segment.

The `phase_1.rs` and `phase_2.rs` loops both tell `rayon` how much work a task must carry before it's worth splitting further, via `.with_min_task(WorkPerItem::FieldMuls)`. The structurally identical loop in `monster.rs` never got that call — it was left at `rayon`'s default splitting heuristic.

### The idea

Add the same task-size hint to the one loop that's missing it:

```
values.spare_capacity_mut()[..n_full]
    .par_iter_mut()
    .enumerate()
+   .with_min_task(WorkPerItem::FieldMuls)
    .for_each(|(chunk_index, slot)| { ... })
```

`with_min_task` raises rayon's per-task item count so that task handoff overhead (roughly a microsecond per split) stays under about 1% of a task's own work. Without it, rayon's default splitting can hand out tasks far smaller than that for a cheap per-item closure like this one.

This changes nothing about what is computed — every element's value is identical — only how the work is chopped up across threads.

### The change

- **changed:** `crates/prover/src/protocols/shift/monster.rs` — one `.with_min_task(WorkPerItem::FieldMuls)` call added to the `build_segment` closure's parallel fill, plus the `task_size` import
- **untouched:** every other file; the loop's inputs, outputs, and the values it writes

### Soundness

No soundness surface at all — this only tunes a scheduling hint on an existing parallel iterator. The values written are bit-identical to before.

### Scope

- one closure in one function (`build_monster_segments`'s `build_segment`)
- no call-site changes anywhere else in the crate or in `m4-prover`

### Verification

- `cargo check` / `cargo clippy --all-targets -- -D warnings` / `cargo +nightly fmt --check`, with and without `--features rayon` — clean
- `cargo test -p binius-prover` (67 unit + 17 + 1 integration), with and without `--features rayon` — all pass

### Benchmark

`cargo bench -p binius-prover --bench shift_reduction --features rayon -- phase2_build_monster_segments`, on a shared machine under variable background load (other sessions on the same box), so absolute numbers are noisy — reported as several independent trials rather than one clean number:

| variant | trial 1 | trial 2 | trial 3 |
|---|---|---|---|
| before (no `with_min_task`) | 5.16 ms (2.85–8.47 ms) | — | — |
| after (with `with_min_task`) | 1.31 ms (1.26–1.37 ms) | 1.61 ms (1.23–2.16 ms) | 1.61 ms (1.23–2.16 ms) |

The "after" trials are consistently tighter (9–75% spread) than the one "before" trial (3× spread), which is the signature of the fix working as intended: less scheduling overhead means less sensitivity to whatever else is competing for the same cores. The headline ratio between medians should not be trusted as a clean speedup number given the load conditions; a rerun on an idle machine would give a trustworthy one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
