### PR TITLE
BINIUS-525: Collapse phase-2's four segment-buffer arguments into a SegmentPair type

### DIFF
--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::DerefMut};
+use std::iter;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -13,7 +13,7 @@ use binius_ip_prover::{
 		ProveSingleOutput, bivariate_product_prover, prove_single, round_evals::RoundEvals,
 	},
 };
-use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_zero};
+use binius_math::{FieldVec, multilinear::eq::eq_ind_zero};
 use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
 	rayon::{
@@ -52,6 +52,59 @@ where
 	extended
 }
 
+/// A witness or constraint-matrix buffer, split into the public and hidden segments the
+/// phase-2 sumcheck's selector variable chooses between.
+///
+/// The hidden segment is normally the wider of the two, spanning the whole word-index space,
+/// with the public segment sitting at its base.
+struct SegmentPair<'a, P: PackedField, A: Allocator> {
+	/// The public segment, at the base of the shared word-index space.
+	public: &'a FieldVec<P, A>,
+	/// The hidden segment, normally spanning the whole word-index space.
+	hidden: FieldVec<P, A>,
+}
+
+impl<'a, P: PackedField, A: Allocator> SegmentPair<'a, P, A> {
+	/// Pairs a public and hidden segment sharing one word-index space.
+	const fn new(public: &'a FieldVec<P, A>, hidden: FieldVec<P, A>) -> Self {
+		Self { public, hidden }
+	}
+
+	/// Folds the two segments at the selector challenge.
+	///
+	/// Consumes and overwrites the hidden buffer for memory efficiency.
+	/// The result is `(1 - alpha) * public_padded + alpha * hidden`, exactly what folding the
+	/// materialized combined buffer's highest variable would produce.
+	fn fold<F>(self, alpha: F) -> FieldVec<P, A>
+	where
+		F: Field,
+		P: PackedField<Scalar = F>,
+	{
+		let Self { public, mut hidden } = self;
+
+		// Scale the dominant hidden segment in place, in parallel.
+		let alpha_broadcast = P::broadcast(alpha);
+		hidden
+			.as_mut()
+			.par_iter_mut()
+			.with_min_task(WorkPerItem::FieldMuls)
+			.for_each(|hidden_i| *hidden_i *= alpha_broadcast);
+
+		// Add the small public prefix sequentially.
+		// Its trailing partial packed element carries zero high lanes, so whole-element
+		// updates are correct.
+		let one_minus_alpha = P::broadcast(F::ONE - alpha);
+		let n_public_packed = public.as_ref().len();
+		for (value, &public_i) in
+			iter::zip(&mut hidden.as_mut()[..n_public_packed], public.as_ref())
+		{
+			*value += public_i * one_minus_alpha;
+		}
+
+		hidden
+	}
+}
+
 /// Computes the phase-2 first-round message: the degree-2 round polynomial that binds the
 /// segment selector, evaluated sparsely without materializing the combined witness.
 ///
@@ -65,28 +118,26 @@ where
 /// public prefix.
 /// Both corrections run over whole packed elements, so past the public length the stray terms
 /// the zero padding introduces cancel between the two sums.
