### PR TITLE
Introduce Fraction<T> for the numerator/denominator pair

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/fraction.rs
+++ b/crates/ip-prover/src/fracaddcheck/fraction.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 The Binius Developers
+
+//! The numerator/denominator pair a fractional-addition instance is built from.
+
+use binius_field::Field;
+
+/// A numerator paired with its denominator.
+///
+/// Fractional addition never touches one half alone:
+///
+/// ```text
+///     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
+/// ```
+///
+/// So the two travel together, through every layer and every claim.
+/// Pairing them in one type makes a half-formed pair unrepresentable.
+/// A bare tuple leaves each caller to remember which element is which.
+///
+/// `T` is whatever stands for one half.
+/// A scalar gives a claimed fraction; a column buffer gives one layer of the circuit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fraction<T> {
+	/// The numerator.
+	pub num: T,
+	/// The denominator.
+	pub den: T,
+}
+
+impl<T> Fraction<T> {
+	/// Pairs a numerator with a denominator.
+	pub const fn new(num: T, den: T) -> Self {
+		Self { num, den }
+	}
+
+	/// Borrows both halves, so a fraction can be read without moving out of it.
+	pub const fn as_ref(&self) -> Fraction<&T> {
+		Fraction {
+			num: &self.num,
+			den: &self.den,
+		}
+	}
+
+	/// Applies `f` to each half.
+	///
+	/// This is how a fraction changes representation, such as a pair of layer buffers reduced to
+	/// the pair of scalars at their root.
+	pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> Fraction<U> {
+		Fraction {
+			num: f(self.num),
+			den: f(self.den),
+		}
+	}
+}
+
+impl<F: Field> Fraction<F> {
+	/// The zero fraction $0/1$.
+	///
+	/// This is the additive identity of fractional addition: adding it changes nothing.
+	/// So it is what a padding leaf holds when a batch lifts a shallow tree to its depth, and what
+	/// fills the selector slots past the last real instance.
+	pub const ZERO: Self = Self {
+		num: F::ZERO,
+		den: F::ONE,
+	};
+}
+
+impl<T> From<(T, T)> for Fraction<T> {
+	fn from((num, den): (T, T)) -> Self {
+		Self { num, den }
+	}
+}
+
+impl<T> From<Fraction<T>> for (T, T) {
+	fn from(Fraction { num, den }: Fraction<T>) -> Self {
+		(num, den)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::FieldOps;
+	use binius_math::test_utils::{Packed128b, random_scalars};
+	use rand::prelude::*;
+
+	use super::*;
+
+	type F = <Packed128b as FieldOps>::Scalar;
+
+	#[test]
+	fn zero_fraction_is_the_additive_identity() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let [num, den]: [F; 2] = random_scalars::<F>(&mut rng, 2)
+			.try_into()
+			.expect("two scalars");
+		let f = Fraction::new(num, den);
+
+		// Adding 0/1 to a/b by the fractional-addition rule must give back a/b unchanged.
+		let pad = Fraction::<F>::ZERO;
+		let sum = Fraction::new(f.num * pad.den + pad.num * f.den, f.den * pad.den);
+		assert_eq!(sum, f);
+	}
+
+	#[test]
+	fn tuple_conversion_round_trips() {
+		let mut rng = StdRng::seed_from_u64(1);
+		let [num, den]: [F; 2] = random_scalars::<F>(&mut rng, 2)
+			.try_into()
+			.expect("two scalars");
+
+		let tuple: (F, F) = Fraction::new(num, den).into();
+		assert_eq!(tuple, (num, den));
+		assert_eq!(Fraction::from(tuple), Fraction::new(num, den));
+	}
+
+	#[test]
+	fn map_and_as_ref_reach_both_halves() {
+		let f = Fraction::new(vec![1u8, 2], vec![3u8]);
+		assert_eq!(f.as_ref().map(Vec::len), Fraction::new(2, 1));
+	}
+}

--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -24,9 +24,9 @@ use itertools::izip;
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
-		batch::batch_prove_mle_with_coeff_and_write_evals,
+		batch::batch_prove_mle,
 		common::MleCheckProver,
-		frac_add_mle::{self, FracAddFusedEvaluator},
+		frac_add_mle,
 		mle_store::MleStore,
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
@@ -213,50 +213,6 @@ where
 		(remaining, layer_prover)
 	}
 
-	/// Pops the last layer as a prover carrying the two fractional claims batched into one.
-	///
-	/// Same reduction as [`Self::layer_prover`], in one pass over the four columns instead of two.
-	/// The numerator's pass and the denominator's pass read the same denominator halves.
-	/// They read the same equality indicator too.
-	/// A fused evaluator loads both once.
-	///
-	/// The caller must sample `batch_coeff` from the channel before calling this.
-	/// It must then drive the returned prover with a driver that does not sample another one.
-	/// The round polynomials and reduced column evaluations match [`Self::layer_prover`]'s.
-	/// So the transcript is unchanged.
-	fn fused_layer_prover(
-		mut self,
-		claim: FracEvalClaim<F>,
-		batch_coeff: F,
-	) -> (Option<Self>, LayerProver<'a, A, F, P>) {
-		let (num_claim, den_claim) = claim;
-		assert_eq!(
-			num_claim.point, den_claim.point,
-			"fractional claims must share the evaluation point"
-		);
-
-		let alloc = self.alloc;
-		let (num, den) = self.layers.pop().expect("layers is non-empty");
-
-		let remaining = if self.layers.is_empty() {
-			None
-		} else {
-			Some(self)
-		};
-
-		// The store owns the two popped buffers and shares each between its halves.
-		// The two-evaluator path does the same; only the evaluator group differs.
-		let mut store = MleStore::new(num.log_len() - 1, alloc);
-		let [num_0, num_1] = store.push_split_half(num);
-		let [den_0, den_1] = store.push_split_half(den);
-		let evaluator = FracAddFusedEvaluator::new([num_0, num_1, den_0, den_1], batch_coeff);
-
-		// One claim, batched the way the verifier batches the two it holds.
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P> + 'a>); 1] =
-			[(num_claim.eval + batch_coeff * den_claim.eval, Box::new(evaluator))];
-		(remaining, SharedMleCheckProver::new(store, claims_with_evaluators, num_claim.point))
-	}
-
 	/// Runs the fractional addition check protocol and returns the final evaluation claims.
 	///
 	/// This consumes the prover and runs sumcheck reductions from the smallest layer back to
