### PR TITLE
BINIUS-97: Rename BinaryField128bGhash to Ghash128b

### DIFF
--- a/crates/core/src/constraint_system/constraint.rs
+++ b/crates/core/src/constraint_system/constraint.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 use std::fmt;
 
-use binius_field::BinaryField128bGhash as B128;
+use binius_field::Ghash128b as B128;
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
 

--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -2,7 +2,7 @@
 
 use std::array;
 
-use binius_field::{BinaryField128bGhash, Field, aes_field::AESTowerField8b};
+use binius_field::{Field, Ghash128b, aes_field::AESTowerField8b};
 use criterion::{
 	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -40,7 +40,7 @@ fn bench_all_fields<Op: FieldOperation>(c: &mut Criterion) {
 	group.throughput(criterion::Throughput::Elements(BATCH_SIZE as _));
 
 	run_bench!(group, AESTowerField8b, Op);
-	run_bench!(group, BinaryField128bGhash, Op);
+	run_bench!(group, Ghash128b, Op);
 }
 
 struct MultiplyOp;

--- a/crates/field/benches/ghash_invert.rs
+++ b/crates/field/benches/ghash_invert.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 //! Benchmark GHASH field inversion (Itoh-Tsujii, which now backs `InvertOrZero`) across packing
-//! widths: the scalar `BinaryField128bGhash` and the 1x/2x/4x packed fields.
+//! widths: the scalar `Ghash128b` and the 1x/2x/4x packed fields.
 //!
 //! Throughput is reported in scalar elements (batch size times packing width), so the numbers are
 //! directly comparable across widths.
@@ -9,7 +9,7 @@
 use std::hint::black_box;
 
 use binius_field::{
-	BinaryField128bGhash as GhashB128, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
+	Ghash128b as GhashB128, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
 	PackedBinaryGhash4x128b, PackedField,
 };
 use criterion::{

--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -18,7 +18,7 @@ use bytemuck::TransparentWrapper;
 
 use super::super::m128::M128;
 use crate::{
-	BinaryField128bGhash as GhashB128, WideMul,
+	Ghash128b as GhashB128, WideMul,
 	arch::PackedPrimitiveType,
 	arithmetic_traits::{MulXWide, Square},
 };

--- a/crates/field/src/arch/arch_optimal.rs
+++ b/crates/field/src/arch/arch_optimal.rs
@@ -25,5 +25,5 @@ cfg_if! {
 	}
 }
 
-pub type OptimalB128 = crate::BinaryField128bGhash;
+pub type OptimalB128 = crate::Ghash128b;
 pub type OptimalPackedB1 = PackedSubfield<OptimalPackedB128, BinaryField1b>;

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -12,7 +12,7 @@ use bytemuck::TransparentWrapper;
 
 use super::super::univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64};
 use crate::{
-	BinaryField128bGhash as GhashB128, WideMul,
+	Ghash128b as GhashB128, WideMul,
 	arch::PackedPrimitiveType,
 	arithmetic_traits::{MulXWide, Square},
 };

--- a/crates/field/src/arch/portable/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash_sq.rs
@@ -12,13 +12,13 @@
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	BinaryField128bGhash, PackedGhashSq1x256b, SlicedGhashSqWide, WideMul,
+	Ghash128b, PackedGhashSq1x256b, SlicedGhashSqWide, WideMul,
 	arithmetic_traits::MulXWide,
 	packed_ghash_sq::{ghash_sq_coords, ghash_sq_from_coords},
 };
 
 /// The unreduced product of a single GHASH coordinate multiply.
-type GhashWide = <BinaryField128bGhash as WideMul>::Output;
+type GhashWide = <Ghash128b as WideMul>::Output;
 
 /// [`WideMul`] strategy for [`PackedGhashSq1x256b`] keeping the three Karatsuba products of the
 /// coordinate multiply separate, so that the multiply-by-`X` can be deferred into a reduction.
@@ -36,9 +36,9 @@ impl WideMul for GhashSqSlicedWideMul<PackedGhashSq1x256b> {
 		let [b0, b1] = ghash_sq_coords(Self::peel(b));
 
 		SlicedGhashSqWide {
-			t0: BinaryField128bGhash::wide_mul(a0, b0),
-			t2: BinaryField128bGhash::wide_mul(a1, b1),
-			t1: BinaryField128bGhash::wide_mul(a0 + a1, b0 + b1),
+			t0: Ghash128b::wide_mul(a0, b0),
+			t2: Ghash128b::wide_mul(a1, b1),
+			t1: Ghash128b::wide_mul(a0 + a1, b0 + b1),
 		}
 	}
 
@@ -49,8 +49,8 @@ impl WideMul for GhashSqSlicedWideMul<PackedGhashSq1x256b> {
 	/// accumulated wide product, so the two coordinates cost two reductions in total.
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
-		let z0 = BinaryField128bGhash::reduce(wide.t0 + wide.t2.mul_x_wide());
-		let z1 = z0 + BinaryField128bGhash::reduce(wide.t1 + wide.t2);
+		let z0 = Ghash128b::reduce(wide.t0 + wide.t2.mul_x_wide());
+		let z1 = z0 + Ghash128b::reduce(wide.t1 + wide.t2);
 
 		Self::wrap(ghash_sq_from_coords([z0, z1]))
 	}

