### PR TITLE
Delete the unused AsSlicesMut trait

### DIFF
--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -6,6 +6,11 @@ use std::{
 	slice,
 };
 
+// The `BufferData` bound on `FieldBuffer`'s backing store lives in `binius-compute` so that it
+// can bound `Allocator::Vec` (letting an allocator's buffer back a `FieldBuffer` without a
+// `where`-clause on every signature) and so its `PoolVec` can implement it. Re-exported here
+// since it is part of this module's public API.
+pub use binius_compute::BufferData;
 use binius_compute::{Allocator, VecLike};
 use binius_field::{
 	Field, PackedField,
@@ -16,17 +21,6 @@ use binius_utils::{
 	rayon::{iter::Either, prelude::*, slice::ParallelSlice},
 };
 use bytemuck::zeroed_vec;
-
-/// Trait for types that can provide multiple mutable field slices.
-pub trait AsSlicesMut<P: PackedField, const N: usize> {
-	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; N];
-}
-
-// The `BufferData` bound on `FieldBuffer`'s backing store lives in `binius-compute` so that it can
-// bound `Allocator::Vec` (letting an allocator's buffer back a `FieldBuffer` without a
-// `where`-clause on every signature) and so its `PoolVec` can implement it. Re-exported here since
-// it is part of this module's public API.
-pub use binius_compute::BufferData;
 
 /// A power-of-two-sized buffer containing field elements, stored in packed fields.
 ///
@@ -689,14 +683,6 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> AsMut<[P]> for FieldBuffer<P,
 	}
 }
 
-impl<P: PackedField, Data: DerefMut<Target = [P]>, const N: usize> AsSlicesMut<P, N>
-	for [FieldBuffer<P, Data>; N]
-{
-	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; N] {
-		self.each_mut().map(|buf| buf.to_mut())
-	}
-}
-
 impl<F: Field, Data: Deref<Target = [F]>> Index<usize> for FieldBuffer<F, Data> {
 	type Output = F;
 
@@ -824,29 +810,6 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for FieldBufferSplitMut<
 			// The arrays may have been modified by the closure
 			(self.data[0], _) = lo_half.interleave(hi_half, self.log_len);
 		}
-	}
-}
-
-impl<P: PackedField, Data: DerefMut<Target = [P]>> AsSlicesMut<P, 2>
-	for FieldBufferSplitMut<P, Data>
-{
-	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; 2] {
-		let (first, second) = self.halves();
-		[first, second]
-	}
-}
-
-impl<P: PackedField, Data: DerefMut<Target = [P]>> AsSlicesMut<P, 4>
-	for [FieldBufferSplitMut<P, Data>; 2]
-{
-	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; 4] {
-		// Borrow the two splits independently so both stay mutable at once.
-		let [first, second] = self;
-		// Each split yields its own low and high half.
-		let (lo_0, hi_0) = first.halves();
-		let (lo_1, hi_1) = second.halves();
-		// Order the four slices as first-low, first-high, second-low, second-high.
-		[lo_0, hi_0, lo_1, hi_1]
 	}
 }
 
