### PR TITLE
Benchmark the batched fracadd driver logUp* actually calls

### DIFF
--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -3,18 +3,29 @@
 use binius_compute::BufferPool;
 use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::fracaddcheck::FracAddEvalClaim;
-use binius_ip_prover::fracaddcheck::{FracAddCheckProver, fraction::Fraction};
+use binius_ip_prover::fracaddcheck::{
+	FracAddCheckProver, batch_prove_unequal_depths, fraction::Fraction,
+};
 use binius_math::{
 	FieldBuffer,
 	multilinear::evaluate::evaluate,
 	test_utils::{random_field_buffer, random_scalars},
 };
 use binius_transcript::ProverTranscript;
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 type P = OptimalPackedB128;
 type F = <P as FieldOps>::Scalar;
+
+/// Tree depths for the batched benchmark, shaped like a logUp* instance: one tree per looker or
+/// table, and one label per shape.
+const BATCH_SHAPES: &[(&str, &[usize])] = &[
+	("mixed_depths=18,16,14,12", &[18, 16, 14, 12]),
+	("equal_depths=18,18,18,18", &[18, 18, 18, 18]),
+	("mixed_depths=20,18,16,14,12,10,8,6", &[20, 18, 16, 14, 12, 10, 8, 6]),
+];
 
 fn bench_fracaddcheck_new(c: &mut Criterion) {
 	let mut group = c.benchmark_group("fracaddcheck/new");
@@ -88,11 +99,11 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 				point: vec![],
 			};
 
-			let mut transcript = ProverTranscript::new(StdChallenger::default());
-
+			// A transcript shared across iterations grows without bound, so each iteration gets a
+			// fresh one and every sample proves the same amount of work.
 			b.iter_batched(
-				|| (prover.clone(), claim.clone()),
-				|(prover, claim)| prover.prove(claim, &mut transcript),
+				|| (prover.clone(), claim.clone(), ProverTranscript::new(StdChallenger::default())),
+				|(prover, claim, mut transcript)| prover.prove(claim, &mut transcript),
 				BatchSize::SmallInput,
 			);
 		});
@@ -101,5 +112,65 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 	group.finish();
 }
 
