### PR TITLE
Give the buffer traits one home, in binius-utils

### DIFF
--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -8,3 +8,4 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-utils = { path = "../utils", default-features = false }

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -6,12 +6,13 @@
 //! instead of returning them to the global allocator, handing out [`PoolVec`] buffers that return
 //! their block to the pool on drop. See the [`buffer_pool`] module for the concrete implementation.
 //!
-//! [`Allocator`] and [`VecLike`] abstract over that machinery: an [`Allocator`] hands out
-//! [`VecLike`] buffers, letting the prover's allocation code be written against `&impl Allocator`
-//! rather than a concrete pool. `&BufferPool` is the primary [`Allocator`], producing [`PoolVec`]
-//! buffers.
+//! [`Allocator`] abstracts over that machinery: an allocator hands out [`VecLike`] buffers, letting
+//! the prover's allocation code be written against `&impl Allocator` rather than a concrete pool.
+//! `&BufferPool` is the primary [`Allocator`], producing [`PoolVec`] buffers.
 
-use std::{mem, mem::MaybeUninit, ops::DerefMut};
+use std::mem::MaybeUninit;
+
+use binius_utils::buffer::{BufferData, VecLike};
 
 pub mod buffer_pool;
 
@@ -45,82 +46,10 @@ pub trait Allocator: Sync + Copy {
 	fn alloc<T: Send>(&self, capacity: usize) -> Self::Vec<T>;
 }
 
-/// Backing store of a `binius_math::FieldBuffer` that can be shrunk in place.
-///
-/// This lives here, rather than in `binius-math`, so that it can be a bound on
-/// [`Allocator::Vec`] — that bound is what lets generic allocation code back a `FieldBuffer` with
-/// an allocator's buffer `A::Vec<P>` without threading a `where A::Vec<P>: BufferData<P>` clause
-/// through every signature. `FieldBuffer::truncate` shrinks its backing store to match a smaller
-/// `log_len`, so it is available only for the mutable backings that support that in place.
-///
-/// This trait is the shrinkable-store capability alone, and [`VecLike`] is that plus growth.
-/// Three backings implement it:
-///
-/// - `Vec<T>` and [`PoolVec`] both shrink and grow, so both are [`VecLike`] as well.
-/// - `&mut [T]` only shrinks, by re-slicing, which is what slice-backed sumcheck halves need.
-pub trait BufferData<T>: DerefMut<Target = [T]> {
-	/// Shrinks the store in place to its first `len` elements.
-	///
-	/// `len` must be at most the current length.
-	fn truncate(&mut self, len: usize);
-}
-
-impl<T> BufferData<T> for Vec<T> {
-	fn truncate(&mut self, len: usize) {
-		Vec::truncate(self, len);
-	}
-}
-
 impl<T> BufferData<T> for PoolVec<'_, T> {
 	fn truncate(&mut self, len: usize) {
 		PoolVec::truncate(self, len);
 	}
-}
-
-impl<T> BufferData<T> for &mut [T] {
-	fn truncate(&mut self, len: usize) {
-		// A `&'a mut [T]` cannot be re-sliced in place through `&mut self`, so move it out and
-		// slice the owned value back in.
-		let full = mem::take(self);
-		*self = &mut full[..len];
-	}
-}
-
-/// A growable, `Vec`-like buffer.
-///
-/// Abstracts the buffer surface the prover uses: [`BufferData`] plus a subset of [`Vec`]'s API.
-/// Implemented by `Vec<T>` and [`PoolVec`], with methods added as callers need them.
-/// It is not meant to mirror all of [`Vec`].
-pub trait VecLike<T>: BufferData<T> + Extend<T> {
-	/// Returns the number of elements the buffer can hold without reallocating.
-	fn capacity(&self) -> usize;
-
-	/// Appends an element to the back of the buffer.
-	fn push(&mut self, value: T);
-
-	/// Clears the buffer, removing all elements while retaining its capacity.
-	fn clear(&mut self);
-
-	/// Resizes the buffer to `new_len`, filling any new slots with `value`.
-	fn resize(&mut self, new_len: usize, value: T)
-	where
-		T: Clone;
-
-	/// Appends all elements of `other` to the back of the buffer.
-	fn extend_from_slice(&mut self, other: &[T])
-	where
-		T: Clone;
-
-	/// Returns the spare capacity of the buffer as a slice of `MaybeUninit<T>`.
-	fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>];
-
-	/// Forces the length of the buffer to `new_len`.
-	///
-	/// # Safety
-	///
-	/// Same contract as [`Vec::set_len`]: `new_len` must be at most [`capacity`](Self::capacity)
-	/// and the elements in `0..new_len` must be initialized.
-	unsafe fn set_len(&mut self, new_len: usize);
 }
 
 impl<T> VecLike<T> for PoolVec<'_, T> {