@@ -317,18 +273,13 @@ where
 			let prover = prover_opt
 				.take()
 				.expect("precondition: n_layers <= self.n_layers()");
-			// The fused evaluator emits the already-batched round polynomial.
-			// So it needs the batching coefficient at construction.
-			// Sampling it here matches the transcript position the batched driver draws it from.
-			let batch_coeff = channel.sample();
-			let (remaining, sumcheck_prover) = prover.fused_layer_prover(claim, batch_coeff);
+			let (remaining, sumcheck_prover) = prover.layer_prover(claim);
 			prover_opt = remaining;
 
-			let output = batch_prove_mle_with_coeff_and_write_evals(
-				vec![sumcheck_prover],
-				batch_coeff,
-				channel,
-			);
+			// The driver draws the batching coefficient and Horner-folds the layer's two claims,
+			// which is the polynomial the verifier's `batch_verify_mle` reconstructs.
+			let output = batch_prove_mle(vec![sumcheck_prover], channel);
+			output.send_evals(channel);
 
 			let mut multilinear_evals = output.multilinear_evals;
 			let evals = multilinear_evals.pop().expect("batch contains one prover");

--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -32,8 +32,10 @@ use crate::{
 	},
 };
 
+pub mod fraction;
 pub mod zero_pad_mle;
 
+use fraction::Fraction;
 use zero_pad_mle::{ConstantFraction, ZeroPadMleCheckProver};
 
 pub use crate::sumcheck::frac_add_mle::LayerProver;
@@ -43,16 +45,13 @@ pub use crate::sumcheck::frac_add_mle::LayerProver;
 /// Both claims share the same evaluation point, that of the layer they describe.
 pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 
-/// A numerator/denominator pair of pooled column buffers.
-type PooledFractionalBuffer<A, P> = (FieldVec<P, A>, FieldVec<P, A>);
-
 /// Prover for the fractional addition protocol.
 ///
 /// Each layer is a double of the numerator and denominator values of fractional terms. Each layer
 /// represents the addition of siblings with respect to the fractional addition rule:
 /// $$\frac{a_0}{b_0} + \frac{a_1}{b_1} = \frac{a_0b_1 + a_1b_0}{b_0b_1}$
 pub struct FracAddCheckProver<'a, A: Allocator, P: PackedField> {
-	layers: Vec<PooledFractionalBuffer<A, P>>,
+	layers: Vec<Fraction<FieldVec<P, A>>>,
 	/// Allocator the layer buffers are drawn from.
 	pub(crate) alloc: &'a A,
 }
@@ -86,13 +85,16 @@ where
 	/// * `witness` - The witness numerator/denominator layers
 	///
 	/// # Preconditions
-	/// * `witness.0.log_len() >= k`
+	/// * `witness.num.log_len() >= k`
 	pub fn new(
 		k: usize,
 		alloc: &'a A,
-		witness: PooledFractionalBuffer<A, P>,
-	) -> (Self, PooledFractionalBuffer<A, P>) {
-		let (witness_num, witness_den) = witness;
+		witness: Fraction<FieldVec<P, A>>,
+	) -> (Self, Fraction<FieldVec<P, A>>) {
+		let Fraction {
+			num: witness_num,
+			den: witness_den,
+		} = witness;
 		assert_eq!(
 			witness_num.log_len(),
 			witness_den.log_len(),
@@ -101,12 +103,12 @@ where
 		assert!(witness_num.log_len() >= k);
 
 		let mut layers = Vec::with_capacity(k + 1);
-		layers.push((witness_num, witness_den));
+		layers.push(Fraction::new(witness_num, witness_den));
 
 		for _ in 0..k {
 			let prev_layer = layers.last().expect("layers is non-empty");
 
-			let (num, den) = prev_layer;
+			let Fraction { num, den } = prev_layer;
 			let num_log_len = num.log_len() - 1;
 			let den_log_len = den.log_len() - 1;
 			let (num_0, num_1) = num.split_half_ref();
@@ -161,8 +163,10 @@ where
 				num_data.set_len(out_len);
 				den_data.set_len(out_len);
 			}
-			let next_layer =
-				(FieldBuffer::new(num_log_len, num_data), FieldBuffer::new(den_log_len, den_data));
+			let next_layer = Fraction::new(
+				FieldBuffer::new(num_log_len, num_data),
+				FieldBuffer::new(den_log_len, den_data),
+			);
 
 			layers.push(next_layer);
 		}
@@ -191,7 +195,7 @@ where
 		);
 
 		let alloc = self.alloc;
-		let (num, den) = self.layers.pop().expect("layers is non-empty");
+		let Fraction { num, den } = self.layers.pop().expect("layers is non-empty");
 
 		let remaining = if self.layers.is_empty() {
 			None
@@ -324,7 +328,7 @@ pub struct BatchProveOutput<F> {
 	/// The reduced evaluation point (`selector ++ content`) at which the fractions are claimed.
 	pub eval_point: Vec<F>,
 	/// Each input prover's reduced `(num, den)` fraction at `eval_point`, in input order.
-	pub fractions: Vec<(F, F)>,
+	pub fractions: Vec<Fraction<F>>,
 }
 
 /// Runs a batched fractional-addition check for multiple independent fracaddcheck provers,
@@ -366,7 +370,7 @@ pub struct BatchProveOutput<F> {
 /// * `content_point.len() == witness.log_len() - n_layers` for each prover.
 pub fn batch_prove<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
-	claimed_fractions: Vec<(F, F)>,
+	claimed_fractions: Vec<Fraction<F>>,
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
@@ -434,7 +438,7 @@ fn reduce_layer<'a, A, F, P, MP>(
 	eval_point: &[F],
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
-) -> (Vec<(F, F)>, Vec<F>)
+) -> (Vec<Fraction<F>>, Vec<F>)
 where
 	A: Allocator,
 	F: Field,
@@ -496,16 +500,18 @@ where
 		})
 		.collect();
 
