### PR TITLE
Proptest the layer recurrence and the batched round trip

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -602,7 +602,7 @@ mod tests {
 		// 3. Generate random n-dimensional challenge point
 		let eval_point = random_scalars::<P::Scalar>(&mut rng, n);
 
-		// 4. Evaluate sums at challenge point to createzz claims
+		// 4. Evaluate sums at challenge point to create claims
 		let sum_num_eval = evaluate(&sums.num, &eval_point);
 		let sum_den_eval = evaluate(&sums.den, &eval_point);
 		// The prover and the verifier take the same claim type, so one claim serves both.
@@ -640,8 +640,8 @@ mod tests {
 		test_frac_add_check_prove_verify_helper::<Packed128b>(0, 4);
 	}
 
-	fn test_frac_add_check_layer_computation_helper<P: PackedField>(n: usize, k: usize) {
-		let mut rng = StdRng::seed_from_u64(0);
+	fn check_all_layers<P: PackedField>(n: usize, k: usize, seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
 		let alloc = GlobalAllocator;
 
 		// Create random witness with log_len = n + k
@@ -649,36 +649,49 @@ mod tests {
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// Create prover (computes fractional-add layers)
-		let (_prover, sums) = FracAddCheckProver::new(
+		let (prover, sums) = FracAddCheckProver::new(
 			k,
 			&alloc,
 			Fraction::new(witness_num.clone(), witness_den.clone()),
 		);
 
-		// For each index i in the sums layer, verify it equals the fractional sum of witness values
-		// at indices i + z * 2^n for z in 0..2^k (strided access, not contiguous)
-		let stride = 1 << n;
-		let num_terms = 1 << k;
-		for i in 0..(1 << n) {
-			let mut expected_num = witness_num.get(i);
-			let mut expected_den = witness_den.get(i);
-			for z in 1..num_terms {
-				let idx = i + z * stride;
-				let num_z = witness_num.get(idx);
-				let den_z = witness_den.get(idx);
-				expected_num = expected_num * den_z + num_z * expected_den;
-				expected_den *= den_z;
+		// `new` pops the root off as `sums`, so the circuit is `layers` followed by it.
+		for (j, layer) in prover.layers.iter().chain(iter::once(&sums)).enumerate() {
+			// Entry i of layer j is the fractional sum of the 2^j witness values strided by that
+			// layer's own width (strided access, not contiguous).
+			let width = 1 << (n + k - j);
+			let num_terms = 1 << j;
+			for i in 0..width {
+				let mut expected_num = witness_num.get(i);
+				let mut expected_den = witness_den.get(i);
+				for z in 1..num_terms {
+					let idx = i + z * width;
+					let num_z = witness_num.get(idx);
+					let den_z = witness_den.get(idx);
+					expected_num = expected_num * den_z + num_z * expected_den;
+					expected_den *= den_z;
+				}
+				let actual_num = layer.num.get(i);
+				let actual_den = layer.den.get(i);
+				assert_eq!(actual_num, expected_num, "layer {j} numerator mismatch at index {i}");
+				assert_eq!(actual_den, expected_den, "layer {j} denominator mismatch at index {i}");
 			}
-			let actual_num = sums.num.get(i);
-			let actual_den = sums.den.get(i);
-			assert_eq!(actual_num, expected_num, "Numerator mismatch at index {i}");
-			assert_eq!(actual_den, expected_den, "Denominator mismatch at index {i}");
 		}
 	}
 
-	#[test]
-	fn test_frac_add_check_layer_computation() {
-		test_frac_add_check_layer_computation_helper::<Packed128b>(4, 3);
+	proptest! {
+		// Invariant: every layer of the circuit is the fractional-addition fold of the witness.
+		//
+		// Pinning each layer to that fold pins the sibling recurrence the layers are built from.
+		// Only an end-to-end proof failure notices if `new` folds the wrong pairs.
+		#[test]
+		fn frac_add_check_layers_fold_the_witness(
+			seed in any::<u64>(),
+			n in 0usize..=4,
+			k in 0usize..=4,
+		) {
+			check_all_layers::<Packed128b>(n, k, seed);
+		}
 	}
 
 	// ==================== batch_prove_unequal_depths tests ====================
@@ -733,8 +746,8 @@ mod tests {
 
 	/// Proves a batch of unequal-depth trees against the depth-oblivious verifier, then unpads each
 	/// tree's leaf claims and checks them against that tree's own witness.
-	fn test_unequal_depths_helper<P: PackedField>(depths: &[usize]) {
-		let mut rng = StdRng::seed_from_u64(11);
+	fn test_unequal_depths_helper<P: PackedField>(depths: &[usize], seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
 		let alloc = GlobalAllocator;
 
 		let k = log2_ceil_usize(depths.len());
@@ -785,42 +798,62 @@ mod tests {
 
 	#[test]
 	fn test_unequal_depths_mixed() {
-		test_unequal_depths_helper::<Packed128b>(&[2, 4, 5]);
+		test_unequal_depths_helper::<Packed128b>(&[2, 4, 5], 11);
 	}
 
 	#[test]
 	fn test_unequal_depths_single_prover() {
-		test_unequal_depths_helper::<Packed128b>(&[3]);
+		test_unequal_depths_helper::<Packed128b>(&[3], 11);
 	}
 
 	#[test]
 	fn test_unequal_depths_power_of_two_provers() {
 		// The shallowest tree is padded by more than one layer, the deepest not at all.
-		test_unequal_depths_helper::<Packed128b>(&[1, 2, 5, 5]);
+		test_unequal_depths_helper::<Packed128b>(&[1, 2, 5, 5], 11);
 	}
 
 	#[test]
 	fn test_unequal_depths_all_minimal() {
 		// Depth 1 throughout: every tree retains its final layer immediately.
-		test_unequal_depths_helper::<Packed128b>(&[1, 1, 1]);
+		test_unequal_depths_helper::<Packed128b>(&[1, 1, 1], 11);
 	}
 
 	#[test]
 	fn test_unequal_depths_zero_depth_tree() {
 		// A depth-0 tree never pops a layer: it is all padding, so its leaf claim is its root.
-		test_unequal_depths_helper::<Packed128b>(&[0, 3]);
+		test_unequal_depths_helper::<Packed128b>(&[0, 3], 11);
 	}
 
 	#[test]
 	fn test_unequal_depths_maximal_padding() {
 		// A single-layer tree beside a deep one: all but its last reduction is padding.
-		test_unequal_depths_helper::<Packed128b>(&[1, 6]);
+		test_unequal_depths_helper::<Packed128b>(&[1, 6], 11);
 	}
 
 	#[test]
 	fn test_unequal_depths_equal_depths() {
 		// Equal depths pad nothing, so every wrapper is a pass-through.
-		test_unequal_depths_helper::<Packed128b>(&[4, 4, 4]);
+		test_unequal_depths_helper::<Packed128b>(&[4, 4, 4], 11);
+	}
+
+	proptest! {
+		// A full batched prove-verify per case, so trade the default case count down for runtime.
+		#![proptest_config(ProptestConfig::with_cases(64))]
+
+		// Invariant: the batched round trip holds for any mix of tree depths.
+		//
+		// The cases above pin named edge shapes; this covers the space between them.
+		// Padding is bookkept per tree, so it is the mix of depths that stresses it.
+		#[test]
+		fn unequal_depths_round_trip(
+			seed in any::<u64>(),
+			depths in prop::collection::vec(0usize..=6, 1..=5),
+		) {
+			// Batching needs at least one layer to reduce, so an all-depth-0 batch is not a case.
+			prop_assume!(depths.iter().any(|&depth| depth > 0));
+
+			test_unequal_depths_helper::<Packed128b>(&depths, seed);
+		}
 	}
 
 	proptest! {


### PR DESCRIPTION
Test only. No production code changes.

### The problem

Two of this module's strongest properties were pinned at single points.

**The layer recurrence** was checked at one hard-coded shape (`n = 4, k = 3`), and only against the root layer that `build` pops off. Every intermediate layer went unchecked.

**The batched round trip** had seven hand-picked depth vectors. Good shapes, but nothing covered the space between them.

### The idea

Generate the shapes instead — and in the first case, check more of the circuit while doing it.

The layer proptest now walks **every** layer, not just the root, pinning each to the same strided reference fold the old test used:

```
entry i of layer j  ==  fracadd fold of the 2^j witness values strided by 2^(n+k-j)
```

Pinning every layer to that fold implies the sibling recurrence between consecutive layers, so this is strictly stronger than the two-sibling form — and it reuses the existing reference rather than inventing a second one.

### The hand-picked cases stay

The seven depth vectors are kept as explicit regression tests, not replaced.

Each documents a named edge shape — a depth-0 tree, maximal padding, all-equal depths — and a generator that happened not to produce one would silently lose that coverage. The proptest covers between them; it does not replace them.

### Ranges, and why these

| proptest | range | cost |
|---|---|---|
| layer recurrence | `n in 0..=4`, `k in 0..=4`, 256 cases | 0.01 s |
| batched round trip | depths `0..=6`, length `1..=5`, 64 cases | 0.03 s |

The layer proptest caps `n + k` at 8, so the largest witness is 256 scalars, and both degenerate shapes are in range: `k = 0` (no reduction layers) and `n = 0` (no content variables).

The round trip runs a full prove-verify per case, so it is capped at 64. Measured: 24 cases cost 0.01 s, 64 cost 0.03 s, 256 cost 0.11 s. 256 would have roughly doubled the crate's test time for the last factor of four in coverage.

`prop_assume!` rejects the all-depth-0 vector, which `batch_prove_unequal_depths` forbids outright (`assert!(n_layers >= 1)`).

### Both were checked for bite

A proptest that passes but cannot fail is worthless, so each was verified by breaking what it covers:

| break | result | shrunk to |
|---|---|---|
| reference fold: `* den_z + num_z *` → `* num_z *` | FAILED, "layer 1 numerator mismatch" | `seed = 0, n = 0, k = 1` |
| **production** fold: `den_out.write(den_0 * den_1)` → `+ den_0` | FAILED, "layer 1 denominator mismatch" | `seed = 0, n = 0, k = 1` |
| wrong pad length: `n_layers - depth` → `0` | FAILED | `seed = 0, depths = [2, 0]` |
| perturbed verifier claim: `num_eval + ONE` | FAILED | `seed = 0, depths = [1]` |

Two things worth drawing out.

The layer proptest catches a perturbation of the **production** fold, not only a self-inconsistent reference — so it is testing the code, not itself.

And the wrong-pad-length break shrank to `depths = [2, 0]`, the minimal *unequal* pair. Equal-depth vectors pass that break, so the generator is discriminating on the depth mix, which is exactly what it exists to reach.

All perturbations reverted; every `proptest-regressions` artifact deleted.

### Scope

- **changed:** the `#[cfg(test)] mod tests` block of `fracaddcheck/mod.rs` only
- **untouched:** all production code
- Also fixes a `createzz` typo in a test comment.

`test_unequal_depths_helper` gained a `seed` parameter so the proptest can vary field randomness; the seven existing callers pass the original `11`, so their behaviour is unchanged.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-ip-prover` — 94 passed, and again with `--features rayon` — 94 passed

Net +1 test: one fixed-shape test removed, two proptests added. Test-binary time is 0.13 s before and 0.12 s after, so no measurable slowdown.

### One heads-up on ordering

The strengthened layer test reads `prover.layers`, a private field, which is legal because the test module is a child of the module owning the type.

A separate in-flight change moves that type into its own `circuit.rs`. When that lands, this test needs to move with it — the natural home anyway, since it tests the circuit. Whichever merges second, I will follow up; flagging it because the two do not conflict textually, so a merge check will not catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)