### PR TITLE
Use FracAddEvalClaim as the fracadd prover's claim type

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -4,10 +4,7 @@ use std::iter;
 
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
-use binius_ip::{
-	fracaddcheck::FracAddEvalClaim, mlecheck, prodcheck::MultilinearEvalClaim,
-	sumcheck::RoundCoeffs,
-};
+use binius_ip::{fracaddcheck::FracAddEvalClaim, mlecheck, sumcheck::RoundCoeffs};
 use binius_math::{
 	FieldBuffer, FieldVec,
 	batch_invert::BatchInversion,
@@ -42,11 +39,6 @@ use fraction::Fraction;
 use zero_pad_mle::{ConstantFraction, ZeroPadMleCheckProver};
 
 pub use crate::sumcheck::frac_add_mle::LayerProver;
-
-/// The numerator and denominator evaluation claims of one fractional-addition layer.
-///
-/// Both claims share the same evaluation point, that of the layer they describe.
-pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 
 /// Prover for the fractional addition protocol.
 ///
@@ -189,14 +181,8 @@ where
 	/// layers and `None` otherwise.
 	pub fn layer_prover(
 		mut self,
-		claim: FracEvalClaim<F>,
+		claim: FracAddEvalClaim<F>,
 	) -> (Option<Self>, LayerProver<'a, A, F, P>) {
-		let (num_claim, den_claim) = claim;
-		assert_eq!(
-			num_claim.point, den_claim.point,
-			"fractional claims must share the evaluation point"
-		);
-
 		let alloc = self.alloc;
 		let Fraction { num, den } = self.layers.pop().expect("layers is non-empty");
 
@@ -214,8 +200,8 @@ where
 			alloc,
 			num,
 			den,
-			num_claim.point,
-			[num_claim.eval, den_claim.eval],
+			claim.point,
+			[claim.num_eval, claim.den_eval],
 		);
 		(remaining, layer_prover)
 	}
