### PR TITLE
Bound the rayon split in the bit-axis folds

### DIFF
--- a/crates/prover/benches/fold_words.rs
+++ b/crates/prover/benches/fold_words.rs
@@ -11,7 +11,9 @@ use rand::prelude::*;
 fn bench_fold_words(c: &mut Criterion) {
 	let mut group = c.benchmark_group("fold_words");
 
-	for log_n_words in [12, 16, 20] {
+	// Sizes below the task floor show what bounding the split is worth.
+	// The floor is 2^12 words, so 2^10 folds as one task and 2^20 as many.
+	for log_n_words in [10, 12, 14, 16, 20] {
 		let n_words = 1 << log_n_words;
 
 		// Set throughput to measure elements per second

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -41,6 +41,19 @@ const BITS_PER_BYTE: usize = Word::BITS / Word::BYTES;
 ///
 /// Sixteen chunks is 1024 words, which is the setting that loses at neither end.
 const MIN_CHUNKS_PER_TASK: usize = 16;
+/// Minimum words one parallel task folds along the bit axis.
+///
+/// A packed element is the unit of work here, and it holds as few as one word.
+/// Left unbounded, the split reaches one task per word, and the handoff costs more than the fold.
+///
+/// A floor also caps how far a loop can divide.
+/// A list of `n` words splits into at most `n / floor` tasks.
+/// So the floor must stay below the shortest list this fold runs at, divided by the core count.
+/// Otherwise the split stops before the cores are full.
+///
+/// The shared task-size budgets in the utilities crate are calibrated for wider items.
+/// They land high enough here to breach that cap on a mid-sized list.
+const MIN_WORDS_PER_TASK: usize = 1 << 12;
 
 /// Base-2 log of the row group a single subset-sum table covers.
 ///
@@ -182,6 +195,8 @@ impl<F: BinaryField> BitAxisFolder<F> {
 
 		(values_aligned, word_chunks)
 			.into_par_iter()
+			// One item is one packed element, so the floor converts from words to items.
+			.with_min_len(MIN_WORDS_PER_TASK.div_ceil(P::WIDTH))
 			.for_each(|(out, word_chunk)| {
 				// Safety:
 				// - words_aligned has length that is a multiple of P::WIDTH
@@ -286,6 +301,8 @@ impl<F: BinaryField> BitAxisFolder<F> {
 			b_aligned.par_chunks_exact(P::WIDTH),
 		)
 			.into_par_iter()
+			// One item is one packed element of each output, so the floor converts from words.
+			.with_min_len(MIN_WORDS_PER_TASK.div_ceil(P::WIDTH))
 			.for_each(|(a_i, b_i, c_i, a_chunk, b_chunk)| {
 				// Safety:
 				// - both aligned slices have length n_chunks * P::WIDTH


### PR DESCRIPTION
Stops the two bit-axis folds from dividing their work into tasks smaller than the handoff that creates them. One added call per loop — no behavior change.

### The problem

Both bit-axis folds hand rayon **one packed element per task**:

```
words_aligned.par_chunks_exact(P::WIDTH)
```

A packed element holds one field element on NEON, two under AVX2, four under AVX-512.
So the unit of parallel work is as little as **one word**: eight table lookups and seven XORs.

Handing a slice of work to another worker costs about a microsecond.
Folding one word costs about three nanoseconds.
Below roughly from^{14}$ words the handoffs cost more than the fold, and at from^{12}$ words the parallel fold is *slower than a sequential one*.

### The idea

Floor the split at a fixed number of **words**, then convert to packed elements by the packing width:

```
.with_min_len(MIN_WORDS_PER_TASK.div_ceil(P::WIDTH))
```

Expressing the floor in words rather than items is what makes it mean the same thing on every target.
A task then folds the same number of words whether a packed element holds one of them or four.

### Why this value

A floor caps how far a loop *can* divide: `n` words split into at most `n / floor` tasks.
So the floor must stay below the shortest list this fold runs at, divided by the core count — otherwise the split stops before the cores are full.

The shared task-size budgets in `binius-utils` are calibrated for wider items and land near from^{15}$ words here.
That breaches the cap at from^{16}$ words, folding the loop back to two tasks on ten cores, and measures *worse* than no floor at all. So this loop sets its own.

| words | no floor | floor from^{12}$ | floor from^{15}$ (shared budget) |
|---|---|---|---|
| from^{12}$ | 0.034 ms | **0.010 ms** | 0.011 ms |
| from^{14}$ | 0.046 ms | **0.025 ms** | 0.033 ms |
| from^{16}$ | 0.061 ms | **0.051 ms** | 0.075 ms |
| from^{20}$ | 0.347 ms | 0.345 ms | **0.319 ms** |

from^{12}$ words is the honest cross-check: a floor of from^{12}$ makes the whole list one task, and that ties the sequential fold exactly — which is the right answer at that size.

### Benchmark

Apple M1 Pro, 8P + 2E, 10 rayon threads. Criterion, `--save-baseline` before / `--baseline` after, every comparison $p = 0.00$:

| words | before | after | change |
|---|---|---|---|
| from^{10}$ | 105.1 us | 4.73 us | **-95.5%** |
| from^{12}$ | 136.9 us | 10.46 us | **-92.3%** |
| from^{14}$ | 170.6 us | 82.0 us | **-51.1%** |
| from^{16}$ | 207.9 us | 121.5 us | **-41.2%** |
| from^{20}$ | 547.5 us | 412.5 us | **-23.0%** |

The win grows as the list shrinks, which is the signature of the problem being scheduling rather than arithmetic.
The small sizes gain most because a fine-grained loop is also far more sensitive to a contended machine than a floored one.

The fused three-output fold gets the same treatment, and that one is ~18% of AND-reduction prove time at from^{21}$ words.

### Scope

- **changed:** one added call in the single-column bit-axis fold, one in the fused three-output fold
- **new:** the floor constant, documented with the reasoning behind its magnitude
- the bench gains from^{10}$ and from^{14}$ — the existing sizes started at from^{12}$ and so never showed the effect
- nothing else touched; the folds compute exactly what they computed before

### Verification

- `cargo check -p binius-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt` — clean
- `cargo test -p binius-prover --lib fold_word` — 7 passed, and again with `--features rayon`
- `cargo test -p binius-prover and_reduction --features rayon` — 5 passed

`with_min_len` exists in the no-rayon shim as well as in rayon, so both build configurations were tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)