### PR TITLE
Drop Index/IndexMut on FieldBuffer in favor of get/set

### DIFF
--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use std::{
-	ops::{Deref, DerefMut, Index, IndexMut},
+	ops::{Deref, DerefMut},
 	slice,
 };
 
@@ -695,20 +695,6 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> AsMut<[P]> for FieldBuffer<P,
 	#[inline]
 	fn as_mut(&mut self) -> &mut [P] {
 		&mut self.values[..1 << self.log_len.saturating_sub(P::LOG_WIDTH)]
-	}
-}
-
-impl<F: Field, Data: Deref<Target = [F]>> Index<usize> for FieldBuffer<F, Data> {
-	type Output = F;
-
-	fn index(&self, index: usize) -> &Self::Output {
-		&self.values[index]
-	}
-}
-
-impl<F: Field, Data: DerefMut<Target = [F]>> IndexMut<usize> for FieldBuffer<F, Data> {
-	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-		&mut self.values[index]
 	}
 }
 

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -305,7 +305,7 @@ fn evaluate_image<F: BinaryField>(
 		.map(|&word| {
 			(0..64)
 				.filter(|&i| (word >> i) & Word::ONE == Word::ONE)
-				.map(|i| l_tilde[i as usize])
+				.map(|i| l_tilde.get(i as usize))
 				.sum()
 		})
 		.collect::<Vec<_>>();

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -270,15 +270,15 @@ mod tests {
 		}
 
 		let mut rng = StdRng::seed_from_u64(0);
-		let coeffs_vals = random_field_buffer(&mut rng, 2);
+		let coeffs_vals = random_field_buffer::<B128>(&mut rng, 2);
 		let coords_vals = random_scalars(&mut rng, 2);
 		let expected = multilinear::evaluate::evaluate(&coeffs_vals, &coords_vals);
 
 		test_helper::<MultilinearCircuit, 7>([
-			coeffs_vals[0],
-			coeffs_vals[1],
-			coeffs_vals[2],
-			coeffs_vals[3],
+			coeffs_vals.get(0),
+			coeffs_vals.get(1),
+			coeffs_vals.get(2),
+			coeffs_vals.get(3),
 			coords_vals[0],
 			coords_vals[1],
 			expected,


### PR DESCRIPTION
### The problem

`FieldBuffer<P, Data>` is generic over a *packed* field `P`, and its scalar accessors are `get(i) -> P::Scalar` and `set(i, x)`. Alongside them sat a pair of `Index`/`IndexMut` impls, and the giveaway is their bound: they were written over `F: Field`, not `P: PackedField`. A packed type is not a `Field`, so the subscript syntax existed for `FieldBuffer<B128>` and silently did not exist for `FieldBuffer<Packed128b>`. Same container, same conceptual operation — element access — and whether you write `buf[i]` or `buf.get(i)` depended on which instantiation you happened to be holding.

That asymmetry is not an oversight that could be patched. `Index::index` must return `&Self::Output`, a *reference* to an element living somewhere in memory. In a packed buffer no scalar lives anywhere on its own: `values` is a slice of packed words, and the `i`-th scalar is a lane inside `values[i >> P::LOG_WIDTH]`. There is no `&F` to hand out, which is exactly why `get` returns `P::Scalar` by value in the first place. `Index` is structurally the wrong trait for this type, and the `F: Field` bound was the compiler telling us so.

There is a second, quieter point, and it is worth stating precisely rather than dramatically. `get` asserts `index < self.len()`, a bound derived from the logical `log_len`. `Index` forwarded straight to `self.values[index]`, whose bounds check is against the length of the *backing store*. Those are two different quantities in principle, and nothing in the type system ties them together: a buffer whose store outlived its logical length would make the two spellings disagree about what "in bounds" even means.

In practice that divergence is not reachable, and it is worth being explicit about that rather than insinuating a bug. `new` is the only public constructor that adopts a caller-supplied store, and it asserts exact equality — `values.len() == 1 << log_len.saturating_sub(P::LOG_WIDTH)`, not an upper bound — with both `FieldSlice::from_slice` and `FieldSliceMut::from_slice` routing through it. Every other constructor sizes the store itself, `truncate` shrinks the store and `log_len` together, and the internal struct literals are all exact, including the one that looks like a counterexample: `FieldBufferSplitMut::halves` holds the parent's full store behind a halved `log_len`, but hands out `split_at_mut(half_len)`, so each half is exactly its own length. `Vec` spare *capacity* is not length, and `self.values[index]` checks length. And the deleted impl was bounded on `F: Field`, which is `PackedField<Scalar = Self>` with `LOG_WIDTH == 0`, so on every type it actually applied to the two bounds were arithmetically the same number. So: a latent divergence in the API's shape, not a live defect — one more reason a second element-access path earns nothing, not a bug being fixed.

### The idea

Delete both impls and let `get`/`set` be the only way to touch a scalar. That is the API that works for every instantiation, checks the bound that is definitionally the right one, and does not promise a reference it cannot produce.

The surface turns out to be all but unused. `IndexMut` had zero callers in the workspace. `Index` had two, both in tests: one in `crates/prover/tests/shift.rs` summing Lagrange evaluations, one in a `spartan-frontend` unit test, each rewritten to `get`. In the latter, `coeffs_vals` had been inferring its packed parameter *from* the `Index` impl's `F: Field` bound, so it now needs the turbofish it should always have carried — `random_field_buffer::<B128>`. That is its own small argument for the removal: an impl that silently pins a caller's generic parameter is doing something the caller cannot see.

Worth flagging plainly for review: `Index` and `IndexMut` on a public type are public API, and removing them is a breaking change for any out-of-tree caller. The argument for doing it anyway is that the trait cannot be honored for the general packed case, so the impl was never more than a convenience for one corner of the type's domain — but that is a judgment call a reviewer can reasonably push back on in one comment.

### Scope

- **deleted:** the `Index<usize>` and `IndexMut<usize>` impls for `FieldBuffer` in `crates/math/src/field_buffer.rs`, and `Index, IndexMut` from the file's `std::ops` import.
- **changed:** `crates/prover/tests/shift.rs`, `l_tilde[i as usize]` becomes `l_tilde.get(i as usize)`.
- **changed:** `crates/spartan-frontend/src/circuits.rs`, four `coeffs_vals[n]` become `coeffs_vals.get(n)`, and `random_field_buffer` gains an explicit `::<B128>` now that inference has nothing to pin `P` to.

No behavior changes anywhere: `get` returns the same scalar the subscript did at every index these call sites use.

### Verification

`cargo check --workspace --all-targets --all-features` is the load-bearing gate here, since the deleted impls were visible to the entire workspace. It is clean, and the run *before* the call-site fixes produced exactly five errors across the two files named above — which is the evidence that nothing else in-tree subscripts a `FieldBuffer`. Note that the four `spartan-frontend` errors live in a `#[cfg(test)]` module inside a lib, so they only surface under `--all-targets`.

The bounds-check claim in the third and fourth paragraphs was checked rather than asserted: a throwaway test walked every public construction path — `zeros`, `from_values`, `scalar_with_capacity` (a `Vec` of capacity 1024 holding one element), `truncate` down to 4, to 1, and to a single scalar — comparing `len()` against `take_data().len()`, and found them equal in every case, with `new` rejecting an oversized store. The test was deleted; it exists only as the reason the paragraph says "not reachable" instead of "bug".

```
cargo check --workspace --all-targets --all-features -j 3
    Finished `dev` profile [optimized + debuginfo] target(s) in 11.06s

cargo clippy -p binius-math -p binius-prover -p binius-spartan-frontend --all-targets --all-features -- -D warnings
    Finished `dev` profile [optimized + debuginfo] target(s) in 37.48s

cargo test -p binius-math
    test result: ok. 144 passed; 0 failed; 0 ignored
    test result: ok. 1 passed; 0 failed; 0 ignored   (doc-tests)

cargo test -p binius-math --features rayon
    test result: ok. 144 passed; 0 failed; 0 ignored
    test result: ok. 1 passed; 0 failed; 0 ignored   (doc-tests)

cargo test -p binius-prover --test shift
    test result: ok. 1 passed; 0 failed; 0 ignored
cargo test -p binius-prover --test shift --features rayon
    test result: ok. 1 passed; 0 failed; 0 ignored

cargo test -p binius-spartan-frontend --lib
    test result: ok. 27 passed; 0 failed; 0 ignored

cargo +nightly fmt --check
    clean
```

Both feature configurations matter because the default build uses the hand-written no-rayon shim rather than real rayon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