@@ -167,42 +96,6 @@ impl<'alloc> Allocator for &'alloc BufferPool {
 		// for `'alloc`, not merely for this call's `&self` borrow.
 		let pool: &'alloc BufferPool = self;
 		pool.alloc_vec(capacity)
-	}
-}
-
-impl<T> VecLike<T> for Vec<T> {
-	fn capacity(&self) -> usize {
-		Vec::capacity(self)
-	}
-
-	fn push(&mut self, value: T) {
-		Vec::push(self, value);
-	}
-
-	fn clear(&mut self) {
-		Vec::clear(self);
-	}
-
-	fn resize(&mut self, new_len: usize, value: T)
-	where
-		T: Clone,
-	{
-		Vec::resize(self, new_len, value);
-	}
-
-	fn extend_from_slice(&mut self, other: &[T])
-	where
-		T: Clone,
-	{
-		Vec::extend_from_slice(self, other);
-	}
-
-	fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
-		Vec::spare_capacity_mut(self)
-	}
-
-	unsafe fn set_len(&mut self, new_len: usize) {
-		unsafe { Vec::set_len(self, new_len) }
 	}
 }
 

--- a/crates/frontend/src/artifact/circuit.rs
+++ b/crates/frontend/src/artifact/circuit.rs
@@ -3,13 +3,17 @@
 
 //! The artifact a build hands back: a constraint system plus what it takes to fill a witness.
 
-use binius_compute::{Allocator, BufferData, VecLike};
+use binius_compute::Allocator;
 use binius_core::{
 	ValueTable,
 	constraint_system::{ConstraintSystem, ValueIndex, ValueSegment, ValueVec, ValueVecLayout},
 	word::Word,
 };
-use binius_utils::{rayon::prelude::*, strided_array::StridedArray2DViewMut};
+use binius_utils::{
+	buffer::{BufferData, VecLike},
+	rayon::prelude::*,
+	strided_array::StridedArray2DViewMut,
+};
 use cranelift_entity::SecondaryMap;
 
 use crate::{

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -3,9 +3,10 @@
 
 use std::{fmt, marker::PhantomData, mem::MaybeUninit, slice};
 
-use binius_compute::{Allocator, GlobalAllocator, VecLike};
+use binius_compute::{Allocator, GlobalAllocator};
 use binius_field::Field;
 use binius_utils::{
+	buffer::VecLike,
 	checked_arithmetics::checked_log_2,
 	rayon::{self, prelude::*, slice::ParallelSlice},
 };

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -3,11 +3,11 @@
 
 use std::{iter, ops::Deref};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_iop::fri::FRIParams;
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT, reed_solomon::ReedSolomonCode};
-use binius_utils::{rand::par_rand, rayon::prelude::*};
+use binius_utils::{buffer::VecLike, rand::par_rand, rayon::prelude::*};
 use rand::{CryptoRng, rngs::StdRng};
 
 /// Reed-Solomon encodes one input oracle's interleaved message.

