### PR TITLE
BINIUS-504: run a lone SHA-256 compression in both 32-bit lanes

### DIFF
--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -62,29 +62,207 @@ impl State {
 	}
 }
 
+/// Rounds [`sha256_compress`] runs in its high lane, the first half of the 64.
+///
+/// The low lane runs the other half, so both lanes carry 32 rounds and neither idles.
+const HIGH_LANE_ROUNDS: usize = 32;
+
+/// Gap in schedule index between the two lanes of [`sha256_compress`]'s message schedule.
+///
+/// The 48 derived words split evenly in two, so 24 packed passes derive all of them:
+///
+/// ```text
+///     low  lane derives w[16..40]
+///     high lane derives w[40..64]
+/// ```
+const SCHEDULE_LANE_GAP: usize = 24;
+
+/// Packed schedule words a compression builds, pairing `w[0..40]` with `w[24..64]`.
+const PACKED_SCHEDULE_WORDS: usize = 64 - SCHEDULE_LANE_GAP;
+
+/// Distance from a round index to the packed schedule word holding that round's low-lane word.
+///
+/// The rounds want `w[j]` beside `w[j + 32]`, while the schedule pairs `w[i]` with `w[i + 24]`.
+/// So the second of the pair sits 32 - 24 = 8 packed words further along.
+const ROUND_WORD_LAG: usize = HIGH_LANE_ROUNDS - SCHEDULE_LANE_GAP;
+
 /// SHA-256 compression function.
 ///
-/// Runs the message schedule and 64 rounds over `state_in` for a single 512-bit block, then adds
-/// the round output back into `state_in`, returning the updated state.
+/// Runs the message schedule and 64 rounds over `state_in` for one 512-bit block.
+/// The round output is then added back into `state_in`, giving the updated state.
+///
+/// A gate costs one constraint whatever its operand width.
+/// So one compression is evaluated as the two 32-bit lanes of a single 64-bit core.
+///
+/// Each phase is cut in half, and the halves run side by side instead of one after the other:
+///
+/// ```text
+///     schedule, high lane [32:64]:  w[24] .. w[39]  ->  w[40] .. w[63]
+///     schedule, low  lane [0:32] :  w[0]  .. w[15]  ->  w[16] .. w[39]
+///
+///     rounds,   high lane [32:64]:  round 0  -> ... -> round 31
+///     rounds,   low  lane [0:32] :  round 32 -> ... -> round 63
+/// ```
+///
+/// Each half now needs what the other half produces, which no ordering of gates can supply.
+///
+/// - The schedule's high lane opens at `w[24]`, which the low lane only reaches at the end.
+/// - The rounds' low lane opens at the state after round 31, which the high lane ends on.
+///
+/// A hint breaks both dependencies at once by computing those two seeds off-circuit.
+///
+/// Every hinted word is then constrained against what the circuit itself computed.
+/// So the hint can be wrong, but a wrong one has no satisfying witness.
+///
+/// 24 packed passes and 32 packed rounds replace 48 and 64 single-lane ones.
+/// That halves the AND constraints a compression spends.
 ///
 /// # Arguments
 ///
-/// - `state_in`: the 8-word input state (each word in the low 32 bits of a wire).
-/// - `m`: 16 message words for this block, each a 32-bit big-endian word in the low 32 bits of a
-///   wire.
+/// - `state_in`: the 8-word input state, value in the low 32 bits of each wire.
+/// - `m`: 16 big-endian message words for this block, value in the low 32 bits of each wire.
 ///
-/// It is a PRECONDITION that the high halves of the `m` wires be empty, i.e. `m[i] & 0xffffffff ==
-/// m[i]` must hold for each wire. It is the caller's responsibility to ensure this; otherwise the
-/// gadget's behavior is undefined / insecure.
+/// # Preconditions
+///
+/// - Every input wire holds a valid 32-bit value in its low 32 bits.
+/// - High halves need not be empty.
+///   - A message word's high half is masked off.
+///   - A state word's is discarded by the shift that lifts it into the high lane.
 ///
 /// # Returns
 ///
