### PR TITLE
Make prove_layers private and fix its stale docs

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -207,11 +207,11 @@ where
 	/// the largest.
 	///
 	/// # Arguments
-	/// * `claim` - The initial multilinear evaluation claims (numerator, denominator)
-	/// * `channel` - The channel for sending prover messages and sampling challenges
+	/// * `claim` - The numerator and denominator claims at their shared evaluation point.
+	/// * `channel` - The channel for sending prover messages and sampling challenges.
 	///
 	/// # Preconditions
-	/// * `claim.0.point.len() == witness.log_len() - k` (where k is the number of reduction layers)
+	/// * `claim.point.len() == witness.log_len() - k`, for `k` the number of reduction layers.
 	pub fn prove(
 		self,
 		claim: FracAddEvalClaim<F>,
@@ -229,13 +229,12 @@ where
 	/// Each layer adds one variable via a sumcheck and a line-fold.
 	/// So starting from a claim over `d` variables, the returned claim is over `d + n_layers`.
 	///
-	/// This is the building block of [`Self::prove`], which runs every layer.
-	/// Stopping early leaves the remaining prover on its untouched layers.
-	/// A caller can splice the leaf layer into another reduction, as the logUp* final layer does.
+	/// This is the layer loop of [`Self::prove`], which runs every layer.
+	/// The returned prover still holds the layers that were not proved.
 	///
 	/// # Arguments
 	/// * `n_layers` - The number of layers to prove, at most [`Self::n_layers`].
-	/// * `claim` - The initial numerator/denominator claims, sharing an evaluation point.
+	/// * `claim` - The numerator and denominator claims at their shared evaluation point.
 	/// * `channel` - The channel for sending prover messages and sampling challenges.
 	///
 	/// # Returns
@@ -244,7 +243,7 @@ where
 	///
 	/// # Preconditions
 	/// * `n_layers <= self.n_layers()`.
-	pub fn prove_layers(
+	fn prove_layers(
 		mut self,
 		n_layers: usize,
 		claim: FracAddEvalClaim<F>,


### PR DESCRIPTION
Docs and visibility only. The body is untouched.

### The problem

`FracAddCheckProver::prove_layers` is the layer loop of `prove`. It was `pub`, and its doc described a caller that no longer exists.

A census over the whole workspace finds exactly two references:

```
mod.rs:222   let (remaining, claim) = self.prove_layers(n_layers, claim, channel);   # prove's body
mod.rs:247   pub fn prove_layers(                                                   # the definition
```

Both in the same `impl` block. No re-exports, no doc references, no external callers.

### The stale claim, with its receipt

The doc said:

> A caller can splice the leaf layer into another reduction, as the logUp* final layer does.

That caller was deleted. Commit `be66218c` is *"BINIUS-406: remove the stop-before-the-final-layer batch drivers (#2053)"*, and its message says outright that the driver existed so the logUp* table side could retain its final layer and splice it into the batched final-layer sumcheck, that #2052 replaced that reduction, and that both the fracaddcheck and prodcheck variants were then removed as callerless.

So the sentence has been describing a deleted caller since 2026-08-10.

### Two more doc lines had drifted

**`prove`'s precondition** read:

```
- claim.0.point.len() == witness.log_len() - k
+ claim.point.len() == witness.log_len() - k
```

The `.0` index is left over from the claim *pair* that `FracAddEvalClaim` replaced — the parameter is now one struct with one shared point.

I checked the arithmetic rather than just the syntax. `new` builds `k + 1` layers and pops the last as `sums`, so the initial claim sits at `witness.log_len() - k` variables and `n_layers() == k`. The precondition is correct once the index is dropped.

**Both functions described `claim` as a pair** — "the initial multilinear evaluation claims (numerator, denominator)" and "the initial numerator/denominator claims, sharing an evaluation point". Both now read as the single struct they take.

### Scope

- **changed:** `prove_layers` is private; three stale doc lines corrected across `prove` and `prove_layers`
- **untouched:** every function body, every signature but the visibility keyword

Clippy raises no `dead_code` on the now-private function, since `prove` calls it.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean, and it reflowed nothing, which confirms no doc bullet wraps
- `cargo test -p binius-ip-prover` — 92 passed, and again with `--features rayon` — 92 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --no-deps` — clean, and the `[Self::prove]` / `[Self::n_layers]` links inside the now-private doc still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)