### PR TITLE
Move two private helpers onto the types they operate on

### DIFF
--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -201,7 +201,7 @@ fn strauss_accumulate(
 	// Flatten each table entry into its constituent wires for the multi-wire multiplexer.
 	let tables_flat: Vec<Vec<Vec<Wire>>> = tables
 		.iter()
-		.map(|table| table.iter().map(point_to_wires).collect())
+		.map(|table| table.iter().map(Secp256k1Affine::to_wires).collect())
 		.collect();
 	let table_refs: Vec<Vec<&[Wire]>> = tables_flat
 		.iter()
@@ -241,39 +241,13 @@ fn strauss_accumulate(
 				sel = b.bxor(sel, b.shl(bit_val, j as u32));
 			}
 
-			let selected = point_from_wires(&multi_wire_multiplex(b, &table_refs[point_idx], sel));
+			let selected =
+				Secp256k1Affine::from_wires(&multi_wire_multiplex(b, &table_refs[point_idx], sel));
 			acc = curve.add_incomplete(b, &acc, &selected);
 		}
 	}
 
 	acc
-}
-
-// Flatten an affine point into its constituent wires: x limbs, then y limbs, then the
-// point-at-infinity flag. Inverse of `point_from_wires`.
-fn point_to_wires(p: &Secp256k1Affine) -> Vec<Wire> {
-	assert_eq!(p.x.limbs.len(), N_LIMBS);
-	assert_eq!(p.y.limbs.len(), N_LIMBS);
-
-	let mut wires = Vec::with_capacity(2 * N_LIMBS + 1);
-	wires.extend_from_slice(&p.x.limbs);
-	wires.extend_from_slice(&p.y.limbs);
-	wires.push(p.is_point_at_infinity);
-	wires
-}
-
-// Reconstruct an affine point from the flat wire layout produced by `point_to_wires`.
-fn point_from_wires(wires: &[Wire]) -> Secp256k1Affine {
-	assert_eq!(wires.len(), 2 * N_LIMBS + 1);
-	Secp256k1Affine {
-		x: BigUint {
-			limbs: wires[..N_LIMBS].to_vec(),
-		},
-		y: BigUint {
-			limbs: wires[N_LIMBS..2 * N_LIMBS].to_vec(),
-		},
-		is_point_at_infinity: wires[2 * N_LIMBS],
-	}
 }
 
 #[cfg(test)]

--- a/crates/circuits/src/secp256k1/point.rs
+++ b/crates/circuits/src/secp256k1/point.rs
@@ -2,7 +2,7 @@
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
-use super::common::{coord_zero, coords_gen};
+use super::common::{N_LIMBS, coord_zero, coords_gen};
 use crate::bignum::{BigUint, select as select_biguint};
 
 /// Curve point in affine form - a tuple `(x, y)` that satisfies `y^2 = x^3 + 7`,
@@ -44,6 +44,42 @@ impl Secp256k1Affine {
 			x: self.x.clone(),
 			y: self.y.clone(),
 			is_point_at_infinity,
+		}
+	}
+
+	/// Flattens the point into a single wire list: x limbs, then y limbs, then the infinity flag.
+	///
+	/// This is the layout a wire-level multiplexer selects over.
+	///
+	/// # Panics
+	///
+	/// Panics unless both coordinates carry the full limb count.
+	pub(crate) fn to_wires(&self) -> Vec<Wire> {
+		assert_eq!(self.x.limbs.len(), N_LIMBS);
+		assert_eq!(self.y.limbs.len(), N_LIMBS);
+
+		let mut wires = Vec::with_capacity(2 * N_LIMBS + 1);
+		wires.extend_from_slice(&self.x.limbs);
+		wires.extend_from_slice(&self.y.limbs);
+		wires.push(self.is_point_at_infinity);
+		wires
+	}
+
+	/// Rebuilds a point from the flat wire layout, undoing the flattening.
+	///
+	/// # Panics
+	///
+	/// Panics unless the list is exactly two coordinates plus the infinity flag long.
+	pub(crate) fn from_wires(wires: &[Wire]) -> Self {
+		assert_eq!(wires.len(), 2 * N_LIMBS + 1);
+		Self {
+			x: BigUint {
+				limbs: wires[..N_LIMBS].to_vec(),
+			},
+			y: BigUint {
+				limbs: wires[N_LIMBS..2 * N_LIMBS].to_vec(),
+			},
+			is_point_at_infinity: wires[2 * N_LIMBS],
 		}
 	}
 }