@@ -1648,41 +1611,6 @@ mod tests {
 	fn test_split_half_mut_size_one() {
 		let mut buffer = FieldBuffer::<P>::zeros(0); // 1 element
 		let _ = buffer.split_half_mut();
-	}
-
-	// Invariant: viewing two split buffers as four field slices yields exactly their four halves.
-	// The order is first-low, first-high, second-low, second-high.
-	// The reference halves come from a borrow-only split of each buffer.
-	#[test]
-	fn test_split_pair_as_slices_mut_matches_split_half_ref() {
-		// Cover log_len below, at, and above the packing width (P::LOG_WIDTH == 2).
-		for log_len in 1..=5 {
-			let n = 1 << log_len;
-			let mut buf_0 = FieldBuffer::<P>::zeros(log_len);
-			let mut buf_1 = FieldBuffer::<P>::zeros(log_len);
-			for i in 0..n {
-				buf_0.set(i, F::new(i as u128));
-				buf_1.set(i, F::new((i + 100) as u128));
-			}
-
-			// Reference halves: a borrow-only split of each buffer, read low then high.
-			let (ref_lo_0, ref_hi_0) = buf_0.split_half_ref();
-			let (ref_lo_1, ref_hi_1) = buf_1.split_half_ref();
-			let reference: [Vec<F>; 4] = [
-				ref_lo_0.iter_scalars().collect(),
-				ref_hi_0.iter_scalars().collect(),
-				ref_lo_1.iter_scalars().collect(),
-				ref_hi_1.iter_scalars().collect(),
-			];
-
-			// Consume the buffers into owning splits and view the pair as four slices.
-			let mut pair = [buf_0.split_half(), buf_1.split_half()];
-			let slices = pair.as_slices_mut();
-			let actual: [Vec<F>; 4] =
-				std::array::from_fn(|i| slices[i].iter_scalars().collect::<Vec<_>>());
-
-			assert_eq!(actual, reference, "half mismatch at log_len {log_len}");
-		}
 	}
 
 	#[test]

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -28,6 +28,6 @@ pub mod test_utils;
 pub mod univariate;
 
 pub use binary_subspace::BinarySubspace;
-pub use field_buffer::{AsSlicesMut, FieldBuffer, FieldSlice, FieldSliceMut, FieldVec};
+pub use field_buffer::{FieldBuffer, FieldSlice, FieldSliceMut, FieldVec};
 pub use matrix::Matrix;
 pub use reed_solomon::ReedSolomonCode;


### PR DESCRIPTION
### The problem

`crates/math/src/field_buffer.rs` defines a trait whose job is to hand out several mutable field slices at once:

```rust
pub trait AsSlicesMut<P: PackedField, const N: usize> {
	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; N];
}
```

It is re-exported from `binius_math`, so it is public API. Nothing calls it. `rg 'as_slices_mut|AsSlicesMut' crates/` over the whole workspace returns eleven hits, and every one of them is either the definition, one of its three impls, or the single test `test_split_pair_as_slices_mut_matches_split_half_ref` — a test whose subject is the trait itself. There is no production call site, no bench, no example, no downstream crate in the tree that names it.

The second problem is structural, and it is the reason this is worth deleting rather than leaving to rot. The three impls are `[FieldBuffer<P, Data>; N]` for every `N`, `FieldBufferSplitMut` at `N = 2`, and `[FieldBufferSplitMut; 2]` at `N = 4`. That is not one abstraction; it is a `(type, N)` cross product written out by hand. The generic-over-`N` impl covers arrays of buffers, but every combination involving a split has to be spelled out one at a time, because `N` is a const parameter of the trait rather than something derived from the receiver. So the moment a caller wanted `[FieldBufferSplitMut; 4]` — four splits, eight halves — it would not get it from the trait; it would need a fourth impl at `N = 8`. A trait that requires a new impl per arity is not saving anyone from writing the thing it abstracts over, which is one line: `let (lo, hi) = split.halves();`.

### The idea

Delete the trait, its three impls, and the `lib.rs` re-export.

The only real question is the test, because it does assert something: that `[FieldBufferSplitMut; 2]::as_slices_mut()` yields the four halves in the order first-low, first-high, second-low, second-high, cross-checked against `split_half_ref` across `log_len` 1 through 5. The four-slice ordering is an artifact of the trait and dies with it. What survives the trait is the underlying claim, that `halves()` on a split agrees with `split_half_ref` on the same buffer — and that is already pinned, twice and more tightly. `test_split_half` checks `split_half_ref` against literal expected values at `log_len` 4, 2, and 1, and `test_split_half_mut_no_closure` checks `halves()` against literal expected values at the same three sizes, including the write-back through `Drop`. Those three sizes are the whole structural space here: above the packing width, exactly at it, and below it (`P::LOG_WIDTH == 2` for the test packing). `log_len` 3 and 5 take the same above-width code path as 4. Asserting against literals is strictly stronger than cross-checking two functions against each other, since a shared bug would pass the cross-check. So the test is deleted outright rather than rewritten against `halves()`: rewriting it would add a third copy of coverage that already exists.

I want to be straight about the argument for the other direction, because it is a real one. Nothing in the code distinguishes `AsSlicesMut` from an oversight — no doc comment names a caller it is waiting for, no `#[allow]`, no TODO. If it is in fact scaffolding for work in flight, the correct change is the opposite of this PR: keep the trait and give it a doc comment saying who is going to call it and why the arity enumeration is acceptable. That is a one-comment rejection and I will take it. This PR is the reading that the absence of any such marker means what it looks like.

### Scope

- **`crates/math/src/field_buffer.rs`** — remove the `AsSlicesMut` definition and its three impls, and remove `test_split_pair_as_slices_mut_matches_split_half_ref`.
- **`crates/math/src/lib.rs`** — drop `AsSlicesMut` from the `field_buffer` re-export list.
- **Incidental churn** — the trait definition sat between the `use` block and `pub use binius_compute::BufferData;`, acting as a group separator for rustfmt. With it gone, `group_imports = "StdExternalCrate"` folds that `pub use` into the import block and rewraps its four-line comment. Six lines, and unavoidable while this PR stands alone: the fmt gate demands the move, and inserting an artificial separator to keep the formatter off those lines would be worse than the churn itself. Worth knowing that the branch `tcoratger/buffer-traits-one-home` deletes exactly these lines — it moves `BufferData` and `VecLike` out of `binius-compute` into `binius-utils`, so both the comment and the `pub use` disappear. If that one merges first, this churn evaporates on rebase and the diff here becomes purely the `AsSlicesMut` deletion. Sequencing the two is easier than fighting rustfmt.

No behaviour changes; `FieldBufferSplitMut`, `halves()`, `split_half`, `split_half_ref`, and `split_half_mut` are untouched.

### Verification

`cargo check --workspace --all-targets --all-features -j 3` — the gate that proves nothing depended on the removed public surface. `Finished dev profile in 4m 02s`, no warnings.

`cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean, `Finished dev profile in 1.63s`.

`cargo test -p binius-math` — `143 passed; 0 failed`, plus `1 passed` doctest. The split tests specifically still run: `test_split_half ... ok`, `test_split_half_mut_no_closure ... ok`, `test_split_half_ref_size_one - should panic ... ok`, `test_split_half_mut_size_one - should panic ... ok`.

`cargo test -p binius-math --features rayon` — `143 passed; 0 failed`, same four split tests passing. Both configurations matter since the default build uses the hand-written no-rayon shim.

`cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