@@ -233,9 +219,9 @@ where
 	/// * `claim.0.point.len() == witness.log_len() - k` (where k is the number of reduction layers)
 	pub fn prove(
 		self,
-		claim: FracEvalClaim<F>,
+		claim: FracAddEvalClaim<F>,
 		channel: &mut impl IPProverChannel<F>,
-	) -> FracEvalClaim<F> {
+	) -> FracAddEvalClaim<F> {
 		// Proving the full circuit runs every layer, so delegate and drop the leftover prover.
 		let n_layers = self.n_layers();
 		let (remaining, claim) = self.prove_layers(n_layers, claim, channel);
@@ -269,9 +255,9 @@ where
 	pub fn prove_layers(
 		self,
 		n_layers: usize,
-		claim: FracEvalClaim<F>,
+		claim: FracAddEvalClaim<F>,
 		channel: &mut impl IPProverChannel<F>,
-	) -> (Option<Self>, FracEvalClaim<F>) {
+	) -> (Option<Self>, FracAddEvalClaim<F>) {
 		// Each layer consumes the prover and returns the remainder, so thread it through an Option.
 		let mut prover_opt = Some(self);
 		let mut claim = claim;
@@ -306,16 +292,11 @@ where
 			next_point.reverse();
 			next_point.push(r);
 
-			let num_claim = MultilinearEvalClaim {
-				eval: next_num,
-				point: next_point.clone(),
-			};
-			let den_claim = MultilinearEvalClaim {
-				eval: next_den,
+			claim = FracAddEvalClaim {
+				num_eval: next_num,
+				den_eval: next_den,
 				point: next_point,
 			};
-
-			claim = (num_claim, den_claim);
 		}
 
 		(prover_opt, claim)
@@ -603,16 +584,11 @@ where
 	let inner_coords = eval_point[k..].to_vec();
 	let (layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, claimed_fractions)
 		.map(|(prover, &Fraction { num, den })| {
-			let (remaining, layer_prover) = prover.layer_prover((
-				MultilinearEvalClaim {
-					eval: num,
-					point: inner_coords.clone(),
-				},
-				MultilinearEvalClaim {
-					eval: den,
-					point: inner_coords.clone(),
-				},
-			));
+			let (remaining, layer_prover) = prover.layer_prover(FracAddEvalClaim {
+				num_eval: num,
+				den_eval: den,
+				point: inner_coords.clone(),
+			});
 			(layer_prover, remaining)
 		})
 		.unzip();
@@ -784,16 +760,11 @@ where
 				next_provers.push(prover);
 				Either::Right(ConstantFraction::new(num_claim, den_claim))
 			} else {
-				let (rest, layer_prover) = prover.layer_prover((
-					MultilinearEvalClaim {
-						eval: num_claim,
-						point: point.clone(),
-					},
-					MultilinearEvalClaim {
-						eval: den_claim,
-						point,
-					},
-				));
+				let (rest, layer_prover) = prover.layer_prover(FracAddEvalClaim {
+					num_eval: num_claim,
+					den_eval: den_claim,
+					point,
+				});
 				// Every tree is padded to the same depth, so one that pops here still holds a layer
 				// for each round below — until the final layer, whose remainders the caller drops.
 				next_provers.extend(rest);
@@ -904,17 +875,8 @@ mod tests {
 		// 4. Evaluate sums at challenge point to createzz claims
 		let sum_num_eval = evaluate(&sums.num, &eval_point);
 		let sum_den_eval = evaluate(&sums.den, &eval_point);
-		let prover_claim = (
-			MultilinearEvalClaim {
-				eval: sum_num_eval,
-				point: eval_point.clone(),
-			},
-			MultilinearEvalClaim {
-				eval: sum_den_eval,
-				point: eval_point.clone(),
-			},
-		);
-		let verifier_claim = fracaddcheck::FracAddEvalClaim {
+		// The prover and the verifier take the same claim type, so one claim serves both.
+		let claim = FracAddEvalClaim {
 			num_eval: sum_num_eval,
 			den_eval: sum_den_eval,
 			point: eval_point,
@@ -922,18 +884,14 @@ mod tests {
 
 		// 5. Run prover
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let prover_output = prover.prove(prover_claim, &mut prover_transcript);
+		let prover_output = prover.prove(claim.clone(), &mut prover_transcript);
 
 		// 6. Run verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verifier_output =
-			fracaddcheck::verify(k, verifier_claim, &mut verifier_transcript).unwrap();
+		let verifier_output = fracaddcheck::verify(k, claim, &mut verifier_transcript).unwrap();
 
 		// 7. Check outputs match
-		assert_eq!(prover_output.0.point, prover_output.1.point);
-		assert_eq!(prover_output.0.point, verifier_output.point);
-		assert_eq!(prover_output.0.eval, verifier_output.num_eval);
-		assert_eq!(prover_output.1.eval, verifier_output.den_eval);
+		assert_eq!(prover_output, verifier_output);
 
 		// 8. Verify multilinear evaluation of original witness
 		let expected_num = evaluate(&witness_num, &verifier_output.point);

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -7,7 +7,7 @@ use std::iter;
 use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, PackedField};
 use binius_ip::{
-	MultilinearEvalClaim,
+	fracaddcheck::FracAddEvalClaim,
 	logup_star::{LogupOutput, LogupTableOutput},
 };
 use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univariate};
@@ -261,20 +261,15 @@ where
 	// t's tree depth m_t, so the batch pads every shallower instance up — the padding costs O(1)
 	// per round and the layer count depends only on that maximum.
 	let gkr_guard = tracing::debug_span!("Combined GKR").entered();
-	let (top_num_claim, _top_den_claim) = top_prover.prove(
-		(
-			MultilinearEvalClaim {
-				eval: F::ZERO,
-				point: Vec::new(),
-			},
-			MultilinearEvalClaim {
-				eval: root_den,
-				point: Vec::new(),
-			},
-		),
+	let top_claim = top_prover.prove(
+		FracAddEvalClaim {
+			num_eval: F::ZERO,
+			den_eval: root_den,
+			point: Vec::new(),
+		},
 		channel,
 	);
-	let selector_point = top_num_claim.point;
+	let selector_point = top_claim.point;
 	let fracaddcheck::BatchProveOutput {
 		eval_point,
 		fractions,

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -2,7 +2,7 @@
 
 use binius_compute::BufferPool;
 use binius_field::{FieldOps, arch::OptimalPackedB128};
-use binius_ip::prodcheck::MultilinearEvalClaim;
+use binius_ip::fracaddcheck::FracAddEvalClaim;
 use binius_ip_prover::fracaddcheck::{FracAddCheckProver, fraction::Fraction};
 use binius_math::{
 	FieldBuffer,
@@ -82,16 +82,11 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 			);
 			let sum_num_eval = evaluate(&sums.num, &[]);
 			let sum_den_eval = evaluate(&sums.den, &[]);
-			let claim = (
-				MultilinearEvalClaim {
-					eval: sum_num_eval,
-					point: vec![],
-				},
-				MultilinearEvalClaim {
-					eval: sum_den_eval,
-					point: vec![],
-				},
-			);
+			let claim = FracAddEvalClaim {
+				num_eval: sum_num_eval,
+				den_eval: sum_den_eval,
+				point: vec![],
+			};
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
 


### PR DESCRIPTION
Rebased onto `main` now that #2254 and #2255 have merged, so this is a single commit against current `main`.

Pure refactor — no behavior change, no transcript change.

### The problem

A fractional-addition layer is claimed by **two evaluations at one point**.
The prover represented that as a pair of claims, each carrying its own copy of the point:

```rust
pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
```

Nothing makes the two points agree, so `layer_prover` opened by asserting it:

```rust
assert_eq!(num_claim.point, den_claim.point, "fractional claims must share the evaluation point");
```

Then it threw the pair away — because `frac_add_mle::new_split_half` takes one point and two evals, which is what the layer actually has.
**The pair existed only to be destructured.**

### The idea

`binius_ip::fracaddcheck::FracAddEvalClaim` is already that shape:

```rust
pub struct FracAddEvalClaim<F> {
    pub num_eval: F,
    pub den_eval: F,
    pub point: Vec<F>,
}
```

It was already imported in this file, and already the return type of this module's own `unpad_leaf_claim`.
The right type was in the room; the prover just was not using it.

### What that deletes

- **the assert** — a mismatched pair is no longer representable, so there is nothing to check
- **a `Vec<F>` clone per layer** — `prove_layers` was building the same point twice:

```
- point: next_point.clone(),   // numerator
- point: next_point,           // denominator
+ point: next_point,           // one claim, one point
```

- **two claim constructions per layer** at each of the three build sites, now one

### A nice consequence

The prover and the verifier now agree on the claim type.
So a test that built one claim for the prover and a second, identical one for the verifier builds a single claim for both, and this:

```
assert_eq!(prover_output.0.point, prover_output.1.point);
assert_eq!(prover_output.0.point, verifier_output.point);
assert_eq!(prover_output.0.eval, verifier_output.num_eval);
assert_eq!(prover_output.1.eval, verifier_output.den_eval);
```

becomes:

```
assert_eq!(prover_output, verifier_output);
```

The first of those four lines was checking that the prover's own two output points agree — a fact the type now guarantees.

### Soundness

The same point and the same two evaluations reach `new_split_half`, in the same order, so every round polynomial and every reduced evaluation is what it was.
`FracEvalClaim` had no external users, so nothing outside this crate sees the change.

### Scope

- **removed:** the `FracEvalClaim` alias and the point-equality assert
- **changed:** `layer_prover`, `prove`, `prove_layers`, `batch_prove_layer`, `layer_provers`; the `top_prover.prove` call in `logup_star/prove.rs`; the bench's claim
- **untouched:** every reduction, the verifier, the transcript

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-ip-prover` — 97 passed, and again with `--features rayon` — 97 passed

The fracaddcheck and logUp* prove/verify round trips run against the unchanged verifier, which is what pins the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
