### PR TITLE
Delete the unused mutable chunk accessor

### DIFF
--- a/crates/math/src/field_buffer/chunks.rs
+++ b/crates/math/src/field_buffer/chunks.rs
@@ -73,12 +73,6 @@ impl<P: PackedField> SubWordChunk<P> {
 		self.word_index
 	}
 
-	/// Element count of the chunk, as a base-2 logarithm.
-	#[inline]
-	pub(super) const fn log_len(self) -> usize {
-		self.log_len
-	}
-
 	/// Reads the chunk's elements out of the word holding it.
 	#[inline]
 	pub(super) fn scalars(self, word: P) -> impl Iterator<Item = P::Scalar> + Send + Clone {
@@ -91,14 +85,6 @@ impl<P: PackedField> SubWordChunk<P> {
 	#[inline]
 	pub(super) fn repack(self, words: &[P]) -> P {
 		P::from_scalars(self.scalars(words[self.word_index]))
-	}
-
-	/// Copies an edited chunk back into the lanes it came from.
-	#[inline]
-	pub(super) fn merge_into(self, word: &mut P, chunk: &P) {
-		for i in 0..1 << self.log_len {
-			word.set(self.lane_offset | i, chunk.get(i));
-		}
 	}
 }
 

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -54,7 +54,7 @@ use chunks::SubWordChunk;
 pub use chunks::{Chunks, ChunksMut};
 pub use scalars::Scalars;
 pub use view::{FieldSlice, FieldSliceData, FieldSliceMut, FieldVec};
-pub use write_back::{FieldBufferChunkMut, FieldBufferSplitMut};
+pub use write_back::FieldBufferSplitMut;
 
 /// A power-of-two-sized buffer containing field elements, stored in packed fields.
 ///
@@ -591,49 +591,6 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 
 		let chunk_count = 1 << (self.log_len - log_chunk_size);
 		ChunksMut::new(self.as_mut(), log_chunk_size, chunk_count)
-	}
-
-	/// Get a mutable aligned chunk of size `2^log_chunk_size`.
-	///
-	/// Addresses the same chunk as the shared accessor, and lends it mutably.
-	///
-	/// A chunk smaller than one packed word comes back behind a write-back guard.
-	/// Edits reach the parent word when that guard drops.
-	///
-	/// # Preconditions
-	///
-	/// * `log_chunk_size` must be at most `log_len`.
-	/// * `chunk_index` must be less than the chunk count.
-	#[track_caller]
-	pub fn chunk_mut(
-		&mut self,
-		log_chunk_size: usize,
-		chunk_index: usize,
-	) -> FieldBufferChunkMut<'_, P> {
-		assert!(
-			log_chunk_size <= self.log_len,
-			"precondition: log_chunk_size must be at most log_len"
-		);
-
-		let chunk_count = 1 << (self.log_len - log_chunk_size);
-		assert!(
-			chunk_index < chunk_count,
-			"precondition: chunk_index must be less than chunk_count"
-		);
-
-		if log_chunk_size >= P::LOG_WIDTH {
-			// Large chunk: return a mutable slice directly
-			let packed_log_chunk_size = log_chunk_size - P::LOG_WIDTH;
-			let chunk = &mut self.values[chunk_index << packed_log_chunk_size..]
-				[..1 << packed_log_chunk_size];
-			FieldBufferChunkMut::borrowed(log_chunk_size, chunk)
-		} else {
-			// Small chunk: copy the lanes out, and write them back when the guard drops.
-			let location = SubWordChunk::new(log_chunk_size, chunk_index);
-			let chunk = location.repack(&self.values);
-			let parent = &mut self.values[location.word_index()];
-			FieldBufferChunkMut::detached(location, chunk, parent)
-		}
 	}
 
 	/// Consumes the buffer and halves it, returning a guard that owns the store.
