### PR TITLE
BINIUS-527: Move zero_extend onto FieldBuffer, next to its inverse

### DIFF
--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -181,6 +181,45 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 
 		FieldBuffer::new(log_len, packed_values)
 	}
+
+	/// Grows the buffer to span `log_len` variables, padding the new positions with zeros.
+	///
+	/// Returns the buffer untouched when it already spans that many.
+	/// Padding the shorter of two buffers to match the longer hits that case when both are equal.
+	///
+	/// New memory comes from `alloc`.
+	/// A pooled buffer therefore stays pooled, instead of escaping the pool on a reallocation.
+	///
+	/// # Panics
+	///
+	/// Panics if `log_len` is shorter than what the buffer already spans.
+	/// Shrinking is a separate operation.
+	/// Silently returning a narrower buffer than asked for would hide the mistake.
+	pub fn zero_extend_in<A>(self, alloc: &A, log_len: usize) -> Self
+	where
+		A: Allocator<Vec<P> = Data>,
+	{
+		assert!(
+			log_len >= self.log_len,
+			"precondition: log_len must be at least the buffer's own log_len"
+		);
+		// Nothing to pad, so the caller's buffer is handed straight back with no copy.
+		if log_len == self.log_len {
+			return self;
+		}
+
+		// The target starts fully zeroed, so only the occupied words need writing.
+		let mut extended = Self::zeros_in(alloc, log_len);
+
+		// Whole packed words move across untouched.
+		//
+		// Invariant: lanes past the logical length are zero.
+		// So a trailing partial word already carries zeros in its high lanes.
+		// Those are exactly the zeros the padding would otherwise write.
+		extended.as_mut()[..self.as_ref().len()].copy_from_slice(self.as_ref());
+
+		extended
+	}
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -904,7 +943,7 @@ mod tests {
 		}
 	}
 