--- a/crates/frontend/src/artifact/circuit.rs
+++ b/crates/frontend/src/artifact/circuit.rs
@@ -6,7 +6,7 @@
 use binius_compute::{Allocator, BufferData, VecLike};
 use binius_core::{
 	ValueTable,
-	constraint_system::{ConstraintSystem, ValueIndex, ValueVec, ValueVecLayout},
+	constraint_system::{ConstraintSystem, ValueIndex, ValueSegment, ValueVec, ValueVecLayout},
 	word::Word,
 };
 use binius_utils::{rayon::prelude::*, strided_array::StridedArray2DViewMut};
@@ -119,13 +119,21 @@ impl Circuit {
 		self.value_vec_layout.word_offset(self.witness_index(wire))
 	}
 
-	/// Whether this circuit's scratch segment shares slots between uncommitted values.
+	/// Panics if the wire's storage is a scratch slot shared with another value.
 	///
-	/// A shared slot can end up holding a different value than the wire that first wrote it.
-	/// So a scratch-segment wire is safe to read back only when this is `false`.
-	#[inline(always)]
-	pub(crate) const fn scratch_pooled(&self) -> bool {
-		self.scratch_pooled
+	/// Scratch pooling reclaims a slot once its current value's last read has run.
+	/// A shared slot then holds whatever value most recently claimed it, not this wire's.
+	/// So this rejects the read outright rather than returning that wrong value.
+	pub(crate) fn assert_not_pooled(&self, wire: Wire, index: ValueIndex) {
+		assert!(
+			!self.scratch_pooled || index.segment() != ValueSegment::Scratch,
+			"wire {wire:?} cannot be read back through a witness filler: its storage is a scratch \
+			 slot shared with another value under scratch pooling, and the slot may already hold a \
+			 different value by the time the circuit has finished evaluating. Disable scratch \
+			 pooling for this build (set `Options::enable_scratch_pooling` to `false`), or make \
+			 this value committed instead of scratch, e.g. by marking it inout or referencing it \
+			 from a constraint."
+		);
 	}
 
 	/// Creates a new witness filler for this circuit.

--- a/crates/frontend/src/artifact/witness.rs
+++ b/crates/frontend/src/artifact/witness.rs
@@ -8,27 +8,10 @@ use std::{
 	ops::{Index, IndexMut},
 };
 
-use binius_core::{ValueIndex, ValueSegment, ValueVec, Word};
+use binius_core::{ValueVec, Word};
 use binius_utils::strided_array::StridedArray2DViewMut;
 
 use crate::{Circuit, Wire};
-
-/// Panics if the wire's storage is a scratch slot shared with another value.
-///
-/// Scratch pooling reclaims a slot once its current value's last read has run.
-/// A shared slot then holds whatever value most recently claimed it, not this wire's.
-/// So this rejects the read outright rather than returning that wrong value.
-fn assert_not_pooled(circuit: &Circuit, wire: Wire, index: ValueIndex) {
-	assert!(
-		!circuit.scratch_pooled() || index.segment() != ValueSegment::Scratch,
-		"wire {wire:?} cannot be read back through a witness filler: its storage is a scratch \
-		 slot shared with another value under scratch pooling, and the slot may already hold a \
-		 different value by the time the circuit has finished evaluating. Disable scratch \
-		 pooling for this build (set `Options::enable_scratch_pooling` to `false`), or make this \
-		 value committed instead of scratch, e.g. by marking it inout or referencing it from a \
-		 constraint."
-	);
-}
 
 /// A single assertion that did not hold while populating the witness.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -148,7 +131,7 @@ impl Index<Wire> for WitnessFiller<'_> {
 	/// Panics if the wire's storage is a pooled scratch slot shared with another value.
 	fn index(&self, wire: Wire) -> &Self::Output {
 		let index = self.circuit.witness_index(wire);
-		assert_not_pooled(self.circuit, wire, index);
+		self.circuit.assert_not_pooled(wire, index);
 		&self.value_vec[index]
 	}
 }
