### PR TITLE
Retire the fused fractional-addition round evaluator

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -24,9 +24,9 @@ use itertools::izip;
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
-		batch::batch_prove_mle_with_coeff_and_write_evals,
+		batch::batch_prove_mle,
 		common::MleCheckProver,
-		frac_add_mle::{self, FracAddFusedEvaluator},
+		frac_add_mle,
 		mle_store::MleStore,
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
@@ -213,50 +213,6 @@ where
 		(remaining, layer_prover)
 	}
 
-	/// Pops the last layer as a prover carrying the two fractional claims batched into one.
-	///
-	/// Same reduction as [`Self::layer_prover`], in one pass over the four columns instead of two.
-	/// The numerator's pass and the denominator's pass read the same denominator halves.
-	/// They read the same equality indicator too.
-	/// A fused evaluator loads both once.
-	///
-	/// The caller must sample `batch_coeff` from the channel before calling this.
-	/// It must then drive the returned prover with a driver that does not sample another one.
-	/// The round polynomials and reduced column evaluations match [`Self::layer_prover`]'s.
-	/// So the transcript is unchanged.
-	fn fused_layer_prover(
-		mut self,
-		claim: FracEvalClaim<F>,
-		batch_coeff: F,
-	) -> (Option<Self>, LayerProver<'a, A, F, P>) {
-		let (num_claim, den_claim) = claim;
-		assert_eq!(
-			num_claim.point, den_claim.point,
-			"fractional claims must share the evaluation point"
-		);
-
-		let alloc = self.alloc;
-		let (num, den) = self.layers.pop().expect("layers is non-empty");
-
-		let remaining = if self.layers.is_empty() {
-			None
-		} else {
-			Some(self)
-		};
-
-		// The store owns the two popped buffers and shares each between its halves.
-		// The two-evaluator path does the same; only the evaluator group differs.
-		let mut store = MleStore::new(num.log_len() - 1, alloc);
-		let [num_0, num_1] = store.push_split_half(num);
-		let [den_0, den_1] = store.push_split_half(den);
-		let evaluator = FracAddFusedEvaluator::new([num_0, num_1, den_0, den_1], batch_coeff);
-
-		// One claim, batched the way the verifier batches the two it holds.
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P> + 'a>); 1] =
-			[(num_claim.eval + batch_coeff * den_claim.eval, Box::new(evaluator))];
-		(remaining, SharedMleCheckProver::new(store, claims_with_evaluators, num_claim.point))
-	}
-
 	/// Runs the fractional addition check protocol and returns the final evaluation claims.
 	///
 	/// This consumes the prover and runs sumcheck reductions from the smallest layer back to
@@ -317,18 +273,13 @@ where
 			let prover = prover_opt
 				.take()
 				.expect("precondition: n_layers <= self.n_layers()");
-			// The fused evaluator emits the already-batched round polynomial.
-			// So it needs the batching coefficient at construction.
-			// Sampling it here matches the transcript position the batched driver draws it from.
-			let batch_coeff = channel.sample();
-			let (remaining, sumcheck_prover) = prover.fused_layer_prover(claim, batch_coeff);
+			let (remaining, sumcheck_prover) = prover.layer_prover(claim);
 			prover_opt = remaining;
 
-			let output = batch_prove_mle_with_coeff_and_write_evals(
-				vec![sumcheck_prover],
-				batch_coeff,
-				channel,
-			);
+			// The driver draws the batching coefficient and Horner-folds the layer's two claims,
+			// which is the polynomial the verifier's `batch_verify_mle` reconstructs.
+			let output = batch_prove_mle(vec![sumcheck_prover], channel);
+			output.send_evals(channel);
 
 			let mut multilinear_evals = output.multilinear_evals;
 			let evals = multilinear_evals.pop().expect("batch contains one prover");

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -120,43 +120,6 @@ where
 	drive::batch(provers.into_iter().map(MleCheckRounds), channel)
 }
 