-	/// Runs the two allocator-backed constructors against one allocator.
+	/// Runs every allocator-backed constructor and the zero-padding grow against one allocator.
 	///
 	/// Both a plain heap allocator and a recycling pool must satisfy the same contract.
 	fn check_alloc_constructors<A: Allocator>(alloc: &A) {
@@ -939,6 +978,40 @@ mod tests {
 		let zeros_small: FieldVec<P, A> = FieldBuffer::zeros_in(alloc, 1);
 		assert_eq!(zeros_small.as_ref().len(), 1);
 		assert!(zeros_small.iter_scalars().all(|scalar| scalar == F::ZERO));
+
+		// Padding to a wider length keeps the live scalars and zeros every position above them.
+		//
+		//     source (log_len 4)    [0 .. 16]
+		//     result (log_len 5)    [0 .. 16] unchanged, [16 .. 32] zero
+		//
+		// Under a pool the target may sit on memory a prior buffer dirtied.
+		// So the zeros above the copied words have to be written, never assumed.
+		let src_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.to_ref());
+		let extended = src_vec.zero_extend_in(alloc, 5);
+		assert_eq!(extended.log_len(), 5);
+		for i in 0..16 {
+			assert_eq!(extended.get(i), F::new(i as u128));
+		}
+		assert!((16..32).all(|i| extended.get(i) == F::ZERO));
+
+		// An already-wide-enough buffer comes back unchanged, with no copy taken.
+		let same: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.to_ref());
+		let same = same.zero_extend_in(alloc, 4);
+		assert_eq!(same.log_len(), 4);
+		assert_eq!(same.to_ref(), src.to_ref());
+
+		// A source narrower than one packed word pads out of that word's dead lanes.
+		//
+		//     source (log_len 1)    [0, 1 | dead, dead]
+		//     result (log_len 3)    [0, 1 | 0, 0] [0, 0 | 0, 0]
+		//
+		// The two dead lanes become live, so they read back as zeros, not stale scalars.
+		let small_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.to_ref());
+		let widened = small_vec.zero_extend_in(alloc, 3);
+		assert_eq!(widened.log_len(), 3);
+		assert_eq!(widened.get(0), F::new(0));
+		assert_eq!(widened.get(1), F::new(1));
+		assert!((2..8).all(|i| widened.get(i) == F::ZERO));
 	}
 
 	#[test]

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -24,34 +24,6 @@ use binius_utils::{
 use binius_verifier::protocols::shift::evaluate_words_mle;
 use tracing::instrument;
 
-/// Zero-extends a segment buffer to span `log_len` word-index variables.
-///
-/// Returns the buffer untouched when it already spans that many, which is the common case: the
-/// hidden segment is normally the wider of the two, so no copy happens.
-///
-/// # Panics
-///
-/// Panics if `log_len` is less than the buffer's own length.
-pub(super) fn zero_extend<F, P: PackedField<Scalar = F>, A: Allocator>(
-	alloc: &A,
-	buffer: FieldVec<P, A>,
-	log_len: usize,
-) -> FieldVec<P, A>
-where
-	F: BinaryField,
-{
-	assert!(log_len >= buffer.log_len());
-	if log_len == buffer.log_len() {
-		return buffer;
-	}
-
-	// Whole packed words copy across: a trailing partial word carries zero high lanes, which are
-	// exactly the zeros the extension pads with.
-	let mut extended = FieldVec::<P, A>::zeros_in(alloc, log_len);
-	extended.as_mut()[..buffer.as_ref().len()].copy_from_slice(buffer.as_ref());
-	extended
-}
-
 /// A witness or constraint-matrix buffer, split into the public and hidden segments the
 /// phase-2 sumcheck's selector variable chooses between.
 ///

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -18,7 +18,7 @@ use super::{
 	claims::{OperatorClaims, PreparedOperatorClaims},
 	key_collection::KeyCollection,
 	phase_1::{Phase1Output, SparseShiftRows},
-	phase_2::{ShiftOutput, run_sumcheck, zero_extend},
+	phase_2::{ShiftOutput, run_sumcheck},
 	shift_ind::{ShiftChallengePoint, ShiftIndSumcheck},
 };
 use crate::fold_word::fold_words;
@@ -344,8 +344,8 @@ where
 		// The hidden segment is normally wider, but a system with more public words than
 		// private values inverts that, so the hidden half is zero-extended to match.
 		let log_segment_words = max(public_folded.log_len(), hidden_folded.log_len());
-		let hidden_folded = zero_extend(self.alloc, hidden_folded, log_segment_words);
-		let hidden_monster = zero_extend(self.alloc, hidden_monster, log_segment_words);
+		let hidden_folded = hidden_folded.zero_extend_in(self.alloc, log_segment_words);
+		let hidden_monster = hidden_monster.zero_extend_in(self.alloc, log_segment_words);
 
 		run_sumcheck(
 			&public_folded,


### PR DESCRIPTION
Closes [BINIUS-527](https://linear.app/jimpo/issue/BINIUS-527).

Pure refactor — no behaviour change.

### The problem

`zero_extend` is a `pub(super)` free function in the shift protocol's phase-2 module, in `binius-prover`.

Nothing in its body is shift-specific: it grows a field buffer and pads the new positions with zeros. Only its doc comment mentioned segments.

The type it operates on lives one crate away, in `binius-math`, and already owns the inverse operation as a method.

### The idea

The two traits behind the buffer's backing store already encode the shrink/grow split:

```
BufferData<T>: DerefMut<Target = [T]>          // truncate only
VecLike<T>:    Deref + DerefMut + Extend<T>    // capacity, push, clear, resize
```

Shrinking sits in the block bounded by the first. The allocator-aware constructors sit in the block bounded by the second. So growing has a designated home — the second block, beside the constructors that also take an allocator.

Those constructors also solve the awkward part. An allocator cannot be an impl-level parameter here: it appears only inside the projection `A::Vec<P>`, so nothing would constrain it. They make it a method-level parameter tied back to the backing store by an equality bound, and the new method does the same:

```
pub fn zero_extend_in<A>(self, alloc: &A, log_len: usize) -> Self
where A: Allocator<Vec<P> = Data>
```

The `_in` suffix follows the convention already used for the allocator-aware constructors in that file.

### The change

```
- zero_extend(self.alloc, hidden_folded, log_segment_words)
+ hidden_folded.zero_extend_in(self.alloc, log_segment_words)
```

Two call sites, on adjacent lines in the shift prover.

A spurious bound goes with it: the free function required the scalar to be a binary field, which the body never used.

### What is deliberately kept

**The fresh allocation.** The method allocates and copies rather than growing in place through the `resize` the backing store exposes. A pooled buffer has pool-backed capacity, so resizing past it would reallocate outside the pool — defeating the pooling those constructors exist to provide. Asking the allocator for a correctly sized buffer keeps a pooled buffer pooled.

**The fast path.** When the buffer already spans the requested length it is handed straight back, with no copy. That is the common case at both call sites.

### One inconsistency this makes visible

- Shrinking is a **no-op** when the requested length is not smaller.
- Growing **panics** when the requested length is smaller.

As neighbours on one type, that disagreement should be a deliberate choice rather than an accident of distance. Keeping the grow strict is the safer half — silently returning a buffer narrower than asked for would hide the mistake — and the docs now say so.

### Verification

Coverage went into the existing helper that runs every allocator-backed operation against both a plain heap allocator **and** a recycling pool. The pooled path matters here: a pool hands out memory a prior buffer dirtied, so the zeros above the copied words have to be written rather than assumed.

Three cases: a wider target, an equal-length target taking the no-copy path, and a sub-packing-width source whose dead lanes become live and must read back as zeros.

Both assertions were shown to bite, by two negative controls:

- skipping the copy → both tests fail
- tightening the assert so the equal-length fast path is unreachable → both tests fail

- `cargo clippy -p binius-math -p binius-prover --all-targets --all-features -- -D warnings` — clean
- `cargo test -p binius-math --lib` — 144 pass
- `cargo test -p binius-prover` — 67 + 17 + 1 pass
- `cargo +nightly fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)