@@ -159,7 +142,7 @@ impl IndexMut<Wire> for WitnessFiller<'_> {
 	/// Panics if the wire's storage is a pooled scratch slot shared with another value.
 	fn index_mut(&mut self, wire: Wire) -> &mut Self::Output {
 		let index = self.circuit.witness_index(wire);
-		assert_not_pooled(self.circuit, wire, index);
+		self.circuit.assert_not_pooled(wire, index);
 		&mut self.value_vec[index]
 	}
 }


### PR DESCRIPTION
Pure refactor — no behaviour change, no public API change.

### The problem

A workspace sweep looked for free functions whose first argument is the type they belong on — the shape BINIUS-526 and BINIUS-527 already fixed for the shift prover and the field buffer.

It found six private candidates. **Two of them genuinely were.** The other four look identical from a grep and are not, which is the more useful half of this PR.

### The two that moved

**`assert_not_pooled` → a method on the circuit.**
It reads only circuit state; its `wire` argument just feeds the panic message. The circuit's file already imported everything the signature needs.

It also exposed dead code: a crate-private `scratch_pooled()` accessor existed *solely* to feed that one call site. With the check inside the type, the private field is read in place and the accessor is deleted.

**`point_to_wires` → a method on the curve point.**
Pure flattening of the point's own fields into its wire layout. Its new home already imported `Wire`, `BigUint` and the builder — the only addition is a limb-count constant from a sibling module.

Its exact inverse `point_from_wires` moved with it. The two are a round-trip pair whose doc comments referenced each other, and orphaning half of it in the old file would have been worse than moving neither. Both stay crate-private, so the public surface is untouched.

### The four that stayed, and why

Each is a real argument, not a shrug.

**`div_pow2_round` — the orphan rule forbids it.**
`endosplit.rs` does `use num_bigint::BigUint`. The receiver is a **foreign** type, not the crate's own circuit-level bignum that holds `limbs: Vec<Wire>`. An inherent impl is illegal, and an extension trait to host one private rounding helper is strictly worse.

**`dump_composition` — the layering trap, textbook.**
Its receiver's file is an 84-line primitive knowing only `cranelift_entity`. The move would drag `serde`, `serde_json`, `GateBody`, and four private support types into it. And the tree is not the subject: the primary data is the gate records, with the tree used only as a parent/root lookup.

**`verify_phase_5` — looks like the BINIUS-526 analogue, is not.**
Its receiver lives in a dependency-light module that the **prover** crate also imports. The function needs the verifier channel, logUp\*, looker and table claims, batch sumcheck, and the error type. Moving ~180 lines there drags the whole verification stack into shared data.

It is also one of five inputs and returns a different type entirely. It is a protocol step, and the file reads as an ordered transcript of phases 1 through 5.

**`eval_element` — no dependency drag, but the abstraction is wrong.**
The lo-word/hi-word pair is one constraint kind's encoding of a 128-bit GHASH element, not something a word-addressed storage buffer should know. Confirmed no second user: the other constraint keeps its halves separate and never packs them.

The move would also *widen* visibility from module-private to crate-private, for a helper with one caller three lines away.

### Scope

- **changed:** 4 files across `binius-frontend` and `binius-circuits`; 4 call sites.
- **deleted:** one crate-private accessor that became dead.
- **untouched:** `binius-core` and `binius-verifier`, since their two candidates stayed put.

One incidental edit: moving the assertion gained an indentation level and pushed a continuation line past 100 columns, so the message string is re-wrapped at word boundaries. The assembled message was checked byte-identical.

### Verification

- `cargo clippy -p binius-frontend -p binius-circuits --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-frontend` — 259 + 2 + 2 + 1 + 1 pass.
- `cargo test -p binius-circuits` — 396 + 3 + 2 pass (8 pre-existing ignored).
- Both again with the rayon feature, which lives on `binius-utils` rather than either touched crate — 0 failed.
- `cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)