### PR TITLE
Put the chunk guard's write-back on the type users see

### DIFF
--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -49,7 +49,6 @@ mod write_back;
 use chunks::SubWordChunk;
 pub use chunks::{Chunks, ChunksMut};
 pub use view::{FieldSlice, FieldSliceData, FieldSliceMut, FieldVec};
-use write_back::FieldBufferChunkMutInner;
 pub use write_back::{FieldBufferChunkMut, FieldBufferSplitMut};
 
 /// A power-of-two-sized buffer containing field elements, stored in packed fields.
@@ -597,28 +596,19 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 			"precondition: chunk_index must be less than chunk_count"
 		);
 
-		let inner = if log_chunk_size >= P::LOG_WIDTH {
+		if log_chunk_size >= P::LOG_WIDTH {
 			// Large chunk: return a mutable slice directly
 			let packed_log_chunk_size = log_chunk_size - P::LOG_WIDTH;
 			let chunk = &mut self.values[chunk_index << packed_log_chunk_size..]
 				[..1 << packed_log_chunk_size];
-			FieldBufferChunkMutInner::Slice {
-				log_len: log_chunk_size,
-				chunk,
-			}
+			FieldBufferChunkMut::borrowed(log_chunk_size, chunk)
 		} else {
 			// Small chunk: copy the lanes out, and write them back when the guard drops.
 			let location = SubWordChunk::new(log_chunk_size, chunk_index);
 			let chunk = location.repack(&self.values);
-
-			FieldBufferChunkMutInner::Single {
-				location,
-				chunk,
-				parent: &mut self.values[location.word_index()],
-			}
-		};
-
-		FieldBufferChunkMut(inner)
+			let parent = &mut self.values[location.word_index()];
+			FieldBufferChunkMut::detached(location, chunk, parent)
+		}
 	}
 
 	/// Consumes the buffer and halves it, returning a guard that owns the store.

