### PR TITLE
Give the word-axis fold a parallel driver

### DIFF
--- a/crates/prover/benches/fold_across_words.rs
+++ b/crates/prover/benches/fold_across_words.rs
@@ -1,34 +1,99 @@
 // Copyright 2026 The Binius Developers
 use binius_core::word::Word;
-use binius_field::arch::OptimalPackedB128;
 use binius_math::test_utils::random_scalars;
-use binius_prover::fold_word::fold_across_words;
+use binius_prover::fold_word::WordFolder;
 use binius_verifier::config::B128;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
 
-fn bench_fold_across_words(c: &mut Criterion) {
+/// Word columns a single proof folds against one shared point.
+///
+/// The integer-multiplication protocol sends four, and binary multiplication sends six.
+/// Six is the wider case, so it is the one benched.
+const N_COLUMNS: usize = 6;
+
+/// One column folded against one point, with the two drivers side by side.
+///
+/// Both compute the same array. The sequential driver leaves every core but one idle, so the pair
+/// measures what dividing the chunk axis is worth.
+fn bench_single_column(c: &mut Criterion) {
 	let mut group = c.benchmark_group("fold_across_words");
 
 	for log_n_words in [12, 16, 20] {
 		let n_words = 1 << log_n_words;
+		let mut rng = rand::rng();
+		let words = (0..n_words)
+			.map(|_| Word::from_u64(rng.random()))
+			.collect::<Vec<_>>();
+		let point = random_scalars::<B128>(&mut rng, log_n_words);
+		let folder = WordFolder::<B128>::new(&point);
 
-		// Set throughput to measure words per second.
+		// Words per second, so the two drivers compare directly across sizes.
 		group.throughput(Throughput::Elements(n_words as u64));
 
-		group.bench_with_input(BenchmarkId::from_parameter(n_words), &n_words, |b, &n_words| {
-			let mut rng = rand::rng();
-			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random()))
-				.collect::<Vec<_>>();
-			let point = random_scalars::<B128>(&mut rng, log_n_words);
-
-			b.iter(|| fold_across_words::<_, OptimalPackedB128>(&words, &point));
+		group.bench_with_input(BenchmarkId::new("sequential", n_words), &n_words, |b, _| {
+			b.iter(|| folder.fold(&words))
+		});
+		group.bench_with_input(BenchmarkId::new("parallel", n_words), &n_words, |b, _| {
+			b.iter(|| folder.fold_par(&words))
 		});
 	}
 
 	group.finish();
 }
 
-criterion_group!(benches, bench_fold_across_words);
+/// The shape a proof actually folds in: several columns against one shared point.
+///
+/// The folder is built once outside the loop either way, so this isolates the driver alone.
+fn bench_shared_point_columns(c: &mut Criterion) {
+	let mut group = c.benchmark_group("fold_across_words/shared_point");
+
+	for log_n_words in [16, 20] {
+		let n_words = 1 << log_n_words;
+		let mut rng = rand::rng();
+
+		// One independent column per output the protocol sends.
+		let columns = (0..N_COLUMNS)
+			.map(|_| {
+				(0..n_words)
+					.map(|_| Word::from_u64(rng.random()))
+					.collect::<Vec<_>>()
+			})
+			.collect::<Vec<_>>();
+		let point = random_scalars::<B128>(&mut rng, log_n_words);
+		let folder = WordFolder::<B128>::new(&point);
+
+		// All six columns' words, so throughput counts the whole phase.
+		group.throughput(Throughput::Elements((N_COLUMNS * n_words) as u64));
+
+		group.bench_with_input(
+			BenchmarkId::new(format!("{N_COLUMNS}col sequential"), n_words),
+			&n_words,
+			|b, _| {
+				b.iter(|| {
+					columns
+						.iter()
+						.map(|col| folder.fold(col))
+						.collect::<Vec<_>>()
+				})
+			},
+		);
+		group.bench_with_input(
+			BenchmarkId::new(format!("{N_COLUMNS}col parallel"), n_words),
+			&n_words,
+			|b, _| {
+				b.iter(|| {
+					columns
+						.iter()
+						.map(|col| folder.fold_par(col))
+						.collect::<Vec<_>>()
+				})
+			},
+		);
+	}
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_single_column, bench_shared_point_columns);
 criterion_main!(benches);

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -31,6 +31,19 @@ const CHUNK_SIZE: usize = 1 << LOG_CHUNK_SIZE;
 /// Number of bits in a byte; [`fold_across_words`] processes each chunk in groups of this many
 /// words, one per byte of the words.
 const BITS_PER_BYTE: usize = Word::BITS / Word::BYTES;
+/// Minimum chunks one parallel task folds along the word axis.
+///
+/// A chunk is 64 words and folds in well under a microsecond, which is about what a handoff costs.
+/// Left unbounded, the split reaches one chunk per task and the handoffs dominate.
+///
+/// A floor also caps how far a loop can divide.
+/// A list of `n` chunks splits into at most `n / floor` tasks.
+/// So a floor set too high starves the cores on a short list, and one set too low drowns a long
+/// list in handoffs.
+///
+/// Sixteen chunks is 1024 words, which is the setting that loses at neither end.
+const MIN_CHUNKS_PER_TASK: usize = 16;
+
 /// Base-2 log of the row group a single subset-sum table covers.
 ///
 /// Eight rows is the widest group whose lookup index still fits one byte.
@@ -430,69 +443,20 @@ fn accumulate_word_chunk<F: BinaryField>(
 /// this computes a vector of `F` elements, where the entry at index $i$ is the inner product of the
 /// tensor expansion of the point and the bits at position $i$ across the words.
 ///
-/// Like [`fold_words`], this uses the [Method of Four Russians] to fold groups of words via
-/// precomputed lookup tables. The point is split into a `LOG_CHUNK_SIZE`-coordinate prefix and a
-/// suffix: the prefix tensor expansion is folded into each chunk of `CHUNK_SIZE` words by lookup,
-/// and the suffix tensor expansion scales each chunk's contribution before the chunks are summed.
+/// This builds the folding tables and then folds one list, running parallel over that list's
+/// chunks. A caller folding several lists against one point should build the folder once and reuse
+/// it, rather than calling this repeatedly.
 ///
-/// A list shorter than the word axis reads its missing high rows as zero, exactly as
-/// [`WordFolder::fold`] does.
+/// A list shorter than the word axis reads its missing high rows as zero.
 ///
 /// ## Preconditions
 ///
 /// * `words.len() <= 1 << point.len()`
-///
-/// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
-pub fn fold_across_words<F, P>(words: &[Word], point: &[F]) -> [F; Word::BITS]
+pub fn fold_across_words<F>(words: &[Word], point: &[F]) -> [F; Word::BITS]
 where
 	F: BinaryField,
-	P: PackedField<Scalar = F>,
 {
-	assert!(words.len() <= 1 << point.len());
-
-	// Build the point tables, then fold the one word-list over its chunks in parallel.
-	// A single list can span many chunks (up to 2^20 words in the benchmark).
-	// Parallelizing over the chunk axis is what keeps a lone fold fast.
-	let folder = WordFolder::<F>::new(point);
-	let (chunks, tail) = words.as_chunks::<CHUNK_SIZE>();
-
-	// Each chunk contributes to every bit position, scaled by that chunk's suffix weight. Summing
-	// the per-chunk accumulators contracts the word axis. Weights past the list's end pair with
-	// absent rows, so the zip drops them.
-	let folded_chunks = chunks
-		.par_iter()
-		.zip(folder.suffix_weights.as_ref().par_iter())
-		.map(|(chunk, &suffix_weight)| {
-			let mut acc = [F::ZERO; Word::BITS];
-			accumulate_word_chunk(chunk, &folder.lookups, suffix_weight, &mut acc);
-			acc
-		})
-		.reduce(
-			|| [F::ZERO; Word::BITS],
-			|mut lhs, rhs| {
-				for (lhs_i, rhs_i) in iter::zip(&mut lhs, rhs) {
-					*lhs_i += rhs_i;
-				}
-				lhs
-			},
-		);
-
-	// The chunk the list ends in, completed with its zero rows.
-	if tail.is_empty() {
-		return folded_chunks;
-	}
-
-	let mut chunk = [Word::ZERO; CHUNK_SIZE];
-	chunk[..tail.len()].copy_from_slice(tail);
-
-	let mut folded = folded_chunks;
-	accumulate_word_chunk(
-		&chunk,
-		&folder.lookups,
-		folder.suffix_weights.get(chunks.len()),
-		&mut folded,
-	);
-	folded
+	WordFolder::new(point).fold_par(words)
 }
 
 /// A reusable [Method of Four Russians] folder over a fixed evaluation point.
@@ -558,8 +522,9 @@ impl<F: BinaryField> WordFolder<F> {
 	///
 	/// with a clear bit read as zero and a set bit read as one.
 	///
-	/// This runs sequentially over the list's chunks.
-	/// A caller folding many lists against one point should parallelize across the lists instead.
+	/// This runs sequentially over the list's chunks, so it leaves every other core free.
+	/// It is the right driver for a caller already parallel over many lists.
+	/// A caller with few lists wants the parallel driver below instead.
 	///
 	/// A list shorter than the word axis reads its missing high rows as zero: an absent row's
 	/// weight multiplies nothing, so it contributes nothing to any bit position. Chunks lying
@@ -580,19 +545,77 @@ impl<F: BinaryField> WordFolder<F> {
 			accumulate_word_chunk(chunk, &self.lookups, suffix_weight, &mut folded);
 		}
 
-		// The chunk the list ends in, completed with its zero rows.
-		if !tail.is_empty() {
-			let mut chunk = [Word::ZERO; CHUNK_SIZE];
-			chunk[..tail.len()].copy_from_slice(tail);
-			accumulate_word_chunk(
-				&chunk,
-				&self.lookups,
-				self.suffix_weights.get(chunks.len()),
-				&mut folded,
+		self.accumulate_tail(tail, chunks.len(), &mut folded);
+		folded
+	}
+
+	/// Folds one word-list against the point, parallel over that list's chunks.
+	///
+	/// Returns the same array the sequential fold returns, under the same contract.
+	/// The two differ only in how the chunk axis is divided across workers.
+	///
+	/// Reach for this when few lists share the point, so the chunk axis is the only one wide enough
+	/// to divide. A caller folding many lists against one point should instead parallelize across
+	/// the lists and fold each one sequentially.
+	///
+	/// ## Preconditions
+	///
+	/// * `words.len() <= 1 << point.len()`
+	pub fn fold_par(&self, words: &[Word]) -> [F; Word::BITS] {
+		assert!(words.len() <= self.n_words, "words.len() must not exceed 2^point.len()");
+
+		let (chunks, tail) = words.as_chunks::<CHUNK_SIZE>();
+
+		// Each chunk contributes to every bit position, scaled by that chunk's suffix weight.
+		// Summing the per-chunk accumulators contracts the word axis.
+		// Weights past the list's end pair with absent rows, so the zip drops them.
+		let mut folded = chunks
+			.par_iter()
+			.zip(self.suffix_weights.as_ref().par_iter())
+			// One item is one chunk of 64 words, so the floor needs no conversion.
+			.with_min_len(MIN_CHUNKS_PER_TASK)
+			.map(|(chunk, &suffix_weight)| {
+				let mut acc = [F::ZERO; Word::BITS];
+				accumulate_word_chunk(chunk, &self.lookups, suffix_weight, &mut acc);
+				acc
+			})
+			.reduce(
+				|| [F::ZERO; Word::BITS],
+				|mut lhs, rhs| {
+					for (lhs_i, rhs_i) in iter::zip(&mut lhs, rhs) {
+						*lhs_i += rhs_i;
+					}
+					lhs
+				},
 			);
+
+		self.accumulate_tail(tail, chunks.len(), &mut folded);
+		folded
+	}
+
+	/// Accumulates the chunk the list ends in, completed with its zero rows.
+	///
+	/// A list whose length is a whole number of chunks has no such chunk, and this does nothing.
+	///
+	/// # Arguments
+	///
+	/// * `tail` - the words after the last whole chunk, fewer than one chunk of them
+	/// * `n_whole_chunks` - how many whole chunks came before, which selects the weight to use
+	/// * `folded` - the accumulator the tail's contribution is added into
+	fn accumulate_tail(&self, tail: &[Word], n_whole_chunks: usize, folded: &mut [F; Word::BITS]) {
+		if tail.is_empty() {
+			return;
 		}
 
-		folded
+		// Rows past the list's end read as zero, which contributes nothing to any bit position.
+		let mut chunk = [Word::ZERO; CHUNK_SIZE];
+		chunk[..tail.len()].copy_from_slice(tail);
+		accumulate_word_chunk(
+			&chunk,
+			&self.lookups,
+			self.suffix_weights.get(n_whole_chunks),
+			folded,
+		);
 	}
 }
 
@@ -999,7 +1022,7 @@ mod tests {
 				.collect::<Vec<_>>();
 			let point = random_scalars::<B128>(&mut rng, log_n);
 
-			let result_optimized = fold_across_words::<_, OptimalPackedB128>(&words, &point);
+			let result_optimized = fold_across_words(&words, &point);
 			let result_naive = naive_fold_across_words(&words, &point);
 
 			assert_eq!(result_optimized, result_naive, "mismatch at log_n = {log_n}");
@@ -1042,9 +1065,51 @@ mod tests {
 				"short WordFolder::fold differs at log_rows = {log_rows}, n_words = {n_words}"
 			);
 			assert_eq!(
-				fold_across_words::<_, OptimalPackedB128>(&words, &point),
+				fold_across_words(&words, &point),
 				expected,
 				"short fold_across_words differs at log_rows = {log_rows}, n_words = {n_words}"
+			);
+		}
+	}
+
+	#[test]
+	fn parallel_driver_matches_sequential_driver() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: dividing the chunk axis across workers changes nothing about the result.
+		// Field addition is associative and exact, so any grouping of the chunk sums agrees.
+		//
+		//     sequential: (((c_0 + c_1) + c_2) + c_3)
+		//     parallel  : ((c_0 + c_1) + (c_2 + c_3))
+		//     → identical, because the merge order is the only difference
+		//
+		// Fixture state: word counts crossing every regime of both drivers.
+		//
+		//     0                 → empty list, no chunks and no tail
+		//     1                 → tail only, no whole chunk
+		//     CHUNK_SIZE        → exactly one whole chunk, no tail
+		//     CHUNK_SIZE + 1    → one whole chunk plus a tail
+		//     5 * CHUNK_SIZE    → several whole chunks, no tail
+		//     5 * CHUNK_SIZE+17 → several whole chunks plus a tail
+		let log_rows = LOG_CHUNK_SIZE + 3;
+		for n_words in [
+			0,
+			1,
+			CHUNK_SIZE,
+			CHUNK_SIZE + 1,
+			5 * CHUNK_SIZE,
+			5 * CHUNK_SIZE + 17,
+		] {
+			let words = (0..n_words)
+				.map(|_| Word::from_u64(rng.random()))
+				.collect::<Vec<_>>();
+			let point = random_scalars::<B128>(&mut rng, log_rows);
+
+			let folder = WordFolder::new(&point);
+			assert_eq!(
+				folder.fold_par(&words),
+				folder.fold(&words),
+				"drivers disagree at n_words = {n_words}"
 			);
 		}
 	}

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -127,13 +127,16 @@ where
 
 	// Send the raw per-bit output evaluations of each word column at r_x. One folder is built for
 	// the shared point and reused across all six columns.
+	//
+	// Six columns cannot fill a machine on their own, so each column divides its own chunk axis
+	// rather than the six being run against each other.
 	let folder = WordFolder::<F>::new(&eval_point);
-	let a_lo_evals = folder.fold(a_lo);
-	let a_hi_evals = folder.fold(a_hi);
-	let b_lo_evals = folder.fold(b_lo);
-	let b_hi_evals = folder.fold(b_hi);
-	let c_lo_evals = folder.fold(c_lo);
-	let c_hi_evals = folder.fold(c_hi);
+	let a_lo_evals = folder.fold_par(a_lo);
+	let a_hi_evals = folder.fold_par(a_hi);
+	let b_lo_evals = folder.fold_par(b_lo);
+	let b_hi_evals = folder.fold_par(b_hi);
+	let c_lo_evals = folder.fold_par(c_lo);
+	let c_hi_evals = folder.fold_par(c_hi);
 
 	channel.send_many(&a_lo_evals);
 	channel.send_many(&a_hi_evals);

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -44,7 +44,7 @@ use super::{
 	error::Error,
 	witness::{Witness, limb_index, two_valued_field_buffer},
 };
-use crate::fold_word::{fold_across_words, fold_words};
+use crate::fold_word::{WordFolder, fold_words};
 
 /// Proves the integer multiplication (IntMul) reduction over the four operand columns.
 ///
@@ -400,11 +400,13 @@ where
 		// verifier binds the stacked-index claim via the GF(2)-linearity of the embedding, the `b`
 		// evals via sum_i eq(r_I^b, i) * b(i, r_out) = B(r_out), and the parity bits directly.
 		let output_guard = tracing::debug_span!("Compute output bit evals").entered();
-		let per_bit_evals = |exponents: &[Word]| fold_across_words::<_, P>(exponents, r_out);
-		let a_evals = per_bit_evals(a_exponents);
-		let c_lo_evals = per_bit_evals(c_lo_exponents);
-		let c_hi_evals = per_bit_evals(c_hi_exponents);
-		let b_evals = per_bit_evals(b_exponents);
+		// All four columns fold against the same point, so the lookup tables and the per-chunk
+		// weights are built once and shared.
+		let folder = WordFolder::<F>::new(r_out);
+		let a_evals = folder.fold_par(a_exponents);
+		let c_lo_evals = folder.fold_par(c_lo_exponents);
+		let c_hi_evals = folder.fold_par(c_hi_exponents);
+		let b_evals = folder.fold_par(b_exponents);
 		drop(output_guard);
 
 		self.channel.send_many(&a_evals);


### PR DESCRIPTION
Lets a caller fold several word columns against one shared point without choosing between reusing the folder's tables and using all the cores. No protocol change — the folded values are identical.

### The problem

A `&[Word]` list is a matrix over GF(2): rows are words, columns are bit positions.
The word-axis fold contracts the row axis, giving one field element per bit position.

The reusable folder that does this only had a **sequential** driver.
So a caller had two options, and both are wrong:

- reuse the folder's tables, and fold on one core
- rebuild the tables per column via the one-shot function, and fold on all of them

Both real callers landed on the wrong side of that:

- binary multiplication folds **six** columns against one point, sequentially
- integer multiplication folds **four**, rebuilding the tables each time

Table construction is not the expensive part — it is ~40 us against a ~6.6 ms fold at from^{20}$ words.
The sequential driver is.

### The idea

Add a second driver that divides the **chunk axis** of a single list.
A chunk is 64 words, so a list of from^{20}$ words is 16384 independent chunks — plenty to divide.

The two drivers then cover the two shapes a caller can be in:

- **many** lists share the point: parallelize across lists, fold each sequentially
- **few** lists share the point: fold each one across its own chunks

Six columns cannot fill a ten-core machine on their own, which is exactly the second case.

### The change

```
binmul: six columns, one shared point
- let a_lo_evals = folder.fold(a_lo);          // one core
+ let a_lo_evals = folder.fold_par(a_lo);      // all of them

intmul: four columns, one shared point
- let per_bit_evals = |e: &[Word]| fold_across_words::<_, P>(e, r_out);   // rebuilds tables x4
+ let folder = WordFolder::<F>::new(r_out);                               // built once
+ let a_evals = folder.fold_par(a_exponents);
```

The one-shot free function becomes a thin wrapper over the new driver.
That deletes the chunk-and-tail driver it had duplicated from the sequential one, so the trailing partial chunk is now handled in exactly one place.

Its unused `P` type parameter goes too — it was never read.

### Why the split needs a floor

Left unbounded, rayon divides down to one chunk per task.
A chunk folds in well under a microsecond, which is about what a handoff costs, so at from^{12}$ words the unbounded parallel fold is **slower than sequential** (29.7 us against 25.5 us).

A floor also caps how far a loop *can* divide: `n` chunks split into at most `n / floor` tasks.
Set it too high and a short list starves the cores; too low and a long list drowns in handoffs.
Sixteen chunks — 1024 words — loses at neither end:

| words | sequential | no floor | floor 16 | floor 64 |
|---|---|---|---|---|
| from^{12}$ | 0.0255 ms | 0.0297 ms | **0.0198 ms** | 0.0325 ms |
| from^{16}$ | 0.4094 ms | 0.1085 ms | **0.0862 ms** | 0.0850 ms |
| from^{20}$ | 6.6203 ms | 1.1231 ms | **1.1281 ms** | 1.0989 ms |

### Benchmark

Apple M1 Pro, 8P + 2E, 10 rayon threads, min of many runs. One column, both drivers:

| words | sequential | parallel | speedup |
|---|---|---|---|
| from^{12}$ | 0.0255 ms | 0.0198 ms | 1.29x |
| from^{14}$ | 0.1032 ms | 0.0356 ms | 2.90x |
| from^{16}$ | 0.4094 ms | 0.0862 ms | 4.75x |
| from^{18}$ | 1.6408 ms | 0.2966 ms | 5.53x |
| from^{20}$ | 6.6203 ms | 1.1281 ms | **5.87x** |

The binary-multiplication shape — six columns, one shared point — through the in-repo criterion bench:

| words per column | sequential | parallel | speedup |
|---|---|---|---|
| from^{16}$ | 2.455 ms | 0.832 ms | 2.95x |
| from^{20}$ | 39.5 ms | 7.71 ms | **5.12x** |

The single-column ratio is the better estimate of the ceiling; the six-column figure is measured on a contended machine and is the conservative one.

A follow-up that changes the merge strategy of this same loop is worth a further ~1.2x on top.

### Soundness

Field addition is associative and exact, so any grouping of the per-chunk sums gives the same element:

```
sequential: (((c_0 + c_1) + c_2) + c_3)
parallel  : ((c_0 + c_1) + (c_2 + c_3))
```

The transcript is byte-identical to before. Nothing about the challenge distribution changes.

### Scope

- **new:** the parallel driver, a private helper for the trailing partial chunk, and a test pinning the two drivers equal across every chunk regime including the empty list
- **changed:** six call sites in binary multiplication, four in integer multiplication
- **left untouched:** the sequential driver, which is still the right one for the batched instance fold in `binius-m4-prover` — that caller is already parallel over thousands of columns
- the bench now runs both drivers side by side, at one column and at six

### Verification

- `cargo check -p binius-prover -p binius-m4-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt` — clean
- `cargo test -p binius-prover --lib fold_word` — 8 passed, and again with `--features rayon`
- `cargo test -p binius-prover protocols::binmul` — 3 passed; `protocols::intmul` — 7 passed; both with and without `--features rayon`

The no-rayon shim is the default test path in this repo, so every test above was run in both configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)