-/// Prove a batched MLE-check whose batching coefficient the caller has already sampled.
-///
-/// This is [`batch_prove_mle`] with the coefficient supplied rather than drawn.
-/// A caller needs that when it must know the coefficient before building its provers.
-/// An evaluator that emits one already-batched round polynomial is such a caller.
-///
-/// The coefficient must come from the same channel immediately before this call.
-/// Then the transcript is the one [`batch_prove_mle`] would have produced.
-pub(crate) fn batch_prove_mle_with_coeff<F, MleCheckProver_>(
-	provers: Vec<MleCheckProver_>,
-	batch_coeff: F,
-	channel: &mut impl IPProverChannel<F>,
-) -> BatchSumcheckOutput<F>
-where
-	F: Field,
-	MleCheckProver_: MleCheckProver<F>,
-{
-	drive::batch_with_coeff(provers.into_iter().map(MleCheckRounds).collect(), batch_coeff, channel)
-}
-
-/// [`batch_prove_mle_with_coeff`], then the evaluation claims written to the channel.
-///
-/// See [`batch_prove_mle_with_coeff`] for when a caller needs the coefficient up front.
-pub(crate) fn batch_prove_mle_with_coeff_and_write_evals<F, MleCheckProver_>(
-	provers: Vec<MleCheckProver_>,
-	batch_coeff: F,
-	channel: &mut impl IPProverChannel<F>,
-) -> BatchSumcheckOutput<F>
-where
-	F: Field,
-	MleCheckProver_: MleCheckProver<F>,
-{
-	let output = batch_prove_mle_with_coeff(provers, batch_coeff, channel);
-	output.send_evals(channel);
-	output
-}
-
 #[cfg(test)]
 mod tests {
 	use binius_field::{

--- a/crates/ip-prover/src/sumcheck/drive.rs
+++ b/crates/ip-prover/src/sumcheck/drive.rs
@@ -202,16 +202,13 @@ where
 	batch_with_coeff(provers, batch_coeff, channel)
 }
 
-/// Drives a group of provers with a batching coefficient the caller already drew.
+/// The round loop of [`batch`], once its batching coefficient has been drawn.
 ///
 /// The group's round polynomials are combined into one, so it costs a single round proof per
 /// variable. An empty group runs zero rounds.
 ///
-/// The coefficient must come from the same channel immediately before this call, so that the
-/// transcript matches the one [`batch`] would have produced.
-///
 /// The group arrives materialized because every round walks all of it.
-pub fn batch_with_coeff<F, Prover>(
+fn batch_with_coeff<F, Prover>(
 	mut provers: Vec<Prover>,
 	batch_coeff: F,
 	channel: &mut impl IPProverChannel<F>,

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -1,14 +1,12 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_compute::Allocator;
-use binius_field::{Field, PackedField, WideMul};
-use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldSlice, FieldVec};
+use binius_field::{Field, PackedField};
+use binius_math::FieldVec;
 
 use crate::sumcheck::{
-	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore, RoundContext},
+	mle_store::{ColId, MleStore},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evals::RoundEvals,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 
@@ -102,128 +100,6 @@ where
 	(numerator, denominator)
 }
 
-/// Round evaluator that reduces both fractional-addition claims in a single pass.
-///
-/// [`evaluators`] returns one evaluator per claim, so each claim walks the columns itself:
-///
-/// ```text
-///     numerator pass    num_a num_b den_a den_b   eq      8 column loads + 1 eq load
-///     denominator pass              den_a den_b   eq      4 column loads + 1 eq load
-/// ```
-///
-/// This evaluator reads the four columns once and fills both claims' accumulator slots.
-/// The sums `den_a.lo + den_a.hi` and `den_b.lo + den_b.hi` are then formed once, not twice.
-///
-/// It emits one round polynomial, already batched, rather than one per claim.
-/// That is exact, because [`RoundEvals::interpolate_eq`] is affine in its claim and evaluations:
-///
-/// ```text
-///     interp(c_num + z*c_den, y_num + z*y_den) = interp(c_num, y_num) + z*interp(c_den, y_den)
-/// ```
-///
-/// So the driving prover carries the single batched claim `c_num + z*c_den`.
-/// The polynomial this emits is the one the verifier's batched MLE-check reconstructs.
-pub struct FracAddFusedEvaluator<F> {
-	/// Layer columns in the order `[num_a, num_b, den_a, den_b]`.
-	cols: [ColId; 4],
-	/// The coefficient that batches the denominator claim onto the numerator claim.
-	batch_coeff: F,
-}
-
-impl<F: Field> FracAddFusedEvaluator<F> {
-	/// Creates the fused evaluator over the four layer columns.
-	///
-	/// # Arguments
-	///
-	/// * `cols` - The columns `[num_a, num_b, den_a, den_b]`.
-	/// * `batch_coeff` - The coefficient the driving protocol batches the two claims with.
-	///
-	/// The prover's claim for this evaluator must be `num_claim + batch_coeff * den_claim`.
-	pub const fn new(cols: [ColId; 4], batch_coeff: F) -> Self {
-		Self { cols, batch_coeff }
-	}
-}
-
-impl<F, P> MleCheckRoundEvaluator<F, P> for FracAddFusedEvaluator<F>
-where
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	fn degree(&self) -> usize {
-		// Four slots: the numerator's `y_1` and `y_inf`, then the denominator's.
-		// Each quadratic claim contributes the two sampled evaluations of its prime polynomial.
-		// The emitted polynomial is still degree 2.
-		4
-	}
-
-	fn accumulate(
-		&self,
-		chunk: &EvaluationChunk<'_, P>,
-		eq_ind: FieldSlice<'_, P>,
-		accum: &mut [<P as WideMul>::Output],
-	) {
-		// Each column arrives split on the round's top variable: `lo` fixes it to 0, `hi` to 1.
-		let [num_a, num_b, den_a, den_b]: [&ColumnChunk<'_, P>; 4] =
-			self.cols.map(|id| chunk.col(id));
-
-		let mut num_y_1 = <P as WideMul>::Output::default();
-		let mut num_y_inf = <P as WideMul>::Output::default();
-		let mut den_y_1 = <P as WideMul>::Output::default();
-		let mut den_y_inf = <P as WideMul>::Output::default();
-
-		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
-			// One load per column half, shared by both claims.
-			let na_lo = num_a.lo.as_ref()[idx];
-			let na_hi = num_a.hi.as_ref()[idx];
-			let nb_lo = num_b.lo.as_ref()[idx];
-			let nb_hi = num_b.hi.as_ref()[idx];
-			let da_lo = den_a.lo.as_ref()[idx];
-			let da_hi = den_a.hi.as_ref()[idx];
-			let db_lo = den_b.lo.as_ref()[idx];
-			let db_hi = den_b.hi.as_ref()[idx];
-
-			// The `x = 1` branch reads the high halves directly.
-			num_y_1 += P::wide_mul(na_hi * db_hi + nb_hi * da_hi, eq_i);
-			den_y_1 += P::wide_mul(da_hi * db_hi, eq_i);
-
-			// The `x = infinity` branch reads `lo + hi`, each multilinear's leading coefficient.
-			// The two denominator sums serve both claims.
-			let na = na_lo + na_hi;
-			let nb = nb_lo + nb_hi;
-			let da = da_lo + da_hi;
-			let db = db_lo + db_hi;
-			num_y_inf += P::wide_mul(na * db + nb * da, eq_i);
-			den_y_inf += P::wide_mul(da * db, eq_i);
-		}
-
-		// The run holds the two claims back to back: numerator first, then denominator.
-		let (numerator, denominator) = accum.split_at_mut(2);
-		RoundEvals([num_y_1, num_y_inf]).add_to(numerator);
-		RoundEvals([den_y_1, den_y_inf]).add_to(denominator);
-	}
-
-	fn interpolate(
-		&self,
-		ctx: &RoundContext<'_, P>,
-		accum: &[P],
-		claim: F,
-		alpha: F,
-	) -> RoundCoeffs<F> {
-		// The store has not yet folded this round, so its count is this round's.
-		let n_vars_remaining = ctx.n_vars();
-		assert!(n_vars_remaining > 0);
-
-		// Sum each claim's packed lanes into scalars.
-		let (num_slots, den_slots) = accum.split_at(2);
-		let numerator = RoundEvals::<P, 2>::from_slots(num_slots).sum_scalars(n_vars_remaining);
-		let denominator = RoundEvals::<P, 2>::from_slots(den_slots).sum_scalars(n_vars_remaining);
-
-		// Batch the sampled evaluations, then interpolate once against the batched claim.
-		// That order is equivalent to interpolating each claim and batching the polynomials.
-		(numerator + &(denominator * self.batch_coeff)).interpolate_eq(claim, alpha)
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use binius_field::arch::{OptimalB128, OptimalPackedB128};
@@ -244,112 +120,10 @@ mod tests {
 	use crate::sumcheck::{
 		MleToSumCheckEvaluator,
 		batch::batch_prove,
-		common::{MleCheckProver, SumcheckProver},
+		common::SumcheckProver,
 		mle_store::MleStore,
-		round_evaluator::{SharedMleCheckProver, SharedSumcheckProver, SumcheckRoundEvaluator},
+		round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 	};
-
-	// One layer's two honest claims: the numerator and denominator compositions.
-	// Each is its composite multilinear evaluated at the shared point.
-	fn layer_claims<F, P>(
-		num_parent: &FieldBuffer<P>,
-		den_parent: &FieldBuffer<P>,
-		eval_point: &[F],
-	) -> (F, F)
-	where
-		F: Field,
-		P: PackedField<Scalar = F>,
-	{
-		let n_vars = eval_point.len();
-		let (num_a, num_b) = num_parent.split_half_ref();
-		let (den_a, den_b) = den_parent.split_half_ref();
-		let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
-
-		// The composite values over the halved hypercube, word by word.
-		let numerator: Vec<P> = (0..packed_len)
-			.map(|i| num_a.as_ref()[i] * den_b.as_ref()[i] + num_b.as_ref()[i] * den_a.as_ref()[i])
-			.collect();
-		let denominator: Vec<P> = (0..packed_len)
-			.map(|i| den_a.as_ref()[i] * den_b.as_ref()[i])
-			.collect();
-
-		(
-			evaluate(&FieldBuffer::new(n_vars, numerator), eval_point),
-			evaluate(&FieldBuffer::new(n_vars, denominator), eval_point),
-		)
-	}
-
-	#[test]
-	fn fused_evaluator_matches_batched_split_evaluators() {
-		type F = OptimalB128;
-		type P = OptimalPackedB128;
-
-		let mut rng = StdRng::seed_from_u64(0);
-		let alloc = GlobalAllocator;
-
-		// 1 and 3 are single-chunk rounds throughout.
-		// 8 and 14 cross the chunk cap, so 14 also exercises eq suffix folding in the driver.
-		for n_vars in [1, 3, 8, 14] {
-			// The parents carry the variable that splits them into the four layer columns.
-			let num_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
-			let den_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
-			let eval_point = random_scalars::<F>(&mut rng, n_vars);
-			let batch_coeff = random_scalars::<F>(&mut rng, 1)[0];
-			let (num_claim, den_claim) = layer_claims(&num_parent, &den_parent, &eval_point);
-
-			// Reference: one evaluator per claim, the two round polynomials batched by the driver.
-			let mut split_store = MleStore::new(n_vars, &alloc);
-			let [s_num_a, s_num_b] = split_store.push_split_half(num_parent.clone());
-			let [s_den_a, s_den_b] = split_store.push_split_half(den_parent.clone());
-			let (num_evaluator, den_evaluator) =
-				evaluators::<F, P>([s_num_a, s_num_b, s_den_a, s_den_b]);
-			let split_claims: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
-				(num_claim, Box::new(num_evaluator)),
-				(den_claim, Box::new(den_evaluator)),
-			];
-			let mut split_prover =
-				SharedMleCheckProver::new(split_store, split_claims, eval_point.clone());
-
-			// Fused: one evaluator, one claim, already batched.
-			let mut fused_store = MleStore::new(n_vars, &alloc);
-			let [f_num_a, f_num_b] = fused_store.push_split_half(num_parent.clone());
-			let [f_den_a, f_den_b] = fused_store.push_split_half(den_parent.clone());
-			let fused_evaluator =
-				FracAddFusedEvaluator::new([f_num_a, f_num_b, f_den_a, f_den_b], batch_coeff);
-			let mut fused_prover = SharedMleCheckProver::new(
-				fused_store,
-				[(num_claim + batch_coeff * den_claim, fused_evaluator)],
-				eval_point.clone(),
-			);
-
-			// Both provers see the same challenges, so every round must agree.
-			for round in 0..n_vars {
-				// The driver Horner-folds the two claims into `num + batch_coeff * den`.
-				let batched_reference = split_prover
-					.execute()
-					.into_iter()
-					.rfold(RoundCoeffs::default(), |acc, coeffs| acc * batch_coeff + &coeffs);
-
-				let fused_round = fused_prover.execute();
-				assert_eq!(fused_round.len(), 1, "the fused evaluator emits one polynomial");
-				assert_eq!(
-					fused_round[0].0, batched_reference.0,
-					"round {round} polynomial differs at n_vars={n_vars}"
-				);
-
-				let challenge = random_scalars::<F>(&mut rng, 1)[0];
-				split_prover.fold(challenge);
-				fused_prover.fold(challenge);
-			}
-
-			// Both stores hold the same four columns, so they must reduce to the same evaluations.
-			assert_eq!(
-				split_prover.finish(),
-				fused_prover.finish(),
-				"column evaluations differ at n_vars={n_vars}"
-			);
-		}
-	}
 
 	fn test_frac_add_sumcheck_prove_verify<F, P>(
 		prover: impl SumcheckProver<F>,


### PR DESCRIPTION
Removes `FracAddFusedEvaluator` and the `fused_layer_prover` path that fed it.
Pure refactor — the transcript is byte-for-byte unchanged.

### The problem

`FracAddFusedEvaluator` reduced both fractional-addition claims in a single column pass, emitting one already-batched round polynomial instead of one per claim.
The saving it was built for is the second walk over the four layer columns.

That second walk does not exist.
`SharedMleCheckProver::execute` makes **one** parallel pass over the store's chunks and calls every evaluator on a chunk before moving to the next.
So both claims already see the same data while it is still hot in L1.

What the fusion actually saved was two field adds per lane and one re-read of the eq slice.

### The measurement

The fused prover against the ordinary two-claim prover, over identical layers, asserting first that they emit the identical batched round polynomial in every round and the identical four final evaluations.

| `log_len` | two-claim | fused | speedup |
|---|---:|---:|---:|
| 14 | 197.9 µs | 191.1 µs | 1.036× |
| 18 | 1857.3 µs | 1827.1 µs | 1.017× |
| 22 | 13525.3 µs | 13571.6 µs | 0.997× |

M1 Pro, `OptimalPackedB128`, best of five interleaved runs.
The win vanishes exactly where it would have mattered.

### What it cost

- a near-duplicate of `layer_prover`
- ~120 lines of `accumulate` / `interpolate`
- a caller contract: sample the batching coefficient *first*, then drive with something that will not sample another

That contract is why `batch_prove_mle_with_coeff` and its `_and_write_evals` wrapper existed, and why `drive::batch_with_coeff` was public.
One micro-optimisation held four items in place.

### The change

`prove_layers` builds the ordinary two-claim layer prover and lets the driver do the batching:

```
- let batch_coeff = channel.sample();
- let (remaining, sumcheck_prover) = prover.fused_layer_prover(claim, batch_coeff);
- let output = batch_prove_mle_with_coeff_and_write_evals(vec![sumcheck_prover], batch_coeff, channel);
+ let (remaining, sumcheck_prover) = prover.layer_prover(claim);
+ let output = batch_prove_mle(vec![sumcheck_prover], channel);
+ output.send_evals(channel);
```

`batch_prove_mle` draws the coefficient itself, at the same transcript position, then Horner-folds the two round polynomials.

### Soundness — the transcript is identical

The fused evaluator batched the sampled evaluations and interpolated once against the batched claim.
The two-claim path interpolates each claim and batches the polynomials.
These agree because `interpolate_eq` is affine in its claim and evaluations:

```
interp(c_num + z*c_den, y_num + z*y_den) = interp(c_num, y_num) + z*interp(c_den, y_den)
```

That is the identity the fused evaluator relied on to be correct in the first place, so dropping it cannot change the message.
Both stores hold the same four columns in the same push order, so `finish` returns the same four evaluations.

The logUp* end-to-end round trips confirm it against the unchanged verifier — a one-element shift would be rejected.

### Scope

- **removed:** `FracAddFusedEvaluator`, `fused_layer_prover`, `batch_prove_mle_with_coeff`, `batch_prove_mle_with_coeff_and_write_evals`
- **changed:** `prove_layers` uses `layer_prover` + `batch_prove_mle`; `drive::batch_with_coeff` drops to private with one in-module caller
- **untouched:** the two-evaluator `frac_add_mle::evaluators` path, every batched driver, the verifier

The last two removals are forced, not opportunistic — with the fused path gone they are `pub(crate)` functions with no callers, which fails the `-D warnings` gate.

### Coverage

The deleted test pinned the fused evaluator against the split pair, so it goes with it.
Nothing is lost: `round_evaluator::test_shared_frac_add_prove_verify` already drives the surviving two-evaluator path through `batch_prove_mle` at `n_vars` in `[1, 2, 3, 8, 14, 15]` — a superset of the deleted `[1, 3, 8, 14]`, including the 15-variable case that exercises `map_reduce_with_fold`.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-ip-prover` — 94 passed, and again with `--features rayon` — 94 passed

Includes the logUp* prove/verify round trips and the fracaddcheck prove/verify tests, which are what pin the transcript.

Reverses #1980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)