-fn first_round_coeffs<F, P: PackedField<Scalar = F>, Data: std::ops::Deref<Target = [P]>>(
-	public_folded: &FieldBuffer<P, Data>,
-	hidden_folded: &FieldBuffer<P, Data>,
-	public_monster: &FieldBuffer<P, Data>,
-	hidden_monster: &FieldBuffer<P, Data>,
+fn first_round_coeffs<F, P: PackedField<Scalar = F>, A: Allocator>(
+	witness: &SegmentPair<'_, P, A>,
+	monster: &SegmentPair<'_, P, A>,
 	gamma: F,
 ) -> RoundCoeffs<F>
 where
 	F: BinaryField,
 {
 	// The dense hidden-segment pass.
-	let wide_dense = (hidden_folded.as_ref(), hidden_monster.as_ref())
+	let wide_dense = (witness.hidden.as_ref(), monster.hidden.as_ref())
 		.into_par_iter()
 		.with_min_task(WorkPerItem::FieldMuls)
 		.map(|(&hidden_i, &monster_i)| P::wide_mul(hidden_i, monster_i))
 		.reduce(<P as WideMul>::Output::default, |lhs, rhs| lhs + rhs);
 
 	// The public-prefix corrections.
-	let n_public_packed = public_folded.as_ref().len();
+	let n_public_packed = witness.public.as_ref().len();
 	let (wide_low_hidden, wide_low_cross) = iter::zip(
-		iter::zip(public_folded.as_ref(), &hidden_folded.as_ref()[..n_public_packed]),
-		iter::zip(public_monster.as_ref(), &hidden_monster.as_ref()[..n_public_packed]),
+		iter::zip(witness.public.as_ref(), &witness.hidden.as_ref()[..n_public_packed]),
+		iter::zip(monster.public.as_ref(), &monster.hidden.as_ref()[..n_public_packed]),
 	)
 	.map(|((&public_i, &hidden_i), (&public_monster_i, &hidden_monster_i))| {
 		(
@@ -106,36 +157,6 @@ where
 	let y_inf = y_1 + sum_lanes(wide_low_hidden) + sum_lanes(wide_low_cross);
 
 	RoundEvals([y_1, y_inf]).interpolate(gamma)
-}
-
-/// Folds the two segment buffers of the witness at the selector challenge.
-///
-/// Consumes and overwrites the hidden buffer for memory efficiency.
-/// The result is `(1 - alpha) * public_padded + alpha * hidden`, exactly what folding the
-/// materialized combined buffer's highest variable would produce.
-fn fold_segments<F: Field, P: PackedField<Scalar = F>, Data: DerefMut<Target = [P]>>(
-	public: &FieldBuffer<P, Data>,
-	mut hidden: FieldBuffer<P, Data>,
-	alpha: F,
-) -> FieldBuffer<P, Data> {
-	// Scale the dominant hidden segment in place, in parallel.
-	let alpha_broadcast = P::broadcast(alpha);
-	hidden
-		.as_mut()
-		.par_iter_mut()
-		.with_min_task(WorkPerItem::FieldMuls)
-		.for_each(|hidden_i| *hidden_i *= alpha_broadcast);
-
-	// Add the small public prefix sequentially.
-	// Its trailing partial packed element carries zero high lanes, so whole-element updates
-	// are correct.
-	let one_minus_alpha = P::broadcast(F::ONE - alpha);
-	let n_public_packed = public.as_ref().len();
-	for (value, &public_i) in iter::zip(&mut hidden.as_mut()[..n_public_packed], public.as_ref()) {
-		*value += public_i * one_minus_alpha;
-	}
-
-	hidden
 }
 
 /// Executes the phase-2 sumcheck over the witness, with a sparse first round.
@@ -186,17 +207,19 @@ where
 	assert_eq!(public_monster.log_len(), public_folded.log_len());
 	assert!(public_folded.log_len() <= log_hidden);
 
+	let witness = SegmentPair::<'_, P, A>::new(public_folded, hidden_folded);
+	let monster = SegmentPair::<'_, P, A>::new(public_monster, hidden_monster);
+
 	// Round 1: bind the segment selector.
-	let round_coeffs =
-		first_round_coeffs(public_folded, &hidden_folded, public_monster, &hidden_monster, gamma);
+	let round_coeffs = first_round_coeffs(&witness, &monster, gamma);
 	channel.send_many(round_coeffs.clone().truncate().coeffs());
 	let alpha = channel.sample();
 	let round_sum = round_coeffs.evaluate(&alpha);
 
 	// Fold the segment pairs at the selector challenge and run the remaining rounds with the
 	// standard prover.
-	let folded_witness = fold_segments(public_folded, hidden_folded, alpha);
-	let folded_monster = fold_segments(public_monster, hidden_monster, alpha);
+	let folded_witness = witness.fold(alpha);
+	let folded_monster = monster.fold(alpha);
 	let prover = bivariate_product_prover(alloc, [folded_witness, folded_monster], round_sum);
 
 	let ProveSingleOutput {


### PR DESCRIPTION
Closes [BINIUS-525](https://linear.app/jimpo/issue/BINIUS-525/collapse-phase-2s-four-segment-buffer-arguments-into-a-segmentpair).

Pure internal refactor — no behavior change.

### The problem

Phase 2 of the shift reduction works on two (public, hidden) segment pairs: the witness and the constraint-matrix multilinear.

Two of its private helpers, `first_round_coeffs` and `fold_segments`, both took all four buffers as separate arguments — `public_folded`, `hidden_folded`, `public_monster`, `hidden_monster` — even though each function only ever used them in matching public/hidden pairs.

`run_sumcheck` itself carries `#[allow(clippy::too_many_arguments)]` for the same reason: 10 parameters, four of which are really two pairs.

### The idea

Introduce a private `SegmentPair` type that holds one such pair, and give it the one operation both helpers needed: folding the pair at the selector challenge.

```
struct SegmentPair<'a, P, A> {
    public: &'a FieldVec<P, A>,
    hidden: FieldVec<P, A>,
}
```

`fold_segments`'s entire body becomes `SegmentPair::fold`, unchanged.
`first_round_coeffs` takes two `&SegmentPair` instead of four buffer references, reading `witness.public`/`witness.hidden`/`monster.public`/`monster.hidden` where it used to read four separately-named parameters.

`run_sumcheck` builds the two pairs right after its existing invariant checks, then drives the same two calls it always did — just through the pair values instead of four loose buffers.

### The change

```
- fn first_round_coeffs(public_folded, hidden_folded, public_monster, hidden_monster, gamma)
+ fn first_round_coeffs(witness: &SegmentPair, monster: &SegmentPair, gamma)

- let folded_witness = fold_segments(public_folded, hidden_folded, alpha);
- let folded_monster = fold_segments(public_monster, hidden_monster, alpha);
+ let folded_witness = witness.fold(alpha);
+ let folded_monster = monster.fold(alpha);
```

### Soundness

Pure internal refactor. `first_round_coeffs`'s math and `fold_segments`'s math are unchanged, character for character — only how their inputs are grouped changed.

### Scope

- **changed:** `crates/prover/src/protocols/shift/phase_2.rs` only
- **untouched:** `run_sumcheck`'s external signature, so `m4-prover` and the benchmark (both call it directly with individual buffers) needed no changes at all
- **not removed:** `run_sumcheck`'s `#[allow(clippy::too_many_arguments)]` — its external parameter count is still 10 and can't shrink without breaking those two callers, so clippy still requires the allow (verified by removing it and confirming clippy re-flags it)

### Verification

- `cargo check` / `cargo clippy -p binius-prover --all-targets -- -D warnings` / `cargo +nightly fmt --check`, with and without `--features rayon` — clean
- `cargo test -p binius-prover` (67 unit + 17 + 1 integration) and `cargo test -p binius-m4-prover` (42 + 1 + 1), both with and without `--features rayon` — all pass
- `git diff --stat` on `crates/m4-prover` and `crates/prover/benches` — empty, confirming the change is invisible outside the one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