@@ -1238,100 +1195,6 @@ mod tests {
 		let values: Vec<F> = (0..1 << log_len).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
 		let _ = buffer.chunk(4, 1 << (log_len - 4)); // out of range
-	}
-
-	#[test]
-	fn chunk_mut() {
-		let log_len = 8;
-		let mut buffer = FieldBuffer::<P>::zeros(log_len);
-
-		// Initialize with test data
-		for i in 0..1 << log_len {
-			buffer.set(i, F::new(i as u128));
-		}
-
-		// Test mutations for different chunk sizes
-		for log_chunk_size in 0..=log_len {
-			let chunk_count = 1 << (log_len - log_chunk_size);
-
-			// Modify each chunk by multiplying by 10
-			for chunk_index in 0..chunk_count {
-				let mut chunk_wrapper = buffer.chunk_mut(log_chunk_size, chunk_index);
-				let mut chunk = chunk_wrapper.get();
-				for i in 0..1 << log_chunk_size {
-					let old_val = chunk.get(i);
-					chunk.set(i, F::new(u128::from(old_val.val()) * 10));
-				}
-				// chunk_wrapper drops here and writes back changes
-			}
-
-			// Verify modifications
-			for chunk_index in 0..chunk_count {
-				for i in 0..1 << log_chunk_size {
-					let index = chunk_index << log_chunk_size | i;
-					let expected = F::new((index as u128) * 10);
-					assert_eq!(
-						buffer.get(index),
-						expected,
-						"Failed at log_chunk_size={}, chunk_index={}, i={}",
-						log_chunk_size,
-						chunk_index,
-						i
-					);
-				}
-			}
-
-			// Reset buffer for next iteration
-			for i in 0..1 << log_len {
-				buffer.set(i, F::new(i as u128));
-			}
-		}
-
-		// Test large chunks (log_chunk_size >= P::LOG_WIDTH)
-		let mut buffer = FieldBuffer::<P>::zeros(6);
-		for i in 0..64 {
-			buffer.set(i, F::new(i as u128));
-		}
-
-		// Modify first chunk of size 16 (log_chunk_size = 4 >= P::LOG_WIDTH = 2)
-		{
-			let mut chunk_wrapper = buffer.chunk_mut(4, 0);
-			let mut chunk = chunk_wrapper.get();
-			for i in 0..16 {
-				chunk.set(i, F::new(100 + i as u128));
-			}
-		}
-
-		// Verify large chunk modifications
-		for i in 0..16 {
-			assert_eq!(buffer.get(i), F::new(100 + i as u128));
-		}
-		for i in 16..64 {
-			assert_eq!(buffer.get(i), F::new(i as u128));
-		}
-
-		// Test small chunks (log_chunk_size < P::LOG_WIDTH)
-		let mut buffer = FieldBuffer::<P>::zeros(3);
-		for i in 0..8 {
-			buffer.set(i, F::new(i as u128));
-		}
-
-		// Modify third chunk of size 1 (log_chunk_size = 0 < P::LOG_WIDTH = 2)
-		{
-			let mut chunk_wrapper = buffer.chunk_mut(0, 3);
-			let mut chunk = chunk_wrapper.get();
-			chunk.set(0, F::new(42));
-		}
-
-		// Verify small chunk modifications
-		for i in 0..8 {
-			let expected = if i == 3 {
-				F::new(42)
-			} else {
-				F::new(i as u128)
-			};
-			assert_eq!(buffer.get(i), expected);
-		}
 	}
 
 	#[test]

--- a/crates/math/src/field_buffer/write_back.rs
+++ b/crates/math/src/field_buffer/write_back.rs
@@ -1,24 +1,22 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-//! Guards for writing through a region of a field buffer narrower than one packed word.
+//! Guard for writing through halves of a field buffer narrower than one packed word.
 //!
