### PR TITLE
Move a gate's bytecode emission and constraining onto the gate

### DIFF
--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 		circuit::Circuit,
 	},
 	eval_form,
-	gates::{self, Opcode},
+	gates::Opcode,
 	ir::{
 		GateGraph, Wire, WireKind,
 		hints::{Hint, HintRegistry},
@@ -646,7 +646,7 @@ impl CircuitBuilder {
 			{
 				continue;
 			}
-			gates::constrain(gate_id, &graph, &mut builder, &shared.hint_registry);
+			gate_id.constrain(&graph, &mut builder, &shared.hint_registry);
 		}
 
 		// Perform fusion if the corresponding feature flag is turned on.

--- a/crates/frontend/src/eval_form/const_eval.rs
+++ b/crates/frontend/src/eval_form/const_eval.rs
@@ -216,7 +216,6 @@ mod tests {
 
 		use crate::{
 			eval_form::{BytecodeBuilder, exec::Executor, scalar::ExecutionContext},
-			gates,
 			ir::Wire,
 		};
 
@@ -238,7 +237,7 @@ mod tests {
 		let wire_to_reg =
 			|wire: Wire| -> u32 { data.wires.iter().position(|&w| w == wire).unwrap() as u32 };
 		let mut builder = BytecodeBuilder::new();
-		gates::emit_gate_bytecode(gate, graph, &mut builder, wire_to_reg, hints);
+		gate.emit_bytecode(graph, &mut builder, wire_to_reg, hints);
 		let (bytecode, _) = builder.finalize();
 		let mut ctx = ExecutionContext::new(&mut value_vec);
 		Executor::new(&bytecode, hints).run(&mut ctx);

--- a/crates/frontend/src/eval_form/mod.rs
+++ b/crates/frontend/src/eval_form/mod.rs
@@ -28,7 +28,6 @@ use scalar::ExecutionContext;
 
 use crate::{
 	artifact::witness::PopulateError,
-	gates,
 	ir::{GateGraph, Wire, hints::HintRegistry, path::PathSpecTree},
 };
 
@@ -67,13 +66,7 @@ impl EvalForm {
 
 		// Build bytecode for each gate
 		for gate_id in gate_graph.gates.keys() {
-			gates::emit_gate_bytecode(
-				gate_id,
-				gate_graph,
-				&mut builder,
-				wire_to_reg,
-				&hint_registry,
-			);
+			gate_id.emit_bytecode(gate_graph, &mut builder, wire_to_reg, &hint_registry);
 		}
 
 		let (bytecode, n_eval_insn) = builder.finalize();

--- a/crates/frontend/src/gates/mod.rs
+++ b/crates/frontend/src/gates/mod.rs
@@ -148,41 +148,43 @@ impl Opcode {
 	}
 }
 
-/// Appends the constraints one gate contributes.
-///
-/// A hint contributes none: the surrounding circuit constrains the value it computes.
-pub fn constrain(
-	gate: Gate,
-	graph: &GateGraph,
-	builder: &mut ConstraintBuilder,
-	hint_registry: &HintRegistry,
-) {
-	let data = &graph.gates[gate];
-	match data.body {
-		GateBody::Op(opcode) => {
-			(opcode.vtable().constrain)(data.gate_param(hint_registry), builder);
+impl Gate {
+	/// Appends the constraints this gate contributes.
+	///
+	/// A hint contributes none: the surrounding circuit constrains the value it computes.
+	pub fn constrain(
+		self,
+		graph: &GateGraph,
+		builder: &mut ConstraintBuilder,
+		hint_registry: &HintRegistry,
+	) {
+		let data = &graph.gates[self];
+		match data.body {
+			GateBody::Op(opcode) => {
+				(opcode.vtable().constrain)(data.gate_param(hint_registry), builder);
+			}
+			GateBody::Hint(_) => {}
 		}
-		GateBody::Hint(_) => {}
 	}
-}
 
-/// Emits the instructions that derive one gate's outputs at witness time.
-pub fn emit_gate_bytecode(
-	gate: Gate,
-	graph: &GateGraph,
-	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(Wire) -> u32 + Copy,
-	hint_registry: &HintRegistry,
-) {
-	let data = &graph.gates[gate];
-	let params = data.gate_param(hint_registry);
-	let ctx = EmitCtx {
-		resolve: &wire_to_reg,
-		path: graph.assertion_names[gate],
-	};
-	match data.body {
-		GateBody::Op(opcode) => (opcode.vtable().emit)(params, ctx, builder),
-		GateBody::Hint(hint_id) => emit_hint(hint_id, params, &data.dimensions, ctx, builder),
+	/// Emits the instructions that derive this gate's outputs at witness time.
+	pub fn emit_bytecode(
+		self,
+		graph: &GateGraph,
+		builder: &mut BytecodeBuilder,
+		wire_to_reg: impl Fn(Wire) -> u32 + Copy,
+		hint_registry: &HintRegistry,
+	) {
+		let data = &graph.gates[self];
+		let params = data.gate_param(hint_registry);
+		let ctx = EmitCtx {
+			resolve: &wire_to_reg,
+			path: graph.assertion_names[self],
+		};
+		match data.body {
+			GateBody::Op(opcode) => (opcode.vtable().emit)(params, ctx, builder),
+			GateBody::Hint(hint_id) => emit_hint(hint_id, params, &data.dimensions, ctx, builder),
+		}
 	}
 }
 


### PR DESCRIPTION
Pure refactor — bodies otherwise byte-identical.

### The problem

`crates/frontend/src/gates/mod.rs` has two free functions over `Gate`:

```
emit_gate_bytecode(gate, ..)
constrain(gate, ..)
```

The first is **the only function in the entire workspace whose name repeats its own receiver's type name**. A scan for that pattern returned exactly one hit. Name stutter like that is the classic sign of a method stuck in a free function: `gate.emit_bytecode(..)` says the same thing without saying "gate" twice.

### The idea

The gate is genuinely the subject, not merely the first parameter.

`Gate` is a `u32` entity handle. Both functions do the same two steps: resolve the handle in the graph, then dispatch on that gate's own body to the vtable row for its opcode. What comes out is *that one gate's* instructions and *that one gate's* constraints.

The other two arguments are not candidates:

- the graph is only the arena the handle derefs against;
- the builder is a sink that a loop over all gates accumulates into.

`builder.emit_gate(..)` would also be wrong mechanically — the bytecode builder and the constraint builder live in different modules, and neither knows the gate vtable. The opcode dispatch table is owned by `gates/mod.rs`, so the logic has to sit at that layer whatever the receiver.

```
- gates::emit_gate_bytecode(gate_id, ..)  ->  gate_id.emit_bytecode(..)
- gates::constrain(gate_id, ..)           ->  gate_id.constrain(..)
```

The stutter is dropped from the first. The second never stuttered, so its name is unchanged.

### Where the impl block lives

In `gates/mod.rs`, **not** in the file where `Gate` is declared.

That file imports only the word type, `cranelift_entity`, `rustc_hash`, `smallvec`, and the opcode module. It knows nothing of the bytecode builder, the constraint builder, or the emit context. Putting the methods there would pull both the bytecode and lowering layers into an IR primitive — the same mistake as trying to move a polynomial-buffer operation onto a low-level subspace type.

There is house precedent for the placement: `gates/mod.rs` already holds the sole inherent impl for the **opcode** type, even though that type is declared in `gates/opcode.rs`. Same shape — the inherent impl lives with the dispatch layer, not the declaring file.

Checked: no other `impl Gate` exists anywhere, so the workspace's `clippy::multiple_inherent_impl = "warn"` is not tripped.

### Scope

- **changed:** 4 files, all in `binius-frontend`; 3 call sites; 3 imports that became dead.
- **left free:** a sibling that emits a hint. It is about the hint and takes a gate *parameter*, never a gate.
- **not renamed:** the per-kind trait method of the same name, an unrelated inherent method on a bignum type, and prose in comments — all distinguished by reading them, since "constrain" is a common word.

### Verification

- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-frontend` — 259 + 2 + 2 + 1 + 1 pass, 0 failed, run to completion.
- `cargo +nightly fmt --check` — clean.

Only `binius-frontend` was edited, so no other crate needed a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)