--- a/crates/math/src/field_buffer/write_back.rs
+++ b/crates/math/src/field_buffer/write_back.rs
@@ -31,6 +31,10 @@ pub struct FieldBufferSplitMut<P: PackedField, Data: DerefMut<Target = [P]>> {
 }
 
 impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBufferSplitMut<P, Data> {
+	/// Lends the two halves out as mutable views, the low half first.
+	///
+	/// A half of whole words is a view straight onto the store, so edits land at once.
+	/// A narrower half is a view onto a detached word, so edits land when this guard drops.
 	pub fn halves(&mut self) -> (FieldSliceMut<'_, P>, FieldSliceMut<'_, P>) {
 		match &mut self.singles {
 			Some([lo_half, hi_half]) => (
@@ -63,9 +67,8 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBufferSplitMut<P, Data> 
 
 impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for FieldBufferSplitMut<P, Data> {
 	fn drop(&mut self) {
+		// Detached halves are the only shape with anything to write back.
 		if let Some([lo_half, hi_half]) = self.singles {
-			// Write back the results by interleaving them back together
-			// The arrays may have been modified by the closure
 			(self.data[0], _) = lo_half.interleave(hi_half, self.log_len);
 		}
 	}
@@ -76,9 +79,27 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for FieldBufferSplitMut<
 /// A chunk of at least one packed word is lent straight from the store.
 /// A smaller one is detached into an owned word and merged back on drop.
 #[derive(Debug)]
-pub struct FieldBufferChunkMut<'a, P: PackedField>(pub(super) FieldBufferChunkMutInner<'a, P>);
+pub struct FieldBufferChunkMut<'a, P: PackedField>(FieldBufferChunkMutInner<'a, P>);
 
 impl<'a, P: PackedField> FieldBufferChunkMut<'a, P> {
+	/// Guards a chunk narrower than a packed word, already detached out of `parent`.
+	pub(super) const fn detached(location: SubWordChunk<P>, chunk: P, parent: &'a mut P) -> Self {
+		Self(FieldBufferChunkMutInner::Single {
+			location,
+			chunk,
+			parent,
+		})
+	}
+
+	/// Guards a chunk of whole words, lent straight from the store.
+	pub(super) const fn borrowed(log_len: usize, chunk: &'a mut [P]) -> Self {
+		Self(FieldBufferChunkMutInner::Slice { log_len, chunk })
+	}
+
+	/// Lends the chunk out as a mutable view.
+	///
+	/// A chunk of whole words is a view straight onto the store, so edits land at once.
+	/// A narrower chunk is a view onto a detached word, so edits land when this guard drops.
 	pub const fn get(&mut self) -> FieldSliceMut<'_, P> {
 		match &mut self.0 {
 			FieldBufferChunkMutInner::Single {
@@ -97,8 +118,23 @@ impl<'a, P: PackedField> FieldBufferChunkMut<'a, P> {
 	}
 }
 
+impl<P: PackedField> Drop for FieldBufferChunkMut<'_, P> {
+	fn drop(&mut self) {
+		match &mut self.0 {
+			FieldBufferChunkMutInner::Single {
+				location,
+				chunk,
+				parent,
+			} => location.merge_into(parent, chunk),
+			// A chunk lent from the store was edited in place, so there is nothing to merge.
+			FieldBufferChunkMutInner::Slice { .. } => {}
+		}
+	}
+}
+
+/// The two shapes a mutably borrowed chunk takes, decided by its size against the packing width.
 #[derive(Debug)]
-pub(super) enum FieldBufferChunkMutInner<'a, P: PackedField> {
+enum FieldBufferChunkMutInner<'a, P: PackedField> {
 	Single {
 		/// Which lanes of the parent word the chunk occupies.
 		location: SubWordChunk<P>,
@@ -111,17 +147,4 @@ pub(super) enum FieldBufferChunkMutInner<'a, P: PackedField> {
 		log_len: usize,
 		chunk: &'a mut [P],
 	},
-}
-
-impl<'a, P: PackedField> Drop for FieldBufferChunkMutInner<'a, P> {
-	fn drop(&mut self) {
-		match self {
-			Self::Single {
-				location,
-				chunk,
-				parent,
-			} => location.merge_into(parent, chunk),
-			Self::Slice { .. } => {}
-		}
-	}
 }


### PR DESCRIPTION
Moves a `Drop` impl onto the type users actually see, and makes that move safe rather than cosmetic. Pure refactor — no behaviour change.

### The problem

`FieldBufferChunkMut` is a guard: it lends out a chunk of a buffer smaller than one packed word, and merges the caller's edits back into the parent word when it drops.

The merge is the whole point of the type, and it was implemented on a **private inner enum**, not on the guard itself:

```
pub struct FieldBufferChunkMut<'a, P>(FieldBufferChunkMutInner<'a, P>);   // public, no Drop
enum FieldBufferChunkMutInner<'a, P> { .. }                              // private, has Drop
```

So the safety-critical write-back sat one indirection away from the type a reader sees. Worse, the inner enum was constructible from `mod.rs`, which meant it could in principle be built and dropped without ever being wrapped — the guard's own invariant depended on every construction site remembering to wrap.

### The idea

Put `Drop` on the public type, and close the hole that made that unsafe to do.

The inner enum gains two `pub(super)` constructors named for the two chunk shapes, so the enum itself never leaves the module:

```
ChunkMut::detached(..)   a chunk smaller than one packed word, copied out and merged back on drop
ChunkMut::borrowed(..)   a chunk of one or more whole words, lent straight from the store
```

`chunk_mut` loses its build-inner-then-wrap two-step, and the `use write_back::FieldBufferChunkMutInner;` import in `mod.rs` goes with it. The inner enum is now genuinely private, so the wrap is structural rather than a convention.

### What this is *not* — the guard unification was evaluated and rejected

The plan this came from proposed collapsing the two write-back guards into one `WriteBack<'a, P, const N: usize>`. That was evaluated against the code and **rejected on four counts**:

- **The premise had already dissolved.** #2267 moved the chunk merge onto a shared value object, so the two `Drop` bodies are now 6 and 9 lines, the chunk one a single delegating call. The only repeated text left is a struct literal.
- **The generics do not line up.** The split guard *owns* its backing store, because consuming a buffer means keeping the store alive. This guard *borrows* one word from a buffer that is still live. A unified type is generic over both, and then says which it is nowhere.
- **`const N: usize` admits values the type cannot honour.** Only 1 and 2 are meaningful, so the merged `Drop` needs an `unreachable!()` arm — trading two total `Drop` impls for one partial one, in the one place where a missed branch corrupts a buffer silently instead of panicking.
- **It would trade a compiler-checked invariant for a hand-checked one.** The two merges differ in kind: an interleave into word 0, versus a lane copy into a located range. A unified struct needs two correlated `Option` fields, `Some` exactly when `N` takes one value — where today an enum variant makes that impossible to get wrong.

The call-site counts point the same way. `FieldBufferSplitMut` has 4 consumers; `FieldBuffer::chunk_mut` has **zero** outside its own test. The unification would have joined one hot type to a dead one, paid for out of the hot type's readability.

### One planned cleanup turned out to be invalid

The plan also called for dropping a misleading `const` from the guard's accessor. That **fails CI**: `Cargo.toml` sets `missing_const_for_fn = "warn"` workspace-wide and CI runs clippy with `-D warnings`, so the lint *demands* that `const`. It is compelled by policy, not an author's slip. Left as it was.

### Scope

- **changed:** `field_buffer/write_back.rs` — `Drop` moved to the public guard, two `pub(super)` constructors added, the inner enum fully privatised.
- **changed:** `field_buffer/mod.rs` — `chunk_mut` calls a constructor instead of assembling the enum; one import removed.
- **not renamed:** `FieldBufferSplitMut` / `FieldBufferChunkMut` still carry the module-restating prefix. That rename belongs with the rest of the naming pass, not here.
- **also:** doc comments on the module's only two undocumented public methods, and a stale comment that referred to a closure the code does not have.

### Soundness

The merge arithmetic is untouched — only where the `Drop` impl lives changed. Two existing tests pin the behaviour and both still pass:

- The chunk test sweeps chunk sizes 0 through 8 on an 8-element buffer, so sub-word sizes take the detached arm at every index. It also asserts the **seven neighbouring elements are unchanged** after a single-element write, so a merge that clobbered lanes outside the chunk's range would fail.
- The split test covers the sub-word split at two arities and asserts the interleave landed.

### Verification

- `cargo check --workspace --all-targets --all-features` — clean.
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-math` — 143 passed, plus 1 doctest. Same again with `--features rayon`, since the default build uses the hand-written no-rayon shim.
- `cargo test -p binius-ip-prover -p binius-iop-prover` — 46 + 2 + 92 passed.
- `cargo doc -p binius-math --no-deps --all-features` — zero warnings.
- `cargo +nightly fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
