### PR TITLE
BINIUS-526: Move build_g and build_monster_segments onto their owning types

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -16,8 +16,7 @@ use binius_prover::{
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims, ShiftChallengePoint,
 		ShiftIndOutput, ShiftIndSumcheck, ShiftOutput,
-		monster::build_monster_segments,
-		phase_1::{Phase1Output, SparseShiftRows, build_g},
+		phase_1::{Phase1Output, SparseShiftRows},
 		phase_2::run_sumcheck,
 	},
 };
@@ -75,7 +74,9 @@ where
 	// by every instance, so the single-instance builder folds them directly from their bits; the
 	// hidden words are already folded over instances. This scalar path drives the single-instance
 	// phase-1 sumcheck.
-	let public = build_g::<F, F>(public_words, &key_collection.public, &prepared);
+	let public = key_collection
+		.public
+		.build_g::<F, F>(public_words, &prepared);
 	let hidden =
 		build_g_from_folded_words(folded_witness.words(), &key_collection.hidden, &prepared);
 	// `g` is the sum of its rows, so the two segments' rows concatenate rather than merge.
@@ -129,9 +130,8 @@ where
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
 
-	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
+	let (public_monster, hidden_monster) = key_collection.build_monster_segments::<F, P, _>(
 		alloc,
-		key_collection,
 		&prepared,
 		shift_ind_eval,
 		&inner_shift,
@@ -154,7 +154,7 @@ where
 
 /// Accumulates the phase-1 "g" rows of one key segment, from instance-folded words.
 ///
-/// This is the batched analogue of the single-instance [`build_g`].
+/// This is the batched analogue of the single-instance key-segment method.
 /// It consumes a key segment's words already folded over the instance axis.
 /// So each word is a [`FoldedWord`], whose bits are field elements rather than a packed `u64`.
 ///
@@ -163,7 +163,7 @@ where
 /// The two coincide when the folded bit is 0 or 1.
 ///
 /// Use this for the hidden (committed) segment, whose words are folded over instances.
-/// Use [`build_g`] for the public segment, whose words are shared constants.
+/// Use the single-instance method for the public segment, whose words are shared constants.
 /// Collecting both results' rows gives the complete g multilinear.
 ///
 /// # Arguments
@@ -534,7 +534,9 @@ mod tests {
 		// The g rows: the public segment folds from raw constant words via the single-instance
 		// builder, the hidden segment from the instance-folded words. The h multilinear comes
 		// from the single-instance prover.
-		let public = build_g::<B128, B128>(public_words, &key_collection.public, &prepared);
+		let public = key_collection
+			.public
+			.build_g::<B128, B128>(public_words, &prepared);
 		let hidden = build_g_from_folded_words(&hidden_folded, &key_collection.hidden, &prepared);
 		let psi = lagrange_evals(&domain_subspace, r_z);
 

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -17,8 +17,8 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		OperatorClaims, OperatorData, ShiftProver, build_key_collection,
-		monster::{build_monster_segments, shift_operator_table},
-		phase_1::{Phase1Output, SparseShiftRows, build_g},
+		monster::shift_operator_table,
+		phase_1::{Phase1Output, SparseShiftRows},
 		phase_2::run_sumcheck,
 	},
 };
