### PR TITLE
Pin unpad_leaf_claim against its verifier-side inverse

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -566,7 +566,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::PackedField;
+	use binius_field::{FieldOps, PackedField};
 	use binius_ip::fracaddcheck;
 	use binius_math::{
 		inner_product::inner_product,
@@ -575,8 +575,10 @@ mod tests {
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
+	use proptest::prelude::*;
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	type F = <Packed128b as FieldOps>::Scalar;
 	use binius_compute::GlobalAllocator;
 	use rand::prelude::*;
 
@@ -687,7 +689,7 @@ mod tests {
 	/// One prover per entry of `depths`, each reducing over all of its witness variables.
 	#[allow(clippy::type_complexity)]
 	fn unequal_depth_provers<'a, P: PackedField>(
-		rng: &mut impl Rng,
+		rng: &mut impl rand::Rng,
 		alloc: &'a GlobalAllocator,
 		depths: &[usize],
 	) -> (
@@ -819,5 +821,41 @@ mod tests {
 	fn test_unequal_depths_equal_depths() {
 		// Equal depths pad nothing, so every wrapper is a pass-through.
 		test_unequal_depths_helper::<Packed128b>(&[4, 4, 4]);
+	}
+
+	proptest! {
+		// Invariant: `unpad_leaf_claim` is the exact inverse of `pad_leaf_fraction`.
+		//
+		// The verifier pads a transparent leaf fraction, the prover unpads the claim it gets back.
+		// Only an end-to-end proof failure notices if either map drifts from the other.
+		#[test]
+		fn unpad_leaf_claim_inverts_pad_leaf_fraction(
+			seed in any::<u64>(),
+			n_pad_vars in 0usize..=5,
+			n_real_vars in 0usize..=5,
+		) {
+			let mut rng = StdRng::seed_from_u64(seed);
+
+			// Splitting the point's length in two keeps `n_pad_vars <= point.len()` by construction.
+			let point = random_scalars::<F>(&mut rng, n_pad_vars + n_real_vars);
+			let halves = random_scalars::<F>(&mut rng, 2);
+			let fraction = Fraction::new(halves[0], halves[1]);
+
+			let pad_eq = point[..n_pad_vars]
+				.iter()
+				.map(|&coord| OneCube::eq_one_var(F::ZERO, coord))
+				.product::<F>();
+			// Unpadding asserts on a zero weight, which needs a padding coordinate equal to one.
+			// Random 128-bit coordinates never are, so this rejects nothing.
+			prop_assume!(pad_eq != F::ZERO);
+
+			let padded = fracaddcheck::pad_leaf_fraction(fraction.into(), pad_eq);
+			let claim = unpad_leaf_claim(padded.into(), &point, n_pad_vars);
+
+			prop_assert_eq!(claim.num_eval, fraction.num);
+			prop_assert_eq!(claim.den_eval, fraction.den);
+			// The padding variables are the lowest ones, so unpadding strips them off the point.
+			prop_assert_eq!(claim.point, point[n_pad_vars..].to_vec());
+		}
 	}
 }


### PR DESCRIPTION
Test only. Adds one proptest; no production code changes.

### The problem

Two functions in two crates are exact inverses of each other, and nothing said so.

- `unpad_leaf_claim`, in the prover, turns a claim on a padded witness into a claim on the tree's own witness.
- `binius_ip::fracaddcheck::pad_leaf_fraction`, in the verifier, is the forward map. The logUp* verifier calls it at `logup_star/verify.rs:269` and `:281`.

If either drifts from the other, the only thing that notices is an **end-to-end logUp* proof failing**, with nothing pointing at the cause. That is an expensive way to find out.

### The idea

Round-trip them directly:

```
pad_eq   = prod over the first n_pad_vars coords of eq_one_var(0, coord)
padded   = pad_leaf_fraction(fraction, pad_eq)        // the verifier's map
claim    = unpad_leaf_claim(padded, point, n_pad_vars) // the prover's map

claim.num_eval == fraction.num
claim.den_eval == fraction.den
claim.point    == point[n_pad_vars..]
```

The last line is part of the property, not bookkeeping: the padding variables are the lowest ones, so unpadding must strip exactly that prefix off the point.

### Two details in the generator

**The point's length is built, not filtered.** Drawing `n_pad_vars` and `n_real_vars` separately and taking a point of length `n_pad_vars + n_real_vars` makes `n_pad_vars <= point.len()` true by construction, so nothing is rejected for being malformed.

**One `prop_assume`, and it rejects nothing.** Unpadding asserts on a zero equality weight. That requires a padding coordinate equal to one, and random $\mathbb{F}_{2^{128}}$ coordinates never are — so the guard is there for honesty about the precondition, not to filter cases.

### The test was checked for bite

A passing test proves nothing on its own. I mutated `pad_leaf_fraction` to drop its one-padding selector:

```
- E::one() + (den - E::one()) * pad_eq
+ den * pad_eq
```

The new test fails and shrinks to `n_pad_vars = 1, n_real_vars = 0` — a minimal, pointed counterexample. The mutation was reverted and the `proptest-regressions` artifact deleted; only the intended file is modified.

The existing end-to-end tests catch that mutation too, but only as a whole-proof mismatch with no pointer to the cause. That difference is the point of this test.

### Scope

- **new:** one `proptest!` block in `fracaddcheck/mod.rs`'s test module
- **incidental:** `proptest`'s prelude collides with `rand`'s on `Rng`, so one existing helper's bound is now spelled `impl rand::Rng` — the same qualification `sumcheck/sparse_dense_product.rs` already uses for the same reason. A concrete `F` alias was added, since the module previously only had a generic `P::Scalar`.
- **untouched:** all production code, `crates/ip/` included

### A note on naming

The new test carries no `test_` prefix, matching Rust convention and the sibling `zero_pad_mle.rs`. The other 11 tests in this file do carry it, so the file is briefly mixed.

I had believed this file was the crate's only prefix user; a proper census says otherwise — `sumcheck/` has 40 `#[test]` functions and 26 of them carry the prefix. So the crate is genuinely mixed, and picking one convention is a separate, repo-wide decision. Happy to add the prefix here instead if you would rather keep this file internally uniform for now.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean, no reflow of the new code
- `cargo test -p binius-ip-prover` — 93 passed, and again with `--features rayon` — 93 passed

93 is the previous 92 plus this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)