--- a/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
+++ b/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
@@ -25,7 +25,7 @@ use crate::{
 	BinaryField1b, Divisible, ExtensionField,
 	arch::M128,
 	arithmetic_traits::{InvertOrZero, Square},
-	ghash::BinaryField128bGhash as GhashB128,
+	ghash::Ghash128b as GhashB128,
 	linear_transformation::{
 		BytewiseLookupTransformation, BytewiseLookupTransformationFactory,
 		InputWrappingTransformationFactory, LinearTransformationFactory,
@@ -107,7 +107,7 @@ fn compute_power_map_matrix(n: usize) -> [GhashB128; FIELD_BITS] {
 /// `InvertOrZero` in its where-clause, so requiring it here would form a trait-resolution cycle
 /// when this function backs the `InvertOrZero` impls. `Divisible<GhashB128>` carries no such
 /// obligation, keeps the function statically GHASH-typed, and is satisfied both by the GHASH packed
-/// fields and (reflexively) by the scalar `BinaryField128bGhash`, so the scalar inverts directly
+/// fields and (reflexively) by the scalar `Ghash128b`, so the scalar inverts directly
 /// without routing through a packed type.
 pub fn invert_b128<P>(x: P) -> P
 where

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -28,7 +28,7 @@ use crate::{
 /// On x86_64/aarch64 `M128` is a SIMD register and on wasm32 (with `simd128`) a `v128`; here it is
 /// a plain `u128` newtype. Wrapping rather than aliasing `u128` keeps `M128` a distinct type on
 /// every target, so the `M128 <-> u128` conversions never collide with `u128`'s own reflexive
-/// impls and the architecture-gated `BinaryField128bGhash` conversions need no cfg gate.
+/// impls and the architecture-gated `Ghash128b` conversions need no cfg gate.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, From, Into)]
 #[repr(transparent)]
 pub struct M128(u128);

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -14,7 +14,7 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	BinaryField128bGhash as GhashB128, Divisible, WideMul,
+	Divisible, Ghash128b as GhashB128, WideMul,
 	arch::PackedPrimitiveType,
 	arithmetic_traits::{MulXWide, Square},
 	underlier::UnderlierType,

--- a/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
@@ -14,14 +14,14 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	BinaryField128bGhash, Divisible, PackedBinaryGhash2x128b, PackedGhashSq1x256b, WideMul,
+	Divisible, Ghash128b, PackedBinaryGhash2x128b, PackedGhashSq1x256b, WideMul,
 	packed_extension::PackedExtension, packed_ghash_sq::ghash_sq_from_coords,
 };
 
 /// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.
 type DiagWide = <PackedBinaryGhash2x128b as WideMul>::Output;
 /// The single unreduced GHASH cross product `(a+b)·(e+f)` from a scalar widening multiply.
-type CrossWide = <BinaryField128bGhash as WideMul>::Output;
+type CrossWide = <Ghash128b as WideMul>::Output;
 
 /// The unreduced product of two [`PackedGhashSq1x256b`] elements.
 ///
@@ -96,14 +96,14 @@ impl WideMul for GhashSqHybridWideMul<PackedGhashSq1x256b> {
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
 		// The GHASH² coordinates already sit in the two 128-bit lanes of the 256-bit value, so
 		// viewing an operand as a packed GHASH pair is a free reinterpretation.
-		let a = PackedExtension::<BinaryField128bGhash>::cast_base(Self::peel(a));
-		let b = PackedExtension::<BinaryField128bGhash>::cast_base(Self::peel(b));
+		let a = PackedExtension::<Ghash128b>::cast_base(Self::peel(a));
+		let b = PackedExtension::<Ghash128b>::cast_base(Self::peel(b));
 
 		WideGhashSqProduct {
 			// Diagonal `[a·e, b·f]` as one two-lane packed widening multiply.
 			diag: PackedBinaryGhash2x128b::wide_mul(a, b),
 			// Karatsuba cross product `(a+b)·(e+f)` as a scalar widening multiply.
-			cross: BinaryField128bGhash::wide_mul(a.get(0) + a.get(1), b.get(0) + b.get(1)),
+			cross: Ghash128b::wide_mul(a.get(0) + a.get(1), b.get(0) + b.get(1)),
 		}
 	}
 
@@ -113,7 +113,7 @@ impl WideMul for GhashSqHybridWideMul<PackedGhashSq1x256b> {
 		let diag = PackedBinaryGhash2x128b::reduce(wide.diag);
 		let t0 = diag.get(0);
 		let t2 = diag.get(1);
-		let t1 = BinaryField128bGhash::reduce(wide.cross);
+		let t1 = Ghash128b::reduce(wide.cross);
 
 		// Fold `Y² = X·Y + X`, recovering the cross term as `t_1 + t_0 + t_2`:
 		// `z_0 = t_0 + X·t_2`, `z_1 = (t_1 + t_0 + t_2) + X·t_2 = z_0 + t_1 + t_2`.

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -63,7 +63,7 @@ macro_rules! binary_field {
 
 		// NOTE: `new` is intentionally NOT generated here. Each field defines its own `new` so it
 		// can take an ergonomic constructor type independent of the underlier (e.g.
-		// `BinaryField128bGhash::new` takes `u128` even though its underlier is `M128`).
+		// `Ghash128b::new` takes `u128` even though its underlier is `M128`).
 		impl $name {
 			pub const fn val(self) -> $typ {
 				self.0
@@ -642,8 +642,8 @@ pub(crate) mod tests {
 
 	use super::BinaryField1b as BF1;
 	use crate::{
-		AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash, ExtensionField, Field,
-		GhashSq256b, arithmetic_traits::InvertOrZero,
+		AESTowerField8b, BinaryField, BinaryField1b, ExtensionField, Field, Ghash128b, GhashSq256b,
+		arithmetic_traits::InvertOrZero,
 	};
 
 	#[test]
@@ -735,7 +735,7 @@ pub(crate) mod tests {
 	fn test_multiplicative_generators() {
 		assert!(is_binary_field_valid_generator::<BinaryField1b>());
 		assert!(is_binary_field_valid_generator::<AESTowerField8b>());
-		assert!(is_binary_field_valid_generator::<BinaryField128bGhash>());
+		assert!(is_binary_field_valid_generator::<Ghash128b>());
 	}
 
 	/// The absolute trace $\operatorname{Tr}(x) = \sum_{i=0}^{n-1} x^{2^i}$, computed by repeated
@@ -761,7 +761,7 @@ pub(crate) mod tests {
 		}
 		check::<BinaryField1b>();
 		check::<AESTowerField8b>();
-		check::<BinaryField128bGhash>();
+		check::<Ghash128b>();
 		check::<GhashSq256b>();
 	}
 
@@ -780,24 +780,21 @@ pub(crate) mod tests {
 	fn test_field_degrees() {
 		assert_eq!(BinaryField1b::N_BITS, 1);
 		assert_eq!(AESTowerField8b::N_BITS, 8);
-		assert_eq!(BinaryField128bGhash::N_BITS, 128);
+		assert_eq!(Ghash128b::N_BITS, 128);
 	}
 
 	#[test]
 	fn test_field_formatting() {
 		assert_eq!(format!("{}", BinaryField1b::from(1)), "0x1");
 		assert_eq!(format!("{}", AESTowerField8b::from(3)), "0x03");
-		assert_eq!(
-			format!("{}", BinaryField128bGhash::new(5)),
-			"0x00000000000000000000000000000005"
-		);
+		assert_eq!(format!("{}", Ghash128b::new(5)), "0x00000000000000000000000000000005");
 	}
 
 	#[test]
 	fn test_inverse_on_zero() {
 		assert!(BinaryField1b::ZERO.invert_or_zero().is_zero());
 		assert!(AESTowerField8b::ZERO.invert_or_zero().is_zero());
-		assert!(BinaryField128bGhash::ZERO.invert_or_zero().is_zero());
+		assert!(Ghash128b::ZERO.invert_or_zero().is_zero());
 	}
 
 	proptest! {
@@ -811,10 +808,10 @@ pub(crate) mod tests {
 
 		#[test]
 		fn test_inverse_128b(val in 1u128..) {
-			let x = BinaryField128bGhash::from(val);
+			let x = Ghash128b::from(val);
 			// Safety: `val` is in `1..`, so `x` is non-zero.
 			let x_inverse = unsafe { x.invert() };
-			assert_eq!(x * x_inverse, BinaryField128bGhash::ONE);
+			assert_eq!(x * x_inverse, Ghash128b::ONE);
 		}
 	}
 
@@ -826,7 +823,7 @@ pub(crate) mod tests {
 
 		// `BinaryField1b` has a trivial multiplicative group, so for the three pairs with that
 		// subfield this sweeps `ONE` alone, which together with `ZERO` is already the whole field.
-		// Only `BinaryField128bGhash` in `GhashSq256b` walks non-trivial subfield values.
+		// Only `Ghash128b` in `GhashSq256b` walks non-trivial subfield values.
 		let mut elem = FSub::ONE;
 		for _ in 0..4 {
 			assert_eq!(TryInto::<FSub>::try_into(F::from(elem)).ok(), Some(elem));
@@ -843,9 +840,9 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_subfield_extraction() {
-		assert_subfield_extraction::<BinaryField1b, BinaryField128bGhash>();
+		assert_subfield_extraction::<BinaryField1b, Ghash128b>();
 		assert_subfield_extraction::<BinaryField1b, AESTowerField8b>();
-		assert_subfield_extraction::<BinaryField128bGhash, GhashSq256b>();
+		assert_subfield_extraction::<Ghash128b, GhashSq256b>();
 		assert_subfield_extraction::<BinaryField1b, GhashSq256b>();
 	}
 
@@ -854,7 +851,7 @@ pub(crate) mod tests {
 		let mut buffer = BytesMut::new();
 		let b1 = BinaryField1b::from(0x1);
 		let b8 = AESTowerField8b::new(0x12);
-		let b128 = BinaryField128bGhash::new(0x147AD0369CF258BE8899AABBCCDDEEFF);
+		let b128 = Ghash128b::new(0x147AD0369CF258BE8899AABBCCDDEEFF);
 
 		b1.serialize(&mut buffer).unwrap();
 		b8.serialize(&mut buffer).unwrap();
@@ -864,6 +861,6 @@ pub(crate) mod tests {
 
 		assert_eq!(BinaryField1b::deserialize(&mut read_buffer).unwrap(), b1);
 		assert_eq!(AESTowerField8b::deserialize(&mut read_buffer).unwrap(), b8);
-		assert_eq!(BinaryField128bGhash::deserialize(&mut read_buffer).unwrap(), b128);
+		assert_eq!(Ghash128b::deserialize(&mut read_buffer).unwrap(), b128);
 	}
 }

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -30,29 +30,29 @@ use crate::{
 
 // `1 << 121` is the lowest single-bit element of trace 1; `1 << 127` is the only other one.
 binary_field!(
-	pub BinaryField128bGhash(M128),
+	pub Ghash128b(M128),
 	M128::from_u128(0x494ef99794d5244f9152df59d87a9186),
 	M128::from_u128(1 << 121)
 );
 
 // Convenience `u128` conversions. `binary_field!` already provides `From<M128>`/`From<.. for
-// M128>`; these let callers keep constructing/inspecting `BinaryField128bGhash` via `u128`. `M128`
+// M128>`; these let callers keep constructing/inspecting `Ghash128b` via `u128`. `M128`
 // is a distinct type from `u128` on every target, so these never collide with the macro's impls.
-impl From<u128> for BinaryField128bGhash {
+impl From<u128> for Ghash128b {
 	fn from(value: u128) -> Self {
 		Self(M128::from(value))
 	}
 }
 
-impl From<BinaryField128bGhash> for u128 {
-	fn from(value: BinaryField128bGhash) -> Self {
+impl From<Ghash128b> for u128 {
+	fn from(value: Ghash128b) -> Self {
 		value.0.into()
 	}
 }
 
-unsafe impl Pod for BinaryField128bGhash {}
+unsafe impl Pod for Ghash128b {}
 
-impl BinaryField128bGhash {
+impl Ghash128b {
 	/// Constructs an element from its `u128` value. The underlier is `M128`, but `u128` is the
 	/// ergonomic constructor type, so this converts.
 	pub const fn new(value: u128) -> Self {
@@ -92,11 +92,11 @@ impl BinaryField128bGhash {
 	}
 }
 
-impl_field_extension!(BinaryField1b(U1) < @7 => BinaryField128bGhash(M128));
+impl_field_extension!(BinaryField1b(U1) < @7 => Ghash128b(M128));
 
-mul_by_binary_field_1b!(BinaryField128bGhash);
+mul_by_binary_field_1b!(Ghash128b);
 
-impl SerializeBytes for BinaryField128bGhash {
+impl SerializeBytes for Ghash128b {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
 		self.0.serialize(write_buf)
 	}
@@ -115,7 +115,7 @@ impl SerializeBytes for BinaryField128bGhash {
 	}
 }
 
-impl DeserializeBytes for BinaryField128bGhash {
+impl DeserializeBytes for Ghash128b {
 	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
@@ -124,11 +124,11 @@ impl DeserializeBytes for BinaryField128bGhash {
 	}
 }
 
-impl FixedSizeSerializeBytes for BinaryField128bGhash {
+impl FixedSizeSerializeBytes for Ghash128b {
 	const BYTE_SIZE: usize = 16;
 }
 
-impl From<AESTowerField8b> for BinaryField128bGhash {
+impl From<AESTowerField8b> for Ghash128b {
 	#[inline]
 	fn from(value: AESTowerField8b) -> Self {
 		// Raw GHASH values as `u128`, converted to the `M128` underlier at the lookup site so the
@@ -392,7 +392,7 @@ impl From<AESTowerField8b> for BinaryField128bGhash {
 			0x71af641f08dbd1a0990483806bffbe0d,
 		];
 
-		BinaryField128bGhash::new(LOOKUP_TABLE[value.0 as usize])
+		Ghash128b::new(LOOKUP_TABLE[value.0 as usize])
 	}
 }
 
@@ -408,76 +408,76 @@ mod tests {
 
 	#[test]
 	fn test_ghash_mul() {
-		let a = BinaryField128bGhash::new(1u128);
-		let b = BinaryField128bGhash::new(1u128);
+		let a = Ghash128b::new(1u128);
+		let b = Ghash128b::new(1u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::new(1u128));
+		assert_eq!(c, Ghash128b::new(1u128));
 
-		let a = BinaryField128bGhash::new(1u128);
-		let b = BinaryField128bGhash::new(2u128);
+		let a = Ghash128b::new(1u128);
+		let b = Ghash128b::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::new(2u128));
+		assert_eq!(c, Ghash128b::new(2u128));
 
-		let a = BinaryField128bGhash::new(1u128);
-		let b = BinaryField128bGhash::new(1297182698762987u128);
+		let a = Ghash128b::new(1u128);
+		let b = Ghash128b::new(1297182698762987u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::new(1297182698762987u128));
+		assert_eq!(c, Ghash128b::new(1297182698762987u128));
 
-		let a = BinaryField128bGhash::new(2u128);
-		let b = BinaryField128bGhash::new(2u128);
+		let a = Ghash128b::new(2u128);
+		let b = Ghash128b::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::new(4u128));
+		assert_eq!(c, Ghash128b::new(4u128));
 
-		let a = BinaryField128bGhash::new(2u128);
-		let b = BinaryField128bGhash::new(3u128);
+		let a = Ghash128b::new(2u128);
+		let b = Ghash128b::new(3u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::new(6u128));
+		assert_eq!(c, Ghash128b::new(6u128));
 
-		let a = BinaryField128bGhash::new(3u128);
-		let b = BinaryField128bGhash::new(3u128);
+		let a = Ghash128b::new(3u128);
+		let b = Ghash128b::new(3u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::new(5u128));
+		assert_eq!(c, Ghash128b::new(5u128));
 
-		let a = BinaryField128bGhash::from(1u128 << 127);
-		let b = BinaryField128bGhash::new(2u128);
+		let a = Ghash128b::from(1u128 << 127);
+		let b = Ghash128b::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(0b10000111));
+		assert_eq!(c, Ghash128b::from(0b10000111));
 
-		let a = BinaryField128bGhash::from((1u128 << 127) + 1);
-		let b = BinaryField128bGhash::new(2u128);
+		let a = Ghash128b::from((1u128 << 127) + 1);
+		let b = Ghash128b::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(0b10000101));
+		assert_eq!(c, Ghash128b::from(0b10000101));
 
-		let a = BinaryField128bGhash::from(3u128 << 126);
-		let b = BinaryField128bGhash::new(2u128);
+		let a = Ghash128b::from(3u128 << 126);
+		let b = Ghash128b::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(0b10000111 + (1u128 << 127)));
+		assert_eq!(c, Ghash128b::from(0b10000111 + (1u128 << 127)));
 
-		let a = BinaryField128bGhash::from(1u128 << 127);
-		let b = BinaryField128bGhash::new(4u128);
+		let a = Ghash128b::from(1u128 << 127);
+		let b = Ghash128b::new(4u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(0b10000111 << 1));
+		assert_eq!(c, Ghash128b::from(0b10000111 << 1));
 
-		let a = BinaryField128bGhash::from(1u128 << 127);
-		let b = BinaryField128bGhash::from(1u128 << 122);
+		let a = Ghash128b::from(1u128 << 127);
+		let b = Ghash128b::from(1u128 << 122);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from((0b00000111 << 121) + 0b10000111));
+		assert_eq!(c, Ghash128b::from((0b00000111 << 121) + 0b10000111));
 	}
 
 	#[test]
 	fn test_multiplicative_generator() {
-		assert!(is_binary_field_valid_generator::<BinaryField128bGhash>());
+		assert!(is_binary_field_valid_generator::<Ghash128b>());
 	}
 
 	#[test]
@@ -494,9 +494,9 @@ mod tests {
 		];
 
 		for &value in &test_cases {
-			let field_val = BinaryField128bGhash::from(value);
+			let field_val = Ghash128b::from(value);
 			let mul_x_result = field_val.mul_x();
-			let regular_mul_result = field_val * BinaryField128bGhash::new(2u128);
+			let regular_mul_result = field_val * Ghash128b::new(2u128);
 
 			assert_eq!(
 				mul_x_result, regular_mul_result,
@@ -520,11 +520,10 @@ mod tests {
 		];
 
 		for &value in &test_cases {
-			let field_val = BinaryField128bGhash::from(value);
+			let field_val = Ghash128b::from(value);
 			let mul_inv_x_result = field_val.mul_inv_x();
 			// Safety: 2 is a non-zero field element.
-			let regular_mul_result =
-				field_val * unsafe { BinaryField128bGhash::new(2u128).invert() };
+			let regular_mul_result = field_val * unsafe { Ghash128b::new(2u128).invert() };
 
 			assert_eq!(
 				mul_inv_x_result, regular_mul_result,
@@ -539,16 +538,16 @@ mod tests {
 		fn test_conversion_from_aes_consistency(a in any::<u8>(), b in any::<u8>()) {
 			let a_val = AESTowerField8b::new(a);
 			let b_val = AESTowerField8b::new(b);
-			let converted_a = BinaryField128bGhash::from(a_val);
-			let converted_b = BinaryField128bGhash::from(b_val);
-			assert_eq!(BinaryField128bGhash::from(a_val * b_val), converted_a * converted_b);
+			let converted_a = Ghash128b::from(a_val);
+			let converted_b = Ghash128b::from(b_val);
+			assert_eq!(Ghash128b::from(a_val * b_val), converted_a * converted_b);
 		}
 
 		#[test]
 		fn test_wide_mul_correctness(a in any::<u128>(), b in any::<u128>()) {
-			let a = BinaryField128bGhash::from(a);
-			let b = BinaryField128bGhash::from(b);
-			let reduced = BinaryField128bGhash::reduce(BinaryField128bGhash::wide_mul(a, b));
+			let a = Ghash128b::from(a);
+			let b = Ghash128b::from(b);
+			let reduced = Ghash128b::reduce(Ghash128b::wide_mul(a, b));
 			assert_eq!(reduced, a * b);
 		}
 
@@ -558,11 +557,11 @@ mod tests {
 			a1 in any::<u128>(), b1 in any::<u128>(),
 			a2 in any::<u128>(), b2 in any::<u128>(),
 		) {
-			let (a1, b1) = (BinaryField128bGhash::from(a1), BinaryField128bGhash::from(b1));
-			let (a2, b2) = (BinaryField128bGhash::from(a2), BinaryField128bGhash::from(b2));
+			let (a1, b1) = (Ghash128b::from(a1), Ghash128b::from(b1));
+			let (a2, b2) = (Ghash128b::from(a2), Ghash128b::from(b2));
 			let wide =
-				BinaryField128bGhash::wide_mul(a1, b1) + BinaryField128bGhash::wide_mul(a2, b2);
-			assert_eq!(BinaryField128bGhash::reduce(wide), a1 * b1 + a2 * b2);
+				Ghash128b::wide_mul(a1, b1) + Ghash128b::wide_mul(a2, b2);
+			assert_eq!(Ghash128b::reduce(wide), a1 * b1 + a2 * b2);
 		}
 
 		/// Pins the bulk `serialize_slice` override to the per-element loop it replaces.
@@ -572,8 +571,8 @@ mod tests {
 		/// A byte-order or off-by-one slip in the bulk path shows up here, not in a live proof.
 		#[test]
 		fn test_ghash_serialize_slice_matches_loop(values in vec(any::<u128>(), 0..300)) {
-			let values: Vec<BinaryField128bGhash> =
-				values.into_iter().map(BinaryField128bGhash::from).collect();
+			let values: Vec<Ghash128b> =
+				values.into_iter().map(Ghash128b::from).collect();
 
 			let mut expected = Vec::new();
 			for value in &values {
@@ -581,7 +580,7 @@ mod tests {
 			}
 
 			let mut actual = Vec::new();
-			BinaryField128bGhash::serialize_slice(&values, &mut actual).unwrap();
+			Ghash128b::serialize_slice(&values, &mut actual).unwrap();
 
 			assert_eq!(actual, expected);
 
@@ -589,8 +588,8 @@ mod tests {
 			// Read back exactly `values.len()` elements from a cursor over the same buffer.
 			// That matches how a transcript reader consumes `write_scalar_slice`'s output.
 			let mut cursor = actual.as_slice();
-			let deserialized: Vec<BinaryField128bGhash> = (0..values.len())
-				.map(|_| BinaryField128bGhash::deserialize(&mut cursor).unwrap())
+			let deserialized: Vec<Ghash128b> = (0..values.len())
+				.map(|_| Ghash128b::deserialize(&mut cursor).unwrap())
 				.collect();
 			assert_eq!(deserialized, values);
 			assert!(cursor.is_empty());

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -3,13 +3,13 @@
 //! Binary field implementation of GF(2^256) as a degree-two extension of the GHASH field.
 //!
 //! Elements are pairs `(a, b)` representing `a + b·Y`, where `a` and `b` are elements of
-//! [`BinaryField128bGhash`]. The extension is defined by the irreducible polynomial
+//! [`Ghash128b`]. The extension is defined by the irreducible polynomial
 //! `Y² + X·Y + X` over GHASH, so that `Y² = X·Y + X`.
 //!
 //! The field is backed by [`M256`], with the low 128 bits holding the coefficient of `1` (`a`) and
 //! the high 128 bits holding the coefficient of `Y` (`b`). This is the same layout as
 //! [`PackedBinaryGhash2x128b`] (two GHASH lanes in an `M256`) and matches the `{1, Y}` basis used
-//! by the `ExtensionField<BinaryField128bGhash>` implementation.
+//! by the `ExtensionField<Ghash128b>` implementation.
 //!
 //! Reducing with `Y² = X·Y + X` multiplies by `X` (a left shift) rather than by `X⁻¹`, and the
 //! multiply-by-`X` folds into the reduction. Multiplication batches the two GHASH products that
@@ -33,7 +33,7 @@ use super::{
 	extension::ExtensionField,
 };
 use crate::{
-	BinaryField128bGhash, Divisible, Field, PackedBinaryGhash2x128b, PackedField,
+	Divisible, Field, Ghash128b, PackedBinaryGhash2x128b, PackedField,
 	arch::{M128, M256, m256_from_u128s},
 	mul_by_binary_field_1b,
 	underlier::U1,
@@ -55,7 +55,7 @@ unsafe impl Pod for GhashSq256b {}
 impl GhashSq256b {
 	/// Splits the element into its `(a, b)` coefficients over GHASH, where `self = a + b·Y`.
 	#[inline]
-	fn to_coeffs(self) -> [BinaryField128bGhash; 2] {
+	fn to_coeffs(self) -> [Ghash128b; 2] {
 		// `GhashSq256b` and `PackedBinaryGhash2x128b` share the `M256` underlier and lane layout
 		// (low lane = coefficient of `1`, high lane = coefficient of `Y`), so this reinterprets.
 		let packed = PackedBinaryGhash2x128b::from_underlier(self.0);
@@ -64,7 +64,7 @@ impl GhashSq256b {
 
 	/// Builds an element from its `(a, b)` coefficients over GHASH, so that `self = a + b·Y`.
 	#[inline]
-	fn from_coeffs(coeffs: [BinaryField128bGhash; 2]) -> Self {
+	fn from_coeffs(coeffs: [Ghash128b; 2]) -> Self {
 		Self(PackedBinaryGhash2x128b::from_scalars(coeffs).to_underlier())
 	}
 }
@@ -72,7 +72,7 @@ impl GhashSq256b {
 // Degree-two extension over GHASH: the low 128 bits are the coefficient of `1`, the high 128 bits
 // the coefficient of `Y`. `square_transpose` uses the packed fast path via
 // `PackedBinaryGhash2x128b`.
-impl_field_extension!(BinaryField128bGhash(M128) < @1 => GhashSq256b(M256));
+impl_field_extension!(Ghash128b(M128) < @1 => GhashSq256b(M256));
 
 // Extension over GF(2): the 256 underlier bits are the coordinates in the `BinaryField1b` basis.
 impl_field_extension!(BinaryField1b(U1) < @8 => GhashSq256b(M256));
@@ -80,11 +80,11 @@ impl_field_extension!(BinaryField1b(U1) < @8 => GhashSq256b(M256));
 mul_by_binary_field_1b!(GhashSq256b);
 
 // Scalar multiplication by a GHASH subfield element scales both extension coordinates.
-impl Mul<BinaryField128bGhash> for GhashSq256b {
+impl Mul<Ghash128b> for GhashSq256b {
 	type Output = Self;
 
 	#[inline]
-	fn mul(self, rhs: BinaryField128bGhash) -> Self::Output {
+	fn mul(self, rhs: Ghash128b) -> Self::Output {
 		let [a, b] = self.to_coeffs();
 		Self::from_coeffs([a * rhs, b * rhs])
 	}
@@ -136,7 +136,7 @@ mod tests {
 	];
 
 	fn ghash_sq(a: u128, b: u128) -> GhashSq256b {
-		GhashSq256b::from_coeffs([BinaryField128bGhash::new(a), BinaryField128bGhash::new(b)])
+		GhashSq256b::from_coeffs([Ghash128b::new(a), Ghash128b::new(b)])
 	}
 
 	fn arb_elem() -> impl Strategy<Value = GhashSq256b> {
@@ -204,8 +204,8 @@ mod tests {
 	#[test]
 	fn test_subfield_embedding() {
 		// Products of GHASH-subfield elements agree with GHASH multiplication.
-		let a = BinaryField128bGhash::new(0x0123456789abcdef0123456789abcdef);
-		let b = BinaryField128bGhash::new(0xfedcba9876543210fedcba9876543210);
+		let a = Ghash128b::new(0x0123456789abcdef0123456789abcdef);
+		let b = Ghash128b::new(0xfedcba9876543210fedcba9876543210);
 		assert_eq!(GhashSq256b::from(a) * GhashSq256b::from(b), GhashSq256b::from(a * b),);
 	}
 
@@ -301,11 +301,11 @@ mod tests {
 
 		#[test]
 		fn test_ghash_extension_bases_roundtrip(a in arb_elem()) {
-			let bases: Vec<BinaryField128bGhash> =
-				ExtensionField::<BinaryField128bGhash>::iter_bases(&a).collect();
+			let bases: Vec<Ghash128b> =
+				ExtensionField::<Ghash128b>::iter_bases(&a).collect();
 			prop_assert_eq!(bases.len(), 2);
 			prop_assert_eq!(
-				<GhashSq256b as ExtensionField<BinaryField128bGhash>>::from_bases(bases),
+				<GhashSq256b as ExtensionField<Ghash128b>>::from_bases(bases),
 				a,
 			);
 		}
@@ -324,8 +324,8 @@ mod tests {
 		#[test]
 		fn test_square_transpose_ghash(a in arb_elem(), b in arb_elem()) {
 			let mut values = [a, b];
-			let expected = naive_square_transpose::<BinaryField128bGhash>(&values);
-			<GhashSq256b as ExtensionField<BinaryField128bGhash>>::square_transpose(&mut values);
+			let expected = naive_square_transpose::<Ghash128b>(&values);
+			<GhashSq256b as ExtensionField<Ghash128b>>::square_transpose(&mut values);
 			prop_assert_eq!(values.as_slice(), expected.as_slice());
 		}
 

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -261,7 +261,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use crate::{
-		AESTowerField8b, BinaryField1b, BinaryField128bGhash, PackedAESBinaryField1x8b,
+		AESTowerField8b, BinaryField1b, Ghash128b, PackedAESBinaryField1x8b,
 		PackedAESBinaryField16x8b, PackedAESBinaryField32x8b, PackedAESBinaryField64x8b,
 		PackedBinaryField1x1b, PackedBinaryField2x1b, PackedBinaryField4x1b, PackedBinaryField8x1b,
 		PackedBinaryField16x1b, PackedBinaryField32x1b, PackedBinaryField64x1b,
@@ -297,7 +297,7 @@ mod tests {
 		test.run::<PackedAESBinaryField64x8b>();
 
 		// GHASH
-		test.run::<BinaryField128bGhash>();
+		test.run::<Ghash128b>();
 		test.run::<PackedBinaryGhash1x128b>();
 		test.run::<PackedBinaryGhash2x128b>();
 		test.run::<PackedBinaryGhash4x128b>();

--- a/crates/field/src/packed_ghash.rs
+++ b/crates/field/src/packed_ghash.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use crate::{
-	BinaryField128bGhash,
+	Ghash128b,
 	arch::{
 		GhashInvert1x, GhashInvert2x, GhashInvert4x, GhashSquare1x, GhashSquare2x, GhashSquare4x,
 		GhashWideMul1x, GhashWideMul2x, GhashWideMul4x, M128, M256, M512, MulFromWideMul,
@@ -12,7 +12,7 @@ use crate::{
 
 define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
-	BinaryField128bGhash,
+	Ghash128b,
 	M128,
 	(MulFromWideMul),
 	(GhashSquare1x),
@@ -22,7 +22,7 @@ define_packed_binary_field!(
 
 define_packed_binary_field!(
 	PackedBinaryGhash2x128b,
-	BinaryField128bGhash,
+	Ghash128b,
 	M256,
 	(MulFromWideMul),
 	(GhashSquare2x),
@@ -32,7 +32,7 @@ define_packed_binary_field!(
 
 define_packed_binary_field!(
 	PackedBinaryGhash4x128b,
-	BinaryField128bGhash,
+	Ghash128b,
 	M512,
 	(MulFromWideMul),
 	(GhashSquare4x),
@@ -46,20 +46,19 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		BinaryField128bGhash, PackedField, packed_binary_field::test_utils::packed_field_tests,
+		Ghash128b, PackedField, packed_binary_field::test_utils::packed_field_tests,
 		underlier::WithUnderlier,
 	};
 
 	fn check_get_set<const WIDTH: usize, PT>(a: [u128; WIDTH], b: [u128; WIDTH])
 	where
-		PT: PackedField<Scalar = BinaryField128bGhash>
-			+ WithUnderlier<Underlier: From<[u128; WIDTH]>>,
+		PT: PackedField<Scalar = Ghash128b> + WithUnderlier<Underlier: From<[u128; WIDTH]>>,
 	{
 		let mut val = PT::from_underlier(a.into());
 		for i in 0..WIDTH {
-			assert_eq!(val.get(i), BinaryField128bGhash::from(a[i]));
-			val.set(i, BinaryField128bGhash::from(b[i]));
-			assert_eq!(val.get(i), BinaryField128bGhash::from(b[i]));
+			assert_eq!(val.get(i), Ghash128b::from(a[i]));
+			val.set(i, Ghash128b::from(b[i]));
+			assert_eq!(val.get(i), Ghash128b::from(b[i]));
 		}
 	}
 

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -32,7 +32,7 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	BinaryField128bGhash, Divisible, GhashSq256b, PackedBinaryGhash2x128b, PackedField, WideMul,
+	Divisible, Ghash128b, GhashSq256b, PackedBinaryGhash2x128b, PackedField, WideMul,
 	arch::{
 		Divide, GhashSqWideMul1x, M128, M256, M512, MulFromWideMul, PackedPrimitiveType,
 		portable::packed_macros::{portable_macros::*, *},
@@ -44,7 +44,7 @@ use crate::{
 };
 
 /// The packed GHASH coordinate register backing a `SlicedGhashSq256b<U>`.
-type Ghash<U> = PackedPrimitiveType<U, BinaryField128bGhash>;
+type Ghash<U> = PackedPrimitiveType<U, Ghash128b>;
 
 /// A GHASH² packing whose two GHASH coordinates pack into `PackedPrimitiveType<U, Ghash128b>`.
 pub type SlicedGhashSq256b<U> = SlicedPackedField<GhashSq256b, Ghash<U>, 2>;
@@ -62,15 +62,14 @@ type GhashWide<U> = <Ghash<U> as WideMul>::Output;
 ///
 /// `X` scaling is `GF(2)`-linear — a per-lane bit shift with a fixed compensation, not a field
 /// multiply — so this is far cheaper than a CLMUL. It reuses the scalar
-/// [`BinaryField128bGhash::mul_x`] on each 128-bit lane, which every supported underlier divides
+/// [`Ghash128b::mul_x`] on each 128-bit lane, which every supported underlier divides
 /// into.
 #[inline]
 fn ghash_mul_x<U: Divisible<M128>>(u: U) -> U {
-	U::from_iter(Divisible::<M128>::value_iter(u).map(|lane| {
-		BinaryField128bGhash::from_underlier(lane)
-			.mul_x()
-			.to_underlier()
-	}))
+	U::from_iter(
+		Divisible::<M128>::value_iter(u)
+			.map(|lane| Ghash128b::from_underlier(lane).mul_x().to_underlier()),
+	)
 }
 
 /// Multiplies every GHASH lane of a packed coordinate by `X`.
@@ -149,7 +148,7 @@ impl<W: Default + Add<Output = W>> Sum for SlicedGhashSqWide<W> {
 impl<U> WideMul for SlicedGhashSq256b<U>
 where
 	U: UnderlierType + Divisible<M128>,
-	Ghash<U>: PackedField<Scalar = BinaryField128bGhash> + WideMul,
+	Ghash<U>: PackedField<Scalar = Ghash128b> + WideMul,
 {
 	type Output = SlicedGhashSqWide<GhashWide<U>>;
 
@@ -182,7 +181,7 @@ where
 impl<U> Square for SlicedGhashSq256b<U>
 where
 	U: UnderlierType + Divisible<M128>,
-	Ghash<U>: PackedField<Scalar = BinaryField128bGhash>,
+	Ghash<U>: PackedField<Scalar = Ghash128b>,
 {
 	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two, and
 	/// `Y² = X·Y + X`.
@@ -201,7 +200,7 @@ where
 impl<U> InvertOrZero for SlicedGhashSq256b<U>
 where
 	U: UnderlierType + Divisible<M128>,
-	Ghash<U>: PackedField<Scalar = BinaryField128bGhash>,
+	Ghash<U>: PackedField<Scalar = Ghash128b>,
 {
 	/// Inverts through the norm of the degree-two extension. The conjugate of `u = a + b·Y` sends
 	/// `Y` to the other root of `Y² + X·Y + X` (the roots sum to `X` and multiply to `X`), giving
@@ -236,15 +235,15 @@ where
 /// The coordinates already sit in the two 128-bit lanes of the 256-bit value, so this is a free
 /// reinterpretation followed by two lane reads.
 #[inline]
-pub(crate) fn ghash_sq_coords(elem: PackedGhashSq1x256b) -> [BinaryField128bGhash; 2] {
-	let coords = PackedExtension::<BinaryField128bGhash>::cast_base(elem);
+pub(crate) fn ghash_sq_coords(elem: PackedGhashSq1x256b) -> [Ghash128b; 2] {
+	let coords = PackedExtension::<Ghash128b>::cast_base(elem);
 	[coords.get(0), coords.get(1)]
 }
 
 /// Assembles a width-one GHASH² element `a + b·Y` from its GHASH coordinates `[a, b]`.
 #[inline]
-pub(crate) fn ghash_sq_from_coords(coords: [BinaryField128bGhash; 2]) -> PackedGhashSq1x256b {
-	PackedExtension::<BinaryField128bGhash>::cast_ext(PackedBinaryGhash2x128b::from_scalars(coords))
+pub(crate) fn ghash_sq_from_coords(coords: [Ghash128b; 2]) -> PackedGhashSq1x256b {
+	PackedExtension::<Ghash128b>::cast_ext(PackedBinaryGhash2x128b::from_scalars(coords))
 }
 
 /// [`Square`] strategy for [`PackedGhashSq1x256b`].
@@ -256,8 +255,7 @@ impl Square for GhashSqSquare<PackedGhashSq1x256b> {
 	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two.
 	#[inline]
 	fn square(self) -> Self {
-		let sq =
-			Square::square(PackedExtension::<BinaryField128bGhash>::cast_base(Self::peel(self)));
+		let sq = Square::square(PackedExtension::<Ghash128b>::cast_base(Self::peel(self)));
 
 		let x_t2 = sq.get(1).mul_x();
 		Self::wrap(ghash_sq_from_coords([sq.get(0) + x_t2, x_t2]))

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -6,11 +6,11 @@ use std::iter;
 use proptest::prelude::*;
 
 use crate::{
-	AESTowerField8b, BinaryField1b, BinaryField128bGhash, ExtensionField, Field,
-	PackedAESBinaryField16x8b, PackedAESBinaryField32x8b, PackedAESBinaryField64x8b,
-	PackedBinaryField64x1b, PackedBinaryField128x1b, PackedBinaryField256x1b,
-	PackedBinaryField512x1b, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
-	PackedBinaryGhash4x128b, PackedField, SlicedGhashSq2x256b,
+	AESTowerField8b, BinaryField1b, ExtensionField, Field, Ghash128b, PackedAESBinaryField16x8b,
+	PackedAESBinaryField32x8b, PackedAESBinaryField64x8b, PackedBinaryField64x1b,
+	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b,
+	PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
+	SlicedGhashSq2x256b,
 	field::FieldOps,
 	underlier::{SmallU, WithUnderlier},
 };
@@ -22,7 +22,7 @@ fn test_field_text_debug() {
 	assert_eq!(
 		format!(
 			"{:?}",
-			PackedBinaryGhash1x128b::broadcast(BinaryField128bGhash::from(
+			PackedBinaryGhash1x128b::broadcast(Ghash128b::from(
 				162259276829213363391578010288127u128
 			))
 		),
@@ -99,9 +99,9 @@ macro_rules! generate_spread_tests {
 
 generate_spread_tests! {
 	// 128-bit configurations
-	spread_equals_basic_spread_4x128, PackedBinaryGhash4x128b, BinaryField128bGhash, u128, 4;
-	spread_equals_basic_spread_2x128, PackedBinaryGhash2x128b, BinaryField128bGhash, u128, 2;
-	spread_equals_basic_spread_1x128, PackedBinaryGhash1x128b, BinaryField128bGhash, u128, 1;
+	spread_equals_basic_spread_4x128, PackedBinaryGhash4x128b, Ghash128b, u128, 4;
+	spread_equals_basic_spread_2x128, PackedBinaryGhash2x128b, Ghash128b, u128, 2;
+	spread_equals_basic_spread_1x128, PackedBinaryGhash1x128b, Ghash128b, u128, 1;
 
 	// 8-bit configurations
 	spread_equals_basic_spread_64x8, PackedAESBinaryField64x8b, AESTowerField8b, u8, 64;
@@ -120,7 +120,7 @@ generate_spread_tests_small! {
 #[test]
 fn test_field_ops_powers() {
 	// The iterator starts at the 0'th power, so entry i must equal the base raised to i.
-	let generator = BinaryField128bGhash::MULTIPLICATIVE_GENERATOR;
+	let generator = Ghash128b::MULTIPLICATIVE_GENERATOR;
 	let power_values: Vec<_> = generator.powers().take(10).collect();
 
 	for (i, power) in power_values.iter().enumerate() {
@@ -206,7 +206,7 @@ fn test_packed_field_ops_square_transpose_packed128x1b_over_1b() {
 
 #[test]
 fn test_packed_field_ops_square_transpose_ghashsq2x256b_over_ghash() {
-	check_packed_field_ops_square_transpose::<BinaryField128bGhash, SlicedGhashSq2x256b>();
+	check_packed_field_ops_square_transpose::<Ghash128b, SlicedGhashSq2x256b>();
 }
 
 #[test]

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -139,9 +139,9 @@ mod tests {
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::{BinaryField128bGhash, Random};
+	use crate::{Ghash128b, Random};
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 
 	/// Expands `N` random elements and asserts that entry `index` of the resulting `2^N`-sized
 	/// lookup table equals the subset sum selected by the set bits of `index`.

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -12,7 +12,7 @@
 //! The dispatch loop, the opcode handlers, and the bytecode readers live here once.
 
 use binius_core::{Word, constraint_system::ShiftVariant};
-use binius_field::BinaryField128bGhash;
+use binius_field::Ghash128b;
 use smallvec::{SmallVec, smallvec};
 
 use super::opcode::EvalOpcode;
@@ -22,9 +22,8 @@ use crate::ir::{hints::HintRegistry, path::PathSpec};
 /// of words — `lo` holds the coefficients of $1, X, \ldots, X^{63}$ and `hi` those of
 /// $X^{64}, \ldots, X^{127}$ — and returns the product in the same `(lo, hi)` form.
 pub(super) fn ghash_mul(a_lo: Word, a_hi: Word, b_lo: Word, b_hi: Word) -> (Word, Word) {
-	let to_field = |lo: Word, hi: Word| {
-		BinaryField128bGhash::from((lo.as_u64() as u128) | ((hi.as_u64() as u128) << 64))
-	};
+	let to_field =
+		|lo: Word, hi: Word| Ghash128b::from((lo.as_u64() as u128) | ((hi.as_u64() as u128) << 64));
 	let product = u128::from(to_field(a_lo, a_hi) * to_field(b_lo, b_hi));
 	(Word::from_u64(product as u64), Word::from_u64((product >> 64) as u64))
 }

--- a/crates/hash/benches/blake3_portable.rs
+++ b/crates/hash/benches/blake3_portable.rs
@@ -6,7 +6,7 @@
 
 use std::hint::black_box;
 
-use binius_field::{BinaryField128bGhash as B128, Random};
+use binius_field::{Ghash128b as B128, Random};
 use binius_hash::{
 	ParallelDigest, ParallelDigestAdapter, blake3_portable::PortableBlake3ParallelDigest,
 };

--- a/crates/hash/benches/sha256.rs
+++ b/crates/hash/benches/sha256.rs
@@ -2,7 +2,7 @@
 
 use std::hint::black_box;
 
-use binius_field::{BinaryField128bGhash as B128, Random};
+use binius_field::{Ghash128b as B128, Random};
 use binius_hash::{ParallelDigest, ParallelDigestAdapter, ParallelSha256Digest, StdDigest};
 use binius_utils::rayon::{prelude::*, slice::ParallelSlice};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -492,7 +492,7 @@ impl<D: Clone + Send, A: Allocator> BinaryMerkleTree<D, A> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::BinaryField128bGhash as B128;
+	use binius_field::Ghash128b as B128;
 
 	use super::*;
 	use crate::sha256::{Sha256Compression, Sha256HashSuite};

--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_compute::{BufferPool, GlobalAllocator};
-use binius_field::{BinaryField128bGhash as B128, PackedField, arch::OptimalPackedB128};
+use binius_field::{Ghash128b as B128, PackedField, arch::OptimalPackedB128};
 use binius_hash::{
 	binary_merkle_tree::HashSuite, blake3::Blake3HashSuite, sha256::Sha256HashSuite,
 };

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -690,9 +690,8 @@ mod tests {
 
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
-		BinaryField, BinaryField128bGhash, BinaryField128bGhash as B128, Field,
-		PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
-		Random,
+		BinaryField, Field, Ghash128b, Ghash128b as B128, PackedBinaryGhash1x128b,
+		PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField, Random,
 	};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
@@ -723,14 +722,12 @@ mod tests {
 		security_bits.div_ceil(log_inv_rate)
 	}
 
-	fn make_ntt(
-		log_domain_size: usize,
-	) -> NeighborsLastSingleThread<GaoMateerOnTheFly<BinaryField128bGhash>> {
+	fn make_ntt(log_domain_size: usize) -> NeighborsLastSingleThread<GaoMateerOnTheFly<Ghash128b>> {
 		let domain_context = GaoMateerOnTheFly::generate(log_domain_size);
 		NeighborsLastSingleThread::new(domain_context)
 	}
 
-	fn make_merkle_scheme() -> BinaryMerkleTreeScheme<BinaryField128bGhash, StdHashSuite> {
+	fn make_merkle_scheme() -> BinaryMerkleTreeScheme<Ghash128b, StdHashSuite> {
 		BinaryMerkleTreeScheme::new()
 	}
 
@@ -751,7 +748,7 @@ mod tests {
 
 	#[test]
 	fn test_basefold_channel_single_oracle() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		type P = PackedBinaryGhash1x128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -817,7 +814,7 @@ mod tests {
 
 	#[test]
 	fn test_basefold_channel_two_oracles() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		type P = PackedBinaryGhash1x128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -903,11 +900,11 @@ mod tests {
 	/// Runs a full prove/verify cycle of the Batched ZK BaseFold channel over oracles of the given
 	/// sizes. If `tamper`, the verifier's claim on the first oracle is corrupted; verification must
 	/// then fail. Returns whether verification accepted.
-	fn run_zk_channel<P: PackedField<Scalar = BinaryField128bGhash>>(
+	fn run_zk_channel<P: PackedField<Scalar = Ghash128b>>(
 		n_vars_list: &[usize],
 		tamper: bool,
 	) -> bool {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = n_vars_list
@@ -985,11 +982,11 @@ mod tests {
 
 	/// Like `run_zk_channel` but with per-oracle `(n_vars, is_zk)` flags, exercising the mixed
 	/// ZK/non-ZK opening. If `tamper`, the verifier's claim on the first oracle is corrupted.
-	fn run_mixed_channel<P: PackedField<Scalar = BinaryField128bGhash>>(
+	fn run_mixed_channel<P: PackedField<Scalar = Ghash128b>>(
 		specs: &[(usize, bool)],
 		tamper: bool,
 	) -> bool {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = specs
@@ -1221,7 +1218,7 @@ mod tests {
 	/// arrival position is corrupted; verification must then fail. Returns whether verification
 	/// accepted.
 	fn run_multi_relation_channel(specs: &[(usize, bool, usize)], tamper: Option<usize>) -> bool {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		type P = PackedBinaryGhash1x128b;
 
 		let mut rng = StdRng::seed_from_u64(0);

--- a/crates/iop-prover/src/commit_pipeline.rs
+++ b/crates/iop-prover/src/commit_pipeline.rs
@@ -106,9 +106,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_field::{
-		BinaryField128bGhash as B128, PackedBinaryGhash4x128b, arch::OptimalPackedB128,
-	};
+	use binius_field::{Ghash128b as B128, PackedBinaryGhash4x128b, arch::OptimalPackedB128};
 	use binius_hash::sha256::Sha256HashSuite;
 	use binius_math::{ntt::domain_context::GaoMateerOnTheFly, test_utils::random_field_buffer};
 	use rand::{SeedableRng, rngs::StdRng};

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -175,7 +175,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash1x128b};
+	use binius_field::{Ghash128b as B128, PackedBinaryGhash1x128b};
 	use binius_hash::StdHashSuite;
 	use binius_iop::fri::FRIParams;
 	use binius_math::{

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -587,7 +587,7 @@ impl<F: Field, P: PackedField<Scalar = F>, C, Data: Deref<Target = [P]>>
 
 #[cfg(test)]
 mod tests {
-	use binius_field::BinaryField128bGhash as B128;
+	use binius_field::Ghash128b as B128;
 	use binius_math::{
 		BinarySubspace,
 		ntt::{NeighborsLastReference, domain_context::GenericOnTheFly},

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -4,9 +4,7 @@
 use std::{iter, vec};
 
 use binius_compute::GlobalAllocator;
-use binius_field::{
-	BinaryField, BinaryField128bGhash as B128, Field, PackedBinaryGhash1x128b, PackedField,
-};
+use binius_field::{BinaryField, Field, Ghash128b as B128, PackedBinaryGhash1x128b, PackedField};
 use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::{
 	fri::{CodewordSpec, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -262,7 +262,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_core::word::Word;
-	use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash2x128b};
+	use binius_field::{Ghash128b as B128, PackedBinaryGhash2x128b};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel};
 	use binius_ip::channel::WordIPVerifierChannel;

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -5,7 +5,7 @@ use core::slice;
 
 use binius_compute::BufferPool;
 use binius_field::{
-	BinaryField128bGhash as B128, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
+	Ghash128b as B128, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
 };
 use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::merkle_tree::MerkleTreeScheme;

--- a/crates/iop-prover/tests/merkle_pool_allocations.rs
+++ b/crates/iop-prover/tests/merkle_pool_allocations.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use binius_compute::{BufferPool, GlobalAllocator};
-use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash1x128b};
+use binius_field::{Ghash128b as B128, PackedBinaryGhash1x128b};
 use binius_hash::StdHashSuite;
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_iop_prover::{

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -858,7 +858,7 @@ impl AritySelectionStrategy for ConstantArityStrategy {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::BinaryField128bGhash as B128;
+	use binius_field::Ghash128b as B128;
 	use binius_hash::StdHashSuite;
 
 	use super::*;

--- a/crates/math/benches/batch_invert.rs
+++ b/crates/math/benches/batch_invert.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField128bGhash as Ghash, Random, arch::OptimalPackedB128};
+use binius_field::{Ghash128b as Ghash, Random, arch::OptimalPackedB128};
 use binius_math::batch_invert::BatchInversion;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -254,7 +254,7 @@ fn unproduct_layer<P: PackedField>(input: &[P], output: &mut [P]) {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128bGhash as Ghash, Random, arithmetic_traits::InvertOrZero};
+	use binius_field::{Ghash128b as Ghash, Random, arithmetic_traits::InvertOrZero};
 	use proptest::prelude::*;
 	use rand::{Rng, SeedableRng, rngs::StdRng, seq::IteratorRandom};
 

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -237,7 +237,7 @@ impl<F: BinaryField> Default for BinarySubspace<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{AESTowerField8b as B8, BinaryField128bGhash as B128, Field};
+	use binius_field::{AESTowerField8b as B8, Field, Ghash128b as B128};
 
 	use super::*;
 

--- a/crates/math/src/inner_product.rs
+++ b/crates/math/src/inner_product.rs
@@ -116,10 +116,10 @@ mod tests {
 	// reduced result against a naive scalar-by-scalar reference.
 	#[test]
 	fn test_inner_product_matches_naive() {
-		use binius_field::BinaryField128bGhash;
+		use binius_field::Ghash128b;
 
 		type P = PackedBinaryGhash4x128b;
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(42);
 

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -273,7 +273,7 @@ fn test_equivalence<F: BinaryField, NTT: AdditiveNTT<Field = F>>(ntt: &NTT) {
 #[test]
 fn test_eval() {
 	const LOG_D: usize = 6;
-	type F = binius_field::BinaryField128bGhash;
+	type F = binius_field::Ghash128b;
 
 	// GaoMateer domain context
 	let domain_context = domain_context::GaoMateerPreExpanded::<F>::generate(LOG_D);

--- a/crates/math/src/test_utils.rs
+++ b/crates/math/src/test_utils.rs
@@ -2,13 +2,13 @@
 
 use std::iter::repeat_with;
 
-use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash4x128b, PackedField};
+use binius_field::{Field, Ghash128b, PackedBinaryGhash4x128b, PackedField};
 use rand::prelude::*;
 
 use crate::FieldBuffer;
 
 /// Type alias for 128b field element with fast arithmetic.
-pub type B128 = BinaryField128bGhash;
+pub type B128 = Ghash128b;
 
 /// Type alias for a packed 128b field element with non-trivial packing width.
 pub type Packed128b = PackedBinaryGhash4x128b;
@@ -65,7 +65,7 @@ pub fn random_field_buffer<P: PackedField>(mut rng: impl Rng, log_n: usize) -> F
 /// # Example
 ///
 /// ```
-/// # use binius_field::BinaryField128bGhash as B128;
+/// # use binius_field::Ghash128b as B128;
 /// # use binius_math::test_utils::index_to_hypercube_point;
 /// let point = index_to_hypercube_point::<B128>(3, 5);
 /// // 5 = 0b101, so point = [F::ONE, F::ZERO, F::ONE]
@@ -88,7 +88,7 @@ pub fn index_to_hypercube_point<F: Field>(n_vars: usize, index: usize) -> Vec<F>
 
 #[cfg(test)]
 mod tests {
-	use binius_field::BinaryField128bGhash as B128;
+	use binius_field::Ghash128b as B128;
 	use proptest::prelude::*;
 	use rand::prelude::*;
 

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -267,7 +267,7 @@ fn compute_barycentric_weights<F: Field>(points: &[F]) -> Vec<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128bGhash, Field, Random};
+	use binius_field::{Field, Ghash128b, Random};
 	use rand::prelude::*;
 
 	use super::*;
@@ -282,7 +282,7 @@ mod tests {
 		inner_product(coeffs.iter().copied(), x.powers().take(coeffs.len()))
 	}
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 
 	#[test]
 	fn test_evaluate_univariate_against_reference() {

--- a/crates/prover/benches/binmul.rs
+++ b/crates/prover/benches/binmul.rs
@@ -2,14 +2,14 @@
 
 use binius_compute::BufferPool;
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash, Random, arch::OptimalPackedB128};
+use binius_field::{Ghash128b, Random, arch::OptimalPackedB128};
 use binius_prover::protocols::binmul::prove;
 use binius_transcript::ProverTranscript;
 use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use rand::{SeedableRng, prelude::StdRng};
 
-type F = BinaryField128bGhash;
+type F = Ghash128b;
 type P = OptimalPackedB128;
 
 /// The six word columns `(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi)` of a BinMul witness.

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 The Binius Developers
 use binius_compute::BufferPool;
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b};
+use binius_field::{Field, Ghash128b, PackedBinaryGhash1x128b};
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::MinProofSizeStrategy,
@@ -35,7 +35,7 @@ use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, 
 use rand::prelude::*;
 
 type P = PackedBinaryGhash1x128b;
-type F = BinaryField128bGhash;
+type F = Ghash128b;
 
 /// Number of exponents is `2^LOG_NUM`.
 const LOG_NUM: usize = 14;

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -8,7 +8,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
 	word::Word,
 };
-use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
+use binius_field::{AESTowerField8b, Field, Ghash128b, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_math::{
 	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::subspace_lagrange_evals,
@@ -85,7 +85,7 @@ pub fn create_sha256_cs_with_witness(
 }
 
 fn bench_prove_and_verify(c: &mut Criterion) {
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 	type P = OptimalPackedB128;
 	let mut rng = rand::rng();
 
@@ -229,7 +229,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 /// `intmul/phases` breakdown. Each of the five phase functions is timed on its own, sharing one
 /// expensive circuit / witness / key-collection setup.
 fn bench_shift_phases(c: &mut Criterion) {
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 	type P = OptimalPackedB128;
 	let mut rng = rand::rng();
 

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -300,7 +300,7 @@ mod test {
 	use std::iter::repeat_with;
 
 	use binius_compute::GlobalAllocator;
-	use binius_field::{BinaryField128bGhash as B128, Field, Random};
+	use binius_field::{Field, Ghash128b as B128, Random};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
 		univariate::{extrapolate_over_subspace, subspace_lagrange_evals_scalars},

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -157,7 +157,7 @@ where
 mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_core::word::Word;
-	use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
+	use binius_field::{Ghash128b, PackedBinaryGhash2x128b, Random};
 	use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
 	use binius_iop_prover::channel::naive::NaiveProverChannel;
 	use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
@@ -171,7 +171,7 @@ mod tests {
 
 	use super::{log2_ceil_usize, prove};
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 	type P = PackedBinaryGhash2x128b;
 
 	/// The six word columns `(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi)` of a BinMul witness.

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -3,7 +3,7 @@
 
 use binius_compute::GlobalAllocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
+use binius_field::{Ghash128b, PackedBinaryGhash2x128b, Random};
 use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
 use binius_iop_prover::channel::naive::NaiveProverChannel;
 use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
@@ -25,7 +25,7 @@ use super::{
 };
 use crate::fold_word::fold_words;
 
-type F = BinaryField128bGhash;
+type F = Ghash128b;
 type P = PackedBinaryGhash2x128b;
 
 pub fn evaluate_witness(words: &[Word], eval_point: &[F]) -> F {

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -592,10 +592,10 @@ mod tests {
 	/// parallel path (`n_vars >= P::LOG_WIDTH`) and the scalar fallback (`n_vars < P::LOG_WIDTH`).
 	#[test]
 	fn compute_b_leaves_matches_spec() {
-		use binius_field::{BinaryField128bGhash, Random, arithmetic_traits::Square};
+		use binius_field::{Ghash128b, Random, arithmetic_traits::Square};
 		use rand::prelude::*;
 
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(1);
 		// `Packed128b` has `LOG_WIDTH == 2`: `n_vars = 0` exercises the scalar fallback and
@@ -636,10 +636,10 @@ mod tests {
 	/// path.
 	#[test]
 	fn power_table_matches_sequential() {
-		use binius_field::{BinaryField128bGhash, Random};
+		use binius_field::{Ghash128b, Random};
 		use rand::prelude::*;
 
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(2);
 		let base = F::random(&mut rng);

--- a/crates/prover/src/protocols/shift/key_collection/key.rs
+++ b/crates/prover/src/protocols/shift/key_collection/key.rs
@@ -177,13 +177,13 @@ impl DeserializeBytes for ConstraintIndex {
 mod tests {
 	use std::{iter, mem};
 
-	use binius_field::BinaryField128bGhash;
+	use binius_field::Ghash128b;
 	use binius_math::FieldBuffer;
 
 	use super::*;
 	use crate::protocols::shift::PreparedOperatorData;
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 
 	fn f(value: u128) -> F {
 		F::new(value)

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -215,7 +215,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
+	use binius_field::{AESTowerField8b, Ghash128b, PackedBinaryGhash2x128b, Random};
 	use binius_math::{
 		BinarySubspace, inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval,
 		test_utils::random_scalars, univariate::subspace_lagrange_evals,
@@ -237,7 +237,7 @@ mod tests {
 	/// must give phase 3's claim.
 	#[test]
 	fn h_op_consistency() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		type P = PackedBinaryGhash2x128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -314,7 +314,7 @@ mod tests {
 		// That is the only slice which is not a plain move of the weights.
 		#[test]
 		fn shift_operator_table_matches_the_indicator_definition(seed: u64) {
-			type F = BinaryField128bGhash;
+			type F = Ghash128b;
 
 			let mut rng = StdRng::seed_from_u64(seed);
 			let psi = random_scalars::<F>(&mut rng, Word::BITS);
@@ -332,7 +332,7 @@ mod tests {
 		// Linearity is what lets it fold first and contract after.
 		#[test]
 		fn shift_operator_table_is_linear_in_the_weights(seed: u64) {
-			type F = BinaryField128bGhash;
+			type F = Ghash128b;
 
 			let mut rng = StdRng::seed_from_u64(seed);
 			let psi_1 = random_scalars::<F>(&mut rng, Word::BITS);
@@ -365,7 +365,7 @@ mod tests {
 	// full-write contract: a builder that left cells alone would leak the previous pair's weights.
 	#[test]
 	fn shift_operator_row_matches_its_slice_of_the_table() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let psi = random_scalars::<F>(&mut rng, Word::BITS);
@@ -393,7 +393,7 @@ mod tests {
 	// The half-word forms read the amount modulo 32, so they are the identity at zero as well.
 	#[test]
 	fn the_zero_amount_slice_returns_the_weights_unchanged() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let psi = random_scalars::<F>(&mut rng, Word::BITS);

--- a/crates/prover/src/protocols/shift/outer.rs
+++ b/crates/prover/src/protocols/shift/outer.rs
@@ -191,13 +191,13 @@ impl<F: BinaryField, A: Allocator> OuterShiftStage<F, A> {
 mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_core::constraint_system::Shift;
-	use binius_field::{BinaryField128bGhash, Random};
+	use binius_field::{Ghash128b, Random};
 	use binius_math::test_utils::random_scalars;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 
 	/// Whether output bit `out` of `variant` at `amount` reads input bit `in_bit`.
 	///

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -543,7 +543,7 @@ mod tests {
 	use binius_core::constraint_system::{
 		AndConstraint, ConstraintSystem, InoutSegment, Shift, ShiftedValueIndex, ValueIndex,
 	};
-	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash2x128b};
+	use binius_field::{Field, Ghash128b, PackedBinaryGhash2x128b};
 	use binius_math::{inner_product::inner_product_buffers, test_utils::random_scalars};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::config::StdChallenger;
@@ -552,7 +552,7 @@ mod tests {
 	use super::*;
 	use crate::protocols::shift::KeyCollection;
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 
 	impl<P: PackedField> SparseShiftRows<P> {
 		/// Spreads the rows over the space they still span, as a dense multilinear.

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -343,7 +343,7 @@ fn partial_eval_sigmas_transpose<E: FieldOps>(bit: &[E], amount: &[E]) -> Vec<E>
 mod tests {
 	use std::array;
 
-	use binius_field::{BinaryField128bGhash as B128, Field};
+	use binius_field::{Field, Ghash128b as B128};
 	use binius_math::{
 		BinarySubspace, multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars,
 		univariate::subspace_lagrange_evals_scalars,

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -401,7 +401,7 @@ pub fn prove_public_eval<A, P, Channel>(
 mod test {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
-		BinaryField128bGhash, ExtensionField, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
+		ExtensionField, Ghash128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
 		PackedExtension, PackedField, PackedSubfield,
 	};
 	use binius_math::{
@@ -415,7 +415,7 @@ mod test {
 
 	use super::*;
 
-	type F = BinaryField128bGhash;
+	type F = Ghash128b;
 
 	// The row fold, written straight from its definition:
 	//

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -10,7 +10,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use binius_compute::BufferPool;
 use binius_core::constraint_system::{ConstraintSystem, InoutSegment, ValueVec};
-use binius_field::{BinaryField128bGhash as B128, PackedField};
+use binius_field::{Ghash128b as B128, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
 use binius_ip::channel::WordIPVerifierChannel;

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -18,7 +18,7 @@ use binius_core::{
 	},
 	word::Word,
 };
-use binius_field::{BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
+use binius_field::{Field, Ghash128b, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Options, Wire};
 use binius_hash::StdHashSuite;
 use binius_prover::{Prover, zk_config::ZKProver};
@@ -166,7 +166,7 @@ fn binmul_seventh_power_circuit() -> (ConstraintSystem, ValueVec) {
 
 	// A random input element and its 7th power, computed independently via GHASH-field arithmetic.
 	let mut rng = StdRng::seed_from_u64(0);
-	let x = BinaryField128bGhash::random(&mut rng);
+	let x = Ghash128b::random(&mut rng);
 	let x7 = x.pow([7u64]);
 
 	let x_val = u128::from(x);
@@ -260,8 +260,8 @@ fn non_power_of_two_constraint_circuit() -> (ConstraintSystem, ValueVec) {
 
 	let mut rng = StdRng::seed_from_u64(0);
 	for &[a_lo, a_hi, b_lo, b_hi] in &bmul_wires {
-		let a = u128::from(BinaryField128bGhash::random(&mut rng));
-		let b = u128::from(BinaryField128bGhash::random(&mut rng));
+		let a = u128::from(Ghash128b::random(&mut rng));
+		let b = u128::from(Ghash128b::random(&mut rng));
 		w[a_lo] = Word(a as u64);
 		w[a_hi] = Word((a >> 64) as u64);
 		w[b_lo] = Word(b as u64);

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -324,8 +324,8 @@ pub fn evaluate_witness<F: BinaryField>(words: &[Word], r_j: &[F], r_y: &[F]) ->
 
 #[test]
 fn test_shift_prove_and_verify() {
-	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash2x128b, Random};
-	type F = BinaryField128bGhash;
+	use binius_field::{Field, Ghash128b, PackedBinaryGhash2x128b, Random};
+	type F = Ghash128b;
 	type P = PackedBinaryGhash2x128b;
 	let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -6,7 +6,7 @@ use std::{array, rc::Rc};
 
 use binius_circuits::{bytes::swap_bytes_32, multiplexer::multi_wire_multiplex};
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash as B128, Field, FieldOps};
+use binius_field::{Field, FieldOps, Ghash128b as B128};
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_hash::StdHashSuite;
 use binius_iop::{

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -5,7 +5,7 @@
 use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_core::word::Word;
-use binius_field::BinaryField128bGhash as B128;
+use binius_field::Ghash128b as B128;
 use binius_frontend::WitnessFiller;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{

--- a/crates/recursion/src/hints.rs
+++ b/crates/recursion/src/hints.rs
@@ -10,7 +10,7 @@
 //! result. The inverse gadget does that where it calls this.
 
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash as B128, arithmetic_traits::InvertOrZero};
+use binius_field::{Ghash128b as B128, arithmetic_traits::InvertOrZero};
 use binius_frontend::Hint;
 
 /// Reads a `(lo, hi)` wire pair as a field element.

--- a/crates/recursion/src/merkle/tests.rs
+++ b/crates/recursion/src/merkle/tests.rs
@@ -5,7 +5,7 @@
 use std::array;
 
 use binius_core::Word;
-use binius_field::BinaryField128bGhash as B128;
+use binius_field::Ghash128b as B128;
 use binius_frontend::{CircuitBuilder, CircuitStat, PopulateError, WitnessFiller};
 use binius_hash::{
 	CompressionFunction, hash_serialize,

--- a/crates/recursion/src/symbolic/elem.rs
+++ b/crates/recursion/src/symbolic/elem.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use binius_field::{
-	BinaryField128bGhash as B128, ExtensionField, Field, FieldOps,
+	ExtensionField, Field, FieldOps, Ghash128b as B128,
 	arithmetic_traits::{InvertOrZero, Square},
 };
 use binius_frontend::{CircuitBuilder, Wire};

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -44,7 +44,7 @@ use std::iter;
 
 use binius_compute::GlobalAllocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash1x128b};
+use binius_field::{Ghash128b as B128, PackedBinaryGhash1x128b};
 use binius_frontend::{CircuitStat, MAX_ASSERTION_FAILURES, PopulateError, Wire};
 use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::{

--- a/crates/recursion/tests/channel_builds.rs
+++ b/crates/recursion/tests/channel_builds.rs
@@ -2,7 +2,7 @@
 
 //! A smoke test that the channel records arithmetic into a circuit that compiles.
 
-use binius_field::BinaryField128bGhash as B128;
+use binius_field::Ghash128b as B128;
 use binius_frontend::CircuitStat;
 use binius_ip::channel::IPVerifierChannel;
 use binius_recursion::Binius64BuilderChannel;

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -731,7 +731,7 @@ impl<F: Field, LayoutRef: Deref<Target = WitnessLayout<F>>> CircuitBuilder
 mod tests {
 	use std::iter::successors;
 
-	use binius_field::{BinaryField128bGhash as B128, Field, PackedField};
+	use binius_field::{Field, Ghash128b as B128, PackedField};
 
 	use super::*;
 

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -117,7 +117,7 @@ pub fn assert_is_bit<Builder: CircuitBuilder>(builder: &mut Builder, val: Builde
 mod tests {
 	use std::{array, iter};
 
-	use binius_field::{BinaryField128bGhash as B128, Field, Random, arithmetic_traits::Square};
+	use binius_field::{Field, Ghash128b as B128, Random, arithmetic_traits::Square};
 	use binius_math::{
 		line::extrapolate_line as extrapolate_line_math,
 		multilinear,

--- a/crates/spartan-frontend/src/lib.rs
+++ b/crates/spartan-frontend/src/lib.rs
@@ -29,7 +29,7 @@
 //! # Example
 //!
 //! ```rust
-//! use binius_field::{BinaryField128bGhash as B128, Field};
+//! use binius_field::{Ghash128b as B128, Field};
 //! use binius_spartan_frontend::{
 //!     circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessGenerator},
 //!     compiler::compile,

--- a/crates/spartan-frontend/src/wire_elimination.rs
+++ b/crates/spartan-frontend/src/wire_elimination.rs
@@ -222,7 +222,7 @@ impl<F: Field> WireEliminationPass<F> {
 mod tests {
 	use std::{iter, iter::successors};
 
-	use binius_field::{BinaryField128bGhash as B128, Field, PackedField};
+	use binius_field::{Field, Ghash128b as B128, PackedField};
 
 	use super::*;
 	use crate::circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessGenerator};

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -247,7 +247,7 @@ pub fn build_mulcheck_witness<A: Allocator, F: Field, P: PackedField<Scalar = F>
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_field::{BinaryField128bGhash as B128, Field, Random};
+	use binius_field::{Field, Ghash128b as B128, Random};
 	use binius_math::{
 		multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
 		test_utils::{Packed128b, random_scalars},

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -210,9 +210,7 @@ impl<F: Field> IOPVerifierChannel<F> for ReplayChannel<F> {
 mod tests {
 	use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-	use binius_field::{
-		BinaryField1b as B1, BinaryField128bGhash as B128, ExtensionField, field::FieldOps,
-	};
+	use binius_field::{BinaryField1b as B1, ExtensionField, Ghash128b as B128, field::FieldOps};
 	use binius_spartan_frontend::circuit_builder::{ConstraintBuilder, WitnessGenerator};
 	use binius_spartan_verifier::wrapper::circuit_elem::CircuitElem;
 

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPackedB128};
+use binius_field::{Field, Ghash128b as B128, Random, arch::OptimalPackedB128};
 use binius_hash::StdHashSuite;
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, ConstraintBuilder, InstanceGenerator, WitnessGenerator},

--- a/crates/spartan-prover/tests/proof_size_exactness_test.rs
+++ b/crates/spartan-prover/tests/proof_size_exactness_test.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 The Binius Developers
 
-use binius_field::{BinaryField128bGhash as B128, PackedField, Random, arch::OptimalPackedB128};
+use binius_field::{Ghash128b as B128, PackedField, Random, arch::OptimalPackedB128};
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	channel::{IOPVerifierChannel, size_tracking::SizeTrackingChannel},

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use binius_compute::GlobalAllocator;
-use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPackedB128};
+use binius_field::{Field, Ghash128b as B128, Random, arch::OptimalPackedB128};
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,

--- a/crates/spartan-verifier/src/config.rs
+++ b/crates/spartan-verifier/src/config.rs
@@ -1,10 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField1b, BinaryField128bGhash};
+use binius_field::{BinaryField1b, Ghash128b};
 pub use binius_hash::{StdCompression, StdDigest};
 
 /// The default [`binius_transcript::fiat_shamir::Challenger`] implementation.
 pub type StdChallenger = binius_transcript::fiat_shamir::HasherChallenger<StdDigest>;
 
 pub type B1 = BinaryField1b;
-pub type B128 = BinaryField128bGhash;
+pub type B128 = Ghash128b;

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -23,7 +23,7 @@ mod tests {
 
 	use binius_core::word::Word;
 	use binius_field::{
-		BinaryField1b as B1, BinaryField128bGhash as B128, ExtensionField, Field, Random,
+		BinaryField1b as B1, ExtensionField, Field, Ghash128b as B128, Random,
 		arithmetic_traits::InvertOrZero, field::FieldOps,
 	};
 	use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 The Binius Developers
 
-use binius_field::BinaryField128bGhash as B128;
+use binius_field::Ghash128b as B128;
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	channel::{IOPVerifierChannel, size_tracking::SizeTrackingChannel},

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -439,7 +439,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::BinaryField128bGhash as B128;
+	use binius_field::Ghash128b as B128;
 	use sha2::Sha256;
 
 	use super::*;

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -2,14 +2,14 @@
 //! Specifies standard trait implementations and parameters.
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash};
+use binius_field::{AESTowerField8b, BinaryField, BinaryField1b, Ghash128b};
 use binius_hash::StdDigest;
 use binius_transcript::fiat_shamir::{Challenger, HasherChallenger};
 use binius_utils::checked_arithmetics::checked_log_2;
 
 // Exports the binary fields that this system uses
 pub type B1 = BinaryField1b;
-pub type B128 = BinaryField128bGhash;
+pub type B128 = Ghash128b;
 
 /// The intention of this trait is to capture the moment when a StandardChallenger type is changed.
 pub trait ChallengerWithName: Challenger {

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -286,7 +286,7 @@ mod tests {
 		constraint_system::{AndConstraint, Shift, ShiftedValueIndex, ValueIndex},
 		word::Word,
 	};
-	use binius_field::{BinaryField128bGhash, Field, Random};
+	use binius_field::{Field, Ghash128b, Random};
 	use binius_math::test_utils::random_scalars;
 	use rand::prelude::*;
 
@@ -350,7 +350,7 @@ mod tests {
 		// entries, so scaling the whole table scales the evaluation by the same factor. That holds
 		// however the fixture's terms are spread across the table, which is what lets the fixture
 		// carry doubly shifted terms rather than reading index 0 alone.
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		let mut rng = StdRng::seed_from_u64(7);
 
 		let n_words = 40usize;
@@ -415,7 +415,7 @@ mod tests {
 	/// non-power-of-two one, whose `r_x'` tensor runs past the last constraint.
 	#[test]
 	fn evaluate_monster_native_matches_generic() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		let mut rng = StdRng::seed_from_u64(3);
 
 		let n_words = 40usize;
@@ -451,7 +451,7 @@ mod tests {
 	/// so both are checked.
 	#[test]
 	fn evaluate_monster_ignores_zero_padding_constraints() {
-		type F = BinaryField128bGhash;
+		type F = Ghash128b;
 		let mut rng = StdRng::seed_from_u64(5);
 
 		let n_words = 40usize;

--- a/crates/verifier/src/protocols/shift/shift_ind.rs
+++ b/crates/verifier/src/protocols/shift/shift_ind.rs
@@ -142,7 +142,7 @@ fn evaluate_overflow_ind<E: FieldOps>(r_i: &[E], r_s: &[E]) -> E {
 mod tests {
 	use std::array;
 
-	use binius_field::{BinaryField128bGhash as B128, Field};
+	use binius_field::{Field, Ghash128b as B128};
 	use binius_math::test_utils::random_scalars;
 	use rand::{RngExt, SeedableRng, rngs::StdRng};
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -19,7 +19,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
 	word::Word,
 };
-use binius_field::BinaryField128bGhash as B128;
+use binius_field::Ghash128b as B128;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold::compiler::BaseFoldVerifierCompiler,


### PR DESCRIPTION
Closes [BINIUS-97](https://linear.app/jimpo/issue/BINIUS-97).

Pure rename — no signature, behaviour, or API-shape change beyond the name itself.

### The problem

`BinaryField128bGhash` spells out its tower position and bit width *before* naming the field it actually is.

Its own sibling in the same family does not:

```
binary_field!(pub GhashSq256b(M256), ..)          // GHASH squared, 256 bits
binary_field!(pub BinaryField128bGhash(M128), ..) // GHASH, 128 bits
```

So the two members of one family are named on two different schemes.

### The change

```
- BinaryField128bGhash
+ Ghash128b
```

That makes the family read as one thing — `Ghash128b` and `GhashSq256b` — and drops eight characters from a name that appeared **263 times across 80 files in 14 crates**.

### No compatibility alias

The issue originally proposed re-exporting the old name for backward compatibility. This does not do that.

The old name is gone, not aliased. There is exactly one name for the type, which is the point of renaming it — an alias would leave both spellings in the codebase indefinitely and invite new code to pick either.

Nothing outside this repository depends on the crate, so there is no downstream to break.

### Why a mechanical substitution is safe here

Checked before touching anything, since a rename this wide is only as good as its blast-radius analysis:

- **No partial matches.** `grep -oE "BinaryField128bGhash[A-Za-z0-9_]+"` returns nothing, so no identifier extends the name and a whole-word replace cannot clip a longer symbol.
- **No name-carrying strings.** No assertion anywhere compares against a string literal containing the name. The one formatting test checks `Display`, whose output is the hex value `0x000…005`, not the type name. The one `Debug` assertion on a GHASH packing expects `Packed1x128([..])`, a packed type's name, not this one's.
- **Nothing outside Rust.** No `.md`, `.toml`, or workflow file mentions it.

### A doc that was already ahead of the code

`crates/field/src/packed_ghash_sq.rs` already documented the type as `Ghash128b`:

```
/// A GHASH² packing whose two GHASH coordinates pack into `PackedPrimitiveType<U, Ghash128b>`.
```

That comment referred to a type that did not exist. It is now correct, at no cost.

### Scope

- **changed:** 80 files across `field` (18), `prover` (16), `iop-prover` (9), `recursion` (7), `math` (7), `spartan-prover` (5), `verifier` (4), `spartan-frontend` (4), `spartan-verifier` (3), `hash` (3), and one file each in `transcript`, `iop`, `frontend`, `core`.
- **untouched:** the `B128` alias in the spartan verifier's config keeps its name and simply points at the new one.
- 17 lines got shorter than the formatter's wrap threshold, so nightly `fmt` un-wrapped them — that is the whole difference between the 257 substituted lines and the diff's 267/284.

### Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean. This is the meaningful gate for a pure rename: it compiles every target in every crate, including all test and bench targets, under the strictest configuration.
- `cargo test -p binius-field --lib` — 243 pass, covering the crate that owns the type and both formatting assertions.
- `cargo +nightly fmt --check` — clean.
- `grep -c BinaryField128bGhash` over the tree — **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)