-//! Such a region cannot be lent out as a mutable slice of packed words.
-//! The two halves of a split share a word, and a small chunk occupies only some of a word's lanes.
-//!
-//! Each guard therefore works in three steps:
+//! Two such halves share a single word, so neither can be lent out as a mutable slice of words.
+//! The guard therefore works in three steps:
 //!
 //! ```text
-//! detach   copy the region out into owned words
+//! detach   copy each half out into a word of its own
 //! lend     hand out mutable views over those owned words
-//! merge    fold the words back into the parent word when the guard drops
+//! merge    interleave the words back into the parent word when the guard drops
 //! ```
 
 use std::{ops::DerefMut, slice};
 
 use binius_field::PackedField;
 
-use super::{FieldBuffer, FieldSliceMut, chunks::SubWordChunk};
+use super::{FieldBuffer, FieldSliceMut};
 
 /// Guards the two halves of a buffer that was split along its highest variable.
 ///
@@ -72,79 +70,4 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for FieldBufferSplitMut<
 			(self.data[0], _) = lo_half.interleave(hi_half, self.log_len);
 		}
 	}
-}
-
-/// Guards one mutably borrowed chunk of a buffer.
-///
-/// A chunk of at least one packed word is lent straight from the store.
-/// A smaller one is detached into an owned word and merged back on drop.
-#[derive(Debug)]
-pub struct FieldBufferChunkMut<'a, P: PackedField>(FieldBufferChunkMutInner<'a, P>);
-
-impl<'a, P: PackedField> FieldBufferChunkMut<'a, P> {
-	/// Guards a chunk narrower than a packed word, already detached out of `parent`.
-	pub(super) const fn detached(location: SubWordChunk<P>, chunk: P, parent: &'a mut P) -> Self {
-		Self(FieldBufferChunkMutInner::Single {
-			location,
-			chunk,
-			parent,
-		})
-	}
-
-	/// Guards a chunk of whole words, lent straight from the store.
-	pub(super) const fn borrowed(log_len: usize, chunk: &'a mut [P]) -> Self {
-		Self(FieldBufferChunkMutInner::Slice { log_len, chunk })
-	}
-
-	/// Lends the chunk out as a mutable view.
-	///
-	/// A chunk of whole words is a view straight onto the store, so edits land at once.
-	/// A narrower chunk is a view onto a detached word, so edits land when this guard drops.
-	pub const fn get(&mut self) -> FieldSliceMut<'_, P> {
-		match &mut self.0 {
-			FieldBufferChunkMutInner::Single {
-				location,
-				chunk,
-				parent: _,
-			} => FieldBuffer {
-				log_len: location.log_len(),
-				values: slice::from_mut(chunk),
-			},
-			FieldBufferChunkMutInner::Slice { log_len, chunk } => FieldBuffer {
-				log_len: *log_len,
-				values: chunk,
-			},
-		}
-	}
-}
-
-impl<P: PackedField> Drop for FieldBufferChunkMut<'_, P> {
-	fn drop(&mut self) {
-		match &mut self.0 {
-			FieldBufferChunkMutInner::Single {
-				location,
-				chunk,
-				parent,
-			} => location.merge_into(parent, chunk),
-			// A chunk lent from the store was edited in place, so there is nothing to merge.
-			FieldBufferChunkMutInner::Slice { .. } => {}
-		}
-	}
-}
-
-/// The two shapes a mutably borrowed chunk takes, decided by its size against the packing width.
-#[derive(Debug)]
-enum FieldBufferChunkMutInner<'a, P: PackedField> {
-	Single {
-		/// Which lanes of the parent word the chunk occupies.
-		location: SubWordChunk<P>,
-		/// The detached copy the caller edits.
-		chunk: P,
-		/// The word the copy is merged back into.
-		parent: &'a mut P,
-	},
-	Slice {
-		log_len: usize,
-		chunk: &'a mut [P],
-	},
 }


### PR DESCRIPTION
Deletes a public method and its write-back guard that nothing calls. 235 lines out, 7 in.

