### PR TITLE
Delete the unused both-axes word fold

### DIFF
--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -6,15 +6,10 @@ use std::{array, hint::assert_unchecked, iter};
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{
-	BinaryField, Divisible, PackedBinaryField64x1b, PackedField, WideMul,
-	linear_transformation::{
-		BytewiseLookupTransformationFactory, LinearTransformationFactory,
-		OutputWrappingTransformationFactory, Transformation,
-	},
-	util::expand_subset_sums_array,
+	BinaryField, Divisible, PackedBinaryField64x1b, PackedField, util::expand_subset_sums_array,
 };
 use binius_math::{
-	FieldBuffer, FieldSlice,
+	FieldBuffer,
 	multilinear::hypercube::{Hypercube, OneCube},
 };
 use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -325,65 +320,6 @@ impl<F: BinaryField> BitAxisFolder<F> {
 	}
 }
 
-/// Folds a slice of words along both axes at once, contracting the matrix to a single scalar.
-///
-/// The words form a matrix over GF(2): row `i` is `words[i]`, column `b` is bit position `b`.
-/// The result is the bilinear form
-///
-/// ```text
-/// out = sum_i sum_b bit_b(words[i]) * index_scalars[b] * row_scalars[i]
-/// ```
-///
-/// reading a clear bit as zero and a set bit as one.
-///
-/// - [`fold_words`] contracts only the bit-index axis, giving one scalar per word.
-/// - [`fold_across_words`] contracts only the word axis, giving one scalar per bit position.
-/// - This contracts both axes, giving a single scalar.
-///
-/// A `words` slice shorter than `row_scalars` reads the missing high rows as zero.
-///
-/// ## Preconditions
-///
-/// * `index_scalars.len()` is exactly [`Word::BITS`]
-/// * `words.len()` is less than or equal to `row_scalars.len()`
-pub fn fold_words_both_axes<F, P>(
-	words: &[Word],
-	index_scalars: &[F],
-	row_scalars: FieldSlice<P>,
-) -> F
-where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-{
-	assert_eq!(index_scalars.len(), Word::BITS);
-	assert!(words.len() <= row_scalars.len());
-
-	// Build the Method of Four Russians transform from the bit-index scalars, as `fold_words` does.
-	// Each word then folds to one scalar by bytewise table lookup.
-	let transform = OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-		.create(index_scalars);
-
-	// Fold each chunk to a packed element, then wide-multiply against the matching row element.
-	// Alignment: chunk `c` spans words `c*WIDTH .. (c+1)*WIDTH`, which is exactly packed row
-	// element `c`.
-	//
-	// The zip stops at the shorter word side.
-	// Dropped trailing row scalars pair with zero words, so they add nothing.
-	let wide = words
-		.par_chunks(P::WIDTH)
-		.zip(row_scalars.as_ref().par_iter())
-		.map(|(word_chunk, &row_i)| {
-			let folded =
-				P::from_scalars(word_chunk.iter().map(|&word| transform.transform(&word.0)));
-			P::wide_mul(folded, row_i)
-		})
-		.reduce(<P as WideMul>::Output::default, |lhs, rhs| lhs + rhs);
-
-	// One reduction closes the deferred products.
-	// Summing the lanes collapses the packed inner product to the scalar `out` above.
-	P::reduce(wide).iter().sum()
-}
-
 /// Folds one chunk of words into the accumulator, scaled by that chunk's weight.
 ///
 /// Words are 64-bit rows, so a chunk is 64 of them and the columns are the 64 bit positions.