-	// Split the reduced halves into per-multilinear vectors, padded to 2^k with zeros so they can
-	// be packed into selector-variable buffers.
+	// Split the reduced halves into per-multilinear vectors, padded to 2^k so they can be packed
+	// into selector-variable buffers. Both children of a padding slot are the zero fraction, which
+	// is what makes the numerators fill with 0 and the denominators with 1.
 	let mut num_0s: Vec<F> = finished.iter().map(|e| e[0]).collect();
 	let mut num_1s: Vec<F> = finished.iter().map(|e| e[1]).collect();
 	let mut den_0s: Vec<F> = finished.iter().map(|e| e[2]).collect();
 	let mut den_1s: Vec<F> = finished.iter().map(|e| e[3]).collect();
-	num_0s.resize(1 << k, F::ZERO);
-	num_1s.resize(1 << k, F::ZERO);
-	den_0s.resize(1 << k, F::ONE);
-	den_1s.resize(1 << k, F::ONE);
+	let pad = Fraction::<F>::ZERO;
+	num_0s.resize(1 << k, pad.num);
+	num_1s.resize(1 << k, pad.num);
+	den_0s.resize(1 << k, pad.den);
+	den_1s.resize(1 << k, pad.den);
 
 	// The selector claim is the eq(selector)-weighted sum of the fractional-addition composition of
 	// the reduced halves.
@@ -566,7 +572,7 @@ where
 	// aligned with the selector `eq` weights on subsequent layers; the padded entries are 0/1.
 	let next_fractions = izip!(&num_0s, &num_1s, &den_0s, &den_1s)
 		.map(|(&num_0, &num_1, &den_0, &den_1)| {
-			(extrapolate_line(num_0, num_1, r), extrapolate_line(den_0, den_1, r))
+			Fraction::new(extrapolate_line(num_0, num_1, r), extrapolate_line(den_0, den_1, r))
 		})
 		.collect();
 
@@ -578,11 +584,11 @@ where
 #[allow(clippy::type_complexity)]
 fn batch_prove_layer<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
