### PR TITLE
Rename the free lagrange_evals family to name its subspace specialization

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -24,7 +24,7 @@ use binius_math::{
 	inner_product::inner_product,
 	multilinear::eq::eq_ind_partial_eval_scalars,
 	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
-	univariate::lagrange_evals_scalars,
+	univariate::subspace_lagrange_evals_scalars,
 };
 use binius_prover::{
 	and_reduction,
@@ -245,7 +245,8 @@ impl IOPProver {
 			// oblong claims at their own instance point.
 			// BitAnd is already oblong.
 			// IntMul and BinMul are collapsed from their per-bit form.
-			let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, &z_challenge);
+			let lagrange =
+				subspace_lagrange_evals_scalars::<B128, B128>(&shift_domain, &z_challenge);
 			let and_columns = and_columns
 				.expect("AND columns are retained whenever there are IMUL or BMUL constraints");
 			let log_instances = table.log_instances();

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -9,7 +9,7 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::subspace_lagrange_evals,
 };
 use binius_prover::{
 	fold_word::fold_words,
@@ -86,7 +86,7 @@ where
 	]);
 	// The oblong weights, which phase 1 pushes through both shift slots and phase 3 runs its rounds
 	// over directly.
-	let oblong_weights = lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
+	let oblong_weights = subspace_lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
 	let Phase1Output {
 		r_j,
 		inner: inner_shift,
@@ -236,7 +236,7 @@ mod tests {
 	use binius_math::{
 		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
 		test_utils::random_scalars,
-		univariate::lagrange_evals_scalars,
+		univariate::subspace_lagrange_evals_scalars,
 	};
 	use binius_prover::protocols::shift::{
 		DenseShiftEncoding, OperatorData, build_key_collection, monster::shift_operator_row,
@@ -275,7 +275,7 @@ mod tests {
 	) -> [B128; 3] {
 		let columns = OperandColumns::build(table, constants, and_constraints, &GlobalAllocator);
 		let [a, b] = columns.as_slices();
-		let lagrange = lagrange_evals_scalars::<B128, B128>(domain_subspace, &r_z);
+		let lagrange = subspace_lagrange_evals_scalars::<B128, B128>(domain_subspace, &r_z);
 		let row_point: Vec<B128> = r_rho.iter().chain(r_x).copied().collect();
 		let operand_eval = |column: &[Word]| {
 			let folded_column = fold_words::<B128, P, _>(&GlobalAllocator, column, &lagrange);
@@ -538,7 +538,7 @@ mod tests {
 			.public
 			.build_g::<B128, B128>(public_words, &prepared);
 		let hidden = build_g_from_folded_words(&hidden_folded, &key_collection.hidden, &prepared);
-		let psi = lagrange_evals(&domain_subspace, r_z);
+		let psi = subspace_lagrange_evals(&domain_subspace, r_z);
 
 		// `g` is zero outside the rows the segments name, so the inner product is those rows
 		// alone. A term names a shift *pair*, and its `h` row is the operator applied twice: the

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -527,7 +527,7 @@ mod tests {
 	use binius_ip::channel::Error as ChannelError;
 	use binius_math::{
 		BinarySubspace, FieldBuffer, multilinear::evaluate::evaluate,
-		univariate::lagrange_evals_scalars,
+		univariate::subspace_lagrange_evals_scalars,
 	};
 	use binius_prover::{and_reduction, fold_word::BitAxisFolder};
 	use binius_transcript::{ProverTranscript, VerifierTranscript};
@@ -682,7 +682,7 @@ mod tests {
 		let univariate_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)
 			.isomorphic::<B128>()
 			.reduce_dim(SKIPPED_VARS);
-		let lagrange = lagrange_evals_scalars(&univariate_domain, &z_challenge);
+		let lagrange = subspace_lagrange_evals_scalars(&univariate_domain, &z_challenge);
 		let folded: FieldBuffer<B128> = BitAxisFolder::new(&lagrange).fold(&GlobalAllocator, col);
 		evaluate(&folded, eval_point)
 	}

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -47,8 +47,11 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: &F) -> F {
 ///
 /// # Returns
 /// A vector of Lagrange polynomial evaluations, one for each domain element
-pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> FieldBuffer<F> {
-	let result = lagrange_evals_scalars(subspace, &z);
+pub fn subspace_lagrange_evals<F: BinaryField>(
+	subspace: &BinarySubspace<F>,
+	z: F,
+) -> FieldBuffer<F> {
+	let result = subspace_lagrange_evals_scalars(subspace, &z);
 	FieldBuffer::new(subspace.dim(), result)
 }
 
@@ -72,7 +75,7 @@ fn subspace_barycentric_weight<F: BinaryField, E: FieldOps + From<F>>(
 	unsafe { product.invert() }
 }
 
-/// Scalar variant of [`lagrange_evals`] that returns a `Vec<E>` instead of a `FieldBuffer`.
+/// Scalar variant that returns a plain vector instead of a field buffer.
 ///
 /// Computes Lagrange polynomial evaluations for a binary subspace domain, converting domain
 /// points from `F` to `E` and performing all arithmetic in `E`.
@@ -83,7 +86,7 @@ fn subspace_barycentric_weight<F: BinaryField, E: FieldOps + From<F>>(
 ///
 /// # Returns
 /// A vector of Lagrange polynomial evaluations, one for each domain element
-pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
+pub fn subspace_lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 	subspace: &BinarySubspace<F>,
 	z: &E,
 ) -> Vec<E> {
@@ -296,7 +299,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_lagrange_evals() {
+	fn test_subspace_lagrange_evals() {
 		let mut rng = StdRng::seed_from_u64(0);
 
 		// Test mathematical properties across different domain sizes
@@ -307,7 +310,7 @@ mod tests {
 
 			// Test 1: Partition of Unity - Lagrange polynomials sum to 1
 			let eval_point = F::random(&mut rng);
-			let lagrange_coeffs = lagrange_evals(&subspace, eval_point);
+			let lagrange_coeffs = subspace_lagrange_evals(&subspace, eval_point);
 			let sum: F = lagrange_coeffs.as_ref().iter().copied().sum();
 			assert_eq!(
 				sum,
@@ -318,7 +321,7 @@ mod tests {
 
 			// Test 2: Interpolation Property - L_i(x_j) = δ_ij
 			for (j, &domain_point) in domain.iter().enumerate() {
-				let lagrange_at_domain = lagrange_evals(&subspace, domain_point);
+				let lagrange_at_domain = subspace_lagrange_evals(&subspace, domain_point);
 				for (i, &coeff) in lagrange_at_domain.as_ref().iter().enumerate() {
 					let expected = if i == j { F::ONE } else { F::ZERO };
 					assert_eq!(
@@ -343,7 +346,7 @@ mod tests {
 
 		// Test interpolation at random point
 		let test_point = F::random(&mut rng);
-		let lagrange_coeffs = lagrange_evals(&subspace, test_point);
+		let lagrange_coeffs = subspace_lagrange_evals(&subspace, test_point);
 		let interpolated =
 			inner_product(domain_evals.iter().copied(), lagrange_coeffs.iter_scalars());
 		let direct = evaluate_univariate(&coeffs, &test_point);
@@ -410,7 +413,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_extrapolate_over_subspace_against_lagrange_evals() {
+	fn test_extrapolate_over_subspace_against_subspace_lagrange_evals() {
 		let mut rng = StdRng::seed_from_u64(0);
 
 		for log_domain_size in 0..=6 {
@@ -422,7 +425,7 @@ mod tests {
 
 			let z = F::random(&mut rng);
 			let extrapolated = extrapolate_over_subspace(&subspace, &values, &z);
-			let lagrange = lagrange_evals_scalars(&subspace, &z);
+			let lagrange = subspace_lagrange_evals_scalars(&subspace, &z);
 			let expected = inner_product(values.iter().copied(), lagrange);
 
 			assert_eq!(extrapolated, expected, "Mismatch for log_domain_size={log_domain_size}");

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -7,7 +7,7 @@ use binius_field::{Field, Random};
 use binius_ip_prover::sumcheck::{common::MleCheckProver, quadratic_mlecheck_prover};
 use binius_math::{
 	BinarySubspace,
-	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
+	univariate::{extrapolate_over_subspace, subspace_lagrange_evals_scalars},
 };
 use binius_prover::{
 	OptimalPackedB128,
@@ -96,7 +96,8 @@ fn bench(c: &mut Criterion) {
 
 	group.bench_function(format!("univariate fold 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
+			let lagrange_evals =
+				subspace_lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
 			let folder = BitAxisFolder::new(&lagrange_evals);
 			folder.fold_bitand_operands::<OptimalPackedB128, _>(
 				&GlobalAllocator,
@@ -106,7 +107,7 @@ fn bench(c: &mut Criterion) {
 		});
 	});
 
-	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
+	let lagrange_evals = subspace_lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
 	let folder = BitAxisFolder::new(&lagrange_evals);
 
 	let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -11,7 +11,7 @@ use binius_core::{
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_math::{
-	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::subspace_lagrange_evals,
 };
 use binius_prover::{
 	fold_word::fold_words,
@@ -314,7 +314,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	};
 
 	let g = build_combined_g();
-	let oblong_weights = lagrange_evals(&subspace, prepared.bitand.r_zhat_prime);
+	let oblong_weights = subspace_lagrange_evals(&subspace, prepared.bitand.r_zhat_prime);
 	let Phase1Output {
 		r_j,
 		inner: inner_shift,

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -14,7 +14,7 @@ use binius_ip_prover::{
 };
 use binius_math::{
 	BinarySubspace,
-	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
+	univariate::{extrapolate_over_subspace, subspace_lagrange_evals_scalars},
 };
 use binius_verifier::{
 	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
@@ -172,7 +172,7 @@ where
 		alloc: &'alloc A,
 	) -> impl MleCheckProver<F> + 'alloc {
 		let univariate_domain = round_message_domain.reduce_dim(round_message_domain.dim() - 1);
-		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &challenge);
+		let lagrange_evals = subspace_lagrange_evals_scalars(&univariate_domain, &challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
 		let proving_polys =
@@ -285,7 +285,7 @@ mod test {
 	use binius_field::{AESTowerField8b, arch::OptimalPackedB128};
 	use binius_math::{
 		BinarySubspace, FieldBuffer, multilinear::evaluate::evaluate,
-		univariate::lagrange_evals_scalars,
+		univariate::subspace_lagrange_evals_scalars,
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::CanSample};
 	use binius_verifier::{
@@ -377,7 +377,7 @@ mod test {
 		let one_bit_mlvs = [first_mlv, second_mlv, third_mlv];
 
 		let verifier_lagrange_evals =
-			lagrange_evals_scalars(&verifier_univariate_domain, &z_challenge);
+			subspace_lagrange_evals_scalars(&verifier_univariate_domain, &z_challenge);
 		let folder = BitAxisFolder::new(&verifier_lagrange_evals);
 		for (i, eval) in [a_eval, b_eval, c_eval].iter().enumerate() {
 			let folded: FieldBuffer<B128> = folder.fold(&GlobalAllocator, &one_bit_mlvs[i]);

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -303,7 +303,7 @@ mod test {
 	use binius_field::{BinaryField128bGhash as B128, Field, Random};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
-		univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
+		univariate::{extrapolate_over_subspace, subspace_lagrange_evals_scalars},
 	};
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use binius_verifier::protocols::bitand::SKIPPED_VARS;
@@ -447,7 +447,7 @@ mod test {
 		);
 
 		let lagrange_evals =
-			lagrange_evals_scalars(&verifier_input_domain, &first_sumcheck_challenge);
+			subspace_lagrange_evals_scalars(&verifier_input_domain, &first_sumcheck_challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
 		let folded_first_mle: FieldBuffer<B128> = folder.fold(&GlobalAllocator, mlv_1);

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -218,7 +218,7 @@ mod tests {
 	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	use binius_math::{
 		BinarySubspace, inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval,
-		test_utils::random_scalars, univariate::lagrange_evals,
+		test_utils::random_scalars, univariate::subspace_lagrange_evals,
 	};
 	use binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT;
 	use proptest::prelude::*;
@@ -254,7 +254,7 @@ mod tests {
 
 			// Method 1: the claim phase 3 starts from, with the carried constant set to one.
 			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
-			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+			let l_tilde = subspace_lagrange_evals(&subspace, r_zhat_prime);
 			let claimed = ShiftIndSumcheck::<P, _>::new(
 				&GlobalAllocator,
 				l_tilde.as_ref(),

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -9,7 +9,7 @@ use binius_field::{BinaryField, Field, PackedField};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product,
-	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+	multilinear::eq::eq_ind_partial_eval, univariate::subspace_lagrange_evals,
 };
 use tracing::instrument;
 
@@ -203,7 +203,7 @@ where
 		// The weights the reduction's first factor carries, one per bit position.
 		// Phase 1 and phase 3 both need them, so they are computed once here, drawn from the
 		// BitAnd claim.
-		let oblong_weights = lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
+		let oblong_weights = subspace_lagrange_evals(domain_subspace, prepared.bitand.r_zhat_prime);
 
 		// Phase 1: bind the shift variant, the shift amount, and the bit position.
 		let phase_1_output = self.phase1(key_collection, words, &prepared, oblong_weights.as_ref());

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -346,7 +346,7 @@ mod tests {
 	use binius_field::{BinaryField128bGhash as B128, Field};
 	use binius_math::{
 		BinarySubspace, multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars,
-		univariate::lagrange_evals_scalars,
+		univariate::subspace_lagrange_evals_scalars,
 	};
 	use binius_verifier::protocols::shift::evaluate_shift_inds;
 	use rand::{SeedableRng, rngs::StdRng};
@@ -489,7 +489,7 @@ mod tests {
 		let g_eval = B128::random(&mut rng);
 		let subspace =
 			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic::<B128>();
-		let l_tilde = lagrange_evals_scalars(&subspace, &r_zhat_prime);
+		let l_tilde = subspace_lagrange_evals_scalars(&subspace, &r_zhat_prime);
 		let shift = ShiftChallenge::new(amount, variant);
 		let point = ShiftChallengePoint::new(&bit, &shift);
 		let sumcheck = ShiftIndSumcheck::<P, _>::new(&GlobalAllocator, &l_tilde, &point, g_eval);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -17,7 +17,7 @@ use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec,
 	inner_product::inner_product,
 	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
-	univariate::lagrange_evals,
+	univariate::subspace_lagrange_evals,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{
@@ -214,7 +214,7 @@ impl IOPProver {
 				c_hi_evals,
 			}) => {
 				let r_zhat_prime = bitand_claim.r_zhat_prime;
-				let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+				let l_tilde = subspace_lagrange_evals(&subspace, r_zhat_prime);
 				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 				OperatorData {
 					evals: [
@@ -246,7 +246,7 @@ impl IOPProver {
 				c_hi_evals,
 			}) => {
 				let r_zhat_prime = bitand_claim.r_zhat_prime;
-				let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+				let l_tilde = subspace_lagrange_evals(&subspace, r_zhat_prime);
 				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 				OperatorData {
 					evals: [

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -18,7 +18,7 @@ use binius_math::{
 	BinarySubspace,
 	inner_product::{inner_product, inner_product_buffers},
 	multilinear::eq::eq_ind_partial_eval,
-	univariate::lagrange_evals,
+	univariate::subspace_lagrange_evals,
 };
 use binius_prover::{
 	fold_word::fold_words,
@@ -299,7 +299,7 @@ fn evaluate_image<F: BinaryField>(
 	r_zhat_prime: F,
 	r_x_prime_tensor: &[F],
 ) -> F {
-	let l_tilde = lagrange_evals(subspace, r_zhat_prime);
+	let l_tilde = subspace_lagrange_evals(subspace, r_zhat_prime);
 	let univariate = image
 		.iter()
 		.map(|&word| {

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -22,7 +22,7 @@ use binius_math::{
 		},
 		evaluate::evaluate_inplace_scalars,
 	},
-	univariate::{evaluate_univariate, lagrange_evals_scalars},
+	univariate::{evaluate_univariate, subspace_lagrange_evals_scalars},
 };
 use getset::Getters;
 
@@ -347,7 +347,7 @@ where
 	// intermediate word — the outer one carries the output bit down to `r_k`, the inner one carries
 	// `r_k` down to the witness bit — which is what makes a sequence of two shifts one index entry.
 	let l_tilde_eval =
-		evaluate_inplace_scalars(lagrange_evals_scalars(subspace, r_zhat_prime), r_i);
+		evaluate_inplace_scalars(subspace_lagrange_evals_scalars(subspace, r_zhat_prime), r_i);
 	let outer_ind_eval =
 		evaluate_inplace_scalars(&mut evaluate_shift_inds(r_i, r_k, r_s_outer)[..], r_v_outer);
 	let inner_ind_eval =

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -36,7 +36,7 @@ use binius_math::{
 		eq::{eq_ind, eq_ind_zero},
 		evaluate::evaluate_inplace_scalars,
 	},
-	univariate::{evaluate_univariate, lagrange_evals_scalars},
+	univariate::{evaluate_univariate, subspace_lagrange_evals_scalars},
 };
 
 use crate::{
@@ -246,7 +246,8 @@ where
 
 	// Collapse the multiplications' per-bit operand claims to the oblong form BitAnd already has.
 	// The Lagrange weights fold them at the univariate challenge BitAnd just drew.
-	let lagrange = lagrange_evals_scalars::<B128, Channel::Elem>(&shift_domain, &z_challenge);
+	let lagrange =
+		subspace_lagrange_evals_scalars::<B128, Channel::Elem>(&shift_domain, &z_challenge);
 	let bitand_claim = OperationClaim::new([a_eval, b_eval, c_eval], r_x_and, r_rho_and);
 	let intmul_claim =
 		intmul_output.map(|output| OperationClaim::from_intmul(output, &lagrange, log_instances));


### PR DESCRIPTION
Pure rename — no signature or behaviour change.

### The problem

`crates/math/src/univariate.rs` declares `lagrange_evals` **twice**, in one file:

| line | form | over | returns |
|---|---|---|---|
| ~50 | free function | `&BinarySubspace<F>` | `FieldBuffer<F>` |
| ~200 | method | `EvaluationDomain<F>` | `Vec<F>` |

Worse than a file-level collision, the bare name means two things inside a single function body. `crates/prover/src/and_reduction/prover.rs:175-176` imports the free function *and* binds a local `let lagrange_evals = …`. Same in `benches/and_reduction.rs:99,109` and `sumcheck_round_messages.rs:449`.

### The idea

The file has already resolved this exact collision once — for `extrapolate`:

```
free:    extrapolate_over_subspace(subspace, values, z)
method:  EvaluationDomain::extrapolate(&self, ..)
```

There the free form carries a subspace qualifier and the method keeps the bare name. `lagrange_evals` is the one pair that never got the treatment.

So this is not a new convention being imposed. It is an existing convention applied to the item that escaped it.

```
- univariate::lagrange_evals          -> univariate::subspace_lagrange_evals
- univariate::lagrange_evals_scalars  -> univariate::subspace_lagrange_evals_scalars
  EvaluationDomain::lagrange_evals    -> unchanged
```

The method keeps the bare name because `domain.lagrange_evals(z)` is self-disambiguating at the call site. That is an argument for keeping it, not renaming it — the same call BINIUS-521 made when it renamed only the free `square_transpose` and left both trait methods alone.

### Why not move it onto the subspace type

That is the obvious-looking fix and it is wrong twice over.

- `crates/math/src/binary_subspace.rs` imports exactly `std::ops::Deref` and `binius_field`. It has no `crate::` import at all. The free function returns a `FieldBuffer`, so the move would make a low-level primitive depend on polynomial buffers.
- The type is generic in its storage (`BinarySubspace<F, Data = Vec<F>>`) while the free functions take only the default. A method would either widen to all storages, gratuitously, or sit in a `Data = Vec<F>`-only impl block that reads as an accident.

### On the qualifier — this is not a stutter

`subspace_barycentric_weight` and `subspace_polynomial` look like they echo their argument's type. They do not, and the distinction drove the naming choice:

- A subspace has **one** barycentric weight where a general domain has one per point. The singular is the whole reason that function exists.
- The *subspace polynomial* is the standard name for the vanishing polynomial of a linear subspace. The word is the noun, not a type echo.

A qualifier that names the mathematical specialization is not a stutter, so neither of those is renamed here.

Prefix or suffix follows the file's existing split: `subspace_*` for noun phrases, `*_over_subspace` for verb phrases. "Extrapolate over a subspace" reads naturally; `lagrange_evals_over_subspace_scalars` does not, at 34 characters.

### Scope

- **changed:** the two definitions, plus ~20 call sites across **six** crates — `binius-math`, `binius-prover`, `binius-verifier`, `binius-m4-prover`, and the prover's benches and tests.
- **left alone:** `extrapolate_over_subspace` (already unambiguous), `subspace_barycentric_weight` and `subspace_polynomial` (see above), and local variable bindings named `lagrange_evals`, which name values rather than the function.
- **one doc line changed:** a stale intra-doc link that the rename broke, rewritten in plain English.

### Worth flagging, cutting against this change

`EvaluationDomain` has **zero consumers anywhere in the repo** outside its own two unit tests. It is public dead API.

On pure usage weight, the unused item is the one that should have yielded the name. The free family was renamed anyway, because its bare name is what appears at every real call site, and renaming a method nobody calls buys no reader anything. But the better follow-up is to ask whether that type should be public at all.

### Verification

- `cargo clippy -p binius-math -p binius-prover -p binius-verifier -p binius-m4-prover --all-targets --all-features -- -D warnings` — clean. The scope was widened past the two crates first assumed, since the other two turned out to hold call sites.
- `cargo test -p binius-math --lib` (144), `-p binius-prover` (67 + 17 + 1), `-p binius-verifier -p binius-m4-prover` (42 + 10 + 1) — 0 failed.
- The math and prover suites again with `--features rayon` — 0 failed.
- `cargo +nightly fmt --check` — clean. The +6 net line count is rustfmt reflowing lines the longer name pushed past 100 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)