### PR TITLE
Report the caller's location on a FieldBuffer precondition panic

### DIFF
--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -90,6 +90,7 @@ impl<P: PackedField> FieldBuffer<P> {
 	/// # Preconditions
 	///
 	/// * `values.len()` must be a power of two.
+	#[track_caller]
 	pub fn from_values(values: &[P::Scalar]) -> Self {
 		let log_len =
 			strict_log_2(values.len()).expect("precondition: values.len() must be a power of two");
@@ -164,6 +165,7 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `values.len()` must be a power of two.
+	#[track_caller]
 	pub fn from_values_in<A>(alloc: &A, values: &[P::Scalar]) -> Self
 	where
 		A: Allocator<Vec<P> = Data>,
@@ -195,6 +197,7 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	/// Panics if `log_len` is shorter than what the buffer already spans.
 	/// Shrinking is a separate operation.
 	/// Silently returning a narrower buffer than asked for would hide the mistake.
+	#[track_caller]
 	pub fn zero_extend_in<A>(self, alloc: &A, log_len: usize) -> Self
 	where
 		A: Allocator<Vec<P> = Data>,
@@ -229,6 +232,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `values.len()` must equal the expected packed length for `log_len`.
+	#[track_caller]
 	pub fn new(log_len: usize, values: Data) -> Self {
 		let expected_packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 		assert!(
@@ -264,6 +268,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * the index is in the range `0..self.len()`
+	#[track_caller]
 	pub fn get(&self, index: usize) -> P::Scalar {
 		assert!(
 			index < self.len(),
@@ -292,6 +297,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// * `log_chunk_size` must be at most `log_len`.
 	/// * `chunk_index` must be less than the chunk count.
 	#[inline]
+	#[track_caller]
 	pub fn chunk(&self, log_chunk_size: usize, chunk_index: usize) -> FieldSlice<'_, P> {
 		assert!(
 			log_chunk_size <= self.log_len,
@@ -330,6 +336,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `log_chunk_size` must be at least `P::LOG_WIDTH` and at most `log_len`.
+	#[track_caller]
 	pub fn chunks(&self, log_chunk_size: usize) -> impl Iterator<Item = FieldSlice<'_, P>> + Clone {
 		assert!(
 			log_chunk_size >= P::LOG_WIDTH && log_chunk_size <= self.log_len,
@@ -352,6 +359,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `log_chunk_size` must be at most `log_len`.
+	#[track_caller]
 	pub fn chunks_par(
 		&self,
 		log_chunk_size: usize,
@@ -413,6 +421,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `log_chunk_size` must be at most `log_len`.
+	#[track_caller]
 	pub fn par_chunk_scalars(
 		&self,
 		log_chunk_size: usize,
@@ -461,6 +470,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `self.log_len()` must be greater than 0.
+	#[track_caller]
 	pub fn split_half_ref(&self) -> (FieldSlice<'_, P>, FieldSlice<'_, P>) {
 		assert!(self.log_len > 0, "precondition: cannot split a buffer of length 1");
 
@@ -514,6 +524,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * the index is in the range `0..self.len()`
+	#[track_caller]
 	pub fn set(&mut self, index: usize, value: P::Scalar) {
 		assert!(
 			index < self.len(),
@@ -531,6 +542,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `log_chunk_size` must be at least `P::LOG_WIDTH` and at most `log_len`.
+	#[track_caller]
 	pub fn chunks_mut(
 		&mut self,
 		log_chunk_size: usize,
@@ -561,6 +573,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `log_chunk_size` must be at most `log_len`.
 	/// * `chunk_index` must be less than the chunk count.
+	#[track_caller]
 	pub fn chunk_mut(
 		&mut self,
 		log_chunk_size: usize,
@@ -618,6 +631,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `self.log_len()` must be greater than 0.
+	#[track_caller]
 	pub fn split_half(self) -> FieldBufferSplitMut<P, Data> {
 		assert!(self.log_len > 0, "precondition: cannot split a buffer of length 1");
 
@@ -645,6 +659,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Preconditions
 	///
 	/// * `self.log_len()` must be greater than 0.
+	#[track_caller]
 	pub fn split_half_mut(&mut self) -> FieldBufferSplitMut<P, &'_ mut [P]> {
 		self.to_mut().split_half()
 	}
@@ -729,6 +744,7 @@ impl<'a, P: PackedField> FieldSlice<'a, P> {
 	/// # Preconditions
 	///
 	/// * `slice.len()` must equal the expected packed length for `log_len`.
+	#[track_caller]
 	pub fn from_slice(log_len: usize, slice: &'a [P]) -> Self {
 		FieldBuffer::new(log_len, FieldSliceData::Slice(slice))
 	}
@@ -748,6 +764,7 @@ impl<'a, P: PackedField> FieldSliceMut<'a, P> {
 	/// # Preconditions
 	///
 	/// * `slice.len()` must equal the expected packed length for `log_len`.
+	#[track_caller]
 	pub fn from_slice(log_len: usize, slice: &'a mut [P]) -> Self {
 		FieldBuffer::new(log_len, slice)
 	}


### PR DESCRIPTION
### The problem

`FieldBuffer` guards its contract well: 139 asserts spread across the file catch a bad index, an out-of-range chunk size, a backing store whose length does not match `log_len`. What it does not do is tell you where the mistake was made. Ask a 4-element buffer for an 8-element chunk and the panic reads:

```text
thread 'demo_panic_location' panicked at crates/math/src/field_buffer.rs:296:3:
precondition: log_chunk_size must be at most log_len
```

That points at the assert, which is the one location you already know — the message names it. The line you actually need is the call site that computed `3` for a buffer of `log_len` 2, and the panic does not mention it. Finding it means running the test again under `RUST_BACKTRACE=1` and reading past however many frames of generic instantiation and iterator adapters sit between the call and the assert.

`#[track_caller]` exists for exactly this: the compiler threads the caller's `Location` through, so the panic reports the call site instead of the callee. The same run, with the attribute in place:

```text
thread 'demo_panic_location' panicked at crates/math/tests/track_caller_demo.rs:6:17:
precondition: log_chunk_size must be at most log_len
```

Same assert, same message, but now it names the offending line directly. This is standard practice in `std` for this whole class of container-precondition panic — `slice::split_at`, `Vec::insert`, `RefCell::borrow_mut` all carry it, and none of them would be usable if they blamed their own source file instead of yours.

### The idea

Add `#[track_caller]` to every method in `field_buffer.rs` that can panic because of something the caller did. Two groups qualify.

First, the methods that assert directly on their arguments or on the buffer's own length: `new`, `from_values`, `from_values_in`, `zero_extend_in`, `get`, `set`, `chunk`, `chunk_mut`, `chunks`, `chunks_mut`, `chunks_par`, `par_chunk_scalars`, `split_half_ref`, `split_half`. For the four iterator-returning methods the assert fires eagerly, before the iterator is built, so the attribute lands on the frame that actually panics.

Second, the delegating wrappers. `FieldSlice::from_slice` and `FieldSliceMut::from_slice` forward a caller-supplied `log_len` and slice straight into `new`; `split_half_mut` forwards to `split_half`. Without the attribute on the wrapper, the report stops at the delegating line inside `field_buffer.rs`, which is no more useful than the assert itself. With it, the caller's `Location` passes through the wrapper into the callee, and the report reaches the call site.

Deliberately excluded: `len` and `log_len` are `const fn` with no asserts; `to_ref`, `to_mut`, `clone_from_slice` and `truncate` delegate or compute only from internal state that already satisfies the callee's precondition, so no caller can trip them.

### Scope

- **changed:** `crates/math/src/field_buffer.rs` — 17 added `#[track_caller]` attributes, nothing else. No renames, no logic changes, no doc rewrites.
- **not changed:** `zeros_in`, though it was a candidate at the start. It calls `new`, but it sizes the allocation itself and `resize`s to exactly `expected_packed_len`, so the assert in `new` is satisfied by construction and no caller argument can violate it. `PoolVec::resize` asserts nothing either. An attribute there would be dead weight, so it is not there.
- **not changed:** the `Index` and `IndexMut` impls. They do panic on a caller-supplied index, so the attribute would fit — but `tcoratger/field-buffer-drop-index` removes both impls outright, on the grounds that they are bounded on `F: Field` rather than `P: PackedField` and bypass the `log_len` bound check that `get` performs. Polishing a surface another PR deletes is churn, so this diff leaves them alone.
- **not changed:** no test is added. The demonstration below relies on the panic escaping as a test failure, which a committed test cannot do without a global panic hook, and a hook would race the file's existing `#[should_panic]` tests. So it stays a manual check.

### Verification

`cargo clippy -j 3 -p binius-math --all-targets --all-features -- -D warnings` — clean, no warnings.

`cargo test -j 3 -p binius-math` — `144 passed; 0 failed`, plus `1 passed` doc-test. The default build uses the hand-written no-rayon shim, so `cargo test -j 3 -p binius-math --features rayon` was run too: also `144 passed; 0 failed` and `1 passed` doc-test.

`cargo +nightly fmt --check` — clean, exit 0.

The attribute itself was verified by a temporary integration test at `crates/math/tests/track_caller_demo.rs`, deleted before committing:

```rust
use binius_math::{FieldBuffer, test_utils::Packed128b};

#[test]
fn demo_panic_location() {
	let buf = FieldBuffer::<Packed128b>::zeros(2);
	let _ = buf.chunk(3, 0);
}
```

Run against this branch with the attributes stripped back out, it reports the assert:

```text
thread 'demo_panic_location' (236708) panicked at crates/math/src/field_buffer.rs:296:3:
precondition: log_chunk_size must be at most log_len
```

Run against the branch as committed, it reports the call:

```text
thread 'demo_panic_location' (229470) panicked at crates/math/tests/track_caller_demo.rs:6:17:
precondition: log_chunk_size must be at most log_len
```

Line 6, column 17 is the `.chunk(3, 0)` call, in the caller's own file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