-criterion_group!(fracaddcheck, bench_fracaddcheck_new, bench_fracaddcheck_prove);
+/// Benchmarks the batched driver logUp* actually calls, over trees of mixed and equal depths.
+fn bench_fracaddcheck_batch_unequal_depths(c: &mut Criterion) {
+	let mut group = c.benchmark_group("fracaddcheck/batch_prove_unequal_depths");
+
+	for &(label, depths) in BATCH_SHAPES {
+		// Every leaf of every tree is one hypercube vertex the batch reduces.
+		let total_leaves = depths.iter().map(|&depth| 1u64 << depth).sum();
+		group.throughput(Throughput::Elements(total_leaves));
+		group.bench_function(label, |b| {
+			let mut rng = rand::rng();
+			let pool = BufferPool::new();
+			let alloc = &pool;
+
+			// The selector variables index the trees, as logUp*'s top circuit hands them over.
+			let k = log2_ceil_usize(depths.len());
+			let selector_point = random_scalars::<F>(&mut rng, k);
+
+			// Build every tree once, then clone the batch per iteration (untimed setup).
+			let (provers, roots): (Vec<_>, Vec<_>) = depths
+				.iter()
+				.map(|&depth| {
+					let num_scalars = random_scalars::<F>(&mut rng, 1 << depth);
+					let den_scalars = random_scalars::<F>(&mut rng, 1 << depth);
+					let (prover, sums) = FracAddCheckProver::new(
+						depth,
+						&alloc,
+						Fraction::new(
+							FieldBuffer::<P, _>::from_values_in(&alloc, &num_scalars),
+							FieldBuffer::<P, _>::from_values_in(&alloc, &den_scalars),
+						),
+					);
+					(prover, sums.as_ref().map(|buffer| buffer.get(0)))
+				})
+				.unzip();
+
+			b.iter_batched(
+				|| {
+					(
+						provers.clone(),
+						roots.clone(),
+						selector_point.clone(),
+						ProverTranscript::new(StdChallenger::default()),
+					)
+				},
+				|(provers, roots, selector_point, mut transcript)| {
+					batch_prove_unequal_depths(provers, roots, selector_point, &mut transcript)
+				},
+				BatchSize::SmallInput,
+			);
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(
+	fracaddcheck,
+	bench_fracaddcheck_new,
+	bench_fracaddcheck_prove,
+	bench_fracaddcheck_batch_unequal_depths
+);
 criterion_main!(fracaddcheck);


### PR DESCRIPTION
Bench only. No production code changes.

### The problem

The fracaddcheck bench covers `new` and `prove` — the single-circuit driver.

But `prove` is not the hot path. logUp* calls it once for the small top circuit, then drives **`batch_prove_unequal_depths`** for the bulk of the work: `k` layers of top circuit down to the per-instance roots, then `max(max_n, max_m)` more over the instances themselves. See `crates/ip-prover/src/logup_star/prove.rs`.

That driver had **no benchmark at all**. So the path that matters was unmeasurable, and any claim about speeding it up had nothing to stand on.

### The change

A new group over three logUp*-shaped batches:

| shape | depths | leaves |
|---|---|---|
| mixed | 18, 16, 14, 12 | ~344k |
| equal | 18, 18, 18, 18 | ~1.05M |
| mixed, wide | 20, 18, 16, 14, 12, 10, 8, 6 | ~1.4M |

Throughput is counted in leaves, so the shapes are directly comparable — every leaf of every tree is one hypercube vertex the batch reduces.

The selector point is drawn over `log2_ceil(n_trees)` variables, which is how logUp*'s top circuit hands it over. Trees are built once and the batch cloned per iteration, so construction stays out of the timed region.

### Results, on an idle machine

| shape | time | throughput | spread |
|---|---:|---:|---:|
| mixed 18,16,14,12 | 8.44 ms | 41.3 Melem/s | ±1.1% |
| equal 18,18,18,18 | 24.61 ms | 42.6 Melem/s | ±1.0% |
| mixed 20,…,6 | 32.44 ms | 43.1 Melem/s | ±1.3% |

Throughput lands in a 41–43 Melem/s band across very different shapes, which is a useful sanity signal on its own, and the spreads are tight enough to regress against.

### A correction, since it was my own stated justification

Each iteration now also gets a fresh `ProverTranscript` instead of sharing one across the run.

I had justified that as fixing a ±23% spread on `prove/n_vars=20`. **That attribution was wrong.** Re-measuring the *unmodified* bench on an idle machine:

| case | unmodified bench, idle machine | spread |
|---|---:|---:|
| `prove/n_vars=16` | 1.5288–1.5493 ms | ±0.7% |
| `prove/n_vars=20` | 23.184–23.715 ms | ±1.1% |

Already tight. The ±23% I measured earlier was machine load — this session's own parallel builds — not the transcript.

So the transcript change stays, but as **measurement hygiene rather than a fix**: with one shared transcript, iteration `N` proves against a transcript holding `N-1` prior proofs, so iterations are not measuring identical work, and the buffer grows unboundedly over a run. Both are real; neither was causing a visible spread.

### Scope

- **changed:** `crates/prover/benches/fracaddcheck.rs` only
- **untouched:** all production code

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo bench -p binius-prover --bench fracaddcheck` — runs; numbers above

On method: this machine is a 10-core M1 Pro with a noise floor around 10–15% under load. Every number above was taken with the 1-minute load average below 6, and the before/after comparison was run back-to-back in the same machine state rather than against a baseline recorded hours earlier — which is exactly the mistake that produced the wrong ±23% claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)