@@ -610,7 +546,7 @@ impl<F: BinaryField> WordFolder<F> {
 mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{Field, arch::OptimalPackedB128};
-	use binius_math::test_utils::{random_field_buffer, random_scalars};
+	use binius_math::test_utils::random_scalars;
 	use binius_utils::checked_arithmetics::checked_log_2;
 	use binius_verifier::config::B128;
 	use rand::prelude::*;
@@ -725,68 +661,6 @@ mod tests {
 				c_fused,
 				folder.fold(&GlobalAllocator, &c_words),
 				"c mismatch at n_words = {n_words}"
-			);
-		}
-	}
-
-	fn naive_fold_words_both_axes<F, P>(
-		words: &[Word],
-		index_scalars: &[F],
-		row_scalars: &FieldBuffer<P>,
-	) -> F
-	where
-		F: BinaryField,
-		P: PackedField<Scalar = F>,
-	{
-		assert_eq!(index_scalars.len(), Word::BITS);
-		assert!(words.len() <= row_scalars.len());
-
-		// Contract row by row: fold each word's set bits against `index_scalars`, then weight the
-		// per-word scalar by its row scalar and sum. Words beyond `words.len()` are absent (zero).
-		let mut out = F::ZERO;
-		for (i, &word) in words.iter().enumerate() {
-			let mut per_word = F::ZERO;
-			for bit_idx in 0..Word::BITS {
-				if (word.as_u64() >> bit_idx) & 1 == 1 {
-					per_word += index_scalars[bit_idx];
-				}
-			}
-			out += per_word * row_scalars.get(i);
-		}
-		out
-	}
-
-	#[test]
-	fn test_fold_words_both_axes_equivalence() {
-		let mut rng = StdRng::seed_from_u64(0);
-
-		// (log_rows, n_words) covering: single element, full chunk, shorter power-of-two list,
-		// non-power-of-two list with a partial trailing chunk, a multi-chunk partial list, and the
-		// empty list.
-		for (log_rows, n_words) in [
-			(0, 1),
-			(LOG_CHUNK_SIZE, 1 << LOG_CHUNK_SIZE),
-			(LOG_CHUNK_SIZE, 1 << 3),
-			(LOG_CHUNK_SIZE, 40),
-			(LOG_CHUNK_SIZE + 2, (1 << (LOG_CHUNK_SIZE + 2)) - 3),
-			(3, 0),
-		] {
-			let words = (0..n_words)
-				.map(|_| Word::from_u64(rng.random()))
-				.collect::<Vec<_>>();
-			let index_scalars = random_scalars::<B128>(&mut rng, Word::BITS);
-			let row_scalars = random_field_buffer::<OptimalPackedB128>(&mut rng, log_rows);
-
-			let result_optimized = fold_words_both_axes::<_, OptimalPackedB128>(
-				&words,
-				&index_scalars,
-				row_scalars.to_ref(),
-			);
-			let result_naive = naive_fold_words_both_axes(&words, &index_scalars, &row_scalars);
-
-			assert_eq!(
-				result_optimized, result_naive,
-				"mismatch at log_rows = {log_rows}, n_words = {n_words}"
 			);
 		}
 	}


### PR DESCRIPTION
Removes a public function with no callers, and the reference implementation written to test it. Pure deletion — nothing that runs changes.

Rebased onto a main that now contains #2268, which removed the *other* user of the bytewise-lookup transformation trait. With both gone, the whole import leaves this file.

### The problem

A `&[Word]` list is a matrix over GF(2): rows are words, columns are bit positions.
The word-folding module offers three contractions of it:

| contracts | result | used by |
|---|---|---|
| the bit axis | one element per word | the AND reduction, shift, binmul, intmul, m4 — **many callers** |
| the word axis | one element per bit position | binmul, intmul, the batched instance fold — **several callers** |
| **both axes** | a single element | **nobody** |

The third has zero references anywhere in the workspace. The only thing keeping it alive is its own test, and the naive reference written to check that test.

That is 130 lines that cannot break, cannot be profiled, and cannot drift into agreement with anything — because nothing depends on it.

### The change

```
- pub fn fold_words_both_axes<F, P>(words, index_scalars, row_scalars) -> F
- fn naive_fold_words_both_axes<F, P>(..)          // its reference, test-only
- fn test_fold_words_both_axes_equivalence()       // the only caller
```

Three imports go with it, because this was their last user:

- the whole bytewise-lookup transformation import from the field crate, four names wide
- the wide-multiply trait
- the field-slice type

That first one is worth noting. Before #2268 this file reached its lookup tables through that trait twice: once for the bit-axis fold, once here. #2268 removed the first. This removes the second, so the import disappears entirely rather than shrinking again.

### What is being given up, and why that is the right call

This was the **only** place using the deferred-multiply trick: accumulate unreduced products across a chunk, then reduce once at the end.

```
folded = P::from_scalars(..)
wide  += P::wide_mul(folded, row_i)     // deferred, unreduced
..
P::reduce(wide).iter().sum()            // one reduction closes them all
```

Neither live fold does that. The word-axis fold instead does one full multiply per bit position per chunk — roughly one per word.

So the trick is worth a look. But it is worth **measuring inside the fold that actually runs**, not preserving as 130 lines of unreachable code that nobody will find when they go looking for it.

Deferring across chunks is not possible there — each chunk carries its own weight. Deferring within one chunk's 64 columns is, and that is a self-contained experiment.

### Scope

- **removed:** one `pub` function, its test-only reference, and one test
- **untouched:** both live folds, the folders, the lookup tables, the task-size floors
- net: -130 lines

### Verification

- `cargo check --workspace --all-targets` — clean

  Workspace-wide rather than scoped here, deliberately: a `pub` item is being removed, and the whole point is that nothing outside the crate calls it. A scoped check could not establish that.

- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt` — clean
- `cargo test -p binius-prover --lib` — 66 passed, and again with `--features rayon`

The count drops from 67 to 66: the deleted test is the difference, and no other test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