-/// The updated 8-word state.
+/// The updated 8-word state, value in the low 32 bits of each wire and the high 32 bits zero.
 pub fn sha256_compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> State {
-	// Round constants live in the low 32 bits; the high 32 bits stay zero, matching the
-	// single-lane convention that every wire's high half is empty.
-	let k: [Wire; 64] = std::array::from_fn(|t| builder.add_constant(Word(K[t] as u64)));
-	compress_inner(builder, state_in, m, &k)
+	// One hint seeds both splits.
+	//
+	//     seeds  0..16 :  the schedule's two opening lanes
+	//     seeds 16..24 :  the rounds' two opening states
+	//
+	// Every one is re-derived and constrained below, so the hint is untrusted.
+	let mut hint_inputs = Vec::with_capacity(24);
+	hint_inputs.extend_from_slice(&state_in.0);
+	hint_inputs.extend_from_slice(&m);
+	let seeds = builder.call_hint(Sha256SplitHint, &[], &hint_inputs);
+
+	// Packed word `t` carries w_t in the low lane and w_{t+24} in the high lane.
+	//
+	//     the recurrence reads:  t-16, t-15, t-7, t-2
+	//     shift all four by 24:  the result shifts by 24 too
+	//
+	// So one pass advances both lanes at once.
+	let mut w: Vec<Wire> = seeds[..16].to_vec();
+	for t in 16..PACKED_SCHEDULE_WORDS {
+		let s0 = small_sigma_0(builder, w[t - 15]);
+		let s1 = small_sigma_1(builder, w[t - 2]);
+		let p = builder.iadd_32(w[t - 16], s0);
+		let q = builder.iadd_32(p, w[t - 7]);
+		w.push(builder.iadd_32(q, s1));
+	}
+
+	// Bind the 16 hinted schedule seeds, one 64-bit equality each.
+	// A single equality pins both lanes, since the two halves never overlap.
+	//
+	//     hinted word:  [ high lane = w[i + 24] | low lane = w[i] ]
+	//                          must equal              must equal
+	//                     w[i + 24] << 32       ^      m[i] masked
+	//
+	// The low lane is pinned to the caller's own message word.
+	//
+	// The high lane is pinned to the word the low lane provably derived from it.
+	// Low lanes depend on the message alone, so that derivation is not circular.
+	for (i, seed) in seeds[..16].iter().enumerate() {
+		let low = clear_high_bits(builder, m[i], 32);
+		let high = builder.shl(w[i + SCHEDULE_LANE_GAP], 32);
+		builder.assert_eq("sha256_compress.schedule_seed", *seed, builder.bxor(low, high));
+	}
+
+	// One constant per packed round: the high lane's K[j] over the low lane's K[32 + j].
+	let k: [Wire; HIGH_LANE_ROUNDS] = array::from_fn(|j| {
+		let packed = K[HIGH_LANE_ROUNDS + j] as u64 | ((K[j] as u64) << 32);
+		builder.add_constant(Word(packed))
+	});
+
+	let merged: [Wire; 8] = array::from_fn(|i| seeds[16 + i]);
+	let mut state = State(merged);
+	for j in 0..HIGH_LANE_ROUNDS {
+		// Repack the round's schedule word from the schedule's pairing into the rounds':
+		//
+		//     high lane <- w[j]      = the low  lane of packed word j
+		//     low  lane <- w[j + 32] = the high lane of packed word j + 8
+		//
+		// Each side is one shift of a committed word, so neither needs masking.
+		let w_t = builder.bxor(builder.shl(w[j], 32), builder.shr(w[j + ROUND_WORD_LAG], 32));
+		state = round(builder, k[j], w_t, state);
+	}
+
+	// The high lane has now produced the state the low lane started from.
+	// Bind the hint to it, one 64-bit equality per state word.
+	//
+	//     hinted word:  [ high lane = input state | low lane = state after round 31 ]
+	//                            must equal                    must equal
+	//                     input state << 32          ^        high lane >> 32
+	//
+	// The high lane is pinned to the caller's own state.
+	//
+	// The low lane is pinned to the state the high lane provably reached from it.
+	// Together those leave the hint no freedom.
+	for (hinted, (input, split)) in iter::zip(merged, iter::zip(state_in.0, state.0)) {
+		let expected = builder.bxor(builder.shl(input, 32), builder.shr(split, 32));
+		builder.assert_eq("sha256_compress.round_state", hinted, expected);
+	}
+
+	// Feed-forward, then drop the high lane.
+	//
+	// It carries the round-31 state the split already consumed.
+	// A caller reads one compression's output, in the low 32 bits.
+	State(array::from_fn(|i| {
+		let sum = builder.iadd_32(state_in.0[i], state.0[i]);
+		clear_high_bits(builder, sum, 32)
+	}))
+}
+
+/// Seeds both of [`sha256_compress`]'s lane splits in one call.
+///
+/// Runs the message schedule and the first half of the rounds off-circuit.
+/// Each result is packed so it can be fed straight in as a two-lane opening value.
+///
+/// Every output is re-derived in-circuit and constrained, so the hint only needs to be honest.
+///
+/// Input layout, 24 words with the value in the low 32 bits of each:
+///
+/// - words `0..8`: the input state.
+/// - words `8..24`: the message block.
+///
+/// Output layout, 24 packed words:
+///
+/// - words `0..16`: `w[i]` low, `w[i + 24]` high.
+/// - words `16..24`: the state after round 31 low, the input state high.
+struct Sha256SplitHint;
+
+impl Hint for Sha256SplitHint {
+	const NAME: &'static str = "binius.sha256_compress_split";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(24, 24)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		// The gadget masks every input down to 32 bits, so the hint reads the same low halves.
+		let state_in: [u32; 8] = array::from_fn(|i| inputs[i].as_u64() as u32);
+		let m: [u32; 16] = array::from_fn(|i| inputs[8 + i].as_u64() as u32);
+
+		// Schedule seed `i` pairs the word the caller supplied with the one 24 places later.
+		let w = ref_schedule(m);
+		for (i, slot) in outputs[..16].iter_mut().enumerate() {
+			*slot = Word(w[i] as u64 | ((w[i + SCHEDULE_LANE_GAP] as u64) << 32));
+		}
+
+		// Round seed `i` pairs the two lanes' starting states: round 32's below, round 0's above.
+		let split = ref_rounds(state_in, &w, HIGH_LANE_ROUNDS);
+		for (i, slot) in outputs[16..].iter_mut().enumerate() {
+			*slot = Word(split[i] as u64 | ((state_in[i] as u64) << 32));
+		}
+	}
 }
 
 /// SHA-256 compression function running two independent compressions in parallel.