@@ -301,8 +301,12 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// The witness-and-batching multilinear is built once per key segment; the combined
 	// multilinear is the two segments' rows concatenated.
 	let build_combined_g = || {
-		let public = build_g::<F, P>(public_words, &key_collection.public, &prepared);
-		let hidden = build_g::<F, P>(hidden_words, &key_collection.hidden, &prepared);
+		let public = key_collection
+			.public
+			.build_g::<F, P>(public_words, &prepared);
+		let hidden = key_collection
+			.hidden
+			.build_g::<F, P>(hidden_words, &prepared);
 		SparseShiftRows::from_segments([
 			(&public, &key_collection.public.dense_shift_enc),
 			(&hidden, &key_collection.hidden.dense_shift_enc),
@@ -333,9 +337,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());
-	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
+	let (public_monster, hidden_monster) = key_collection.build_monster_segments::<F, P, _>(
 		&GlobalAllocator,
-		&key_collection,
 		&prepared,
 		shift_ind_eval,
 		&inner_shift,
@@ -373,13 +376,12 @@ fn bench_shift_phases(c: &mut Criterion) {
 		);
 	});
 
-	// Phase 2. `build_monster_segments` takes its inputs by reference; `run_sumcheck` consumes
-	// its buffers and `r_j` by value.
+	// Phase 2 builds its monster segments from its inputs by reference; the sumcheck that
+	// follows consumes its buffers and challenge point by value.
 	group.bench_function("phase2_build_monster_segments", |b| {
 		b.iter(|| {
-			build_monster_segments::<F, P, _>(
+			key_collection.build_monster_segments::<F, P, _>(
 				&GlobalAllocator,
-				&key_collection,
 				&prepared,
 				shift_ind_eval,
 				&inner_shift,

--- a/crates/prover/src/protocols/shift/key_collection/collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection/collection.rs
@@ -1,13 +1,29 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::{Allocator, VecLike};
+use binius_field::{BinaryField, PackedField, WideMul};
+use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
 	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
 };
+use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 use bytes::{Buf, BufMut};
+use tracing::instrument;
 
-use super::key_segment::KeySegment;
+use super::{
+	dense_shift_encoding::DenseShiftEncoding, key_segment::KeySegment, operation::Operation,
+};
+use crate::protocols::shift::{
+	claims::PreparedOperatorClaims,
+	monster::{OuterSlotWeights, ScalarTables},
+	shift_ind::ShiftChallenge,
+};
 
 /// The prover's complete view of a constraint system's shift keys, split by value-vector segment.
 ///
@@ -34,6 +50,147 @@ impl KeyCollection {
 	/// ```
 	pub const fn log_witness_words(&self) -> usize {
 		log2_ceil_usize(self.hidden.n_words())
+	}
+
+	/// Builds the constraint-matrix multilinear's two segments.
+	///
+	/// For each witness word, this sums every one of its keys' contributions.
+	/// A key's contribution is its constraint-index accumulation, scaled by a scalar that
+	/// folds together the batching power, the bit-index evaluation, and the two
+	/// equality-indicator weights of the shift sequence the key names.
+	///
+	/// # Returns
+	///
+	/// The public segment, spanning the rounded-up public word count, and the hidden segment,
+	/// spanning the full witness word count.
+	/// The phase-2 sumcheck's sparse first round consumes both directly, without
+	/// materializing their combined buffer.
+	#[instrument(skip_all, name = "build_monster_segments")]
+	pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
+		&self,
+		alloc: &A,
+		prepared: &PreparedOperatorClaims<F>,
+		h_eval: F,
+		inner: &ShiftChallenge<F>,
+		outer: &ShiftChallenge<F>,
+	) -> (FieldVec<P, A>, FieldVec<P, A>)
+	where
+		F: BinaryField,
+	{
+		let r_v_tensor = eq_ind_partial_eval::<F>(&inner.variant);
+		let r_s_tensor = eq_ind_partial_eval::<F>(&inner.amount);
+
+		// Invariant: a key's sequence weight factorizes across its two slots.
+		//
+		//     eq(r_v1, v_1) * eq(r_s1, s_1)  *  eq(r_v2, v_2) * eq(r_s2, s_2)
+		//     \______ inner slot _________/     \______ outer slot ________/
+		//
+		// So one table per slot suffices, at `2 * SHIFT_COUNT` entries instead of
+		// `SHIFT_COUNT^2`.
+		let outer_weights = OuterSlotWeights::<F>::new(outer);
+
+		// The scalars of one operation, laid out with the operand index innermost, so a
+		// key's weights form one contiguous chunk its wide accumulation can index by
+		// operand.
+		//
+		// A key's sequence selects itself through an equality indicator over both slots.
+		// The h evaluation is one factor shared by every key of the operation.
+		let build_scalars = |arity: usize,
+		                     lambda_powers: &[F],
+		                     dense_shift_enc: &DenseShiftEncoding| {
+			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
+			for (dense_shift_idx, [inner_shift, outer_shift]) in dense_shift_enc.iter().enumerate()
+			{
+				let shift_scalar = h_eval
+					* r_v_tensor.as_ref()[inner_shift.variant as usize]
+					* r_s_tensor.as_ref()[inner_shift.amount as usize]
+					* outer_weights.weight(outer_shift);
+				for operand_idx in 0..arity {
+					scalars[dense_shift_idx * arity + operand_idx] =
+						lambda_powers[operand_idx] * shift_scalar;
+				}
+			}
+			scalars
+		};
+
+		// Each segment has its own dense shift encoding, so it has its own scalar tables.
+		let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
+			zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, dense_shift_enc),
+			bitand: build_scalars(BITAND_ARITY, &prepared.bitand.lambda_powers, dense_shift_enc),
+			intmul: build_scalars(INTMUL_ARITY, &prepared.intmul.lambda_powers, dense_shift_enc),
+			binmul: build_scalars(BINMUL_ARITY, &prepared.binmul.lambda_powers, dense_shift_enc),
+		};
+
+		// The scalar for one word of a segment: the accumulated contribution of all its
+		// keys, summed unreduced and reduced once at the end.
+		let word_scalar = |segment: &KeySegment, tables: &ScalarTables<F>, index: usize| {
+			let wide = segment
+				.word_keys(index)
+				.iter()
+				.map(|key| {
+					// The scalar table is per operation, and its stride is that
+					// operation's arity.
+					let (scalars, arity) = match key.operation {
+						Operation::Zero => (&tables.zero, ZERO_ARITY),
+						Operation::BitwiseAnd => (&tables.bitand, BITAND_ARITY),
+						Operation::IntegerMul => (&tables.intmul, INTMUL_ARITY),
+						Operation::BinMul => (&tables.binmul, BINMUL_ARITY),
+					};
+					let base = key.dense_shift_idx as usize * arity;
+					key.accumulate_wide(
+						&segment.constraint_indices,
+						prepared[key.operation].r_x_prime_tensor.as_ref(),
+						&scalars[base..base + arity],
+					)
+				})
+				.sum::<<F as WideMul>::Output>();
+			F::reduce(wide)
+		};
+
+		// Each segment sits at the base of its buffer: the public piece fills its
+		// power-of-two length exactly, the hidden piece is zero-padded up to the hidden
+		// segment length.
+		let build_segment = |segment: &KeySegment, log_len: usize| {
+			let tables = build_scalar_tables(&segment.dense_shift_enc);
+			let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+			let n_words = segment.n_words();
+			// Full packed elements: each maps exactly `P::WIDTH` words, so `from_scalars`
+			// sees a statically-sized iterator.
+			// The trailing partial element is filled separately below.
+			let n_full = n_words / P::WIDTH;
+			// Allocate the buffer once, then fill its aligned packed elements in parallel
+			// through its spare capacity.
+			let mut values = alloc.alloc::<P>(capacity);
+			values.spare_capacity_mut()[..n_full]
+				.par_iter_mut()
+				.enumerate()
+				.with_min_task(WorkPerItem::FieldMuls)
+				.for_each(|(chunk_index, slot)| {
+					let start = chunk_index * P::WIDTH;
+					slot.write(P::from_scalars(
+						(0..P::WIDTH).map(|i| word_scalar(segment, &tables, start + i)),
+					));
+				});
+			// Safety: the parallel loop above initialized every one of the `n_full`
+			// slots.
+			unsafe { values.set_len(n_full) };
+			if !n_words.is_multiple_of(P::WIDTH) {
+				let start = n_full * P::WIDTH;
+				values.push(P::from_scalars(
+					(start..n_words).map(|word_index| word_scalar(segment, &tables, word_index)),
+				));
+			}
+			values.resize(capacity, P::default());
+			FieldBuffer::new(log_len, values)
+		};
+
+		// The segment word count need not be a power of two; the constraint-matrix
+		// multilinear spans the rounded-up count.
+		let log_public_words = log2_ceil_usize(self.public.n_words());
+		let public_monster = build_segment(&self.public, log_public_words);
+		let hidden_monster = build_segment(&self.hidden, self.log_witness_words());
+
+		(public_monster, hidden_monster)
 	}
 }
 

--- a/crates/prover/src/protocols/shift/key_collection/key_segment.rs
+++ b/crates/prover/src/protocols/shift/key_collection/key_segment.rs
@@ -3,10 +3,22 @@
 
 use std::ops::Range;
 
-use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use binius_core::word::Word;
+use binius_field::{Field, PackedField};
+use binius_utils::{
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
+	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
+};
+use bytemuck::zeroed_vec;
 use bytes::{Buf, BufMut};
+use itertools::izip;
+use tracing::instrument;
 
 use super::{
+	super::{claims::PreparedOperatorClaims, phase_1::row_len},
 	builder::BuilderKey,
 	dense_shift_encoding::DenseShiftEncoding,
 	key::{ConstraintIndex, Key},
@@ -37,6 +49,131 @@ impl KeySegment {
 	pub fn word_keys(&self, index: usize) -> &[Key] {
 		let Range { start, end } = self.key_ranges[index];
 		&self.keys[start as usize..end as usize]
+	}
+
+	/// Accumulates this segment's rows of the witness-and-batching multilinear.
+	///
+	/// Every witness word can carry several shift keys, one per operand position it feeds.
+	/// For each key, this folds its constraint-index tensor and batching powers into one
+	/// accumulator value, then scatters that value across the bit positions the word has set.
+	///
+	/// # Returns
+	///
+	/// One row of weights per shift this segment uses, one weight per bit position of a word,
+	/// at the position this segment's own dense encoding assigns to that shift.
+	#[instrument(skip_all, name = "build_g")]
+	pub fn build_g<F: Field, P: PackedField<Scalar = F>>(
+		&self,
+		words: &[Word],
+		prepared: &PreparedOperatorClaims<F>,
+	) -> Box<[P]> {
+		// One row of `Word::BITS` scalars per shift the segment uses.
+		let row_len = row_len::<P>();
+		let acc_size = self.dense_shift_enc.len() * row_len;
+
+		const {
+			assert!(
+				P::WIDTH <= 8,
+				"the optimizations below work only when the width of `P` is less than 8 (which is true for all packed 128b fields we use for now)"
+			);
+		}
+
+		// Precompute once: a map from an 8-bit mask (one bit per candidate lane) to the packed
+		// lane-selection mask it names.
+		// Every accumulator below reuses this table instead of rebuilding a mask per word.
+		let packed_masks_map = (0..1 << P::WIDTH)
+			.map(|i| P::make_mask((0..P::WIDTH).map(|bit_index| (i >> bit_index) & 1 == 1)))
+			.collect::<Vec<_>>();
+		// A mask for the low bits that actually address a lane.
+		let low_bits_mask = (1u8 << P::WIDTH) - 1;
+
+		// Each word carries the keys its segment-relative range names.
+		//
+		// The fold runs in parallel.
+		// Each task owns a chunk of words and its own accumulator.
+		// The accumulators merge at the end.
+		words
+			.par_iter()
+			.zip(self.key_ranges.par_iter())
+			.with_min_task(WorkPerItem::FieldMuls)
+			.fold(
+				|| zeroed_vec::<P>(acc_size).into_boxed_slice(),
+				|mut multilinears, (word, Range { start, end })| {
+					let keys = &self.keys[*start as usize..*end as usize];
+
+					// A word can carry several keys, one per operand position it feeds.
+					for key in keys {
+						let operator_data = &prepared[key.operation];
+
+						// Fold this key's accumulator value: the constraint-index tensor
+						// weighted by the batching powers for this operand position.
+						let acc = key.accumulate(
+							&self.constraint_indices,
+							operator_data.r_x_prime_tensor.as_ref(),
+							&operator_data.lambda_powers,
+						);
+						let acc_packed = P::broadcast(acc);
+
+						// Scatter the accumulator value into every set bit of the word.
+						//
+						// This walks only the word's nonzero bytes, instead of testing all
+						// `Word::BITS` positions in turn.
+						// Within each byte, it selects every set bit's lane in one packed
+						// operation, using the precomputed mask above.
+						debug_assert!(
+							(key.dense_shift_idx as usize) < self.dense_shift_enc.len(),
+							"a key indexes the dense shift encoding of its own segment"
+						);
+						let start = key.dense_shift_idx as usize * row_len;
+						let values = &mut multilinears[start..start + row_len];
+						let values_per_byte = Word::BYTES >> P::LOG_WIDTH;
+						let mut remaining_word = word.0;
+						let mut byte_index = 0;
+						while remaining_word != 0 {
+							let byte = remaining_word as u8;
+							let byte_values =
+								&mut values[byte_index * values_per_byte..][..values_per_byte];
+							for value_index in 0..(8 >> P::LOG_WIDTH) {
+								unsafe {
+									let packed_mask_index = ((byte >> (value_index * P::WIDTH))
+										& low_bits_mask) as usize;
+
+									// Safety:
+									// - `packed_masks_map` holds one entry per possible
+									//   `P::WIDTH`-bit value, so this index always fits.
+									let packed_mask =
+										packed_masks_map.get_unchecked(packed_mask_index);
+
+									// Safety:
+									// - `values` spans `(8 >> P::LOG_WIDTH)` elements after the
+									//   chunking above.
+									// - `value_index` stays within that range by construction.
+									*byte_values.get_unchecked_mut(value_index) +=
+										acc_packed.select(packed_mask);
+								}
+							}
+							remaining_word >>= 8;
+							byte_index += 1;
+						}
+					}
+
+					multilinears
+				},
+			)
+			// Merge every task's accumulator pairwise.
+			//
+			// A merge seeded with an existing partial never touches a zeroed buffer.
+			// An identity element instead would allocate and zero one accumulator per merge.
+			// Then it would add all of it for nothing.
+			.reduce_with(|mut acc, local| {
+				izip!(acc.iter_mut(), local.iter()).for_each(|(acc, local)| {
+					*acc += *local;
+				});
+				acc
+			})
+			// An empty word list produces no partial accumulator at all.
+			// So its rows are zero.
+			.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice())
 	}
 
 	/// Builds the segment's keys from the builder keys lists of its words.

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -5,24 +5,11 @@ use std::iter;
 
 use binius_compute::{Allocator, VecLike};
 use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
-use binius_field::{BinaryField, Field, PackedField, WideMul};
+use binius_field::{BinaryField, Field, PackedField};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
-use binius_utils::{
-	checked_arithmetics::log2_ceil_usize,
-	rayon::{
-		prelude::*,
-		task_size::{IndexedParallelIteratorExt, WorkPerItem},
-	},
-};
-use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 use tracing::instrument;
 
-use super::{
-	claims::PreparedOperatorClaims,
-	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation},
-	phase_1::SHIFT_OPERATOR_LOG_LEN,
-	shift_ind::ShiftChallenge,
-};
+use super::{phase_1::SHIFT_OPERATOR_LOG_LEN, shift_ind::ShiftChallenge};
 
 /// The width the half-word (`*32`) shift variants act over.
 const HALF_WORD_BITS: usize = 32;
@@ -31,11 +18,11 @@ const HALF_WORD_BITS: usize = 32;
 ///
 /// A table holds the `arity` weights of each shift sequence the segment uses, in dense shift index
 /// order, so a key's weights are the chunk at `key.dense_shift_idx * arity`.
-struct ScalarTables<F> {
-	zero: Vec<F>,
-	bitand: Vec<F>,
-	intmul: Vec<F>,
-	binmul: Vec<F>,
+pub(super) struct ScalarTables<F> {
+	pub(super) zero: Vec<F>,
+	pub(super) bitand: Vec<F>,
+	pub(super) intmul: Vec<F>,
+	pub(super) binmul: Vec<F>,
 }
 
 /// The equality-indicator weights of a shift sequence's outer slot.
@@ -43,7 +30,7 @@ struct ScalarTables<F> {
 /// The sequence weight factorizes across its two slots, so each slot carries its own two tensors:
 /// one over the variant axis, one over the amount axis.
 /// Keeping them apart holds the weights at `2 * SHIFT_COUNT` entries rather than `SHIFT_COUNT^2`.
-struct OuterSlotWeights<F: Field> {
+pub(super) struct OuterSlotWeights<F: Field> {
 	/// The equality indicator over the outer variant axis, one weight per shift variant.
 	variant: FieldBuffer<F>,
 	/// The equality indicator over the outer amount axis, one weight per shift amount.
@@ -52,7 +39,7 @@ struct OuterSlotWeights<F: Field> {
 
 impl<F: Field> OuterSlotWeights<F> {
 	/// The equality indicators of the outer slot's challenge point.
-	fn new(outer: &ShiftChallenge<F>) -> Self {
+	pub(super) fn new(outer: &ShiftChallenge<F>) -> Self {
 		Self {
 			variant: eq_ind_partial_eval::<F>(&outer.variant),
 			amount: eq_ind_partial_eval::<F>(&outer.amount),
@@ -61,7 +48,7 @@ impl<F: Field> OuterSlotWeights<F> {
 
 	/// The weight one outer shift contributes to its sequence's scalar.
 	#[inline]
-	fn weight(&self, shift: Shift) -> F {
+	pub(super) fn weight(&self, shift: Shift) -> F {
 		self.variant.as_ref()[shift.variant as usize] * self.amount.as_ref()[shift.amount as usize]
 	}
 }
@@ -223,163 +210,6 @@ where
 	unsafe { values.set_len(packed_len) };
 
 	FieldBuffer::new(SHIFT_OPERATOR_LOG_LEN, values)
-}
-
-/// Constructs the "monster multilinear" that combines all shift operations into a single
-/// multilinear.
-///
-/// This function builds a comprehensive multilinear polynomial that encapsulates the AND, IMUL and
-/// BMUL constraints with their associated shift operations. For each witness word, it computes the
-/// contribution from all constraints involving that word, weighted by the h evaluation and lambda
-/// powers.
-///
-/// # Construction Process
-///
-/// 1. **Compute lambda powers**: Powers λ^(i+1) for each operand index in both operations
-/// 2. **Build scalar matrix**: Create scalars combining lambda powers, the h evaluation, and the
-///    `r_s` and `r_v` tensors
-/// 3. **Process keys in parallel**: For each word, accumulate contributions from all its
-///    constraints
-///
-/// # Formula
-///
-/// For each word w, computes:
-/// ```text
-/// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor, scalars[key.dense_shift_idx])
-/// ```
-/// where `scalars[key.dense_shift_idx]` is the contiguous per-operand chunk encoding
-/// `λ^(operand_idx+1) × h_eval × r_v_tensor[shift_variant] × r_s_tensor[shift_amount]` for operand
-/// index `operand_idx`, and `(shift_variant, shift_amount)` the pair the key's segment decodes its
-/// dense shift index to. The h evaluation comes from
-/// [`ShiftIndSumcheck`](super::ShiftIndSumcheck), which proves it.
-///
-/// # Usage
-///
-/// Used in phase 2 of the shift protocol. The two returned buffers are the segments of the
-/// witness's monster multilinear: the public piece over `log_public_words` variables and the
-/// hidden piece over `log_witness_words` variables (the hidden words at the base, zeros above).
-/// The sparse first sumcheck round consumes them without materializing the combined buffer.
-#[instrument(skip_all, name = "build_monster_segments")]
-#[allow(clippy::too_many_arguments)]
-pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
-	alloc: &A,
-	key_collection: &KeyCollection,
-	prepared: &PreparedOperatorClaims<F>,
-	h_eval: F,
-	inner: &ShiftChallenge<F>,
-	outer: &ShiftChallenge<F>,
-) -> (FieldVec<P, A>, FieldVec<P, A>)
-where
-	F: BinaryField,
-{
-	let r_v_tensor = eq_ind_partial_eval::<F>(&inner.variant);
-	let r_s_tensor = eq_ind_partial_eval::<F>(&inner.amount);
-
-	// Invariant: a key's sequence weight factorizes across its two slots.
-	//
-	//     eq(r_v1, v_1) * eq(r_s1, s_1)  *  eq(r_v2, v_2) * eq(r_s2, s_2)
-	//     \______ inner slot _________/     \______ outer slot ________/
-	//
-	// So one table per slot suffices, at `2 * SHIFT_COUNT` entries instead of `SHIFT_COUNT^2`.
-	let outer_weights = OuterSlotWeights::<F>::new(outer);
-
-	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
-	// weights for one `key.dense_shift_idx` form a contiguous chunk that [`Key::accumulate_wide`]
-	// can index directly by operand index.
-	//
-	// A key's sequence selects itself through an equality indicator over both slots' axes.
-	// The h evaluation is one factor shared by every key of the operation.
-	let build_scalars = |arity: usize,
-	                     lambda_powers: &[F],
-	                     dense_shift_enc: &DenseShiftEncoding| {
-		let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
-		for (dense_shift_idx, [inner_shift, outer_shift]) in dense_shift_enc.iter().enumerate() {
-			let shift_scalar = h_eval
-				* r_v_tensor.as_ref()[inner_shift.variant as usize]
-				* r_s_tensor.as_ref()[inner_shift.amount as usize]
-				* outer_weights.weight(outer_shift);
-			for operand_idx in 0..arity {
-				scalars[dense_shift_idx * arity + operand_idx] =
-					lambda_powers[operand_idx] * shift_scalar;
-			}
-		}
-		scalars
-	};
-
-	// Each segment has its own dense shift encoding, so it has its own scalar tables.
-	let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
-		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, dense_shift_enc),
-		bitand: build_scalars(BITAND_ARITY, &prepared.bitand.lambda_powers, dense_shift_enc),
-		intmul: build_scalars(INTMUL_ARITY, &prepared.intmul.lambda_powers, dense_shift_enc),
-		binmul: build_scalars(BINMUL_ARITY, &prepared.binmul.lambda_powers, dense_shift_enc),
-	};
-
-	// The scalar for one word of a segment: the accumulated contribution of all its keys. The
-	// per-key wide accumulations are summed unreduced and reduced once at the end.
-	let word_scalar = |segment: &KeySegment, tables: &ScalarTables<F>, index: usize| {
-		let wide = segment
-			.word_keys(index)
-			.iter()
-			.map(|key| {
-				// The scalar table is per operation, and its stride is that operation's arity.
-				let (scalars, arity) = match key.operation {
-					Operation::Zero => (&tables.zero, ZERO_ARITY),
-					Operation::BitwiseAnd => (&tables.bitand, BITAND_ARITY),
-					Operation::IntegerMul => (&tables.intmul, INTMUL_ARITY),
-					Operation::BinMul => (&tables.binmul, BINMUL_ARITY),
-				};
-				let base = key.dense_shift_idx as usize * arity;
-				key.accumulate_wide(
-					&segment.constraint_indices,
-					prepared[key.operation].r_x_prime_tensor.as_ref(),
-					&scalars[base..base + arity],
-				)
-			})
-			.sum::<<F as WideMul>::Output>();
-		F::reduce(wide)
-	};
-
-	// Each segment sits at the base of its buffer: the public piece fills its power-of-two
-	// length exactly, the hidden piece is zero-padded up to the hidden segment length.
-	let build_segment = |segment: &KeySegment, log_len: usize| {
-		let tables = build_scalar_tables(&segment.dense_shift_enc);
-		let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		let n_words = segment.n_words();
-		// Full packed elements: each maps exactly `P::WIDTH` words, so `from_scalars` sees a
-		// statically-sized iterator. The trailing partial element is filled separately below.
-		let n_full = n_words / P::WIDTH;
-		// Allocate the backing buffer up front from the allocator, then fill the `n_full` aligned
-		// packed elements in parallel through its spare capacity — the single allocation happens
-		// before the parallel region, which only writes.
-		let mut values = alloc.alloc::<P>(capacity);
-		values.spare_capacity_mut()[..n_full]
-			.par_iter_mut()
-			.enumerate()
-			.with_min_task(WorkPerItem::FieldMuls)
-			.for_each(|(chunk_index, slot)| {
-				let start = chunk_index * P::WIDTH;
-				slot.write(P::from_scalars(
-					(0..P::WIDTH).map(|i| word_scalar(segment, &tables, start + i)),
-				));
-			});
-		// Safety: the parallel loop above initialized every one of the `n_full` slots.
-		unsafe { values.set_len(n_full) };
-		if !n_words.is_multiple_of(P::WIDTH) {
-			let start = n_full * P::WIDTH;
-			values.push(P::from_scalars(
-				(start..n_words).map(|word_index| word_scalar(segment, &tables, word_index)),
-			));
-		}
-		values.resize(capacity, P::default());
-		FieldBuffer::new(log_len, values)
-	};
-
-	// The segment word count need not be a power of two; the monster spans the rounded-up count.
-	let log_public_words = log2_ceil_usize(key_collection.public.n_words());
-	let public_monster = build_segment(&key_collection.public, log_public_words);
-	let hidden_monster = build_segment(&key_collection.hidden, key_collection.log_witness_words());
-
-	(public_monster, hidden_monster)
 }
 
 #[cfg(test)]

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -1,10 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{
-	iter,
-	ops::{Deref, Range},
-};
+use std::{iter, ops::Deref};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -19,20 +16,11 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{FieldBuffer, FieldVec, multilinear::fold::fold_highest_var_inplace};
-use binius_utils::rayon::{
-	prelude::*,
-	task_size::{IndexedParallelIteratorExt, WorkPerItem},
-};
 use binius_verifier::protocols::shift::LOG_SHIFT_COUNT;
-use bytemuck::zeroed_vec;
-use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	claims::PreparedOperatorClaims,
-	key_collection::{DenseShiftEncoding, KeySegment},
-	monster::shift_operator_table,
-	outer::OuterShiftStage,
+	key_collection::DenseShiftEncoding, monster::shift_operator_table, outer::OuterShiftStage,
 	shift_ind::ShiftChallenge,
 };
 
@@ -79,7 +67,7 @@ pub struct Phase1Output<F> {
 }
 
 /// The number of packed elements one row of `Word::BITS` scalars occupies.
-const fn row_len<P: PackedField>() -> usize {
+pub(super) const fn row_len<P: PackedField>() -> usize {
 	assert!(
 		P::LOG_WIDTH <= Word::LOG_BITS,
 		"a row of `Word::BITS` scalars must be a whole number of packed elements"
@@ -547,133 +535,6 @@ impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckProver<F>
 			Stage::Bits(prover) => prover.finish(),
 		}
 	}
-}
-
-/// Accumulates one key segment's rows of the witness-and-batching multilinear.
-///
-/// Every witness word can carry several shift keys, one per operand position it feeds.
-/// For each key, this folds its constraint-index tensor and batching powers into one
-/// accumulator value, then scatters that value across the bit positions the word has set.
-///
-/// # Returns
-///
-/// One row of weights per shift the segment uses, one weight per bit position of a word, at
-/// the position the segment's own dense encoding assigns to that shift.
-#[instrument(skip_all, name = "build_g")]
-pub fn build_g<F: Field, P: PackedField<Scalar = F>>(
-	words: &[Word],
-	segment: &KeySegment,
-	prepared: &PreparedOperatorClaims<F>,
-) -> Box<[P]> {
-	// One row of `Word::BITS` scalars per shift the segment uses.
-	let row_len = row_len::<P>();
-	let acc_size = segment.dense_shift_enc.len() * row_len;
-
-	const {
-		assert!(
-			P::WIDTH <= 8,
-			"the optimizations below work only when the width of `P` is less than 8 (which is true for all packed 128b fields we use for now)"
-		);
-	}
-
-	// Precompute once: a map from an 8-bit mask (one bit per candidate lane) to the packed
-	// lane-selection mask it names.
-	// Every accumulator below reuses this table instead of rebuilding a mask per word.
-	let packed_masks_map = (0..1 << P::WIDTH)
-		.map(|i| P::make_mask((0..P::WIDTH).map(|bit_index| (i >> bit_index) & 1 == 1)))
-		.collect::<Vec<_>>();
-	// A mask for the low bits that actually address a lane.
-	let low_bits_mask = (1u8 << P::WIDTH) - 1;
-
-	// Each word carries the keys its segment-relative range names.
-	//
-	// The fold runs in parallel.
-	// Each task owns a chunk of words and its own accumulator.
-	// The accumulators merge at the end.
-	words
-		.par_iter()
-		.zip(segment.key_ranges.par_iter())
-		.with_min_task(WorkPerItem::FieldMuls)
-		.fold(
-			|| zeroed_vec::<P>(acc_size).into_boxed_slice(),
-			|mut multilinears, (word, Range { start, end })| {
-				let keys = &segment.keys[*start as usize..*end as usize];
-
-				// A word can carry several keys, one per operand position it feeds.
-				for key in keys {
-					let operator_data = &prepared[key.operation];
-
-					// Fold this key's accumulator value: the constraint-index tensor
-					// weighted by the batching powers for this operand position.
-					let acc = key.accumulate(
-						&segment.constraint_indices,
-						operator_data.r_x_prime_tensor.as_ref(),
-						&operator_data.lambda_powers,
-					);
-					let acc_packed = P::broadcast(acc);
-
-					// Scatter the accumulator value into every bit position where the word
-					// is set to 1.
-					//
-					// A naive version would loop over all `Word::BITS` positions and test
-					// each bit in turn.
-					//
-					// This instead walks only the word's nonzero bytes.
-					// Inside each byte, it selects every set bit's lane in one packed
-					// operation, using the precomputed mask above.
-					debug_assert!(
-						(key.dense_shift_idx as usize) < segment.dense_shift_enc.len(),
-						"a key indexes the dense shift encoding of its own segment"
-					);
-					let start = key.dense_shift_idx as usize * row_len;
-					let values = &mut multilinears[start..start + row_len];
-					let values_per_byte = Word::BYTES >> P::LOG_WIDTH;
-					let mut remaining_word = word.0;
-					let mut byte_index = 0;
-					while remaining_word != 0 {
-						let byte = remaining_word as u8;
-						let byte_values =
-							&mut values[byte_index * values_per_byte..][..values_per_byte];
-						for value_index in 0..(8 >> P::LOG_WIDTH) {
-							unsafe {
-								let packed_mask_index =
-									((byte >> (value_index * P::WIDTH)) & low_bits_mask) as usize;
-
-								// Safety:
-								// - `packed_masks_map` holds one entry per possible `P::WIDTH`-bit
-								//   value, so this index always fits.
-								let packed_mask = packed_masks_map.get_unchecked(packed_mask_index);
-
-								// Safety:
-								// - `values` spans `(8 >> P::LOG_WIDTH)` elements after the
-								//   chunking above.
-								// - `value_index` stays within that range by construction.
-								*byte_values.get_unchecked_mut(value_index) +=
-									acc_packed.select(packed_mask);
-							}
-						}
-						remaining_word >>= 8;
-						byte_index += 1;
-					}
-				}
-
-				multilinears
-			},
-		)
-		// Merge every task's accumulator pairwise.
-		//
-		// A merge seeded with a partial that already exists never touches a buffer of zeros.
-		// An identity element instead would allocate and zero one accumulator per merge.
-		// Then it would add all of it for nothing.
-		.reduce_with(|mut acc, local| {
-			izip!(acc.iter_mut(), local.iter()).for_each(|(acc, local)| {
-				*acc += *local;
-			});
-			acc
-		})
-		// An empty word list produces no partial accumulator at all.
-		// So its rows are zero.
-		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice())
 }
 
 #[cfg(test)]

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -17,8 +17,7 @@ use super::{
 	SegmentWords,
 	claims::{OperatorClaims, PreparedOperatorClaims},
 	key_collection::KeyCollection,
-	monster::build_monster_segments,
-	phase_1::{Phase1Output, SparseShiftRows, build_g},
+	phase_1::{Phase1Output, SparseShiftRows},
 	phase_2::{ShiftOutput, run_sumcheck, zero_extend},
 	shift_ind::{ShiftChallengePoint, ShiftIndSumcheck},
 };
@@ -271,8 +270,12 @@ where
 		// separately.
 		// The public words are the prefix of the value vector, and each segment's key ranges
 		// are relative to its own segment.
-		let public = build_g::<_, P>(words.public, &key_collection.public, prepared);
-		let hidden = build_g::<_, P>(words.hidden, &key_collection.hidden, prepared);
+		let public = key_collection
+			.public
+			.build_g::<_, P>(words.public, prepared);
+		let hidden = key_collection
+			.hidden
+			.build_g::<_, P>(words.hidden, prepared);
 		let g = SparseShiftRows::from_segments([
 			(&public, &key_collection.public.dense_shift_enc),
 			(&hidden, &key_collection.hidden.dense_shift_enc),
@@ -328,9 +331,8 @@ where
 		let public_folded = fold_words::<_, P, _>(self.alloc, words.public, r_j_tensor.as_ref());
 		let hidden_folded = fold_words::<_, P, _>(self.alloc, words.hidden, r_j_tensor.as_ref());
 
-		let (public_monster, hidden_monster) = build_monster_segments(
+		let (public_monster, hidden_monster) = key_collection.build_monster_segments(
 			self.alloc,
-			key_collection,
 			prepared,
 			shift_ind_eval,
 			&inner,


### PR DESCRIPTION
Closes [BINIUS-526](https://linear.app/jimpo/issue/BINIUS-526).

Turns two "free function that is really a method in disguise" cases into actual methods. Pure refactor — no behavior change.

### The problem

Two functions in the shift-reduction prover take one type as their main argument, but live as free functions instead of methods on that type.

- One function folds a key segment's own keys into the witness-and-batching multilinear, taking the segment as an argument instead of being called on it.
- The other builds a key collection's two constraint-matrix segments, taking the collection as an argument instead of being called on it.

A caller has to know which module holds the right free function, instead of finding the operation on the type it operates on.

### The idea

Move each function onto the type it already treats as primary.

```
build_g(words, segment, prepared)               ->  segment.build_g(words, prepared)
build_monster_segments(alloc, collection, ...)   ->  collection.build_monster_segments(alloc, ...)
```

Both functions keep their bodies unchanged; only the receiver moves from an explicit argument to `self`.

### The change

- `crates/prover/src/protocols/shift/phase_1.rs`: the row-folding function moves onto the key-segment type in `crates/prover/src/protocols/shift/key_collection/key_segment.rs`, next to the type's other methods. `phase_1.rs` keeps only the row-length helper the method still needs, now visible to its new home.
- `crates/prover/src/protocols/shift/monster.rs`: the segment-building function moves onto the key-collection type in `crates/prover/src/protocols/shift/key_collection/collection.rs`. The scalar-table type and the outer-slot-weight helper it depends on are exposed from `monster.rs` at the visibility its new caller needs.
- Three call sites update to the method form: the single-instance prover (`crates/prover/src/protocols/shift/prove.rs`), the batched M4 prover (`crates/m4-prover/src/shift.rs`), and the shift-reduction benchmark (`crates/prover/benches/shift_reduction.rs`).

### Scope

- **changed:** two functions become methods; their imports and visibility follow them; three call sites updated across two crates.
- **left untouched:** every other function in the touched files, including the batched-witness variant of the row-folding function in the M4 crate, which stays a free function since it does not take a key segment as its main argument.

### Verification

- `cargo check -p binius-prover -p binius-m4-prover --all-targets` — clean.
- `cargo clippy -p binius-prover -p binius-m4-prover --all-targets -- -D warnings`, with and without `--features rayon` — clean, no `too_many_arguments` needed on the moved method.
- `cargo +nightly fmt -p binius-prover -p binius-m4-prover` — applied.
- `cargo test -p binius-prover -p binius-m4-prover`, with and without `--features rayon` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