--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_ip::{
 	fracaddcheck::FracAddEvalClaim, mlecheck, prodcheck::MultilinearEvalClaim,
@@ -14,9 +14,12 @@ use binius_math::{
 	line::extrapolate_line,
 	multilinear::eq::{eq_ind_partial_eval, eq_one_var},
 };
-use binius_utils::rayon::{
-	iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
-	task_size::{IndexedParallelIteratorExt, WorkPerItem},
+use binius_utils::{
+	buffer::VecLike,
+	rayon::{
+		iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
 };
 use either::Either;
 use itertools::izip;

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -11,12 +11,15 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec, multilinear::eq::scaled_eq_ind_partial_eval_into,
 };
-use binius_utils::rayon::{current_num_threads, prelude::*};
+use binius_utils::{
+	buffer::VecLike,
+	rayon::{current_num_threads, prelude::*},
+};
 
 use super::prove::TableLookup;
 

--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
@@ -10,9 +10,12 @@ use binius_math::{
 	line::extrapolate_line,
 	multilinear::eq::{eq_ind_partial_eval, eq_one_var},
 };
-use binius_utils::rayon::{
-	prelude::*,
-	task_size::{IndexedParallelIteratorExt, WorkPerItem},
+use binius_utils::{
+	buffer::VecLike,
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
 };
 use itertools::izip;
 

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -3,10 +3,8 @@
 
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{
-	FieldBuffer, field_buffer::BufferData, multilinear::fold::fold_highest_var_inplace,
-};
-use binius_utils::{bitwise::Bitwise, rayon::prelude::*};
+use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
+use binius_utils::{bitwise::Bitwise, buffer::BufferData, rayon::prelude::*};
 use itertools::izip;
 
 use super::{

--- a/crates/ip-prover/src/sumcheck/sparse_dense_product.rs
+++ b/crates/ip-prover/src/sumcheck/sparse_dense_product.rs
@@ -4,12 +4,13 @@
 
 use binius_field::{Field, PackedField};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{
-	FieldBuffer, field_buffer::BufferData, multilinear::fold::fold_highest_var_inplace,
-};
-use binius_utils::rayon::{
-	prelude::*,
-	task_size::{IndexedParallelIteratorExt, WorkPerItem},
+use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
+use binius_utils::{
+	buffer::BufferData,
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
 };
 
 use super::{common::SumcheckProver, round_evals::RoundEvals, round_state::RoundState};

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -3,7 +3,7 @@
 
 use std::{marker::PhantomData, ops::Deref};
 
-use binius_compute::{Allocator, BufferPool, VecLike};
+use binius_compute::{Allocator, BufferPool};
 use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, ValueTable},
 	word::Word,
@@ -35,7 +35,7 @@ use binius_prover::{
 	ring_switch::{self, RingSwitchOutput},
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
-use binius_utils::SerializeBytes;
+use binius_utils::{SerializeBytes, buffer::VecLike};
 use binius_verifier::{
 	config::B128,
 	protocols::{

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -4,12 +4,12 @@
 
 use std::ops::Deref;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::{ValueTable, word::Word};
 use binius_field::{BinaryField, PackedField};
 use binius_math::{FieldVec, inner_product::inner_product};
 use binius_prover::fold_word::WordFolder;
-use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 /// One 64-bit word with its bit axis expanded into full field elements.
 ///

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -5,7 +5,7 @@
 
 use std::{iter, mem::MaybeUninit, ops::Deref, ptr};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::{
 	ValueSegment, ValueTable,
 	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex},
@@ -14,7 +14,10 @@ use binius_core::{
 use binius_field::{Field, PackedField};
 use binius_math::{FieldBuffer, FieldVec};
 use binius_prover::fold_word::fold_words;
-use binius_utils::rayon::{prelude::*, task_size::IndexedParallelIteratorExt};
+use binius_utils::{
+	buffer::VecLike,
+	rayon::{prelude::*, task_size::IndexedParallelIteratorExt},
+};
 use binius_verifier::config::B128;
 
 /// The operand columns of one batched fixed-arity operation.

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -6,17 +6,13 @@ use std::{
 	slice,
 };
 
-// The `BufferData` bound on `FieldBuffer`'s backing store lives in `binius-compute` so that it
-// can bound `Allocator::Vec` (letting an allocator's buffer back a `FieldBuffer` without a
-// `where`-clause on every signature) and so its `PoolVec` can implement it. Re-exported here
-// since it is part of this module's public API.
-pub use binius_compute::BufferData;
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{
 	Field, PackedField,
 	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
 };
 use binius_utils::{
+	buffer::{BufferData, VecLike},
 	checked_arithmetics::strict_log_2,
 	rayon::{iter::Either, prelude::*, slice::ParallelSlice},
 };

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -1,11 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{PackedField, field::FieldOps};
+use binius_utils::buffer::{BufferData, VecLike};
 
 use super::hypercube::{self, Hypercube, OneCube};
-use crate::{FieldBuffer, FieldVec, field_buffer::BufferData};
+use crate::{FieldBuffer, FieldVec};
 
 /// Tensor of values with the eq indicator evaluated at extra_query_coordinates.
 ///

--- a/crates/math/src/multilinear/evaluate.rs
+++ b/crates/math/src/multilinear/evaluate.rs
@@ -3,11 +3,10 @@
 use std::ops::{Deref, DerefMut};
 
 use binius_field::{Field, PackedField, field::FieldOps};
-use binius_utils::rayon::prelude::*;
+use binius_utils::{buffer::BufferData, rayon::prelude::*};
 
 use crate::{
 	FieldBuffer,
-	field_buffer::BufferData,
 	inner_product::inner_product_buffers,
 	multilinear::{eq::eq_ind_partial_eval, fold::fold_highest_var_inplace},
 };

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -2,9 +2,10 @@
 
 use std::ops::{Deref, DerefMut};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_utils::{
+	buffer::{BufferData, VecLike},
 	random_access_sequence::RandomAccessSequence,
 	rayon::{
 		prelude::*,
@@ -12,7 +13,7 @@ use binius_utils::{
 	},
 };
 
-use crate::{FieldBuffer, FieldVec, field_buffer::BufferData, line::extrapolate_line};
+use crate::{FieldBuffer, FieldVec, line::extrapolate_line};
 
 /// Computes the partial evaluation of a multilinear on its highest variable, inplace.
 ///

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -8,14 +8,17 @@
 
 use std::{iter, slice};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, field::FieldOps};
-use binius_utils::rayon::{
-	prelude::*,
-	task_size::{IndexedParallelIteratorExt, WorkPerItem},
+use binius_utils::{
+	buffer::{BufferData, VecLike},
+	rayon::{
+		prelude::*,
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
 };
 
-use crate::{FieldBuffer, FieldVec, field_buffer::BufferData};
+use crate::{FieldBuffer, FieldVec};
 
 /// A hypercube of coefficients for multilinear polynomials.
 ///

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -7,9 +7,12 @@
 
 use std::{marker::PhantomData, ptr};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
-use binius_utils::rayon::{prelude::*, task_size::task_chunk_len};
+use binius_utils::{
+	buffer::VecLike,
+	rayon::{prelude::*, task_size::task_chunk_len},
+};
 use getset::CopyGetters;
 
 use super::{

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -3,7 +3,7 @@
 
 use std::{array, hint::assert_unchecked, iter, ops::BitXor};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{
 	BinaryField, Divisible, PackedBinaryField64x1b, PackedField, UnderlierType, WideMul,
@@ -19,6 +19,7 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
 };
 use binius_utils::{
+	buffer::VecLike,
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 	rayon::prelude::*,
 };

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip_prover::{
@@ -10,7 +10,7 @@ use binius_ip_prover::{
 	sumcheck::{ProveSingleOutput, prove_single_mlecheck, quadratic_mlecheck_prover},
 };
 use binius_math::{FieldVec, field_buffer::FieldBuffer};
-use binius_utils::checked_arithmetics::log2_ceil_usize;
+use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize};
 pub use binius_verifier::protocols::binmul::BinMulOutput;
 
 use crate::fold_word::WordFolder;

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -3,7 +3,7 @@
 
 use std::{iter, mem::MaybeUninit, ops::Deref};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
 use binius_ip_prover::prodcheck::ProdcheckProver;
@@ -12,6 +12,7 @@ use binius_math::{
 	field_buffer::{FieldBuffer, FieldSlice},
 };
 use binius_utils::{
+	buffer::VecLike,
 	checked_arithmetics::log2_ceil_usize,
 	rayon::{
 		prelude::*,

--- a/crates/prover/src/protocols/shift/key_collection/collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection/collection.rs
@@ -1,11 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::constraint_system::{ConstraintSystem, InoutSegment};
 use binius_field::{BinaryField, PackedField, WideMul};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::{
+	buffer::VecLike,
 	checked_arithmetics::log2_ceil_usize,
 	rayon::{
 		prelude::*,

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -3,10 +3,11 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::{ShiftVariant, constraint_system::Shift, word::Word};
 use binius_field::{BinaryField, Field, PackedField};
 use binius_math::{FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
+use binius_utils::buffer::VecLike;
 use tracing::instrument;
 
 use super::{phase_1::SHIFT_OPERATOR_LOG_LEN, shift_ind::ShiftChallenge};

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -3,7 +3,7 @@
 
 use std::{marker::PhantomData, mem::MaybeUninit};
 
-use binius_compute::{Allocator, BufferPool, VecLike};
+use binius_compute::{Allocator, BufferPool};
 use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, Operand, ValueVec},
 	word::Word,
@@ -22,6 +22,7 @@ use binius_math::{
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{
 	SerializeBytes,
+	buffer::VecLike,
 	rayon::{prelude::*, task_size::IndexedParallelIteratorExt},
 };
 use binius_verifier::{

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -3,7 +3,7 @@
 
 use std::{iter, ops::Deref};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{
 	ExtensionField, Field, PackedBinaryField128x1b, PackedExtension, PackedField,
@@ -20,7 +20,7 @@ use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec, inner_product::inner_product_packed,
 	multilinear::eq::eq_ind_partial_eval, tensor_algebra::TensorAlgebra,
 };
-use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use binius_verifier::{
 	config::{B1, B128, LOG_WORDS_PER_ELEM},
 	protocols::shift::evaluate_words_mle,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -37,7 +37,7 @@ use std::{
 	ops::Deref,
 };
 
-use binius_compute::{Allocator, BufferPool, VecLike};
+use binius_compute::{Allocator, BufferPool};
 use binius_field::{BinaryField, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
@@ -60,7 +60,9 @@ use binius_spartan_verifier::{
 	wiring::evaluate_wiring_mle_public,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
-use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2, rayon::prelude::*};
+use binius_utils::{
+	SerializeBytes, buffer::VecLike, checked_arithmetics::checked_log_2, rayon::prelude::*,
+};
 use digest::Output;
 pub use error::*;
 use itertools::chain;

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -1,13 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_math::{FieldBuffer, FieldSlice, FieldVec};
 use binius_spartan_frontend::constraint_system::{
 	MulConstraint, Operand, WitnessIndex, WitnessSegment,
 };
-use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
+use binius_utils::{buffer::VecLike, checked_arithmetics::checked_log_2, rayon::prelude::*};
 
 /// Transpose of a wiring sparse matrix for a specific witness segment.
 ///

--- a/crates/utils/src/buffer.rs
+++ b/crates/utils/src/buffer.rs
@@ -1,0 +1,145 @@
+// Copyright 2026 The Binius Developers
+
+//! Traits abstracting over the buffers that back Binius' working memory.
+//!
+//! [`BufferData`] is the shrinkable-in-place surface, and [`VecLike`] is that plus growth — the
+//! subset of [`Vec`]'s API that callers rely on. Both are container vocabulary: they say what a
+//! buffer can do, not where its memory came from, so a plain [`Vec`], a borrowed `&mut [T]`, or a
+//! buffer drawn from a recycling pool can all satisfy them.
+
+use std::{mem, mem::MaybeUninit, ops::DerefMut};
+
+/// A mutable buffer of `T` that can be shrunk in place.
+///
+/// This is the backing store a `binius_math::FieldBuffer` needs in order to support
+/// `FieldBuffer::truncate`, which shrinks the store to match a smaller `log_len`.
+///
+/// This trait is the shrinkable-store capability alone, and [`VecLike`] is that plus growth.
+/// Three backings implement it:
+///
+/// - `Vec<T>` and `PoolVec` both shrink and grow, so both are [`VecLike`] as well.
+/// - `&mut [T]` only shrinks, by re-slicing, which is what slice-backed sumcheck halves need.
+pub trait BufferData<T>: DerefMut<Target = [T]> {
+	/// Shrinks the store in place to its first `len` elements.
+	///
+	/// `len` must be at most the current length.
+	fn truncate(&mut self, len: usize);
+}
+
+impl<T> BufferData<T> for Vec<T> {
+	fn truncate(&mut self, len: usize) {
+		Vec::truncate(self, len);
+	}
+}
+
+impl<T> BufferData<T> for &mut [T] {
+	fn truncate(&mut self, len: usize) {
+		// A `&'a mut [T]` cannot be re-sliced in place through `&mut self`, so move it out and
+		// slice the owned value back in.
+		let full = mem::take(self);
+		*self = &mut full[..len];
+	}
+}
+
+/// A growable, `Vec`-like buffer.
+///
+/// Abstracts the buffer surface the prover uses: [`BufferData`] plus a subset of [`Vec`]'s API.
+/// Implemented by `Vec<T>` and `PoolVec`, with methods added as callers need them.
+/// It is not meant to mirror all of [`Vec`].
+pub trait VecLike<T>: BufferData<T> + Extend<T> {
+	/// Returns the number of elements the buffer can hold without reallocating.
+	fn capacity(&self) -> usize;
+
+	/// Appends an element to the back of the buffer.
+	fn push(&mut self, value: T);
+
+	/// Clears the buffer, removing all elements while retaining its capacity.
+	fn clear(&mut self);
+
+	/// Resizes the buffer to `new_len`, filling any new slots with `value`.
+	fn resize(&mut self, new_len: usize, value: T)
+	where
+		T: Clone;
+
+	/// Appends all elements of `other` to the back of the buffer.
+	fn extend_from_slice(&mut self, other: &[T])
+	where
+		T: Clone;
+
+	/// Returns the spare capacity of the buffer as a slice of `MaybeUninit<T>`.
+	fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>];
+
+	/// Forces the length of the buffer to `new_len`.
+	///
+	/// # Safety
+	///
+	/// Same contract as [`Vec::set_len`]: `new_len` must be at most [`capacity`](Self::capacity)
+	/// and the elements in `0..new_len` must be initialized.
+	unsafe fn set_len(&mut self, new_len: usize);
+}
+
+impl<T> VecLike<T> for Vec<T> {
+	fn capacity(&self) -> usize {
+		Vec::capacity(self)
+	}
+
+	fn push(&mut self, value: T) {
+		Vec::push(self, value);
+	}
+
+	fn clear(&mut self) {
+		Vec::clear(self);
+	}
+
+	fn resize(&mut self, new_len: usize, value: T)
+	where
+		T: Clone,
+	{
+		Vec::resize(self, new_len, value);
+	}
+
+	fn extend_from_slice(&mut self, other: &[T])
+	where
+		T: Clone,
+	{
+		Vec::extend_from_slice(self, other);
+	}
+
+	fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
+		Vec::spare_capacity_mut(self)
+	}
+
+	unsafe fn set_len(&mut self, new_len: usize) {
+		unsafe { Vec::set_len(self, new_len) }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn vec_truncates_through_buffer_data() {
+		let mut buffer = vec![1u64, 2, 3, 4];
+		BufferData::truncate(&mut buffer, 2);
+		assert_eq!(&*buffer, &[1, 2]);
+	}
+
+	#[test]
+	fn slice_truncates_through_buffer_data() {
+		let mut owned = [1u64, 2, 3, 4];
+		let mut buffer: &mut [u64] = &mut owned;
+		BufferData::truncate(&mut buffer, 3);
+		assert_eq!(buffer, &[1, 2, 3]);
+	}
+
+	#[test]
+	fn vec_fills_through_vec_like() {
+		let mut buffer: Vec<u64> = Vec::with_capacity(4);
+		buffer.push(1);
+		buffer.extend_from_slice(&[2, 3]);
+		VecLike::resize(&mut buffer, 5, 0);
+		assert!(VecLike::capacity(&buffer) >= 5);
+		assert_eq!(&*buffer, &[1, 2, 3, 0, 0]);
+	}
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -5,6 +5,7 @@
 //! Utility modules used in Binius.
 
 pub mod bitwise;
+pub mod buffer;
 pub mod checked_arithmetics;
 pub mod iter;
 #[cfg(feature = "platform-diagnostics")]


### PR DESCRIPTION
### The problem

`crates/math/src/field_buffer.rs` opened with this:

```rust
// The `BufferData` bound on `FieldBuffer`'s backing store lives in `binius-compute` so that it can
// bound `Allocator::Vec` (letting an allocator's buffer back a `FieldBuffer` without a
// `where`-clause on every signature) and so its `PoolVec` can implement it. Re-exported here since
// it is part of this module's public API.
pub use binius_compute::BufferData;
```

Four lines of comment apologising for a `pub use` is the tell. When a design needs a paragraph to
explain where one of its traits lives, the trait is in the wrong place.

Look at what `BufferData<T>` actually is: a `DerefMut<Target = [T]>` that can shrink in place. It
says nothing about compute, nothing about pooling, nothing about fields. Same for its sibling
`VecLike<T>`, which is just the subset of `Vec`'s API the prover leans on. Both are pure container
vocabulary. They ended up in the buffer-pool crate for a graph reason rather than a design one:
`binius-compute` is a leaf with zero binius dependencies and `binius-math` depends on it, so the
arrow could only point that way, and the traits followed the arrow.

The cost is measurable, because the trait acquired two canonical paths and the workspace used both
with no rule for which:

```
crates/math/src/multilinear/{eq,fold,evaluate,hypercube}.rs        use crate::field_buffer::BufferData        (4)
crates/ip-prover/src/sumcheck/{selector_mle,sparse_dense_product}  use binius_math::field_buffer::BufferData  (2)
crates/frontend/src/artifact/circuit.rs                            use binius_compute::BufferData             (1)
```

`VecLike` had the same problem at larger scale — 23 files reaching for a container trait through the
buffer-pool crate. Secondarily, rustdoc listed the item in two crates, and anyone wanting a
`FieldBuffer` over a custom backing store had to depend on a pooling crate they never call.

### The idea

`binius-utils` is also a leaf with zero binius dependencies, so `binius-compute -> binius-utils` is
legal and creates no cycle. Both traits move into a new `binius_utils::buffer` module, which is
where container vocabulary belongs, and every caller gets one path to say.

The one non-obvious mechanical consequence is the orphan rule, and it is what makes the split clean
rather than arbitrary. `impl BufferData for Vec<T>`, `impl BufferData for &mut [T]`, and
`impl VecLike for Vec<T>` all name foreign types, so once the trait is local to `binius-utils` they
have to travel with it — `binius-compute` may not host them any more. `impl BufferData for PoolVec`
and `impl VecLike for PoolVec` stay behind, because `PoolVec` is compute's own type and those impls
belong next to it. So the rule the compiler enforces happens to be exactly the line you would draw
by hand: generic container impls with the traits, pool-specific impls with the pool.

What is left in `binius-compute` is the thing that genuinely is about compute: `Allocator`, its
`type Vec<T: Send>: VecLike<T> + BufferData<T> + Send` bound, and the two allocators. That bound is
the whole reason the traits could not live in `binius-math`, and it keeps working unchanged — a
leaf crate is free to bound its associated type by a trait from another leaf.

Callers use the explicit module path, `binius_utils::buffer::{BufferData, VecLike}`, following what
the neighbours in that crate do (`checked_arithmetics`, `rayon`, `strided_array` are all reached by
module path; only the serialization traits are re-exported at the root). No crate-root re-export was
added, and `binius-compute` imports the traits privately rather than re-exporting them — a `pub use`
there would recreate the two-paths problem this PR exists to remove.

I considered a brand-new `binius-buffer` leaf crate instead. Same diff shape, but it adds a node to
the workspace graph to hold about 150 lines, and `binius-utils` is already the crate for exactly
this kind of vocabulary, so it did not earn its keep.

### Scope

- **New `crates/utils/src/buffer.rs`** holds `BufferData<T>` and `VecLike<T>` plus the three impls the orphan rule forces to live with them, and three unit tests covering `Vec`, `&mut [T]`, and the growable surface.
- **`crates/compute/src/lib.rs`** keeps `Allocator`, `GlobalAllocator`, and the two `PoolVec` impls, and imports the traits from `binius_utils::buffer`. Its crate-level doc no longer claims to define `VecLike`, and `BufferData`'s doc loses the paragraph explaining why it sat in compute.
- **`crates/compute/Cargo.toml`** gains `binius-utils = { path = "../utils", default-features = false }`. No utils feature is needed — the buffer module has no optional dependency.
- **`crates/math/src/field_buffer.rs`** loses the `pub use` and its comment; `BufferData` was not re-exported anywhere else in `binius-math`.
- **28 call sites across 8 crates** switch to the single new path. The 7 `BufferData` sites, plus the `VecLike` importers in `binius-hash`, `binius-iop-prover`, `binius-ip-prover`, `binius-m4-prover`, `binius-math`, `binius-prover`, `binius-spartan-prover`, and `binius-frontend`. Every one of those crates already depended on `binius-utils`, so no other manifest changed.

Worth flagging for whoever reviews second: `tcoratger/veclike-implies-bufferdata` makes `VecLike<T>`
a subtrait of `BufferData<T>` and drops the now-redundant `+ BufferData<T>` from `Allocator::Vec`.
It edits the same two trait definitions this PR relocates, so the two conflict textually while being
independent semantically. Whichever lands second rebases; if that is this one, the rebase is a
one-line edit in the new file.

### Verification

`cargo check --workspace --all-targets --all-features -j 3` — the load-bearing gate, since this
moves a trait that 28 files across 8 crates import. Clean, `Finished dev profile in 3m 08s`.

`cargo clippy --all-targets --all-features -- -D warnings` (the CI flags) over the five crates named
in the plan (`binius-utils`, `binius-compute`, `binius-math`, `binius-frontend`, `binius-ip-prover`)
and then over the five more this PR touches (`binius-hash`, `binius-iop-prover`, `binius-m4-prover`,
`binius-prover`, `binius-spartan-prover`). Both runs clean, no warnings.

`cargo test -p binius-utils -p binius-compute -p binius-math` — 44 + 9 + 144 unit tests pass, 2
doctests pass. Again with `--features rayon`, since the default build uses the hand-written no-rayon
shim: 31 + 9 + 144 pass, 2 doctests pass. The utils count differs between the two because the shim
carries its own tests.

`cargo test -p binius-frontend -p binius-ip-prover` — 259 + 95 unit tests, 4 integration tests, 2
doctests, all pass.

`cargo doc -p binius-compute -p binius-utils -p binius-math --no-deps` — no warnings, so every
intra-doc link still resolves, including the ones in `Allocator`'s docs that now point through a
private import.

`cargo +nightly fmt --check` — clean.

And the outcome this was aiming for. `rg 'BufferData' -g '*.rs' crates/` now shows one definition,
in `crates/utils/src/buffer.rs`, and one import path, `binius_utils::buffer`:

```
crates/utils/src/buffer.rs:pub trait BufferData<T>: DerefMut<Target = [T]> {
crates/utils/src/buffer.rs:impl<T> BufferData<T> for Vec<T> {
crates/utils/src/buffer.rs:impl<T> BufferData<T> for &mut [T] {
crates/compute/src/lib.rs:use binius_utils::buffer::{BufferData, VecLike};
crates/compute/src/lib.rs:impl<T> BufferData<T> for PoolVec<'_, T> {
crates/math/src/field_buffer.rs:	buffer::{BufferData, VecLike},
crates/math/src/multilinear/eq.rs:use binius_utils::buffer::{BufferData, VecLike};
crates/math/src/multilinear/evaluate.rs:use binius_utils::{buffer::BufferData, rayon::prelude::*};
crates/math/src/multilinear/fold.rs:	buffer::{BufferData, VecLike},
crates/math/src/multilinear/hypercube.rs:	buffer::{BufferData, VecLike},
crates/ip-prover/src/sumcheck/selector_mle.rs:use binius_utils::{bitwise::Bitwise, buffer::BufferData, rayon::prelude::*};
crates/ip-prover/src/sumcheck/sparse_dense_product.rs:	buffer::BufferData,
crates/frontend/src/artifact/circuit.rs:	buffer::{BufferData, VecLike},
```

(Trait-bound and doc-mention lines elided; `crates/math/src/field_buffer.rs:pub use
binius_compute::BufferData;` is gone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