@@ -307,6 +485,13 @@ impl Hint for Sha256CompressHint {
 ///
 /// The updated 8-word state.
 pub fn ref_compress(state_in: [u32; 8], m: [u32; 16]) -> [u32; 8] {
+	let w = ref_schedule(m);
+	let out = ref_rounds(state_in, &w, 64);
+	array::from_fn(|i| state_in[i].wrapping_add(out[i]))
+}
+
+/// Expands a block's 16 message words into the full 64-word SHA-256 message schedule.
+fn ref_schedule(m: [u32; 16]) -> [u32; 64] {
 	let mut w = [0u32; 64];
 	w[..16].copy_from_slice(&m);
 	for t in 16..64 {
@@ -317,9 +502,17 @@ pub fn ref_compress(state_in: [u32; 8], m: [u32; 16]) -> [u32; 8] {
 			.wrapping_add(w[t - 7])
 			.wrapping_add(s1);
 	}
+	w
+}
 
+/// Runs the first `rounds` SHA-256 rounds over `state_in`, without the feed-forward add.
+///
+/// # Returns
+///
+/// The working variables a–h once round `rounds - 1` has run.
+fn ref_rounds(state_in: [u32; 8], w: &[u32; 64], rounds: usize) -> [u32; 8] {
 	let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = state_in;
-	for t in 0..64 {
+	for t in 0..rounds {
 		let big_s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
 		let ch = (e & f) ^ ((!e) & g);
 		let t1 = h
@@ -340,24 +533,14 @@ pub fn ref_compress(state_in: [u32; 8], m: [u32; 16]) -> [u32; 8] {
 		a = t1.wrapping_add(t2);
 	}
 
-	[
-		state_in[0].wrapping_add(a),
-		state_in[1].wrapping_add(b),
-		state_in[2].wrapping_add(c),
-		state_in[3].wrapping_add(d),
-		state_in[4].wrapping_add(e),
-		state_in[5].wrapping_add(f),
-		state_in[6].wrapping_add(g),
-		state_in[7].wrapping_add(h),
-	]
+	[a, b, c, d, e, f, g, h]
 }
 
-/// Shared core of [`sha256_compress`] and [`sha256_compress_2x`]: runs the message schedule and 64
-/// rounds over `state_in`, then adds the round output back into `state_in`.
+/// Core of [`sha256_compress_2x`]: runs the message schedule and 64 rounds over `state_in`, then
+/// adds the round output back into `state_in`.
 ///
-/// `k` supplies the 64 round constants as wires, letting the caller decide whether they occupy the
-/// low 32 bits only (single-lane) or both halves (two-lane). Every other operation is a
-/// parallel-halves or lane-agnostic gate, so the same code serves one or two compressions.
+/// Every operation is a parallel-halves or lane-agnostic gate, and `k` replicates each round
+/// constant into both halves, so one pass advances two independent compressions.
 fn compress_inner(
 	builder: &CircuitBuilder,
 	state_in: State,
@@ -623,6 +806,90 @@ mod tests {
 		cs.verify(&w.into_value_vec()).unwrap();
 	}
 
+	/// Runs a single compression over one block and returns its raw 64-bit output words.
+	///
+	/// `dirt` is OR'd into the high 32 bits of every input wire.
+	/// Nothing range-constrains a wire holding a 32-bit value, so a witness may fill its high half.
+	fn run_compress_with_dirt(state_in: [u32; 8], m: [u32; 16], dirt: u32) -> [u64; 8] {
+		let dirt = (dirt as u64) << 32;
+
+		let circuit = CircuitBuilder::new();
+
+		// Witness wires, so the dirt written below is what a prover could really supply.
+		let state_wires: [Wire; 8] = std::array::from_fn(|_| circuit.add_witness());
+		let m_wires: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
+		let out = sha256_compress(&circuit, State::new(state_wires), m_wires);
+
+		// Pin the output, or dead-code elimination prunes the compression away.
+		for wire in out.0 {
+			circuit.mark_inout(wire);
+		}
+
+		let circuit = circuit.build();
+		let cs = circuit.constraint_system();
+		let mut w = circuit.new_witness_filler();
+		for i in 0..8 {
+			w[state_wires[i]] = Word(state_in[i] as u64 | dirt);
+		}
+		for i in 0..16 {
+			w[m_wires[i]] = Word(m[i] as u64 | dirt);
+		}
+
+		// Population runs the hint and fills every wire from it.
+		circuit.populate_wire_witness(&mut w).unwrap();
+		let words: [u64; 8] = std::array::from_fn(|i| w[out.0[i]].as_u64());
+
+		// Checking afterwards is what proves the hint was bound, not merely used.
+		cs.verify(&w.into_value_vec()).unwrap();
+		words
+	}
+
+	/// A state that shares no structure with the IV, so a lane mix-up cannot pass unnoticed.
+	const NONTRIVIAL_STATE: [u32; 8] = [
+		0xdead_beef,
+		0xcafe_babe,
+		0x1234_5678,
+		0x9abc_def0,
+		0x0bad_f00d,
+		0xfeed_face,
+		0x0123_4567,
+		0x89ab_cdef,
+	];
+
+	#[test]
+	fn compress_ignores_dirty_input_high_halves() {
+		// Invariant: the result is the compression of the low halves alone.
+		//
+		// Both phases run in both halves of every word.
+		// So the half a 32-bit input leaves unused is where half of the mixing happens.
+		//
+		//     dirty high half  ->  must not steer the result
+		//     output           ->  must come back with an empty high half
+		let m: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0xdead_beef));
+		let expected = ref_compress(NONTRIVIAL_STATE, m);
+
+		for dirt in [0, 1, 0x8000_0000, 0xffff_ffff] {
+			let actual = run_compress_with_dirt(NONTRIVIAL_STATE, m, dirt);
+			assert_eq!(actual, expected.map(u64::from), "dirt {dirt:#x} changed the result");
+		}
+	}
+
+	proptest! {
+		// The two lanes carry different halves of one compression, joined by a hint.
+		// Random states and blocks cover the carry and rotate patterns the split must survive.
+		#[test]
+		fn compress_matches_reference(
+			state_words in prop::collection::vec(any::<u32>(), 8),
+			block_words in prop::collection::vec(any::<u32>(), 16),
+		) {
+			let state_in: [u32; 8] = std::array::from_fn(|i| state_words[i]);
+			let m: [u32; 16] = std::array::from_fn(|i| block_words[i]);
+
+			let actual = run_compress_with_dirt(state_in, m, 0);
+			prop_assert_eq!(actual, ref_compress(state_in, m).map(u64::from));
+		}
+	}
+
 	fn pack2x(lo: u32, hi: u32) -> u64 {
 		(lo as u64) | ((hi as u64) << 32)
 	}
@@ -688,16 +955,7 @@ mod tests {
 
 		// Lane 1 runs a completely different (state, message) pair to confirm the lanes are
 		// independent — no bits cross the 32-bit boundary.
-		let state1: [u32; 8] = [
-			0xdead_beef,
-			0xcafe_babe,
-			0x1234_5678,
-			0x9abc_def0,
-			0x0bad_f00d,
-			0xfeed_face,
-			0x0123_4567,
-			0x89ab_cdef,
-		];
+		let state1 = NONTRIVIAL_STATE;
 		let m1: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0x0101_0101));
 
 		run_2x(IV, abc_block(), state1, m1);
@@ -832,16 +1090,7 @@ mod tests {
 		//     once against the first compression's in-circuit output.
 		//
 		// Fixture: a non-IV starting state and two unrelated blocks exercise the full lane packing.
-		let state_in: [u32; 8] = [
-			0xdead_beef,
-			0xcafe_babe,
-			0x1234_5678,
-			0x9abc_def0,
-			0x0bad_f00d,
-			0xfeed_face,
-			0x0123_4567,
-			0x89ab_cdef,
-		];
+		let state_in = NONTRIVIAL_STATE;
 		let block1: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0xdead_beef));
 		let block2: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0x0101_0101));
 		run_2x_seq(state_in, block1, block2);

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -1,30 +1,30 @@
 bitcoin_headers circuit
 --
 Gates & Instructions
