### PR TITLE
Give the bitwise row fold its own types

### DIFF
--- a/crates/prover/src/bit_matrix.rs
+++ b/crates/prover/src/bit_matrix.rs
@@ -3,7 +3,7 @@
 
 //! Folding a matrix of single-bit rows against one weight per row.
 
-use std::array;
+use std::{array, iter};
 
 use binius_field::{
 	BinaryField, Divisible, PackedField, WithUnderlier, transpose::transpose_square_blocks_array,
@@ -15,64 +15,135 @@ use binius_verifier::config::B1;
 ///
 /// Eight is the widest group whose lookup index still fits one byte.
 /// One table load then replaces eight conditional additions.
-///
-/// The row fold below weights rows, so its tables cover eight rows.
-/// The bit-axis word fold weights bit positions and reuses the same geometry, so this counts
-/// weights rather than naming either axis.
 pub const WEIGHTS_PER_TABLE: usize = 1 << LOG_WEIGHTS_PER_TABLE;
 
 /// Base-2 log of the weights one subset-sum table covers.
 pub const LOG_WEIGHTS_PER_TABLE: usize = 3;
 
-/// Builds the subset-sum tables of a bitwise row fold.
+/// The rows one table covers, one bit per scalar.
+pub type RowGroup<PB> = [PB; WEIGHTS_PER_TABLE];
+
+/// Subset-sum tables for folding a matrix of single-bit rows against one weight per row.
 ///
-/// # Overview
-///
-/// A row fold contracts a matrix over GF(2) against one weight per row:
+/// The fold contracts the row axis, leaving one field element per column:
 ///
 /// ```text
 ///     out[b] = sum_r weight[r] * bit_b(row[r])
 /// ```
 ///
 /// Taking eight rows at a time turns that inner sum into a single table lookup.
-/// Table `g` covers rows `8g .. 8g+8` and holds every subset sum of their eight weights.
-/// A byte carrying those eight rows' bits at one column then indexes their contribution directly.
-///
-/// # Arguments
-///
-/// * `weights` - one weight per row, from the first row onwards
-///
-/// # Why short input is allowed
-///
-/// Weights past the end of the slice are read as zero.
-/// They would weight rows past the end of a chunk, which are themselves read as zero.
-/// So a zero weight and its absent row contribute nothing either way.
-/// This is what lets one table layout serve a chunk that the row list does not fill.
-pub fn row_fold_tables<F: BinaryField, const N_TABLES: usize>(
-	weights: &[F],
-) -> [[F; 1 << WEIGHTS_PER_TABLE]; N_TABLES] {
-	array::from_fn(|group| {
-		// Weights of the eight rows this table covers, zero where the slice has run out.
-		// A group beyond the end of the slice starts at its end, so it copies nothing.
-		let mut group_weights = [F::ZERO; WEIGHTS_PER_TABLE];
-		let start = (group * WEIGHTS_PER_TABLE).min(weights.len());
-		let available = (weights.len() - start).min(WEIGHTS_PER_TABLE);
-		group_weights[..available].copy_from_slice(&weights[start..start + available]);
-
-		// Enumerate all 256 subset sums, so any byte of set bits indexes its sum in one load.
-		expand_subset_sums_array(group_weights)
-	})
+/// Table `g` covers rows `8g` through `8g + 7` and holds every subset sum of their weights.
+#[derive(Debug, Clone)]
+pub struct RowFoldTables<F, const N_TABLES: usize> {
+	tables: [[F; 1 << WEIGHTS_PER_TABLE]; N_TABLES],
 }
 
-/// Folds one group of eight rows into a column accumulator.
+impl<F: BinaryField, const N_TABLES: usize> RowFoldTables<F, N_TABLES> {
+	/// Builds the tables from one weight per row, from the first row onwards.
+	///
+	/// Weights past the end of the slice read as zero.
+	/// Those weight rows past the end of the matrix, which read as zero as well.
+	/// So one table layout serves a chunk the row list does not fill.
+	pub fn new(weights: &[F]) -> Self {
+		let tables = array::from_fn(|group| {
+			// Weights of the eight rows this table covers, zero where the slice has run out.
+			// A group beyond the end of the slice starts at its end, so it copies nothing.
+			let mut group_weights = [F::ZERO; WEIGHTS_PER_TABLE];
+			let start = (group * WEIGHTS_PER_TABLE).min(weights.len());
+			let available = (weights.len() - start).min(WEIGHTS_PER_TABLE);
+			group_weights[..available].copy_from_slice(&weights[start..start + available]);
+
+			// Enumerate all 256 subset sums, so any byte of set bits indexes its sum in one load.
+			expand_subset_sums_array(group_weights)
+		});
+
+		Self { tables }
+	}
+
+	/// Folds each group of eight rows into the column sums.
+	///
+	/// Groups pair with tables in order, so the `g`th group is weighted by rows `8g` onwards.
+	/// An iterator yielding fewer groups leaves the remaining rows out, which reads them as zero.
+	///
+	/// # Preconditions
+	///
+	/// * A row must be one byte wide per table, so the groups cover every column exactly once.
+	#[inline]
+	pub fn fold_into<PB>(
+		&self,
+		groups: impl IntoIterator<Item = RowGroup<PB>>,
+		sums: &mut ColumnSums<F, N_TABLES>,
+	) where
+		PB: PackedField<Scalar = B1> + WithUnderlier,
+		PB::Underlier: Divisible<u8>,
+	{
+		// One byte of a row per table is what makes the accumulator line up with the columns.
+		const {
+			assert!(
+				PB::WIDTH == WEIGHTS_PER_TABLE * N_TABLES,
+				"the row width must be one byte per table"
+			);
+		}
+
+		// Pairing here rather than at the call site is what keeps a group with its own weights.
+		for (group, table) in iter::zip(groups, &self.tables) {
+			fold_group(group, table, &mut sums.groups);
+		}
+	}
+}
+
+/// One field element per column of the matrix, summed across row groups.
 ///
-/// # Overview
+/// Reading the groups end to end walks the columns in order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnSums<F, const N_TABLES: usize> {
+	// Invariant: entry `j` of group `i` is column `8i + j`, which is flat index `8i + j`.
+	//
+	// So the nesting is the identity permutation, and exists only because an array length of
+	// `WEIGHTS_PER_TABLE * N_TABLES` is not expressible in a const generic on stable.
+	groups: [[F; WEIGHTS_PER_TABLE]; N_TABLES],
+}
+
+impl<F: BinaryField, const N_TABLES: usize> ColumnSums<F, N_TABLES> {
+	/// The sums before any group has been folded in.
+	pub const fn zero() -> Self {
+		Self {
+			groups: [[F::ZERO; WEIGHTS_PER_TABLE]; N_TABLES],
+		}
+	}
+
+	/// The sums, in column order.
+	#[inline]
+	pub const fn as_slice(&self) -> &[F] {
+		self.groups.as_flattened()
+	}
+
+	/// Adds every column's sum into `out`, scaled by one weight.
+	///
+	/// A caller folding a matrix in chunks scales each chunk by its own weight on the way out.
+	///
+	/// # Preconditions
+	///
+	/// * `out` must hold one element per column.
+	#[inline]
+	pub fn add_scaled_to(&self, weight: F, out: &mut [F]) {
+		debug_assert_eq!(out.len(), self.as_slice().len()); // precondition
+
+		for (out_i, &sum) in iter::zip(out, self.as_slice()) {
+			*out_i += sum * weight;
+		}
+	}
+}
+
+impl<F: BinaryField, const N_TABLES: usize> Default for ColumnSums<F, N_TABLES> {
+	fn default() -> Self {
+		Self::zero()
+	}
+}
+
+/// Folds one group of eight rows into the column sums.
 ///
 /// Rows arrive one bit per scalar, so a row is one packed element and a column is a scalar index.
-/// One table covers one group, holding every subset sum of that group's eight row weights.
-///
-/// # Algorithm
-///
 /// Transposing the group exchanges its row axis with the low three bits of the column index:
 ///
 /// ```text
@@ -80,42 +151,176 @@ pub fn row_fold_tables<F: BinaryField, const N_TABLES: usize>(
 ///     after:   element j, bit 8i + t  =  row t, column 8i + j
 /// ```
 ///
-/// So byte `i` of element `j` then carries the eight rows' bits at column `8i + j`.
+/// So byte `i` of element `j` carries the eight rows' bits at column `8i + j`.
 /// One lookup of that byte yields those rows' whole contribution to that column.
-///
-/// The accumulator is nested to match, as `[byte of column index][low three bits]`.
-/// Reading that nesting in order walks the columns in order.
-///
-/// # Preconditions
-///
-/// * The row width in bits must equal eight times the accumulator's outer length.
-/// * Rows past the end of the matrix must be passed as zero, which contributes nothing.
 #[inline]
-pub fn fold_row_group<F, PB, const N_TABLES: usize>(
-	rows: &[PB; WEIGHTS_PER_TABLE],
+fn fold_group<F, PB, const N_TABLES: usize>(
+	mut group: RowGroup<PB>,
 	table: &[F; 1 << WEIGHTS_PER_TABLE],
-	acc: &mut [[F; WEIGHTS_PER_TABLE]; N_TABLES],
+	sums: &mut [[F; WEIGHTS_PER_TABLE]; N_TABLES],
 ) where
 	F: BinaryField,
 	PB: PackedField<Scalar = B1> + WithUnderlier,
 	PB::Underlier: Divisible<u8>,
 {
-	// One byte of a row per table is what makes the nesting below line up with the columns.
-	const {
-		assert!(
-			PB::WIDTH == WEIGHTS_PER_TABLE * N_TABLES,
-			"the row width must be one byte per table"
-		);
-	}
-
-	// The transpose consumes its input, so work on a copy and leave the caller's rows intact.
-	let mut group = *rows;
+	// The transpose rewrites the group in place, and the caller handed over its copy.
 	transpose_square_blocks_array::<PB, LOG_WEIGHTS_PER_TABLE, WEIGHTS_PER_TABLE>(&mut group);
 
 	for (j, row) in group.iter().enumerate() {
 		// Byte `i` holds this group's bits at column `8i + j`, so it indexes that column's sum.
 		for (i, byte) in Divisible::<u8>::value_iter(row.to_underlier()).enumerate() {
-			acc[i][j] += table[byte as usize];
+			sums[i][j] += table[byte as usize];
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{Field, PackedBinaryField64x1b, PackedBinaryField128x1b, Random};
+	use binius_math::test_utils::random_scalars;
+	use binius_verifier::config::B128;
+	use rand::prelude::*;
+
+	use super::*;
+
+	// The fold, written straight from its definition: every set bit adds its row's weight to that
+	// bit's column.
+	//
+	//     out[b] = sum_r weight[r] * bit_b(row[r])
+	fn naive_fold<F: BinaryField, PB: PackedField<Scalar = B1>>(
+		rows: &[PB],
+		weights: &[F],
+	) -> Vec<F> {
+		let mut out = vec![F::ZERO; PB::WIDTH];
+		for (row, &weight) in iter::zip(rows, weights) {
+			for (column, bit) in row.iter().enumerate() {
+				if bit == B1::ONE {
+					out[column] += weight;
+				}
+			}
+		}
+		out
+	}
+
+	// One row per lane of the packed type, grouped eight at a time.
+	fn random_groups<PB: PackedField + Random, const N_TABLES: usize>(
+		rng: &mut StdRng,
+	) -> Vec<RowGroup<PB>> {
+		(0..N_TABLES)
+			.map(|_| array::from_fn(|_| PB::random(&mut *rng)))
+			.collect()
+	}
+
+	fn check_matches_naive<PB, const N_TABLES: usize>(seed: u64, n_weights: usize)
+	where
+		PB: PackedField<Scalar = B1> + WithUnderlier + Random,
+		PB::Underlier: Divisible<u8>,
+	{
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		// One row per weight the fold covers, and one weight per row the tables cover.
+		let groups = random_groups::<PB, N_TABLES>(&mut rng);
+		let weights = random_scalars::<B128>(&mut rng, n_weights);
+
+		let tables = RowFoldTables::<B128, N_TABLES>::new(&weights);
+		let mut sums = ColumnSums::zero();
+		tables.fold_into(groups.iter().copied(), &mut sums);
+
+		// The naive side needs the rows laid out flat, in the order the tables weight them.
+		let rows = groups.concat();
+		let mut padded = weights;
+		padded.resize(rows.len(), B128::ZERO);
+
+		assert_eq!(
+			sums.as_slice(),
+			naive_fold(&rows, &padded),
+			"fold differs at seed {seed}, {n_weights} weights"
+		);
+	}
+
+	#[test]
+	fn fold_matches_the_definition() {
+		// The two row widths the callers run at: 64-bit words and 128-bit field elements.
+		//
+		//     64 columns  -> 8 tables of 8 rows
+		//     128 columns -> 16 tables of 8 rows
+		check_matches_naive::<PackedBinaryField64x1b, 8>(0, 64);
+		check_matches_naive::<PackedBinaryField128x1b, 16>(1, 128);
+	}
+
+	#[test]
+	fn weights_past_the_end_read_as_zero() {
+		// A row list that does not fill the tables must fold as the same list zero-padded up to
+		// them. This is what lets one table layout serve a partial chunk.
+		//
+		//     weights: [w_0 .. w_20]           rows 21..63 weigh nothing
+		//     padded : [w_0 .. w_20, 0 .. 0]
+		check_matches_naive::<PackedBinaryField64x1b, 8>(2, 21);
+		check_matches_naive::<PackedBinaryField64x1b, 8>(3, 0);
+		check_matches_naive::<PackedBinaryField128x1b, 16>(4, 100);
+	}
+
+	#[test]
+	fn sums_read_out_in_column_order() {
+		let mut rng = StdRng::seed_from_u64(5);
+
+		// Weight row 0 alone, so every column's sum is that weight exactly where row 0 has a set
+		// bit, and zero elsewhere. That pins the read-out order against the row's own bits.
+		let weights = random_scalars::<B128>(&mut rng, 1);
+		let row = PackedBinaryField64x1b::random(&mut rng);
+		let mut groups = [[PackedBinaryField64x1b::default(); WEIGHTS_PER_TABLE]; 8];
+		groups[0][0] = row;
+
+		let tables = RowFoldTables::<B128, 8>::new(&weights);
+		let mut sums = ColumnSums::zero();
+		tables.fold_into(groups.iter().copied(), &mut sums);
+
+		for (column, bit) in row.iter().enumerate() {
+			let expected = if bit == B1::ONE {
+				weights[0]
+			} else {
+				B128::ZERO
+			};
+			assert_eq!(sums.as_slice()[column], expected, "column {column}");
+		}
+	}
+
+	#[test]
+	fn scaling_out_multiplies_every_column() {
+		let mut rng = StdRng::seed_from_u64(6);
+
+		// Folding a chunk and scaling it must equal scaling each column sum by hand, which is what
+		// lets a caller pay one multiply per column instead of one per row.
+		let groups = random_groups::<PackedBinaryField64x1b, 8>(&mut rng);
+		let weights = random_scalars::<B128>(&mut rng, 64);
+		let scale = random_scalars::<B128>(&mut rng, 1)[0];
+
+		let tables = RowFoldTables::<B128, 8>::new(&weights);
+		let mut sums = ColumnSums::zero();
+		tables.fold_into(groups.iter().copied(), &mut sums);
+
+		// Start from a non-zero accumulator, so the addition is exercised and not just the scale.
+		let mut out = random_scalars::<B128>(&mut rng, 64);
+		let before = out.clone();
+		sums.add_scaled_to(scale, &mut out);
+
+		for (column, ((&got, &was), &sum)) in
+			iter::zip(iter::zip(&out, &before), sums.as_slice()).enumerate()
+		{
+			assert_eq!(got, was + sum * scale, "column {column}");
+		}
+	}
+
+	#[test]
+	fn folding_no_groups_leaves_the_sums_at_zero() {
+		// An empty matrix contributes nothing, so the sums stay where they started.
+		let mut rng = StdRng::seed_from_u64(7);
+		let weights = random_scalars::<B128>(&mut rng, 64);
+
+		let tables = RowFoldTables::<B128, 8>::new(&weights);
+		let mut sums = ColumnSums::zero();
+		tables.fold_into(iter::empty::<RowGroup<PackedBinaryField64x1b>>(), &mut sums);
+
+		assert_eq!(sums, ColumnSums::zero());
 	}
 }

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -19,9 +19,7 @@ use binius_math::{
 };
 use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
-use crate::bit_matrix::{
-	LOG_WEIGHTS_PER_TABLE, WEIGHTS_PER_TABLE, fold_row_group, row_fold_tables,
-};
+use crate::bit_matrix::{ColumnSums, RowFoldTables, WEIGHTS_PER_TABLE};
 
 /// Number of words folded together within a single chunk.
 ///
@@ -390,7 +388,7 @@ where
 /// A word and a 64-bit row of single-bit scalars share one underlier, so the view below is free.
 fn accumulate_word_chunk<F: BinaryField>(
 	chunk: &[Word; CHUNK_SIZE],
-	tables: &[[F; 1 << WEIGHTS_PER_TABLE]; Word::BYTES],
+	tables: &RowFoldTables<F, { Word::BYTES }>,
 	weight: F,
 	acc: &mut [F; Word::BITS],
 ) {
@@ -400,18 +398,10 @@ fn accumulate_word_chunk<F: BinaryField>(
 		[[PackedBinaryField64x1b; WEIGHTS_PER_TABLE]; Word::BYTES],
 	>(chunk);
 
-	// Accumulate every group into one column accumulator before scaling it.
-	let mut columns = [[F::ZERO; WEIGHTS_PER_TABLE]; Word::BYTES];
-	for (group, table) in iter::zip(groups, tables) {
-		fold_row_group(group, table, &mut columns);
-	}
-
-	// Scale once per column and merge, unpacking the nesting into bit-position order.
-	for (i, group) in columns.iter().enumerate() {
-		for (j, &column) in group.iter().enumerate() {
-			acc[(i << LOG_WEIGHTS_PER_TABLE) | j] += column * weight;
-		}
-	}
+	// Sum every group's contribution before scaling, so the chunk costs one multiply per column.
+	let mut sums = ColumnSums::zero();
+	tables.fold_into(groups.iter().copied(), &mut sums);
+	sums.add_scaled_to(weight, acc);
 }
 
 /// Computes the bitwise fold of the word vector with a tensor product, by bit position.
@@ -453,7 +443,7 @@ pub struct WordFolder<F: BinaryField> {
 	///
 	/// Table `s` folds the words at positions `s * WEIGHTS_PER_TABLE + t` within a chunk.
 	/// Each such word is weighted by prefix-expansion entry `t` of that group.
-	lookups: [[F; 1 << WEIGHTS_PER_TABLE]; Word::BYTES],
+	lookups: RowFoldTables<F, { Word::BYTES }>,
 	/// One weight per chunk of `CHUNK_SIZE` words, from the suffix expansion.
 	suffix_weights: FieldBuffer<F>,
 	/// The word axis's length, which each [`fold`](Self::fold) call's list fits in:
@@ -478,7 +468,7 @@ impl<F: BinaryField> WordFolder<F> {
 		// Those zeros pair with the repeated words a short list is filled with, so they add
 		// nothing.
 		let prefix_expansion = OneCube::eq_ind_partial_eval_scalars::<F>(prefix);
-		let lookups = row_fold_tables::<F, { Word::BYTES }>(&prefix_expansion);
+		let lookups = RowFoldTables::new(&prefix_expansion);
 
 		// One weight per chunk of CHUNK_SIZE words, from the suffix.
 		let suffix_weights = OneCube::eq_ind_partial_eval::<F>(suffix);

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -1,12 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::Deref};
+use std::{array, iter, ops::Deref};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{
-	ExtensionField, Field, PackedBinaryField128x1b, PackedExtension, PackedField,
+	ExtensionField, PackedExtension, PackedField,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, InputWrappingTransformationFactory,
 		LinearTransformationFactory, OutputWrappingTransformationFactory, Transformation,
@@ -30,7 +30,7 @@ use binius_verifier::{
 use itertools::izip;
 
 use crate::{
-	bit_matrix::{LOG_WEIGHTS_PER_TABLE, WEIGHTS_PER_TABLE, fold_row_group, row_fold_tables},
+	bit_matrix::{ColumnSums, LOG_WEIGHTS_PER_TABLE, RowFoldTables},
 	prove::pack_witness,
 };
 
@@ -112,7 +112,7 @@ where
 	// So every row past its end is weighted zero, whatever bits that row holds:
 	// rows past the end of a block read as zero, and a matrix narrower than one packed
 	// element leaves lanes that are not rows at all.
-	let lo_tables = row_fold_tables::<B128, N_ROW_TABLES>(eq_lo.as_ref());
+	let lo_tables = RowFoldTables::<B128, N_ROW_TABLES>::new(eq_lo.as_ref());
 
 	// A sub-width low factor still occupies its one packed element, so the block is that element.
 	let block_packed_len = 1 << eq_lo.log_len().saturating_sub(P::LOG_WIDTH);
@@ -128,32 +128,29 @@ where
 				//
 				// A matrix row is 128 single-bit columns, which is one full-width packed row.
 				let mut rows = P::iter_slice(mat_block);
-				let mut columns = [[B128::ZERO; WEIGHTS_PER_TABLE]; N_ROW_TABLES];
+				let mut sums = ColumnSums::zero();
 
-				for table in &lo_tables {
-					// Gather this group's rows out of the packed elements they sit in.
-					// Rows past the end of the block stay zero, and lanes past the last row
-					// carry weight zero, so neither contributes.
-					// A field element and a 128-bit row of single-bit scalars share one underlier,
-					// so each view is free.
-					let mut group = [PackedBinaryField128x1b::default(); WEIGHTS_PER_TABLE];
-					iter::zip(&mut group, &mut rows)
-						.for_each(|(dst, src)| *dst = PackedExtension::<B1>::cast_base(src));
+				// Gather each group's rows out of the packed elements they sit in, lazily, so a
+				// group is folded as soon as it is complete.
+				// Rows past the end of the block stay zero, and lanes past the last row carry
+				// weight zero, so neither contributes.
+				// A field element and a 128-bit row of single-bit scalars share one underlier, so
+				// each view is free.
+				lo_tables.fold_into(
+					iter::repeat_with(|| {
+						array::from_fn(|_| {
+							rows.next()
+								.map(PackedExtension::<B1>::cast_base)
+								.unwrap_or_default()
+						})
+					})
+					.take(N_ROW_TABLES),
+					&mut sums,
+				);
 
-					fold_row_group(&group, table, &mut columns);
-				}
-
-				// Scale by this block's high-factor entry and merge, unpacking the nesting into
-				// bit-position order.
+				// Scale by this block's high-factor entry and merge.
 				// That is 128 multiplies per block, one per row.
-				{
-					let acc = acc.as_mut();
-					for (i, group) in columns.iter().enumerate() {
-						for (j, &column) in group.iter().enumerate() {
-							acc[(i << LOG_WEIGHTS_PER_TABLE) | j] += eq_hi_val * column;
-						}
-					}
-				}
+				sums.add_scaled_to(eq_hi_val, acc.as_mut());
 				acc
 			},
 		)
@@ -398,7 +395,7 @@ pub fn prove_public_eval<A, P, Channel>(
 mod test {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
-		ExtensionField, Ghash128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
+		ExtensionField, Field, Ghash128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
 		PackedExtension, PackedField, PackedSubfield,
 	};
 	use binius_math::{


### PR DESCRIPTION
Turns two free functions over raw arrays into two named types. Pure refactor — the folded values are identical.

### The problem

The row fold contracts a matrix of single-bit rows against one weight per row, leaving one field element per column. It shipped as two free functions:

```
pub fn row_fold_tables<F, const N>(weights: &[F]) -> [[F; 256]; N]
pub fn fold_row_group<F, PB, const N>(rows: &[PB; 8], table: &[F; 256], acc: &mut [[F; 8]; N])
```

Both callers then wrote the same three things:

```
let mut columns = [[F::ZERO; 8]; N];                       // own the accumulator
for (group, table) in zip(groups, tables) { .. }           // pair group g with table g
for (i, group) in columns.iter().enumerate() {             // scale out, duplicated verbatim
    for (j, &column) in group.iter().enumerate() {
        acc[(i << 3) | j] += column * weight;
    }
}
```

The pairing is the dangerous one.
Nothing checks that group `g` meets table `g`.
Getting it wrong gives a wrong fold, not a compile error.

### The idea

Name the two things the loop is actually made of.

```
pub struct RowFoldTables<F, const N_TABLES: usize>   // the subset-sum tables
pub struct ColumnSums<F, const N_TABLES: usize>      // one element per column
```

The table set folds an **iterator of groups**, zipping them against its own tables:

```
pub fn fold_into<PB>(&self, groups: impl IntoIterator<Item = RowGroup<PB>>,
                     sums: &mut ColumnSums<F, N_TABLES>)
```

That is the load-bearing choice. Pairing happens inside, against `self.tables`, so a group can only ever meet its own weights. It also serves both callers' access patterns without a second method — one has its groups contiguous, the other gathers them lazily.

### The change

```
  fold_word, per chunk
- let mut columns = [[F::ZERO; 8]; Word::BYTES];
- for (group, table) in zip(groups, tables) { fold_row_group(group, table, &mut columns); }
- for (i, group) in columns.iter().enumerate() { for (j, &c) in .. { acc[(i<<3)|j] += c * weight; } }
+ let mut sums = ColumnSums::zero();
+ tables.fold_into(groups.iter().copied(), &mut sums);
+ sums.add_scaled_to(weight, acc);
```

Seven statements become three, and the same three lines replace the ring-switch copy of that loop.

### The nesting was never a permutation

The accumulator was `[[F; 8]; N]`, documented as `[byte of column index][low three bits]`, with callers reading it out through `acc[(i << 3) | j]`.

But entry `j` of group `i` sits at flat index `8i + j`, and `(i << 3) | j` **is** `8i + j`. The unpacking step never happened.

`as_slice` returns the sums flat, in column order, which says so. That is what lets the duplicated read-out loop go.

### One copy less

`fold_row_group` took `&[PB; 8]` and immediately did `let mut group = *rows;`, because the transpose consumes its input.

Taking the group by value makes the caller's move that copy, rather than forcing a second one.

### Soundness

Same tables, same lookups, same additions, in the same order.
The fold is bit-identical, so every transcript is unchanged.

### Scope

- **new:** the two types, a `RowGroup` alias, and five tests
- **changed:** the word-axis fold and the ring-switch fold, which are the only two callers
- **removed:** the two free functions and the two duplicated scale-out loops
- the geometry constants stay public, since a group's width appears in the signatures

### Tests

The primitives had **no direct test** — they were covered only through their two callers. They now have five, against a reference written straight from the definition:

```
out[b] = sum_r weight[r] * bit_b(row[r])
```

- the fold matches that definition, at both row widths the callers use (64 and 128 columns)
- weights past the end of the list read as zero, which is what lets one table layout serve a partial chunk
- the sums read out in column order, pinned against a single weighted row's own bits
- scaling out multiplies every column and adds into a non-zero accumulator
- folding no groups leaves the sums at zero

### Verification

- `cargo check -p binius-prover -p binius-m4-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt` — clean
- `cargo test -p binius-prover --lib` — 72 passed, and again with `--features rayon`

The no-rayon shim is the default test path in this repo, so the tests were run in both configurations.

No benchmark claim. The types are newtypes over the same arrays with the same inlined bodies, and the differences at stake are below what the machine available can resolve — a byte-identical move of this code measured as noise in both directions. If a reviewer wants it measured, `--bench ring_switch` and `--bench fold_across_words` are the two that cover these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)