### PR TITLE
Make VecLike a subtrait of BufferData

### DIFF
--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -11,11 +11,7 @@
 //! rather than a concrete pool. `&BufferPool` is the primary [`Allocator`], producing [`PoolVec`]
 //! buffers.
 
-use std::{
-	mem,
-	mem::MaybeUninit,
-	ops::{Deref, DerefMut},
-};
+use std::{mem, mem::MaybeUninit, ops::DerefMut};
 
 pub mod buffer_pool;
 
@@ -37,11 +33,13 @@ pub use buffer_pool::{BufferPool, PoolVec};
 pub trait Allocator: Sync + Copy {
 	/// The buffer type this allocator hands out for element type `T`.
 	///
-	/// It is both a [`VecLike`] (growable) and a [`BufferData`] (shrinkable-in-place) buffer, so an
-	/// allocated buffer can back a `binius_math::FieldBuffer` directly. It is also [`Send`] so the
-	/// prover can move pooled buffers across rayon tasks (e.g. the parallel fractional-addition GKR
-	/// reduction); every element type the prover pools is itself `Send`.
-	type Vec<T: Send>: VecLike<T> + BufferData<T> + Send;
+	/// It is a [`VecLike`] buffer, and [`VecLike`] implies [`BufferData`].
+	/// It grows and shrinks in place, so it can back a `binius_math::FieldBuffer` directly.
+	///
+	/// It is also [`Send`] so the prover can move pooled buffers across rayon tasks (e.g. the
+	/// parallel fractional-addition GKR reduction); every element type the prover pools is itself
+	/// `Send`.
+	type Vec<T: Send>: VecLike<T> + Send;
 
 	/// Allocates an empty buffer with room for at least `capacity` elements of type `T`.
 	fn alloc<T: Send>(&self, capacity: usize) -> Self::Vec<T>;
@@ -53,13 +51,13 @@ pub trait Allocator: Sync + Copy {
 /// [`Allocator::Vec`] — that bound is what lets generic allocation code back a `FieldBuffer` with
 /// an allocator's buffer `A::Vec<P>` without threading a `where A::Vec<P>: BufferData<P>` clause
 /// through every signature. `FieldBuffer::truncate` shrinks its backing store to match a smaller
-/// `log_len`, so it is available only for the mutable backings that support that in place: the
-/// growable [`VecLike`] buffers (`Vec<T>` and [`PoolVec`]) and `&mut [T]`.
+/// `log_len`, so it is available only for the mutable backings that support that in place.
 ///
-/// A single blanket `impl<V: VecLike<T>> BufferData<T> for V` would be nicer, but it collides with
-/// the `&mut [T]` impl (coherence cannot rule out a downstream `VecLike for &mut [T]`), and the
-/// `&mut [T]` backing is required — the sumcheck store folds and truncates slice-backed halves. So
-/// the two `VecLike` backings are enumerated explicitly instead.
+/// This trait is the shrinkable-store capability alone, and [`VecLike`] is that plus growth.
+/// Three backings implement it:
+///
+/// - `Vec<T>` and [`PoolVec`] both shrink and grow, so both are [`VecLike`] as well.
+/// - `&mut [T]` only shrinks, by re-slicing, which is what slice-backed sumcheck halves need.
 pub trait BufferData<T>: DerefMut<Target = [T]> {
 	/// Shrinks the store in place to its first `len` elements.
 	///
@@ -90,10 +88,10 @@ impl<T> BufferData<T> for &mut [T] {
 
 /// A growable, `Vec`-like buffer.
 ///
-/// Abstracts the buffer surface the prover relies on — a subset of [`Vec`]'s API, plus dereference
-/// to `[T]`. Implemented by [`PoolVec`]; add methods here (and to the implementors) as callers need
-/// them rather than mirroring all of [`Vec`].
-pub trait VecLike<T>: Deref<Target = [T]> + DerefMut + Extend<T> {
+/// Abstracts the buffer surface the prover uses: [`BufferData`] plus a subset of [`Vec`]'s API.
+/// Implemented by `Vec<T>` and [`PoolVec`], with methods added as callers need them.
+/// It is not meant to mirror all of [`Vec`].
+pub trait VecLike<T>: BufferData<T> + Extend<T> {
 	/// Returns the number of elements the buffer can hold without reallocating.
 	fn capacity(&self) -> usize;
 


### PR DESCRIPTION
### The problem

`binius-compute` declares two traits that describe the same family of objects. `BufferData<T>` is "a mutable slice you can shrink in place"; `VecLike<T>` is "a mutable slice you can shrink in place *and* grow". Yet the code declares them as unrelated:

```rust
pub trait BufferData<T>: DerefMut<Target = [T]> { fn truncate(&mut self, len: usize); }
pub trait VecLike<T>: Deref<Target = [T]> + DerefMut + Extend<T> { /* push, resize, ... */ }
```

The `BufferData` doc comment diagnoses the redundancy itself, and then gives up on fixing it:

> A single blanket `impl<V: VecLike<T>> BufferData<T> for V` would be nicer, but it collides with the `&mut [T]` impl (coherence cannot rule out a downstream `VecLike for &mut [T]`), and the `&mut [T]` backing is required — the sumcheck store folds and truncates slice-backed halves. So the two `VecLike` backings are enumerated explicitly instead.

That diagnosis is correct about the blanket impl and wrong about the conclusion. A blanket impl says "anything growable is *automatically* shrinkable, and here is the code that makes it so" — a claim the compiler has to reconcile against the hand-written `impl BufferData for &mut [T]`, which it cannot, because nothing stops a downstream crate from writing `impl VecLike for &mut [T]` and creating two candidate impls for the same type. The coherence error is real, but it is an artefact of the tool, not of the idea.

The idea only needs to say "growable *requires* shrinkable". That is a supertrait bound, and it has no coherence question to answer at all: it obliges each `VecLike` implementor to have a `BufferData` impl, and each of them writes its own. `&mut [T]` never enters the picture, since it does not implement `VecLike`.

### The idea

Two lines. Require `BufferData` from `VecLike`:

```rust
-pub trait VecLike<T>: Deref<Target = [T]> + DerefMut + Extend<T> {
+pub trait VecLike<T>: BufferData<T> + Extend<T> {
```

Nothing is lost from the bound list: `BufferData<T>: DerefMut<Target = [T]>` already implies both `Deref<Target = [T]>` and `DerefMut`. And nothing has to be written to satisfy it — the obligation is already discharged. `Vec<T>` and `PoolVec<'_, T>` are the only two `VecLike` implementors, and both already carry a hand-written `impl BufferData` a few lines above.

That makes the second bound on the allocator's buffer type dead weight:

```rust
-type Vec<T: Send>: VecLike<T> + BufferData<T> + Send;
+type Vec<T: Send>: VecLike<T> + Send;
```

The immediate payoff downstream is that `Data: VecLike<P>` now grants `truncate`, so a `FieldBuffer` caller who wants to grow *and* shrink one buffer writes one bound instead of two — `zero_extend_in` and `truncate` become usable together without a `where Data: BufferData<P>` tacked on. The three-way relationship also becomes legible from the trait declarations alone: `BufferData` is the shrinkable-store capability, `VecLike` is that plus growth, and `&mut [T]` has only the former, which is exactly what the slice-backed sumcheck store needs.

### Scope

- **The two-line trait change**, plus the `Allocator::Vec` bound it makes redundant. No impl blocks are added or removed; `Deref` drops out of the import list because the supertrait now supplies it.
- **Docs rewritten where they stopped being true.** The `BufferData` paragraph about the blanket impl described a problem that does not exist under a supertrait bound, so it is replaced by a statement of what the hierarchy is and which three backings sit where. The `Allocator::Vec` doc no longer claims two independent capabilities, since one bound implies the other.
- **`field_buffer.rs` is deliberately untouched.** Its `Data: VecLike<P>` block and its `Data: BufferData<P>` block stay separate: the slice-backed sumcheck store needs `&mut [P]: BufferData`, and that backing is not `VecLike`, so merging the blocks would take `truncate` away from it. Splitting inherent impls by capability is the right shape here; this PR only makes the wider of the two capabilities imply the narrower.
- **No `where` clause in the workspace named both bounds**, so there was nothing to simplify beyond `Allocator::Vec`. One file, `crates/frontend/src/artifact/circuit.rs`, imports both traits, and still must: bringing `VecLike` into scope does not bring a supertrait's methods into scope, so the `BufferData` import is what makes its `working.truncate(..)` call resolve.
- **Textual conflict expected with `tcoratger/buffer-traits-one-home`**, which moves both traits out of `binius-compute` into `binius-utils`. The two changes are independent in substance — that one relocates the traits, this one relates them — and whichever lands second rebases.

### Verification

`cargo check --workspace --all-targets --all-features` is the load-bearing gate here, because `Allocator::Vec`'s bound is visible to every prover crate in the workspace; it passes with no warnings and needed no manual fix anywhere.

```
$ cargo check --workspace --all-targets --all-features -j 3
    Finished `dev` profile [optimized + debuginfo] target(s) in 3m 07s   (no warnings)

$ cargo clippy -p binius-compute -p binius-math --all-targets --all-features -- -D warnings
    Finished `dev` profile [optimized + debuginfo] target(s)

$ cargo test -p binius-compute
    test result: ok. 9 passed; 0 failed; 0 ignored
    test result: ok. 0 passed; 0 failed; 0 ignored   (doctests)

$ cargo test -p binius-math
    test result: ok. 144 passed; 0 failed; 0 ignored
    test result: ok. 1 passed; 0 failed; 0 ignored   (doctests)

$ cargo test -p binius-math --features rayon
    test result: ok. 144 passed; 0 failed; 0 ignored
    test result: ok. 1 passed; 0 failed; 0 ignored   (doctests)

$ cargo doc -p binius-compute --no-deps
    Finished (no broken intra-doc links)

$ cargo +nightly fmt --check
    clean
```

`binius-compute` has no `rayon` feature to test the second configuration against (`cargo test -p binius-compute --features rayon` errors with "the package 'binius-compute' does not contain this feature"), so its single configuration is the one reported; `binius-math` was run both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