-	claimed_fractions: &[(F, F)],
+	claimed_fractions: &[Fraction<F>],
 	eval_point: &[F],
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
-) -> (Vec<FracAddCheckProver<'a, A, P>>, Vec<(F, F)>, Vec<F>)
+) -> (Vec<FracAddCheckProver<'a, A, P>>, Vec<Fraction<F>>, Vec<F>)
 where
 	A: Allocator,
 	F: Field,
@@ -593,7 +599,7 @@ where
 	let alloc = provers[0].alloc;
 	let inner_coords = eval_point[k..].to_vec();
 	let (layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, claimed_fractions)
-		.map(|(prover, &(num, den))| {
+		.map(|(prover, &Fraction { num, den })| {
 			let (remaining, layer_prover) = prover.layer_prover((
 				MultilinearEvalClaim {
 					eval: num,
@@ -656,7 +662,7 @@ where
 /// witness, given how much depth that tree was padded by.
 pub fn batch_prove_unequal_depths<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
-	claimed_fractions: Vec<(F, F)>,
+	claimed_fractions: Vec<Fraction<F>>,
 	selector_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchProveOutput<F>
@@ -730,7 +736,7 @@ type PaddedLayerProver<'a, A, F, P> =
 fn layer_provers<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
 	pad_lens: &[usize],
-	claims: &[(F, F)],
+	claims: &[Fraction<F>],
 	node_point: &[F],
 ) -> (Vec<FracAddCheckProver<'a, A, P>>, Vec<PaddedLayerProver<'a, A, F, P>>)
 where
@@ -763,7 +769,7 @@ where
 
 	let mut next_provers = Vec::with_capacity(provers.len());
 	let layer_provers = izip!(provers, pad_lens, claims, &pad_eq_invs)
-		.map(|(prover, &tree_pad_len, &(num, den), &pad_eq_inv)| {
+		.map(|(prover, &tree_pad_len, &Fraction { num, den }, &pad_eq_inv)| {
 			let pad_len = tree_pad_len.min(node_len);
 			let point = node_point[pad_len..].to_vec();
 			let [num_claim, den_claim] = zero_pad_mle::unpad_claims(pad_eq_inv, [num, den]);
@@ -832,7 +838,7 @@ where
 /// one. They are the verifier's own challenges, so no prover can induce this; it happens with
 /// probability at most $\nu / |K|$.
 pub fn unpad_leaf_claim<F: Field>(
-	fraction: (F, F),
+	fraction: Fraction<F>,
 	point: &[F],
 	n_pad_vars: usize,
 ) -> FracAddEvalClaim<F> {
@@ -845,7 +851,10 @@ pub fn unpad_leaf_claim<F: Field>(
 	assert!(pad_eq != F::ZERO, "a padding coordinate equals one");
 	let pad_eq_inv = pad_eq.invert_or_zero();
 
-	let (num_eval, den_eval) = fraction;
+	let Fraction {
+		num: num_eval,
+		den: den_eval,
+	} = fraction;
 	FracAddEvalClaim {
 		num_eval: num_eval * pad_eq_inv,
 		den_eval: F::ONE + (den_eval - F::ONE) * pad_eq_inv,
@@ -880,15 +889,18 @@ mod tests {
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// 2. Create prover (computes fractional-add layers)
-		let (prover, sums) =
-			FracAddCheckProver::new(k, &alloc, (witness_num.clone(), witness_den.clone()));
+		let (prover, sums) = FracAddCheckProver::new(
+			k,
+			&alloc,
+			Fraction::new(witness_num.clone(), witness_den.clone()),
+		);
 
 		// 3. Generate random n-dimensional challenge point
 		let eval_point = random_scalars::<P::Scalar>(&mut rng, n);
 
 		// 4. Evaluate sums at challenge point to createzz claims
-		let sum_num_eval = evaluate(&sums.0, &eval_point);
-		let sum_den_eval = evaluate(&sums.1, &eval_point);
+		let sum_num_eval = evaluate(&sums.num, &eval_point);
+		let sum_den_eval = evaluate(&sums.den, &eval_point);
 		let prover_claim = (
 			MultilinearEvalClaim {
 				eval: sum_num_eval,
@@ -946,8 +958,11 @@ mod tests {
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// Create prover (computes fractional-add layers)
-		let (_prover, sums) =
-			FracAddCheckProver::new(k, &alloc, (witness_num.clone(), witness_den.clone()));
+		let (_prover, sums) = FracAddCheckProver::new(
+			k,
+			&alloc,
+			Fraction::new(witness_num.clone(), witness_den.clone()),
+		);
 
 		// For each index i in the sums layer, verify it equals the fractional sum of witness values
 		// at indices i + z * 2^n for z in 0..2^k (strided access, not contiguous)
@@ -963,8 +978,8 @@ mod tests {
 				expected_num = expected_num * den_z + num_z * expected_den;
 				expected_den *= den_z;
 			}
-			let actual_num = sums.0.get(i);
-			let actual_den = sums.1.get(i);
+			let actual_num = sums.num.get(i);
+			let actual_den = sums.den.get(i);
 			assert_eq!(actual_num, expected_num, "Numerator mismatch at index {i}");
 			assert_eq!(actual_den, expected_den, "Denominator mismatch at index {i}");
 		}
@@ -990,7 +1005,7 @@ mod tests {
 		} = output;
 		let selector_weights = eq_ind_partial_eval::<P>(&eval_point[..log_n_provers]);
 		let num_eval = inner_product(
-			fractions.iter().map(|&(n, _)| n),
+			fractions.iter().map(|f| f.num),
 			(0..fractions.len()).map(|i| selector_weights.get(i)),
 		);
 		// The padding slots hold the zero fraction 0/1, so they contribute their eq weight to
@@ -998,7 +1013,7 @@ mod tests {
 		let den_eval = inner_product(
 			fractions
 				.iter()
-				.map(|&(_, d)| d)
+				.map(|f| f.den)
 				.chain(iter::repeat_n(F::ONE, (1 << log_n_provers) - fractions.len())),
 			(0..1 << log_n_provers).map(|i| selector_weights.get(i)),
 		);
@@ -1032,16 +1047,20 @@ mod tests {
 		let (provers, individual_sums): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| {
-				FracAddCheckProver::new(n_layers, &alloc, (witness.0.clone(), witness.1.clone()))
+				FracAddCheckProver::new(
+					n_layers,
+					&alloc,
+					Fraction::new(witness.0.clone(), witness.1.clone()),
+				)
 			})
 			.unzip();
 
-		// Fractions are 0-variate (scalars): just get the single (num, den) value.
-		let claimed_fractions: Vec<(P::Scalar, P::Scalar)> = individual_sums
+		// Fractions are 0-variate (scalars): just get the single num/den value.
+		let claimed_fractions: Vec<Fraction<P::Scalar>> = individual_sums
 			.iter()
-			.map(|(num, den)| {
-				assert_eq!(num.log_len(), 0);
-				(num.get(0), den.get(0))
+			.map(|sums| {
+				assert_eq!(sums.num.log_len(), 0);
+				sums.as_ref().map(|buffer| buffer.get(0))
 			})
 			.collect();
 
@@ -1050,13 +1069,13 @@ mod tests {
 		let selector_challenge = random_scalars::<P::Scalar>(&mut rng, log_n_provers);
 		let eq_weights = eq_ind_partial_eval::<P>(&selector_challenge);
 		let combined_num = inner_product(
-			claimed_fractions.iter().map(|&(n, _)| n),
+			claimed_fractions.iter().map(|f| f.num),
 			(0..n_provers).map(|i| eq_weights.get(i)),
 		);
 		let combined_den = inner_product(
 			claimed_fractions
 				.iter()
-				.map(|&(_, d)| d)
+				.map(|f| f.den)
 				.chain(iter::repeat_n(P::Scalar::ONE, (1 << log_n_provers) - n_provers)),
 			(0..1 << log_n_provers).map(|i| eq_weights.get(i)),
 		);
@@ -1161,30 +1180,34 @@ mod tests {
 		let (provers, individual_sums): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| {
-				FracAddCheckProver::new(n_layers, &alloc, (witness.0.clone(), witness.1.clone()))
+				FracAddCheckProver::new(
+					n_layers,
+					&alloc,
+					Fraction::new(witness.0.clone(), witness.1.clone()),
+				)
 			})
 			.unzip();
 
 		// Shared content point; each claimed fraction is its multilinears evaluated there.
 		let content_point = random_scalars::<P::Scalar>(&mut rng, content_len);
-		let claimed_fractions: Vec<(P::Scalar, P::Scalar)> = individual_sums
+		let claimed_fractions: Vec<Fraction<P::Scalar>> = individual_sums
 			.iter()
-			.map(|(num, den)| {
-				assert_eq!(num.log_len(), content_len);
-				(evaluate(num, &content_point), evaluate(den, &content_point))
+			.map(|sums| {
+				assert_eq!(sums.num.log_len(), content_len);
+				sums.as_ref().map(|buffer| evaluate(buffer, &content_point))
 			})
 			.collect();
 
 		let selector_challenge = random_scalars::<P::Scalar>(&mut rng, log_n_provers);
 		let eq_weights = eq_ind_partial_eval::<P>(&selector_challenge);
 		let combined_num = inner_product(
-			claimed_fractions.iter().map(|&(n, _)| n),
+			claimed_fractions.iter().map(|f| f.num),
 			(0..n_provers).map(|i| eq_weights.get(i)),
 		);
 		let combined_den = inner_product(
 			claimed_fractions
 				.iter()
-				.map(|&(_, d)| d)
+				.map(|f| f.den)
 				.chain(iter::repeat_n(P::Scalar::ONE, (1 << log_n_provers) - n_provers)),
 			(0..1 << log_n_provers).map(|i| eq_weights.get(i)),
 		);
@@ -1245,7 +1268,7 @@ mod tests {
 	// ==================== batch_prove_unequal_depths tests ====================
 
 	/// A numerator/denominator witness pair.
-	type Witness<P> = (FieldBuffer<P>, FieldBuffer<P>);
+	type Witness<P> = Fraction<FieldBuffer<P>>;
 
 	/// One prover per entry of `depths`, each reducing over all of its witness variables.
 	#[allow(clippy::type_complexity)]
@@ -1256,14 +1279,16 @@ mod tests {
 	) -> (
 		Vec<Witness<P>>,
 		Vec<FracAddCheckProver<'a, GlobalAllocator, P>>,
-		Vec<(P::Scalar, P::Scalar)>,
+		Vec<Fraction<P::Scalar>>,
 	) {
 		itertools::multiunzip(depths.iter().map(|&depth| {
-			let num = random_field_buffer::<P>(&mut *rng, depth);
-			let den = random_field_buffer::<P>(&mut *rng, depth);
-			let (prover, sums) = FracAddCheckProver::new(depth, alloc, (num.clone(), den.clone()));
-			assert_eq!(sums.0.log_len(), 0);
-			((num, den), prover, (sums.0.get(0), sums.1.get(0)))
+			let witness = Fraction::new(
+				random_field_buffer::<P>(&mut *rng, depth),
+				random_field_buffer::<P>(&mut *rng, depth),
+			);
+			let (prover, sums) = FracAddCheckProver::new(depth, alloc, witness.clone());
+			assert_eq!(sums.num.log_len(), 0);
+			(witness, prover, sums.as_ref().map(|buffer| buffer.get(0)))
 		}))
 	}
 
@@ -1271,19 +1296,19 @@ mod tests {
 	///
 	/// The selector slots beyond the trees hold the zero fraction 0/1.
 	fn combine_fractions<P: PackedField>(
-		fractions: &[(P::Scalar, P::Scalar)],
+		fractions: &[Fraction<P::Scalar>],
 		selector_point: &[P::Scalar],
 	) -> (P::Scalar, P::Scalar) {
 		let n_slots = 1 << selector_point.len();
 		let eq_weights = eq_ind_partial_eval::<P>(selector_point);
 		let num_eval = inner_product(
-			fractions.iter().map(|&(num, _)| num),
+			fractions.iter().map(|f| f.num),
 			(0..fractions.len()).map(|i| eq_weights.get(i)),
 		);
 		let den_eval = inner_product(
 			fractions
 				.iter()
-				.map(|&(_, den)| den)
+				.map(|f| f.den)
 				.chain(iter::repeat_n(P::Scalar::ONE, n_slots - fractions.len())),
 			(0..n_slots).map(|i| eq_weights.get(i)),
 		);
@@ -1334,11 +1359,11 @@ mod tests {
 
 		// Each tree's reduced claims are on its *padded* witness; unpadding them yields claims on
 		// the witness itself, at a suffix of the shared node point.
-		for (i, (&depth, (num, den))) in iter::zip(depths, &witnesses).enumerate() {
+		for (i, (&depth, witness)) in iter::zip(depths, &witnesses).enumerate() {
 			let leaf = unpad_leaf_claim(fractions[i], &eval_point[k..], n_layers - depth);
 			assert_eq!(leaf.point.len(), depth);
-			assert_eq!(leaf.num_eval, evaluate(num, &leaf.point), "tree {i} numerator");
-			assert_eq!(leaf.den_eval, evaluate(den, &leaf.point), "tree {i} denominator");
+			assert_eq!(leaf.num_eval, evaluate(&witness.num, &leaf.point), "tree {i} numerator");
+			assert_eq!(leaf.den_eval, evaluate(&witness.den, &leaf.point), "tree {i} denominator");
 		}
 	}
 

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::{
 	channel::IPProverChannel,
-	fracaddcheck::{self, FracAddCheckProver, unpad_leaf_claim},
+	fracaddcheck::{self, FracAddCheckProver, fraction::Fraction, unpad_leaf_claim},
 };
 
 /// One looker's column and claim: `(I^* T)(eval_point) = eval_claim` against the table it reads.
@@ -201,9 +201,12 @@ where
 		.map(|(&(looker, c), numerator)| {
 			let den = witness::looker_denominator::<A, F, P>(alloc, c, looker.index);
 			// Lookers may differ in length, so each circuit is built at its own depth.
-			let (prover, root) =
-				FracAddCheckProver::new(looker.eval_point.len(), alloc, (numerator, den));
-			(prover, (root.0.get(0), root.1.get(0)))
+			let (prover, root) = FracAddCheckProver::new(
+				looker.eval_point.len(),
+				alloc,
+				Fraction::new(numerator, den),
+			);
+			(prover, root.as_ref().map(|buffer| buffer.get(0)))
 		})
 		.unzip();
 	// A table's fraction enters the sum of every instance negated, which is what makes that sum's
@@ -216,10 +219,10 @@ where
 		let (table_prover, table_root) = FracAddCheckProver::new(
 			table.log_len(),
 			alloc,
-			(FieldBuffer::clone_from_slice(alloc, pushforward.to_ref()), table_den),
+			Fraction::new(FieldBuffer::clone_from_slice(alloc, pushforward.to_ref()), table_den),
 		);
 		provers.push(table_prover);
-		roots.push((table_root.0.get(0), table_root.1.get(0)));
+		roots.push(table_root.as_ref().map(|buffer| buffer.get(0)));
 	}
 
 	// Top circuit: interpolate every instance's root fraction into a multilinear pair over the k
@@ -229,23 +232,25 @@ where
 	//     sum_j num_j / den_j  -  sum_t num_t / den_t
 	//
 	// which is zero exactly when the logUp identities hold.
-	let (top_prover, (top_root_num, top_root_den)) = FracAddCheckProver::new(k, alloc, {
-		let (mut root_nums, mut root_dens): (Vec<_>, Vec<_>) = roots.iter().copied().unzip();
-		root_nums.resize(1 << k, F::ZERO);
-		root_dens.resize(1 << k, F::ONE);
-		(
+	let (top_prover, top_root) = FracAddCheckProver::new(k, alloc, {
+		let (mut root_nums, mut root_dens): (Vec<_>, Vec<_>) =
+			roots.iter().map(|&root| (root.num, root.den)).unzip();
+		// The slots past the last instance hold the zero fraction, which the sum ignores.
+		root_nums.resize(1 << k, Fraction::ZERO.num);
+		root_dens.resize(1 << k, Fraction::ZERO.den);
+		Fraction::new(
 			FieldBuffer::<P, _>::from_values_in(alloc, &root_nums),
 			FieldBuffer::<P, _>::from_values_in(alloc, &root_dens),
 		)
 	});
-	let root_den = top_root_den.get(0);
+	let root_den = top_root.den.get(0);
 	drop(circuits_guard);
 
 	// A witness satisfying the lookup identity zeroes the root numerator, so it is not sent: the
 	// verifier supplies the zero itself, and a prover whose lookups do not match cannot make the
 	// rest of the GKR agree with it.
 	debug_assert_eq!(
-		top_root_num.get(0),
+		top_root.num.get(0),
 		F::ZERO,
 		"the lookup identities must hold: each table's looker fractions must sum to its own"
 	);

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -120,43 +120,6 @@ where
 	drive::batch(provers.into_iter().map(MleCheckRounds), channel)
 }
 
-/// Prove a batched MLE-check whose batching coefficient the caller has already sampled.
-///
-/// This is [`batch_prove_mle`] with the coefficient supplied rather than drawn.
-/// A caller needs that when it must know the coefficient before building its provers.
-/// An evaluator that emits one already-batched round polynomial is such a caller.
-///
-/// The coefficient must come from the same channel immediately before this call.
-/// Then the transcript is the one [`batch_prove_mle`] would have produced.
-pub(crate) fn batch_prove_mle_with_coeff<F, MleCheckProver_>(
-	provers: Vec<MleCheckProver_>,
-	batch_coeff: F,
-	channel: &mut impl IPProverChannel<F>,
-) -> BatchSumcheckOutput<F>
-where
-	F: Field,
-	MleCheckProver_: MleCheckProver<F>,
-{
-	drive::batch_with_coeff(provers.into_iter().map(MleCheckRounds).collect(), batch_coeff, channel)
-}
-
-/// [`batch_prove_mle_with_coeff`], then the evaluation claims written to the channel.
-///
-/// See [`batch_prove_mle_with_coeff`] for when a caller needs the coefficient up front.
-pub(crate) fn batch_prove_mle_with_coeff_and_write_evals<F, MleCheckProver_>(
-	provers: Vec<MleCheckProver_>,
-	batch_coeff: F,
-	channel: &mut impl IPProverChannel<F>,
-) -> BatchSumcheckOutput<F>
-where
-	F: Field,
-	MleCheckProver_: MleCheckProver<F>,
-{
-	let output = batch_prove_mle_with_coeff(provers, batch_coeff, channel);
-	output.send_evals(channel);
-	output
-}
-
 #[cfg(test)]
 mod tests {
 	use binius_field::{

--- a/crates/ip-prover/src/sumcheck/drive.rs
+++ b/crates/ip-prover/src/sumcheck/drive.rs
@@ -202,16 +202,13 @@ where
 	batch_with_coeff(provers, batch_coeff, channel)
 }
 
-/// Drives a group of provers with a batching coefficient the caller already drew.
+/// The round loop of [`batch`], once its batching coefficient has been drawn.
 ///
 /// The group's round polynomials are combined into one, so it costs a single round proof per
 /// variable. An empty group runs zero rounds.
 ///
-/// The coefficient must come from the same channel immediately before this call, so that the
-/// transcript matches the one [`batch`] would have produced.
-///
 /// The group arrives materialized because every round walks all of it.
-pub fn batch_with_coeff<F, Prover>(
+fn batch_with_coeff<F, Prover>(
 	mut provers: Vec<Prover>,
 	batch_coeff: F,
 	channel: &mut impl IPProverChannel<F>,

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -1,14 +1,12 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_compute::Allocator;
-use binius_field::{Field, PackedField, WideMul};
-use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldSlice, FieldVec};
+use binius_field::{Field, PackedField};
+use binius_math::FieldVec;
 
 use crate::sumcheck::{
-	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore, RoundContext},
+	mle_store::{ColId, MleStore},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evals::RoundEvals,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 
@@ -102,128 +100,6 @@ where
 	(numerator, denominator)
 }
 
-/// Round evaluator that reduces both fractional-addition claims in a single pass.
-///
-/// [`evaluators`] returns one evaluator per claim, so each claim walks the columns itself:
-///
-/// ```text
-///     numerator pass    num_a num_b den_a den_b   eq      8 column loads + 1 eq load
-///     denominator pass              den_a den_b   eq      4 column loads + 1 eq load
-/// ```
-///
-/// This evaluator reads the four columns once and fills both claims' accumulator slots.
-/// The sums `den_a.lo + den_a.hi` and `den_b.lo + den_b.hi` are then formed once, not twice.
-///
-/// It emits one round polynomial, already batched, rather than one per claim.
-/// That is exact, because [`RoundEvals::interpolate_eq`] is affine in its claim and evaluations:
-///
-/// ```text
-///     interp(c_num + z*c_den, y_num + z*y_den) = interp(c_num, y_num) + z*interp(c_den, y_den)
-/// ```
-///
-/// So the driving prover carries the single batched claim `c_num + z*c_den`.
-/// The polynomial this emits is the one the verifier's batched MLE-check reconstructs.
-pub struct FracAddFusedEvaluator<F> {
-	/// Layer columns in the order `[num_a, num_b, den_a, den_b]`.
-	cols: [ColId; 4],
-	/// The coefficient that batches the denominator claim onto the numerator claim.
-	batch_coeff: F,
-}
-
-impl<F: Field> FracAddFusedEvaluator<F> {
-	/// Creates the fused evaluator over the four layer columns.
-	///
-	/// # Arguments
-	///
-	/// * `cols` - The columns `[num_a, num_b, den_a, den_b]`.
-	/// * `batch_coeff` - The coefficient the driving protocol batches the two claims with.
-	///
-	/// The prover's claim for this evaluator must be `num_claim + batch_coeff * den_claim`.
-	pub const fn new(cols: [ColId; 4], batch_coeff: F) -> Self {
-		Self { cols, batch_coeff }
-	}
-}
-
-impl<F, P> MleCheckRoundEvaluator<F, P> for FracAddFusedEvaluator<F>
-where
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	fn degree(&self) -> usize {
-		// Four slots: the numerator's `y_1` and `y_inf`, then the denominator's.
-		// Each quadratic claim contributes the two sampled evaluations of its prime polynomial.
-		// The emitted polynomial is still degree 2.
-		4
-	}
-
-	fn accumulate(
-		&self,
-		chunk: &EvaluationChunk<'_, P>,
-		eq_ind: FieldSlice<'_, P>,
-		accum: &mut [<P as WideMul>::Output],
-	) {
-		// Each column arrives split on the round's top variable: `lo` fixes it to 0, `hi` to 1.
-		let [num_a, num_b, den_a, den_b]: [&ColumnChunk<'_, P>; 4] =
-			self.cols.map(|id| chunk.col(id));
-
-		let mut num_y_1 = <P as WideMul>::Output::default();
-		let mut num_y_inf = <P as WideMul>::Output::default();
-		let mut den_y_1 = <P as WideMul>::Output::default();
-		let mut den_y_inf = <P as WideMul>::Output::default();
-
-		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
-			// One load per column half, shared by both claims.
-			let na_lo = num_a.lo.as_ref()[idx];
-			let na_hi = num_a.hi.as_ref()[idx];
-			let nb_lo = num_b.lo.as_ref()[idx];
-			let nb_hi = num_b.hi.as_ref()[idx];
-			let da_lo = den_a.lo.as_ref()[idx];
-			let da_hi = den_a.hi.as_ref()[idx];
-			let db_lo = den_b.lo.as_ref()[idx];
-			let db_hi = den_b.hi.as_ref()[idx];
-
-			// The `x = 1` branch reads the high halves directly.
-			num_y_1 += P::wide_mul(na_hi * db_hi + nb_hi * da_hi, eq_i);
-			den_y_1 += P::wide_mul(da_hi * db_hi, eq_i);
-
-			// The `x = infinity` branch reads `lo + hi`, each multilinear's leading coefficient.
-			// The two denominator sums serve both claims.
-			let na = na_lo + na_hi;
-			let nb = nb_lo + nb_hi;
-			let da = da_lo + da_hi;
-			let db = db_lo + db_hi;
-			num_y_inf += P::wide_mul(na * db + nb * da, eq_i);
-			den_y_inf += P::wide_mul(da * db, eq_i);
-		}
-
-		// The run holds the two claims back to back: numerator first, then denominator.
-		let (numerator, denominator) = accum.split_at_mut(2);
-		RoundEvals([num_y_1, num_y_inf]).add_to(numerator);
-		RoundEvals([den_y_1, den_y_inf]).add_to(denominator);
-	}
-
-	fn interpolate(
-		&self,
-		ctx: &RoundContext<'_, P>,
-		accum: &[P],
-		claim: F,
-		alpha: F,
-	) -> RoundCoeffs<F> {
-		// The store has not yet folded this round, so its count is this round's.
-		let n_vars_remaining = ctx.n_vars();
-		assert!(n_vars_remaining > 0);
-
-		// Sum each claim's packed lanes into scalars.
-		let (num_slots, den_slots) = accum.split_at(2);
-		let numerator = RoundEvals::<P, 2>::from_slots(num_slots).sum_scalars(n_vars_remaining);
-		let denominator = RoundEvals::<P, 2>::from_slots(den_slots).sum_scalars(n_vars_remaining);
-
-		// Batch the sampled evaluations, then interpolate once against the batched claim.
-		// That order is equivalent to interpolating each claim and batching the polynomials.
-		(numerator + &(denominator * self.batch_coeff)).interpolate_eq(claim, alpha)
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use binius_field::arch::{OptimalB128, OptimalPackedB128};
@@ -244,112 +120,10 @@ mod tests {
 	use crate::sumcheck::{
 		MleToSumCheckEvaluator,
 		batch::batch_prove,
-		common::{MleCheckProver, SumcheckProver},
+		common::SumcheckProver,
 		mle_store::MleStore,
-		round_evaluator::{SharedMleCheckProver, SharedSumcheckProver, SumcheckRoundEvaluator},
+		round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 	};
-
-	// One layer's two honest claims: the numerator and denominator compositions.
-	// Each is its composite multilinear evaluated at the shared point.
-	fn layer_claims<F, P>(
-		num_parent: &FieldBuffer<P>,
-		den_parent: &FieldBuffer<P>,
-		eval_point: &[F],
-	) -> (F, F)
-	where
-		F: Field,
-		P: PackedField<Scalar = F>,
-	{
-		let n_vars = eval_point.len();
-		let (num_a, num_b) = num_parent.split_half_ref();
-		let (den_a, den_b) = den_parent.split_half_ref();
-		let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
-
-		// The composite values over the halved hypercube, word by word.
-		let numerator: Vec<P> = (0..packed_len)
-			.map(|i| num_a.as_ref()[i] * den_b.as_ref()[i] + num_b.as_ref()[i] * den_a.as_ref()[i])
-			.collect();
-		let denominator: Vec<P> = (0..packed_len)
-			.map(|i| den_a.as_ref()[i] * den_b.as_ref()[i])
-			.collect();
-
-		(
-			evaluate(&FieldBuffer::new(n_vars, numerator), eval_point),
-			evaluate(&FieldBuffer::new(n_vars, denominator), eval_point),
-		)
-	}
-
-	#[test]
-	fn fused_evaluator_matches_batched_split_evaluators() {
-		type F = OptimalB128;
-		type P = OptimalPackedB128;
-
-		let mut rng = StdRng::seed_from_u64(0);
-		let alloc = GlobalAllocator;
-
-		// 1 and 3 are single-chunk rounds throughout.
-		// 8 and 14 cross the chunk cap, so 14 also exercises eq suffix folding in the driver.
-		for n_vars in [1, 3, 8, 14] {
-			// The parents carry the variable that splits them into the four layer columns.
-			let num_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
-			let den_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
-			let eval_point = random_scalars::<F>(&mut rng, n_vars);
-			let batch_coeff = random_scalars::<F>(&mut rng, 1)[0];
-			let (num_claim, den_claim) = layer_claims(&num_parent, &den_parent, &eval_point);
-
-			// Reference: one evaluator per claim, the two round polynomials batched by the driver.
-			let mut split_store = MleStore::new(n_vars, &alloc);
-			let [s_num_a, s_num_b] = split_store.push_split_half(num_parent.clone());
-			let [s_den_a, s_den_b] = split_store.push_split_half(den_parent.clone());
-			let (num_evaluator, den_evaluator) =
-				evaluators::<F, P>([s_num_a, s_num_b, s_den_a, s_den_b]);
-			let split_claims: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
-				(num_claim, Box::new(num_evaluator)),
-				(den_claim, Box::new(den_evaluator)),
-			];
-			let mut split_prover =
-				SharedMleCheckProver::new(split_store, split_claims, eval_point.clone());
-
-			// Fused: one evaluator, one claim, already batched.
-			let mut fused_store = MleStore::new(n_vars, &alloc);
-			let [f_num_a, f_num_b] = fused_store.push_split_half(num_parent.clone());
-			let [f_den_a, f_den_b] = fused_store.push_split_half(den_parent.clone());
-			let fused_evaluator =
-				FracAddFusedEvaluator::new([f_num_a, f_num_b, f_den_a, f_den_b], batch_coeff);
-			let mut fused_prover = SharedMleCheckProver::new(
-				fused_store,
-				[(num_claim + batch_coeff * den_claim, fused_evaluator)],
-				eval_point.clone(),
-			);
-
-			// Both provers see the same challenges, so every round must agree.
-			for round in 0..n_vars {
-				// The driver Horner-folds the two claims into `num + batch_coeff * den`.
-				let batched_reference = split_prover
-					.execute()
-					.into_iter()
-					.rfold(RoundCoeffs::default(), |acc, coeffs| acc * batch_coeff + &coeffs);
-
-				let fused_round = fused_prover.execute();
-				assert_eq!(fused_round.len(), 1, "the fused evaluator emits one polynomial");
-				assert_eq!(
-					fused_round[0].0, batched_reference.0,
-					"round {round} polynomial differs at n_vars={n_vars}"
-				);
-
-				let challenge = random_scalars::<F>(&mut rng, 1)[0];
-				split_prover.fold(challenge);
-				fused_prover.fold(challenge);
-			}
-
-			// Both stores hold the same four columns, so they must reduce to the same evaluations.
-			assert_eq!(
-				split_prover.finish(),
-				fused_prover.finish(),
-				"column evaluations differ at n_vars={n_vars}"
-			);
-		}
-	}
 
 	fn test_frac_add_sumcheck_prove_verify<F, P>(
 		prover: impl SumcheckProver<F>,

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -3,7 +3,7 @@
 use binius_compute::BufferPool;
 use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::prodcheck::MultilinearEvalClaim;
-use binius_ip_prover::fracaddcheck::FracAddCheckProver;
+use binius_ip_prover::fracaddcheck::{FracAddCheckProver, fraction::Fraction};
 use binius_math::{
 	FieldBuffer,
 	multilinear::evaluate::evaluate,
@@ -41,7 +41,11 @@ fn bench_fracaddcheck_new(c: &mut Criterion) {
 					)
 				},
 				|(witness_num, witness_den)| {
-					FracAddCheckProver::<_, P>::new(k, &alloc, (witness_num, witness_den))
+					FracAddCheckProver::<_, P>::new(
+						k,
+						&alloc,
+						Fraction::new(witness_num, witness_den),
+					)
 				},
 				BatchSize::SmallInput,
 			);
@@ -71,13 +75,13 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 			let (prover, sums) = FracAddCheckProver::new(
 				k,
 				&alloc,
-				(
+				Fraction::new(
 					FieldBuffer::<P, _>::from_values_in(&alloc, &num_scalars),
 					FieldBuffer::<P, _>::from_values_in(&alloc, &den_scalars),
 				),
 			);
-			let sum_num_eval = evaluate(&sums.0, &[]);
-			let sum_den_eval = evaluate(&sums.1, &[]);
+			let sum_num_eval = evaluate(&sums.num, &[]);
+			let sum_den_eval = evaluate(&sums.den, &[]);
 			let claim = (
 				MultilinearEvalClaim {
 					eval: sum_num_eval,


### PR DESCRIPTION
**Stacked on #2254.** That PR is the first of the two commits here — merge it first, and this one's own diff is the second commit, [`b8003efb`](https://github.com/binius-zk/binius64/pull/2255/commits/b8003efb). GitHub cannot base a cross-fork PR on a fork branch, which is why both commits show up.

Replaces the anonymous numerator/denominator tuples with one named type.
Pure refactor — no behavior change, no transcript change.

### The problem

A fractional-addition instance is always a numerator beside its denominator.
The code carried that pair as an anonymous tuple, in two different shapes:

- `PooledFractionalBuffer<A, P> = (FieldVec<P, A>, FieldVec<P, A>)` for a pair of layer buffers
- a bare `(F, F)` for a pair of scalars — in `BatchProveOutput`, in four function signatures, and at every call site

A tuple does not say which element is which.
So every read went through `.0` and `.1`, and every caller had to remember the order:

```
(prover, (root.0.get(0), root.1.get(0)))
roots.push((table_root.0.get(0), table_root.1.get(0)));
```

### The idea

Name the pair once:

```rust
pub struct Fraction<T> {
    pub num: T,
    pub den: T,
}
```

`T` is whatever stands for one half.
A scalar gives a claimed fraction; a column buffer gives one layer of the circuit.

The same call sites become:

```
(prover, root.as_ref().map(|buffer| buffer.get(0)))
roots.push(table_root.as_ref().map(|buffer| buffer.get(0)));
```

### Where it pays most: the padding fill

Four resizes in `reduce_layer` read:

```
num_0s.resize(1 << k, F::ZERO);
num_1s.resize(1 << k, F::ZERO);
den_0s.resize(1 << k, F::ONE);
den_1s.resize(1 << k, F::ONE);
```

To see why two get `ZERO` and two get `ONE` you have to already know that a padding slot holds the zero fraction $0/1$, and that both its children are that fraction.
That knowledge now sits in the code:

```
let pad = Fraction::<F>::ZERO;
num_0s.resize(1 << k, pad.num);
num_1s.resize(1 << k, pad.num);
den_0s.resize(1 << k, pad.den);
den_1s.resize(1 << k, pad.den);
```

`Fraction::ZERO` is not a convenience name — $0/1$ **is** the additive identity of fractional addition, since

$$
\frac{a}{b} + \frac{0}{1} = \frac{a \cdot 1 + 0 \cdot b}{b \cdot 1} = \frac{a}{b}
$$

which is exactly why zero-fraction padding leaves a tree's fractional sum untouched.
A test pins that identity.

### Scope

- **new:** `fracaddcheck/fraction.rs` — the type, `new` / `as_ref` / `map`, `Fraction::ZERO`, and `From` both ways
- **changed:** `PooledFractionalBuffer` and every `(F, F)` fraction become `Fraction<_>`; 3 call sites in `logup_star/prove.rs`; the bench's witness construction
- **left alone:** the `log_len` equality assert in `new`. That invariant is about buffers, not about the pairing, so the newtype does not remove it — claiming otherwise would be overselling this.

`From<(T, T)>` and `From<Fraction<T>>` both exist because the tuple convention crosses the crate boundary: `binius_ip::fracaddcheck::pad_leaf_fraction` still takes `(E, E)`.
Whether to push the newtype down into `binius-ip` is a separate call, deliberately not made here.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-ip-prover` — 97 passed, and again with `--features rayon` — 97 passed

97 is the previous 94 plus three new tests on the type: the zero-fraction identity, the tuple round trip, and that `map`/`as_ref` reach both halves.
The fracaddcheck and logUp* prove/verify round trips are what confirm the transcript is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)