-├─ Number of gates: 47,118
-└─ Number of evaluation instructions: 47,238
+├─ Number of gates: 38,658
+└─ Number of evaluation instructions: 38,778
 
 Constraints
-├─ ZERO constraints: 3,912 used (95.5% of 2^12)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 184
-├─ AND constraints: 15,104 used (92.2% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,280
+├─ ZERO constraints: 3,432 used (83.8% of 2^12)
+│  [▓▓▓▓▓▓▓▓░░] spare: 664
+├─ AND constraints: 11,810 used (72.1% of 2^14)
+│  [▓▓▓▓▓▓▓░░░] spare: 4,574
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 110 used (85.9% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 18
-└─ Distinct value indices: 46,699
-   ├─ Distinct shifted value indices: 27,370
-   └─ Distinct unshifted value indices: 19,329
+└─ Distinct value indices: 37,981
+   ├─ Distinct shifted value indices: 22,464
+   └─ Distinct unshifted value indices: 15,517
 
 Value Vector
-├─ Public Section: 156 (not committed)
-│  ├─ Constants: 156
+├─ Public Section: 115 (not committed)
+│  ├─ Constants: 115
 │  └─ Inout: 0
-├─ Private Section: 19,180
+├─ Private Section: 15,406
 │  ├─ Witness: 104
-│  └─ Internal: 19,076
-├─ Committed Trace: 19,180 used (58.5% of 2^15)
-│  [▓▓▓▓▓░░░░░] spare: 13,588
-└─ Scratch (uncommitted): 65 (peak live: 65)
+│  └─ Internal: 15,302
+├─ Committed Trace: 15,406 used (94.0% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 978
+└─ Scratch (uncommitted): 38 (peak live: 38)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,30 +1,30 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 150,965
-└─ Number of evaluation instructions: 176,783
+├─ Number of gates: 150,119
+└─ Number of evaluation instructions: 175,937
 
 Constraints
-├─ ZERO constraints: 16,137 used (98.5% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 247
-├─ AND constraints: 84,229 used (64.3% of 2^17)
-│  [▓▓▓▓▓▓░░░░] spare: 46,843
+├─ ZERO constraints: 16,090 used (98.2% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 294
+├─ AND constraints: 83,896 used (64.0% of 2^17)
+│  [▓▓▓▓▓▓░░░░] spare: 47,176
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 3,718
-└─ Distinct value indices: 275,334
-   ├─ Distinct shifted value indices: 139,908
-   └─ Distinct unshifted value indices: 135,426
+└─ Distinct value indices: 274,449
+   ├─ Distinct shifted value indices: 139,441
+   └─ Distinct unshifted value indices: 135,008
 
 Value Vector
-├─ Public Section: 134 (not committed)
-│  ├─ Constants: 134
+├─ Public Section: 93 (not committed)
+│  ├─ Constants: 93
 │  └─ Inout: 0
-├─ Private Section: 135,303
+├─ Private Section: 134,923
 │  ├─ Witness: 9
-│  └─ Internal: 135,294
-├─ Committed Trace: 135,303 used (51.6% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,841
+│  └─ Internal: 134,914
+├─ Committed Trace: 134,923 used (51.5% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 127,221
 └─ Scratch (uncommitted): 109 (peak live: 109)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,30 +1,30 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 391,028
-└─ Number of evaluation instructions: 459,115
+├─ Number of gates: 388,463
+└─ Number of evaluation instructions: 456,550
 
 Constraints
-├─ ZERO constraints: 33,654 used (51.4% of 2^16)
-│  [▓▓▓▓▓░░░░░] spare: 31,882
-├─ AND constraints: 187,912 used (71.7% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 74,232
+├─ ZERO constraints: 33,489 used (51.1% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 32,047
+├─ AND constraints: 186,832 used (71.3% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 75,312
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 31,716 used (96.8% of 2^15)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,052
-└─ Distinct value indices: 537,603
-   ├─ Distinct shifted value indices: 281,702
-   └─ Distinct unshifted value indices: 255,901
+└─ Distinct value indices: 534,925
+   ├─ Distinct shifted value indices: 280,301
+   └─ Distinct unshifted value indices: 254,624
 
 Value Vector
-├─ Public Section: 1,031 (not committed)
-│  ├─ Constants: 729
+├─ Public Section: 999 (not committed)
+│  ├─ Constants: 697
 │  └─ Inout: 302
-├─ Private Section: 254,880
+├─ Private Section: 253,635
 │  ├─ Witness: 1,381
-│  └─ Internal: 253,499
-├─ Committed Trace: 254,880 used (97.2% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7,264
+│  └─ Internal: 252,254
+├─ Committed Trace: 253,635 used (96.8% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 8,509
 └─ Scratch (uncommitted): 1,547 (peak live: 1,547)
 

--- a/crates/recursion/src/challenger.rs
+++ b/crates/recursion/src/challenger.rs
@@ -76,9 +76,9 @@
 //!
 //! | item | AND constraints |
 //! |---|---|
-//! | one compression core, covering two chained blocks | 720 |
-//! | one observed 64-byte block, amortized | 400 |
-//! | one observed word, for the byte reversal | 5 |
+//! | one compression core, covering two chained blocks | 728 |
+//! | one observed 64-byte block, amortized | 396 |
+//! | one observed word, for the byte reversal | 4 |
 //! | one 128-bit challenge, refills excluded | 12 |
 //! | one bit sample, refills excluded | 4 |
 //! | a refill's digest masking, on top of its epoch's compressions | 8 |
@@ -87,10 +87,12 @@
 //!
 //! Consecutive blocks of an epoch chain, so they compress in pairs.
 //! One two-lane core runs both, one per 32-bit lane of a 64-bit datapath.
-//! A one-lane compression costs about 690, so pairing nearly halves the dominant term.
+//!
+//! A lone compression already splits itself across those two lanes, at 368 constraints.
+//! So pairing saves only that split's own overhead, 8 constraints per pair.
 //!
 //! An epoch that observes nothing is a single block.
-//! So 32 bytes of sampler output cost about 700 constraints, however they are cut into values.
+//! So 32 bytes of sampler output cost about 380 constraints, however they are cut into values.
 
 use std::{array, mem};
 
@@ -721,6 +723,9 @@ mod tests {
 		assert_eq!(gadget.n_cores, 1);
 	}
 
+	/// AND constraints one observed 64-byte block adds, hashing and byte reversal together.
+	const OBSERVED_BLOCK_AND: usize = 396;
+
 	/// Builds a circuit that observes some words then samples one challenge, and reports its cost.
 	///
 	/// Varying only the word count isolates the marginal cost of observed data.
@@ -743,23 +748,23 @@ mod tests {
 	}
 
 	#[test]
-	fn consecutive_blocks_share_a_compression_core() {
-		// Invariant: two consecutive blocks of one epoch share a single two-lane core, so their
-		// combined cost stays well under two separate one-lane compressions.
+	fn an_observed_block_costs_about_one_core() {
+		// Invariant: 64 more observed bytes add one compression's worth of constraints, not two.
 		//
 		//     8 words  =  64 bytes  =  1 block
-		//     24 words = 192 bytes  =  3 blocks
-		//     difference            =  2 blocks, which must pair
-		let marginal = cost(24).n_and_constraints - cost(8).n_and_constraints;
+		//     32 words = 256 bytes  =  4 blocks
+		//     difference            =  3 blocks
+		let marginal = (cost(32).n_and_constraints - cost(8).n_and_constraints) / 3;
+		assert_eq!(marginal, OBSERVED_BLOCK_AND, "AND per observed block");
 
-		// A one-block epoch: a single-lane core plus the fixed sampling overhead.
+		// A one-block epoch: one core plus the fixed sampling overhead.
 		let single = cost(0).n_and_constraints;
 
-		// Comparing against 1.5 cores distinguishes paired from unpaired without hardcoding a
-		// constraint count that the compiler is free to improve.
+		// A core already fills both 32-bit lanes with the two halves of its own compression.
+		// So pairing consecutive blocks saves that split's overhead, not half the work.
 		assert!(
-			marginal < single + single / 2,
-			"two observed blocks cost {marginal} AND constraints against {single} for one core"
+			marginal < single + single / 8,
+			"one observed block costs {marginal} AND constraints against {single} for one core"
 		);
 	}
 

--- a/crates/recursion/src/merkle.rs
+++ b/crates/recursion/src/merkle.rs
@@ -40,10 +40,13 @@
 //! Counts below are AND and BMUL constraints as the frontend compiles them.
 //! Every one is pinned by this module's tests.
 //!
-//! One single-lane block compression is 726 AND constraints.
-//! A gate costs one constraint whatever its width, so two compressions can share one core.
-//! Running them as the two 32-bit lanes of that core brings each to about 380.
-//! Every place that hashes independent values takes this route:
+//! One block compression is 368 AND constraints.
+//!
+//! A gate costs one constraint whatever its width.
+//! A compression already spends both 32-bit lanes of every gate, on its own two halves.
+//! So a second compression sharing that core saves only what the split costs, a few percent.
+//!
+//! Every place that hashes independent values still takes this route:
 //!
 //! - folding a layer of digests up to the root above it
 //! - hashing the leaves of a whole committed vector
@@ -55,13 +58,13 @@
 //!
 //! | what is measured                        | AND           | BMUL          |
 //! | --------------------------------------- | ------------- | ------------- |
-//! | a one-element leaf digest               | 697           | 0             |
-//! | a sixteen-element leaf digest           | 2279          | 0             |
+//! | a one-element leaf digest               | 376           | 0             |
+//! | a sixteen-element leaf digest           | 2263          | 0             |
 //! | two one-element leaves sharing a core   | 707 per pair  | 0             |
-//! | one inner node on its own core          | 742           | 0             |
+//! | one inner node on its own core          | 384           | 0             |
 //! | one inner node sharing a core           | 380 per node  | 0             |
 //! | one node of a verified layer's fold     | 380 per node  | 0             |
-//! | one climbed level of a lone opening     | 738           | 8             |
+//! | one climbed level of a lone opening     | 384           | 8             |
 //! | one climbed level of a paired opening   | 377 per query | 8 per query   |
 //! | picking the layer entry of an opening   | 0             | 4 * (2^L - 1) |
 //!
@@ -104,7 +107,7 @@
 //!
 //! - On AND alone the cheapest choice is `L = 7`.
 //! - Charging BMUL at the same rate moves it to `L = 6`.
-//! - Both sit a level below where lone climbs would put them, since a level now costs half.
+//! - Lone climbs land in the same place, since a level costs them barely 2% more.
 //! - Neither is a constant, since both track `log2(n_q)`.
 //! - A different query count means re-running the arithmetic above.
 //! - Which column is scarce depends on what the rest of the circuit put in each one.
@@ -464,8 +467,10 @@ pub fn compress_node(builder: &CircuitBuilder, left: Digest, right: Digest) -> D
 
 /// Two inner Merkle nodes at once, as the two 32-bit lanes of a single compression.
 ///
-/// Nodes at the same level are independent, and a gate costs one constraint whatever its width.
-/// So a pair of nodes costs about what one node costs.
+/// Nodes at the same level are independent, so one core can carry both.
+///
+/// A lone node already fills both lanes with its own split halves.
+/// So the pair saves only that split's overhead, about one percent.
 fn compress_node_2x(builder: &CircuitBuilder, nodes: [(Digest, Digest); 2]) -> [Digest; 2] {
 	// One message block per node, each still a single-lane value in its low 32 bits.
 	let block_0 = node_block(builder, nodes[0].0, nodes[0].1);

--- a/crates/recursion/src/merkle/tests.rs
+++ b/crates/recursion/src/merkle/tests.rs
@@ -851,13 +851,13 @@ proptest! {
 ///
 /// The module docs derive the layer-depth trade-off from this number, so a change here means the
 /// trade-off needs re-deriving.
-const LEVEL_AND: usize = 738;
+const LEVEL_AND: usize = 384;
 
 /// AND constraints one climbed level costs each query, when two openings share cores.
 const PAIRED_LEVEL_AND: usize = 377;
 
 /// AND constraints one inner node costs on its own core.
-const NODE_AND: usize = 742;
+const NODE_AND: usize = 384;
 
 /// AND constraints one inner node costs when it shares a core with a second node.
 const PAIRED_NODE_AND: usize = 380;
@@ -989,12 +989,12 @@ fn verify_opening_2x_follows_the_documented_cost_model() {
 }
 
 #[test]
-fn two_lane_packing_nearly_halves_a_node() {
-	// Invariant: two inner nodes sharing one compression core cost about what one node costs on
-	// its own, since a gate costs one constraint whatever its operand width.
+fn a_shared_core_barely_beats_two_lone_nodes() {
+	// Invariant: a lone node already spends both 32-bit lanes on its own split halves.
+	// So a second node sharing the core saves the split's overhead, not half the work.
 	//
-	//     one node  on its own core :  the low 32-bit lane works, the high one idles
-	//     two nodes on a shared core:  both lanes work, one node each
+	//     one node  on its own core :  both lanes work, one half of one node each
+	//     two nodes on a shared core:  both lanes work, one whole node each
 	let (single, _) = cost(|builder| {
 		// Two children in, one node digest out, pinned to a public claim.
 		let inputs = digest_wires(builder, 2);
@@ -1018,11 +1018,11 @@ fn two_lane_packing_nearly_halves_a_node() {
 }
 
 #[test]
-fn two_lane_packing_nearly_halves_a_single_block_leaf() {
-	// Invariant: two narrow leaves hashed in separate lanes cost about what one costs alone.
+fn a_shared_core_barely_beats_two_lone_leaves() {
+	// Invariant: two narrow leaves in separate lanes cost a little under two lone leaves.
 	//
 	// Fixture state: one element is 16 bytes, so a padded one-element leaf is a single block.
-	// Equal block counts let the two lanes run end to end with no leftover single-lane core.
+	// Equal block counts let the two lanes run end to end with no leftover core.
 	let leaf_cost = |n_leaves: usize| {
 		cost(|builder| {
 			// One element per leaf, so the leaf count is also the element count.
@@ -1046,8 +1046,8 @@ fn two_lane_packing_nearly_halves_a_single_block_leaf() {
 	let (paired, _) = leaf_cost(2);
 	println!("leaf_digest: AND={single}, leaf_digest_2x: AND={paired}");
 
-	// The one-eighth margin covers merging the two lanes and splitting them apart again.
-	assert!(paired < single + single / 8, "two paired leaves must cost about one lone leaf");
+	// A pair must beat two lone leaves, and by more than rounding.
+	assert!(paired < 2 * single - single / 16, "a paired leaf must beat a lone one");
 }
 
 #[test]


### PR DESCRIPTION
Closes [BINIUS-504](https://linear.app/jimpo/issue/BINIUS-504).

Makes a single SHA-256 compression fill both 32-bit lanes of the 64-bit datapath, the way `blake3_compress` already does. **728 -> 368 AND constraints per compression.** Same digest, same public interface.

### The problem

A gate costs one constraint whatever its operand width.

`sha256_compress` puts every value in the low 32 bits of its wire and leaves the high 32 idle. So it pays for a 64-bit gate and uses half of it.

Per compression, in AND constraints:

```
    message schedule :  48 passes x 3 adds        = 144
    rounds           :  64 rounds x (7 adds + 2 ands) = 576
    feed-forward     :  8 adds                    =   8
                                                    ----
                                                     728
```

`blake3_compress` solved this by cutting its round sequence in two and running the halves side by side. SHA-256 is harder because it has *two* sequential phases, and they want the schedule words paired differently.

### The idea

Cut both phases in half and put one half in each lane.

**Message schedule.** Packed word `t` carries `w[t]` low and `w[t+24]` high:

```
    low  lane derives w[16..40]
    high lane derives w[40..64]
```

That works because the recurrence reads `t-16, t-15, t-7, t-2` — shift all four indices by 24 and the result shifts by 24 too. One pass advances both lanes. 24 passes replace 48.

24 is the only gap that wastes nothing: the 48 derived words split exactly in two.

**Rounds.** The high lane runs rounds 0..32, the low lane runs 32..64. 32 packed rounds replace 64.

**The repack.** The two phases disagree on pairing — the schedule pairs index `i` with `i + 24`, the rounds want `j` beside `j + 32`. It lines up for free anyway, because packed word `i` holds `w[i]` low *and* `w[i+24]` high:

```
    R[j] = (W[j] << 32) ^ (W[j + 8] >> 32)

    high lane <- low  half of W[j]      = w[j]
    low  lane <- high half of W[j + 8]  = w[j + 32]
```

One XOR of two shifted operands, for every `j`. No masking, no AND constraints.

### The circular dependency

Each half now needs what the other half produces:

- the schedule's high lane opens at `w[24]`, which the low lane only reaches at the end.
- the rounds' low lane opens at the state after round 31, which the high lane ends on.

No ordering of gates supplies that. One hint computes both seeds off-circuit, and both are then constrained against what the circuit itself computed.

### Soundness

The hint is 24 prover-chosen words. Every one is pinned, in this order:

1. Each schedule seed's **low** half is asserted equal to the caller's message word.
2. Low lanes depend on the message alone, so `w[24..40]` in the low lane is forced — no circularity. Each seed's **high** half is asserted equal to it.
3. With the whole packed schedule pinned, the round seeds' **high** halves are asserted equal to the caller's input state.
4. The high lane's 32-round output is then forced, and each round seed's **low** half is asserted equal to it.

Every assertion is one XOR of shifted committed words, so the binding itself costs no AND constraints. The system has exactly one satisfying assignment: the honest compression.

### The change

```
crates/circuits/src/sha256/compress.rs
- sha256_compress            : 64 single-lane rounds over a 64-word schedule
+ sha256_compress            : 32 packed rounds over a 40-word packed schedule, seeded by one hint
+ Sha256SplitHint            : 24 in, 24 out — both lane seeds in one call
+ ref_schedule / ref_rounds  : ref_compress split so the hint can reuse its halves
```

`sha256_compress_2x` and `sha256_compress_2x_seq` are untouched.

### The precondition also relaxes

Before, a dirty high half on a message wire was undefined behaviour. Now it cannot matter:

- a message word's high half is masked off,
- a state word's is discarded by the shift that lifts it into the high lane,
- the output's high half is cleared, so the documented contract is unchanged for callers.

A new test drives the gadget with `0xffffffff` and friends in every unused half and pins the result.

### One consequence worth reading

A lone compression now costs 368 AND. `sha256_compress_2x` costs 728 for two, i.e. 364 each.

Both hit the same floor: `64 rounds x 9 AND / 2 lanes`. So the `_2x` pairing machinery — `sha256_compress_2x_seq`, `compress_node_2x`, `leaf_digest_2x`, `verify_opening_2x`, the challenger's block pairing — now buys **1-6% instead of ~2x**.

None of it is removed here; that is a separate call. But the cost model that claimed a halving is corrected:

| what is measured | before | after |
|---|---|---|
| one block compression | 726 | 368 |
| a one-element leaf digest | 697 | 376 |
| a sixteen-element leaf digest | 2279 | 2263 |
| one inner node on its own core | 742 | 384 |
| one climbed level of a lone opening | 738 | 384 |
| one observed challenger block, amortized | 400 | 396 |

Every *paired* figure is unchanged, so the merkle layer-depth trade-off is unchanged too.

I also checked whether the challenger's pairing had become a pessimization, by forcing it to compress singly: 400 AND per block unpaired against 396 paired. Still a win, but a thin one.

### Scope

- **changed:** `sha256_compress` and its hint; `ref_compress` split into a schedule and a rounds helper.
- **untouched:** every `_2x` gadget, the chip interface, the public signature of `sha256_compress`.
- **updated:** the recursion cost tables in `merkle.rs` and `challenger.rs`, and the four tests that pinned the old ratio (renamed, since they no longer describe a halving).
- **blessed:** three example snapshots, all of them circuits that reach a lone compression.

| snapshot | AND before | AND after |
|---|---|---|
| `bitcoin_headers.snap` | 15,104 | 11,810 |
| `zklogin.snap` | 187,912 | 186,832 |
| `bitcoin_p2pkh.snap` | 84,229 | 83,896 |

The header chain gains most: it is a chain of double-SHA-256 hashes, and its committed trace drops a whole power of two, from $2^{15}$ to $2^{14}$.

`sha256.snap` is unchanged — that circuit already ran everything through the paired path.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-circuits -p binius-recursion --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `binius-circuits` 399 tests, `binius-recursion` all tests, `binius-prover` SHA-256 prove/verify — pass
- new: a proptest against the scalar reference over random states and blocks, and a dirty-high-half invariance test

### Benchmark

Per compression, from the frontend's own statistics:

| metric | before | after | change |
|---|---|---|---|
| AND constraints | 728 | 368 | **-49.5%** |
| ZERO constraints | 182 | 126 | -31% |
| gates | 2,168 | 1,313 | -39% |
| committed trace (words) | 902 | 486 | -46% |

End-to-end M4 proving of $2^{14}$ lone compressions, release + rayon, interleaved A/B on one binary:

| circuit | AND per instance | `prove` span |
|---|---|---|
| before | 728 | 326 ms |
| after | 368 | 231 ms |

Wall clock moves less than the constraint count because fixed per-proof work does not shrink with it; the gap widens with batch size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