### The problem

`FieldBuffer::chunk_mut` lends one aligned chunk of a buffer mutably. For a chunk smaller than one packed word it hands back `FieldBufferChunkMut`, a guard that copies the chunk out and merges the caller's edits back into the parent word on drop.

That is real machinery — a guard type, two constructors, a `Drop` impl, and a private inner enum. **Nothing in the workspace uses any of it.** The only calls are inside the test that exercises them:

```
crates/math/src/field_buffer/mod.rs:608   pub fn chunk_mut(..)     the definition
crates/math/src/field_buffer/mod.rs:1244  fn chunk_mut()           the test
crates/math/src/field_buffer/mod.rs:1259, 1298, 1321               its three calls
```

`FieldBufferChunkMut` is re-exported from the crate root and appears nowhere outside its own module.

### Why a grep alone was not enough

`rg 'chunk_mut'` finds three more hits, in `binius-hash` and `binius-transcript`. Those are a different method entirely: `bytes::BufMut::chunk_mut`, which takes no arguments where ours takes two. Each site was checked back to its trait impl to be sure:

```
crates/hash/src/serialization.rs:39             unsafe impl<..> BufMut for HashBuffer<..>
crates/transcript/src/fiat_shamir/buffer.rs:35  unsafe impl<..> BufMut for FiatShamirBuf<..>
crates/transcript/.../hasher_challenger.rs:177  unsafe impl<H> BufMut for HasherObserver<H>
```

All three `use bytes::BufMut`. So the count of real consumers is zero.

### What went, including what died with it

- **`mod.rs`** — the method, the guard's half of the crate-root re-export, and the test.
- **`write_back.rs`** — the guard, its two constructors, its accessor, its `Drop`, and the private inner enum. The module doc described two guards, so it now describes the one that remains.
- **`chunks.rs`** — two helpers on the sub-word chunk location that lost their only callers with the guard: the lane-merge, called only from that `Drop`, and the element-count accessor, called only from that accessor. Found by clippy rather than by reading, since the workspace runs `-D warnings`.

Kept: the shared chunk accessor, the mutable chunk *iterator*, the split guard, and the location type with the three methods that still have callers.

### Why the split guard stays

`FieldBufferSplitMut` looks similar and is **not** dead. It has four consumers:

```
crates/math/src/multilinear/fold.rs
crates/math/src/multilinear/hypercube.rs
crates/ip-prover/src/sumcheck/mle_store.rs
crates/prover/src/and_reduction/ntt_lookup.rs
```

Only the chunk guard is unused. This PR touches nothing about the split path.

### Soundness

Removing the chunk guard removes the module's second write-back path, so the question is whether the first one is still covered. It is.

`FieldBufferSplitMut` is now the only detach-and-merge path, and the split test exercises it at two sub-word arities — halves of one element, and halves of zero — both below the test packing width of four, plus a whole-word case that needs no merge at all.

The coverage the deleted test uniquely provided was of code that no longer exists.

### This deletes public API

Stated plainly so it is easy to push back on: if the mutable chunk accessor is scaffolding for work in flight, the right change is the opposite of this one — keep it and give it a doc comment naming the caller it waits for. Nothing in the code today distinguishes it from an oversight.

There is precedent either way. An unused trait was deleted from this same module earlier in this cleanup and merged without objection; a different unused module was proposed for deletion and rejected.

### Verification

- `cargo check --workspace --all-targets --all-features` — clean. This is the gate that proves nothing depended on the removed surface.
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean, and no further dead code surfaced after the two transitive removals.
- `cargo test -p binius-math` — 146 passed, plus 1 doctest. Baseline is 147, so exactly the one deleted test is gone.
- Same again with `--features rayon`, since the default build uses the hand-written no-rayon shim.
- `cargo doc -p binius-math --no-deps --all-features` — zero warnings.
- `cargo +nightly fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
