### PR TITLE
Move build_key_collection onto KeyCollection as a named constructor

### DIFF
--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -829,7 +829,7 @@ where
 		// Save KeyCollection if requested
 		if let Some(path) = key_collection_path.as_deref() {
 			let key_collection_scope = tracing::info_span!("Building key collection").entered();
-			let key_collection = binius_prover::protocols::shift::build_key_collection(
+			let key_collection = binius_prover::protocols::shift::KeyCollection::build(
 				cs,
 				binius_core::constraint_system::InoutSegment::Public,
 			);

--- a/crates/m4-prover/src/composite.rs
+++ b/crates/m4-prover/src/composite.rs
@@ -16,7 +16,7 @@ use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOP
 use binius_ip_prover::channel::WordIPProverChannel;
 use binius_m4_verifier::{IOPVerifierM4, VerifierM4};
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded};
-use binius_prover::{Error, protocols::shift::build_key_collection};
+use binius_prover::{Error, protocols::shift::KeyCollection};
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
 use binius_verifier::config::B128;
@@ -51,7 +51,7 @@ impl IOPProverM4 {
 		let main_cs = iop_verifier.main().constraint_system();
 		let main = binius_prover::IOPProver::new(
 			iop_verifier.main().clone(),
-			build_key_collection(main_cs, InoutSegment::Public),
+			KeyCollection::build(main_cs, InoutSegment::Public),
 		);
 
 		let chips = iop_verifier
@@ -59,7 +59,7 @@ impl IOPProverM4 {
 			.iter()
 			.map(|chip| {
 				let key_collection =
-					build_key_collection(chip.constraint_system(), InoutSegment::Hidden);
+					KeyCollection::build(chip.constraint_system(), InoutSegment::Hidden);
 				IOPProver::new(chip.clone(), key_collection)
 			})
 			.collect();

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -30,7 +30,7 @@ use binius_prover::{
 	and_reduction,
 	protocols::{
 		binmul, intmul,
-		shift::{KeyCollection, OperatorClaims, OperatorData, build_key_collection},
+		shift::{KeyCollection, OperatorClaims, OperatorData},
 	},
 	ring_switch::{self, RingSwitchOutput},
 };
@@ -407,7 +407,7 @@ where
 
 		// Build the shift keys once from the shared constraint system.
 		let key_collection =
-			build_key_collection(verifier.constraint_system(), InoutSegment::Hidden);
+			KeyCollection::build(verifier.constraint_system(), InoutSegment::Hidden);
 
 		let iop_prover = IOPProver::new(verifier.iop_verifier().clone(), key_collection);
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -239,7 +239,7 @@ mod tests {
 		univariate::lagrange_evals_scalars,
 	};
 	use binius_prover::protocols::shift::{
-		DenseShiftEncoding, OperatorData, build_key_collection, monster::shift_operator_row,
+		DenseShiftEncoding, KeyCollection, OperatorData, monster::shift_operator_row,
 		outer::decode_shift,
 	};
 	use binius_transcript::ProverTranscript;
@@ -334,7 +334,7 @@ mod tests {
 
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
-		let key_collection = build_key_collection(&cs, InoutSegment::Hidden);
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Hidden);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =
@@ -485,7 +485,7 @@ mod tests {
 
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
-		let key_collection = build_key_collection(&cs, InoutSegment::Hidden);
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Hidden);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -16,7 +16,7 @@ use binius_math::{
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		OperatorClaims, OperatorData, ShiftProver, build_key_collection,
+		KeyCollection, OperatorClaims, OperatorData, ShiftProver,
 		monster::shift_operator_table,
 		phase_1::{Phase1Output, SparseShiftRows},
 		phase_2::run_sumcheck,
@@ -121,7 +121,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		let zero_evals = [F::random(&mut rng)];
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::ZERO; 4];
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
 		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 		let mut group = c.benchmark_group(format!(
@@ -258,7 +258,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let bitand_evals = [F::random(&mut rng); 3];
 	let intmul_evals = [F::ZERO; 4];
 
-	let key_collection = build_key_collection(&cs, InoutSegment::Public);
+	let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
 	// The phase functions take each segment as the circuit declares it: `build_g` zips the
 	// words with their key ranges and `fold_words` pads each fold to `log2_ceil(len)` variables.
 	let public_words = value_vec.public();

--- a/crates/prover/src/protocols/shift/key_collection/builder.rs
+++ b/crates/prover/src/protocols/shift/key_collection/builder.rs
@@ -1,11 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_core::constraint_system::{ConstraintSystem, InoutSegment, Operand, Shift};
+use binius_core::constraint_system::{ConstraintSystem, Operand, Shift};
 
-use super::{
-	collection::KeyCollection, key::ConstraintIndex, key_segment::KeySegment, operation::Operation,
-};
+use super::{key::ConstraintIndex, operation::Operation};
 
 /// One key still being assembled while its segment is built.
 ///
@@ -22,23 +20,23 @@ pub(super) struct BuilderKey {
 }
 
 /// One builder key list per word of the constraint system, indexed by word position.
-struct BuilderKeyLists(Vec<Vec<BuilderKey>>);
+pub(super) struct BuilderKeyLists(Vec<Vec<BuilderKey>>);
 
 impl BuilderKeyLists {
 	/// An empty list for every one of `word_count` words.
-	fn new(word_count: usize) -> Self {
+	pub(super) fn new(word_count: usize) -> Self {
 		Self((0..word_count).map(|_| Vec::new()).collect())
 	}
 
 	/// Splits the words from `public_word_count` onward into a second set of lists.
 	///
 	/// This is what separates the public segment, kept here, from the hidden one, returned.
-	fn split_off(&mut self, public_word_count: usize) -> Self {
+	pub(super) fn split_off(&mut self, public_word_count: usize) -> Self {
 		Self(self.0.split_off(public_word_count))
 	}
 
 	/// The underlying per-word lists, ready for a segment to be built from them.
-	fn into_inner(self) -> Vec<Vec<BuilderKey>> {
+	pub(super) fn into_inner(self) -> Vec<Vec<BuilderKey>> {
 		self.0
 	}
 
@@ -92,7 +90,7 @@ impl BuilderKeyLists {
 	///
 	/// Operands are indexed by their position in the constraint's operand array.
 	/// That is also the order the shift reduction batches them in.
-	fn update_with_constraints<C, const ARITY: usize>(
+	pub(super) fn update_with_constraints<C, const ARITY: usize>(
 		&mut self,
 		operation: Operation,
 		constraints: &[C],
@@ -108,215 +106,6 @@ impl BuilderKeyLists {
 					.iter()
 					.map(|constraint| &constraint.as_ref()[operand_index]),
 				cs,
-			);
-		}
-	}
-}
-
-/// Walks a constraint system once and builds the prover's dense key collection.
-///
-/// # Arguments
-///
-/// - `cs`: the constraint system to walk.
-/// - `inout`: the split point between the public and hidden key segments.
-pub fn build_key_collection(cs: &ConstraintSystem, inout: InoutSegment) -> KeyCollection {
-	let mut builder_key_lists = BuilderKeyLists::new(cs.value_vec_len());
-
-	// Update the builder keys lists with respect to each operand of each operation.
-	builder_key_lists.update_with_constraints(Operation::Zero, &cs.zero_constraints, cs);
-	builder_key_lists.update_with_constraints(Operation::BitwiseAnd, &cs.and_constraints, cs);
-	builder_key_lists.update_with_constraints(Operation::IntegerMul, &cs.imul_constraints, cs);
-	builder_key_lists.update_with_constraints(Operation::BinMul, &cs.bmul_constraints, cs);
-
-	// Split the builder keys lists at the public segment boundary and build one `KeySegment`
-	// per half.
-	let hidden_lists = builder_key_lists.split_off(cs.n_public_words(inout));
-	KeyCollection {
-		public: KeySegment::build(builder_key_lists.into_inner()),
-		hidden: KeySegment::build(hidden_lists.into_inner()),
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use binius_core::{
-		constraint_system::{AndConstraint, ShiftedValueIndex, ValueIndex},
-		word::Word,
-	};
-	use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
-	use binius_verifier::protocols::shift::SHIFT_COUNT;
-
-	use super::*;
-
-	/// A shift sequence carrying one shift, which the canonical form places in the inner slot.
-	fn single(shift: Shift) -> [Shift; 2] {
-		[shift, Shift::IDENTITY]
-	}
-
-	/// A constraint system with a handful of distinct shifts, differing between the two segments.
-	///
-	/// The public segment references `Sll(0)` and `Slr(3)`.
-	/// The hidden one references `Sll(0)`, `Sar(7)` and `Rotr(1)`.
-	/// Every outer slot is the identity, so the sequences sort by their inner shift alone.
-	fn shifted_constraint_system() -> ConstraintSystem {
-		// The system has four constants and no inout values, so the public segment is the
-		// constants and the hidden one is the private values.
-		let public = ValueIndex::constant(1);
-		let hidden = ValueIndex::private(1);
-		ConstraintSystem {
-			constants: vec![Word::ZERO; 4],
-			n_inout: 0,
-			n_private: 4,
-			zero_constraints: Vec::new(),
-			and_constraints: vec![AndConstraint([
-				vec![
-					ShiftedValueIndex::plain(public),
-					ShiftedValueIndex::srl(public, 3),
-				],
-				vec![ShiftedValueIndex::sar(hidden, 7)],
-				vec![
-					ShiftedValueIndex::rotr(hidden, 1),
-					ShiftedValueIndex::plain(hidden),
-				],
-			])],
-			imul_constraints: Vec::new(),
-			bmul_constraints: Vec::new(),
-		}
-	}
-
-	#[test]
-	fn dense_shift_encoding_covers_the_sequences_its_segment_uses() {
-		let key_collection =
-			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
-
-		let public_sequences = key_collection
-			.public
-			.dense_shift_enc
-			.iter()
-			.collect::<Vec<_>>();
-		assert_eq!(public_sequences, [single(Shift::IDENTITY), single(Shift::srl(3))]);
-
-		let hidden_sequences = key_collection
-			.hidden
-			.dense_shift_enc
-			.iter()
-			.collect::<Vec<_>>();
-		assert_eq!(
-			hidden_sequences,
-			[
-				single(Shift::IDENTITY),
-				single(Shift::sar(7)),
-				single(Shift::rotr(1)),
-			]
-		);
-
-		// The point of the encoding: a segment names far fewer sequences than the space holds, and
-		// the space is now the square of one slot's alphabet.
-		assert!(key_collection.hidden.dense_shift_enc.len() < SHIFT_COUNT * SHIFT_COUNT);
-	}
-
-	#[test]
-	fn dense_shift_encoding_distinguishes_sequences_sharing_an_inner_shift() {
-		// Two terms sharing an inner shift but differing outside must land on distinct indices.
-		// Keyed on the inner shift alone they would collide and accumulate into one row.
-		let hidden = ValueIndex::private(1);
-		let cs = ConstraintSystem {
-			constants: vec![Word::ZERO; 4],
-			n_inout: 0,
-			n_private: 4,
-			zero_constraints: Vec::new(),
-			and_constraints: vec![AndConstraint([
-				vec![
-					ShiftedValueIndex::new(hidden, [Shift::srl(3), Shift::sll(3)]),
-					ShiftedValueIndex::new(hidden, [Shift::srl(3), Shift::sll(5)]),
-					ShiftedValueIndex::srl(hidden, 3),
-				],
-				Vec::new(),
-				Vec::new(),
-			])],
-			imul_constraints: Vec::new(),
-			bmul_constraints: Vec::new(),
-		};
-
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
-		let sequences = key_collection
-			.hidden
-			.dense_shift_enc
-			.iter()
-			.collect::<Vec<_>>();
-		assert_eq!(
-			sequences,
-			[
-				single(Shift::srl(3)),
-				[Shift::srl(3), Shift::sll(3)],
-				[Shift::srl(3), Shift::sll(5)],
-			]
-		);
-
-		// The word's three keys therefore hold three distinct dense indices.
-		let mut indices = key_collection
-			.hidden
-			.word_keys(1)
-			.iter()
-			.map(|key| key.dense_shift_idx)
-			.collect::<Vec<_>>();
-		indices.sort_unstable();
-		assert_eq!(indices, [0, 1, 2]);
-	}
-
-	#[test]
-	fn keys_index_their_segments_dense_encoding() {
-		let key_collection =
-			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
-
-		// The shift sequences a word's keys name, as its own segment's encoding recovers them.
-		let word_sequences = |segment: &KeySegment, word: usize| {
-			let mut sequences = segment
-				.word_keys(word)
-				.iter()
-				.map(|key| {
-					segment
-						.dense_shift_enc
-						.iter()
-						.nth(key.dense_shift_idx as usize)
-						.unwrap()
-				})
-				.collect::<Vec<_>>();
-			sequences.sort();
-			sequences
-		};
-
-		// Value index 1 is the second public word; value index 5 the second hidden one.
-		assert_eq!(
-			word_sequences(&key_collection.public, 1),
-			[single(Shift::IDENTITY), single(Shift::srl(3))]
-		);
-		assert_eq!(
-			word_sequences(&key_collection.hidden, 1),
-			[
-				single(Shift::IDENTITY),
-				single(Shift::sar(7)),
-				single(Shift::rotr(1)),
-			]
-		);
-	}
-
-	#[test]
-	fn dense_shift_encoding_survives_serialization() {
-		let key_collection =
-			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
-
-		let mut buf = Vec::new();
-		key_collection.serialize(&mut buf).unwrap();
-		let deserialized = KeyCollection::deserialize(buf.as_slice()).unwrap();
-
-		for (segment, deserialized) in [
-			(&key_collection.public, &deserialized.public),
-			(&key_collection.hidden, &deserialized.hidden),
-		] {
-			assert_eq!(
-				segment.dense_shift_enc.iter().collect::<Vec<_>>(),
-				deserialized.dense_shift_enc.iter().collect::<Vec<_>>()
 			);
 		}
 	}

--- a/crates/prover/src/protocols/shift/key_collection/collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection/collection.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_compute::{Allocator, VecLike};
+use binius_core::constraint_system::{ConstraintSystem, InoutSegment};
 use binius_field::{BinaryField, PackedField, WideMul};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::{
@@ -17,7 +18,8 @@ use bytes::{Buf, BufMut};
 use tracing::instrument;
 
 use super::{
-	dense_shift_encoding::DenseShiftEncoding, key_segment::KeySegment, operation::Operation,
+	builder::BuilderKeyLists, dense_shift_encoding::DenseShiftEncoding, key_segment::KeySegment,
+	operation::Operation,
 };
 use crate::protocols::shift::{
 	claims::PreparedOperatorClaims,
@@ -40,6 +42,29 @@ pub struct KeyCollection {
 }
 
 impl KeyCollection {
+	/// Walks a constraint system once, collecting every shift key into its segment.
+	///
+	/// # Arguments
+	///
+	/// - `cs`: the constraint system to walk.
+	/// - `inout`: the split point between the public and hidden segments.
+	pub fn build(cs: &ConstraintSystem, inout: InoutSegment) -> Self {
+		let mut builder_key_lists = BuilderKeyLists::new(cs.value_vec_len());
+
+		// Update the builder keys lists with respect to each operand of each operation.
+		builder_key_lists.update_with_constraints(Operation::Zero, &cs.zero_constraints, cs);
+		builder_key_lists.update_with_constraints(Operation::BitwiseAnd, &cs.and_constraints, cs);
+		builder_key_lists.update_with_constraints(Operation::IntegerMul, &cs.imul_constraints, cs);
+		builder_key_lists.update_with_constraints(Operation::BinMul, &cs.bmul_constraints, cs);
+
+		// Split the builder key lists at the public segment boundary, one half per segment.
+		let hidden_lists = builder_key_lists.split_off(cs.n_public_words(inout));
+		Self {
+			public: KeySegment::build(builder_key_lists.into_inner()),
+			hidden: KeySegment::build(hidden_lists.into_inner()),
+		}
+	}
+
 	/// The base-2 logarithm of the hidden segment length in words, rounded up to a power of two.
 	///
 	/// Matches the corresponding quantity for the constraint system the collection was built from.
@@ -219,5 +244,189 @@ impl DeserializeBytes for KeyCollection {
 		let hidden = KeySegment::deserialize(read_buf)?;
 
 		Ok(KeyCollection { public, hidden })
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::{
+		constraint_system::{AndConstraint, Shift, ShiftedValueIndex, ValueIndex},
+		word::Word,
+	};
+	use binius_verifier::protocols::shift::SHIFT_COUNT;
+
+	use super::*;
+
+	/// A shift sequence carrying one shift, which the canonical form places in the inner slot.
+	fn single(shift: Shift) -> [Shift; 2] {
+		[shift, Shift::IDENTITY]
+	}
+
+	/// A constraint system with a handful of distinct shifts, differing between the two segments.
+	///
+	/// The public segment references `Sll(0)` and `Slr(3)`.
+	/// The hidden one references `Sll(0)`, `Sar(7)` and `Rotr(1)`.
+	/// Every outer slot is the identity, so the sequences sort by their inner shift alone.
+	fn shifted_constraint_system() -> ConstraintSystem {
+		// The system has four constants and no inout values, so the public segment is the
+		// constants and the hidden one is the private values.
+		let public = ValueIndex::constant(1);
+		let hidden = ValueIndex::private(1);
+		ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_inout: 0,
+			n_private: 4,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![
+					ShiftedValueIndex::plain(public),
+					ShiftedValueIndex::srl(public, 3),
+				],
+				vec![ShiftedValueIndex::sar(hidden, 7)],
+				vec![
+					ShiftedValueIndex::rotr(hidden, 1),
+					ShiftedValueIndex::plain(hidden),
+				],
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		}
+	}
+
+	#[test]
+	fn dense_shift_encoding_covers_the_sequences_its_segment_uses() {
+		let key_collection =
+			KeyCollection::build(&shifted_constraint_system(), InoutSegment::Public);
+
+		let public_sequences = key_collection
+			.public
+			.dense_shift_enc
+			.iter()
+			.collect::<Vec<_>>();
+		assert_eq!(public_sequences, [single(Shift::IDENTITY), single(Shift::srl(3))]);
+
+		let hidden_sequences = key_collection
+			.hidden
+			.dense_shift_enc
+			.iter()
+			.collect::<Vec<_>>();
+		assert_eq!(
+			hidden_sequences,
+			[
+				single(Shift::IDENTITY),
+				single(Shift::sar(7)),
+				single(Shift::rotr(1)),
+			]
+		);
+
+		// The point of the encoding: a segment names far fewer sequences than the space holds, and
+		// the space is now the square of one slot's alphabet.
+		assert!(key_collection.hidden.dense_shift_enc.len() < SHIFT_COUNT * SHIFT_COUNT);
+	}
+
+	#[test]
+	fn dense_shift_encoding_distinguishes_sequences_sharing_an_inner_shift() {
+		// Two terms sharing an inner shift but differing outside must land on distinct indices.
+		// Keyed on the inner shift alone they would collide and accumulate into one row.
+		let hidden = ValueIndex::private(1);
+		let cs = ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_inout: 0,
+			n_private: 4,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![
+					ShiftedValueIndex::new(hidden, [Shift::srl(3), Shift::sll(3)]),
+					ShiftedValueIndex::new(hidden, [Shift::srl(3), Shift::sll(5)]),
+					ShiftedValueIndex::srl(hidden, 3),
+				],
+				Vec::new(),
+				Vec::new(),
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		};
+
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
+		let sequences = key_collection
+			.hidden
+			.dense_shift_enc
+			.iter()
+			.collect::<Vec<_>>();
+		assert_eq!(
+			sequences,
+			[
+				single(Shift::srl(3)),
+				[Shift::srl(3), Shift::sll(3)],
+				[Shift::srl(3), Shift::sll(5)],
+			]
+		);
+
+		// The word's three keys therefore hold three distinct dense indices.
+		let mut indices = key_collection
+			.hidden
+			.word_keys(1)
+			.iter()
+			.map(|key| key.dense_shift_idx)
+			.collect::<Vec<_>>();
+		indices.sort_unstable();
+		assert_eq!(indices, [0, 1, 2]);
+	}
+
+	#[test]
+	fn keys_index_their_segments_dense_encoding() {
+		let key_collection =
+			KeyCollection::build(&shifted_constraint_system(), InoutSegment::Public);
+
+		// The shift sequences a word's keys name, as its own segment's encoding recovers them.
+		let word_sequences = |segment: &KeySegment, word: usize| {
+			let mut sequences = segment
+				.word_keys(word)
+				.iter()
+				.map(|key| {
+					segment
+						.dense_shift_enc
+						.iter()
+						.nth(key.dense_shift_idx as usize)
+						.unwrap()
+				})
+				.collect::<Vec<_>>();
+			sequences.sort();
+			sequences
+		};
+
+		// Value index 1 is the second public word; value index 5 the second hidden one.
+		assert_eq!(
+			word_sequences(&key_collection.public, 1),
+			[single(Shift::IDENTITY), single(Shift::srl(3))]
+		);
+		assert_eq!(
+			word_sequences(&key_collection.hidden, 1),
+			[
+				single(Shift::IDENTITY),
+				single(Shift::sar(7)),
+				single(Shift::rotr(1)),
+			]
+		);
+	}
+
+	#[test]
+	fn dense_shift_encoding_survives_serialization() {
+		let key_collection =
+			KeyCollection::build(&shifted_constraint_system(), InoutSegment::Public);
+
+		let mut buf = Vec::new();
+		key_collection.serialize(&mut buf).unwrap();
+		let deserialized = KeyCollection::deserialize(buf.as_slice()).unwrap();
+
+		for (segment, deserialized) in [
+			(&key_collection.public, &deserialized.public),
+			(&key_collection.hidden, &deserialized.hidden),
+		] {
+			assert_eq!(
+				segment.dense_shift_enc.iter().collect::<Vec<_>>(),
+				deserialized.dense_shift_enc.iter().collect::<Vec<_>>()
+			);
+		}
 	}
 }

--- a/crates/prover/src/protocols/shift/key_collection/mod.rs
+++ b/crates/prover/src/protocols/shift/key_collection/mod.rs
@@ -10,7 +10,6 @@ mod key;
 mod key_segment;
 mod operation;
 
-pub use builder::build_key_collection;
 pub use collection::KeyCollection;
 pub use dense_shift_encoding::DenseShiftEncoding;
 pub use key_segment::KeySegment;

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -12,9 +12,7 @@ mod segment_words;
 mod shift_ind;
 
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
-pub use key_collection::{
-	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
-};
+pub use key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation};
 pub use phase_2::ShiftOutput;
 pub use prove::{OperatorData, PreparedOperatorData, ShiftProver};
 pub use segment_words::SegmentWords;

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -550,7 +550,7 @@ mod tests {
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::protocols::shift::key_collection::build_key_collection;
+	use crate::protocols::shift::KeyCollection;
 
 	type F = BinaryField128bGhash;
 
@@ -612,7 +612,7 @@ mod tests {
 	#[test]
 	fn from_segments_concatenates_the_two_encodings() {
 		let key_collection =
-			build_key_collection(&overlapping_shift_system(), InoutSegment::Public);
+			KeyCollection::build(&overlapping_shift_system(), InoutSegment::Public);
 
 		// Fill each segment's rows with a distinct constant per row, so a row's value says which
 		// segment it came from.
@@ -682,7 +682,7 @@ mod tests {
 			bmul_constraints: Vec::new(),
 		};
 
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
 		let [inner, outer] = sequence;
 		assert_eq!(
 			key_collection
@@ -761,7 +761,7 @@ mod tests {
 		seed: u64,
 	) -> (SparseShiftRows<P>, FieldVec<P, GlobalAllocator>) {
 		let mut rng = StdRng::seed_from_u64(seed);
-		let key_collection = build_key_collection(cs, InoutSegment::Public);
+		let key_collection = KeyCollection::build(cs, InoutSegment::Public);
 
 		let mut indices = Vec::new();
 		let mut values = Vec::new();
@@ -834,7 +834,7 @@ mod tests {
 			bmul_constraints: Vec::new(),
 		};
 
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
 		assert!(key_collection.public.dense_shift_enc.is_empty());
 		assert!(key_collection.hidden.dense_shift_enc.is_empty());
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -36,10 +36,7 @@ use crate::{
 	and_reduction,
 	protocols::{
 		binmul, intmul,
-		shift::{
-			KeyCollection, OperatorClaims, OperatorData, ShiftOutput, ShiftProver,
-			build_key_collection,
-		},
+		shift::{KeyCollection, OperatorClaims, OperatorData, ShiftOutput, ShiftProver},
 	},
 	ring_switch,
 };
@@ -399,7 +396,7 @@ where
 	/// See [`Prover`] struct documentation for details.
 	pub fn setup(verifier: Verifier<H>) -> Result<Self, Error> {
 		let key_collection =
-			build_key_collection(verifier.constraint_system(), InoutSegment::Public);
+			KeyCollection::build(verifier.constraint_system(), InoutSegment::Public);
 		Self::setup_with_key_collection(verifier, key_collection)
 	}
 

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -24,10 +24,7 @@ use bytes::{Buf, BufMut};
 use digest::Output;
 use rand::CryptoRng;
 
-use crate::{
-	IOPProver,
-	protocols::shift::{KeyCollection, build_key_collection},
-};
+use crate::{IOPProver, protocols::shift::KeyCollection};
 
 type ProverNTT<F> = NeighborsLastMultiThread<GaoMateerPreExpanded<F>>;
 
@@ -66,7 +63,7 @@ where
 	pub fn setup(zk_verifier: &ZKVerifier<H>) -> Result<Self, Error> {
 		let key_collection = {
 			let _guard = tracing::debug_span!("Build key collection").entered();
-			build_key_collection(
+			KeyCollection::build(
 				zk_verifier.inner_iop_verifier().constraint_system(),
 				InoutSegment::Public,
 			)

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -22,7 +22,7 @@ use binius_math::{
 };
 use binius_prover::{
 	fold_word::fold_words,
-	protocols::shift::{OperatorClaims, OperatorData, ShiftProver, build_key_collection},
+	protocols::shift::{KeyCollection, OperatorClaims, OperatorData, ShiftProver},
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -422,7 +422,7 @@ fn test_shift_prove_and_verify() {
 		};
 
 		// Build prover's constraint system
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
 
 		// Create prover transcript and call the prover
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();


### PR DESCRIPTION
Pure refactor — no behavior change.

### The problem

`build_key_collection(cs, inout)` takes a `KeyCollection`'s own inputs and returns a `KeyCollection`, but it lived as a free function off in the builder module instead of on the type it constructs — a named constructor in disguise, the same pattern already fixed for `build_g` and `build_monster_segments` elsewhere in this module.

A caller has to know to look in a sibling module for the one function that actually belongs on `KeyCollection` itself.

### The idea

Move the function onto the type it builds:

```
build_key_collection(cs, inout)     ->  KeyCollection::build(cs, inout)
```

The body is unchanged — same `BuilderKeyLists` walk, same split at the public/hidden boundary. Only the receiver moves from a free-standing call to an associated function on `KeyCollection`.

### The change

- `crates/prover/src/protocols/shift/key_collection/builder.rs`: the function and its test module move out; `BuilderKeyLists` and the handful of methods `KeyCollection::build` needs stay in this file, now `pub(super)` so `collection.rs` can reach them.
- `crates/prover/src/protocols/shift/key_collection/collection.rs`: gains `KeyCollection::build`, plus the (call-site-updated) test module that exercises it.
- Every call site updates to the new form, across three crates: `binius-prover` (`prove.rs`, `zk_config.rs`, `phase_1.rs`'s tests, the `shift_reduction` bench, `tests/shift.rs`), `binius-m4-prover` (`prove.rs`, `composite.rs`, `shift.rs`'s tests), and `binius-examples` (`cli.rs`).

### Scope

- **changed:** one function becomes an associated function; ~20 call sites updated to match.
- **left untouched:** `BuilderKeyLists`'s internal logic, `KeySegment::build`, and everything else in the module — this is a pure move, not a rewrite.

### Verification

- `cargo check -p binius-prover -p binius-m4-prover -p binius-examples --all-targets` — clean.
- `cargo clippy -p binius-prover -p binius-m4-prover -p binius-examples --all-targets -- -D warnings`, with and without `--features rayon` — clean.
- `cargo +nightly fmt -p binius-prover -p binius-m4-prover -p binius-examples` — applied, no diff beyond the refactor itself.
- `cargo test -p binius-prover -p binius-m4-prover -p binius-examples`, with and without `--features rayon` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
