### PR TITLE
Make bit-reversal a method on the mutable buffer view

### DIFF
--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -9,7 +9,6 @@ use std::{
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice,
-	bit_reverse::bit_reverse_packed,
 	multilinear::{
 		fold::{binary_fold_high, fold_highest_var_inplace},
 		hypercube::{Hypercube, OneCube},
@@ -126,9 +125,9 @@ where
 			// Prepend the new variable via bit-reverse + append + bit-reverse. This does not need
 			// to be fast: it runs once per pre-switchover round on a small tensor (see
 			// BINIUS-327).
-			bit_reverse_packed(tensor.to_mut());
+			tensor.to_mut().bit_reverse();
 			let mut tensor = OneCube::tensor_prod_eq_ind(tensor, &[challenge]);
-			bit_reverse_packed(tensor.to_mut());
+			tensor.to_mut().bit_reverse();
 			self.tensor = tensor;
 
 			if self.tensor.log_len() == self.switchover {

--- a/crates/math/benches/bit_reverse.rs
+++ b/crates/math/benches/bit_reverse.rs
@@ -4,7 +4,7 @@ use binius_field::{
 	BinaryField, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
 	PackedField,
 };
-use binius_math::{bit_reverse::bit_reverse_packed, test_utils::random_field_buffer};
+use binius_math::test_utils::random_field_buffer;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
@@ -20,9 +20,9 @@ fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
 		let throughput = Throughput::Bytes(((F::N_BITS / 8) << log_d) as u64);
 		group.throughput(throughput);
 
-		group.bench_function(BenchmarkId::new("bit_reverse_packed", &parameter), |b| {
+		group.bench_function(BenchmarkId::new("bit_reverse", &parameter), |b| {
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| bit_reverse_packed(data.to_mut()))
+			b.iter(|| data.to_mut().bit_reverse())
 		});
 	}
 

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -39,51 +39,52 @@ const CACHE_LINE_BYTES: usize = 64;
 /// - A narrower scalar keeps the capped tile rather than paying for further instances.
 const MAX_LOG_TILE_PACKED: usize = 3;
 
-/// Applies a bit-reversal permutation to packed field elements in a buffer using parallelization.
-///
-/// This function permutes the field elements such that element at index `i` is moved to
-/// index `reverse_bits(i, log_len)`. The permutation is performed in-place and correctly
-/// handles packed field representations.
-///
-/// # Arguments
-///
-/// * `buffer` - Mutable slice of packed field elements to permute
-pub fn bit_reverse_packed<P: PackedField>(buffer: FieldSliceMut<P>) {
-	// A buffer shorter than a square of packed elements leaves the two passes below no room.
-	let log_len = buffer.log_len();
-	if log_len < 2 * P::LOG_WIDTH {
-		return bit_reverse_packed_naive(buffer);
-	}
+impl<P: PackedField> FieldSliceMut<'_, P> {
+	/// Permutes the elements of this buffer by reversing the bits of every index, in place.
+	///
+	/// An index is reversed over the bit width that the length of the buffer takes.
+	/// Packed representations are handled, so one exchange may move lanes within a single element.
+	///
+	/// ```text
+	///     8 elements:   index 001 -> index 100
+	/// ```
+	pub fn bit_reverse(&mut self) {
+		// A buffer shorter than a square of packed elements leaves the two passes below no room.
+		let log_len = self.log_len();
+		if log_len < 2 * P::LOG_WIDTH {
+			return bit_reverse_packed_naive(self.to_mut());
+		}
 
-	// Scalars covering one cache line, which is the granularity a permutation is charged at.
-	let log_scalar_bytes = size_of::<P::Scalar>().next_power_of_two().ilog2() as usize;
-	let log_line = checked_log_2(CACHE_LINE_BYTES).saturating_sub(log_scalar_bytes);
+		// Scalars covering one cache line, which is the granularity a permutation is charged at.
+		let log_scalar_bytes = size_of::<P::Scalar>().next_power_of_two().ilog2() as usize;
+		let log_line = checked_log_2(CACHE_LINE_BYTES).saturating_sub(log_scalar_bytes);
 
-	// Why: a tile under a line wastes bandwidth, and widening one costs sub-block work.
-	// Measured, that trade only wins for a packing under half a line.
-	// From half a line up the added work costs more than the bandwidth it recovers.
-	let log_tile = if P::LOG_WIDTH + 1 < log_line {
-		log_line
-	} else {
-		P::LOG_WIDTH
-	};
+		// Why: a tile under a line wastes bandwidth, and widening one costs sub-block work.
+		// Measured, that trade only wins for a packing under half a line.
+		// From half a line up the added work costs more than the bandwidth it recovers.
+		let log_tile = if P::LOG_WIDTH + 1 < log_line {
+			log_line
+		} else {
+			P::LOG_WIDTH
+		};
 
-	// A short buffer takes the widest tile its own length allows.
-	// The length check above leaves half the length at or above the packing width.
-	// So neither clamp can cut a tile below one packed element.
-	let log_tile = log_tile
-		.min(P::LOG_WIDTH + MAX_LOG_TILE_PACKED)
-		.min(log_len / 2);
+		// A short buffer takes the widest tile its own length allows.
+		// The length check above leaves half the length at or above the packing width.
+		// So neither clamp can cut a tile below one packed element.
+		let log_tile = log_tile
+			.min(P::LOG_WIDTH + MAX_LOG_TILE_PACKED)
+			.min(log_len / 2);
 
-	// Why: a constant tile bound is what keeps each pass's gather and scatter unrolled.
-	// A run-time bound lowers the moves of a one-element tile to a call.
-	// That call is most of the work at that width.
-	match log_tile - P::LOG_WIDTH {
-		0 => bit_reverse_tiled::<P, 0>(buffer),
-		1 => bit_reverse_tiled::<P, 1>(buffer),
-		2 => bit_reverse_tiled::<P, 2>(buffer),
-		// The clamp above caps the tile at the widest instance, which answers every larger value.
-		_ => bit_reverse_tiled::<P, MAX_LOG_TILE_PACKED>(buffer),
+		// Why: a constant tile bound is what keeps each pass's gather and scatter unrolled.
+		// A run-time bound lowers the moves of a one-element tile to a call.
+		// That call is most of the work at that width.
+		match log_tile - P::LOG_WIDTH {
+			0 => bit_reverse_tiled::<P, 0>(self.to_mut()),
+			1 => bit_reverse_tiled::<P, 1>(self.to_mut()),
+			2 => bit_reverse_tiled::<P, 2>(self.to_mut()),
+			// The clamp caps the tile at the widest instance, which answers every larger value.
+			_ => bit_reverse_tiled::<P, MAX_LOG_TILE_PACKED>(self.to_mut()),
+		}
 	}
 }
 
@@ -383,7 +384,7 @@ mod tests {
 		let mut naive = data_orig;
 
 		// Invariant: moving whole tiles lands every element where the definition puts it.
-		bit_reverse_packed(blocked.to_mut());
+		blocked.to_mut().bit_reverse();
 		bit_reverse_packed_naive(naive.to_mut());
 
 		assert_eq!(blocked, naive, "mismatch at log_d={log_d}");
@@ -431,8 +432,8 @@ mod tests {
 			// Invariant: reversing the bits of an index twice is the identity.
 			// So a buffer permuted twice has to come back exactly as it went in.
 			let mut twice = orig.clone();
-			bit_reverse_packed(twice.to_mut());
-			bit_reverse_packed(twice.to_mut());
+			twice.to_mut().bit_reverse();
+			twice.to_mut().bit_reverse();
 
 			prop_assert_eq!(twice, orig);
 		}

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -729,8 +729,6 @@ mod tests {
 		// `BinarySwitchover` prepends one variable per round as bit-reverse + append + bit-reverse.
 		// Check that this composition, iterated over all coordinates (including the
 		// sub-packing-width early rounds), matches a full eq expansion.
-		use crate::bit_reverse::bit_reverse_packed;
-
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let n_vars = 10;
@@ -738,9 +736,9 @@ mod tests {
 
 		let mut tensor = FieldBuffer::<P>::from_values(&[F::ONE]);
 		for &r in point.iter().rev() {
-			bit_reverse_packed(tensor.to_mut());
+			tensor.to_mut().bit_reverse();
 			tensor = OneCube::tensor_prod_eq_ind::<P>(tensor, &[r]);
-			bit_reverse_packed(tensor.to_mut());
+			tensor.to_mut().bit_reverse();
 		}
 
 		assert_eq!(tensor, OneCube::eq_ind_partial_eval(&point));

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -19,7 +19,7 @@ use super::{
 	FieldBuffer, FieldSlice, FieldSliceMut, binary_subspace::BinarySubspace, ntt::AdditiveNTT,
 };
 use crate::{
-	bit_reverse::{bit_reverse_indices, bit_reverse_packed},
+	bit_reverse::bit_reverse_indices,
 	ntt::{DomainContext, NeighborsLastMultiThread, domain_context::GaoMateerOnTheFly},
 };
 
@@ -298,7 +298,7 @@ fn repeated_message_buffer<P: PackedField, A: Allocator>(
 	unsafe { output.set_len(msg_len) };
 
 	// Permute the leading copy, so the copies below inherit it.
-	bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), &mut output));
+	FieldSliceMut::from_slice(msg.log_len(), &mut output).bit_reverse();
 
 	// The source is read through an address rather than a borrow.
 	// That is what lets the workers read the leading copy while the rest is held mutably.
@@ -484,7 +484,7 @@ mod tests {
 		let mut output = Vec::with_capacity(total);
 		output.extend_from_slice(msg.as_ref());
 
-		bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()));
+		FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()).bit_reverse();
 
 		while output.len() < total {
 			output.extend_from_within(..);


### PR DESCRIPTION
Turns a free function whose only argument is the thing it mutates into a method on that thing. Pure refactor — the permutation is untouched.

### The problem

```rust
pub fn bit_reverse_packed<P: PackedField>(buffer: FieldSliceMut<P>)
```

One argument, mutated in place, nothing returned. The buffer is the subject, not a parameter — this is a method that never got written.

Every one of the ten call sites reads the same way:

```
bit_reverse_packed(tensor.to_mut())
```

### The change

```diff
- bit_reverse_packed(tensor.to_mut())
+ tensor.to_mut().bit_reverse()
```

The name also loses a word it no longer needs to carry. "Packed" distinguished this from the index-permuting variant on a plain slice; as a method on the packed-buffer view, the receiver already says it.

### Why a method and not a trait

This is a **container permutation**, not polynomial algebra, so it belongs as an inherent method rather than on an extension trait.

The test that settles it: the operation is meaningful for a buffer that is not a multilinear at all. Two of its callers are the Reed–Solomon encoder, permuting a codeword.

### Where the impl block lives

In `bit_reverse.rs`, next to the tiled algorithm it dispatches to — **not** in `field_buffer/view.rs`, which already carries an inherent impl on the same view type.

Folding it into that existing block would separate the dispatch from what it dispatches to. The entry point's whole job is choosing a tile width from cache-line reasoning; the arms it chooses between are twenty lines below it in this file. It would also force two private helpers to become `pub(crate)` for no gain.

### On `multiple_inherent_impl` — checked, not assumed

This adds `impl<P: PackedField> FieldSliceMut<'_, P>` while `field_buffer/view.rs` already has an identically parameterised block. The workspace sets `multiple_inherent_impl = "warn"` and CI runs clippy with `-D warnings`, so the obvious worry is that this fails the build.

It does not — and the silence was verified rather than trusted. A throwaway non-generic struct with two inherent impls was added to the same file, and clippy did emit `multiple implementations of this structure`. So the lint is genuinely live in this crate; it simply does not apply to generic inherent impls. The probe was removed before committing.

### Scope

- **changed:** `bit_reverse.rs` — the free function becomes an inherent method; the private helpers keep their names and signatures, since "packed" still describes packed field elements there rather than the deleted public name.
- **changed:** 10 call sites across `reed_solomon.rs`, `multilinear/hypercube.rs`, `ip-prover/src/sumcheck/switchover.rs`, this file's own tests, and the bench.
- **changed:** the bench's case label, since the name it quoted no longer exists.
- **not kept:** no free-function form remains. Every caller took method syntax.

Two smaller decisions:

- The receiver is `&mut self`, not `self`. Every other mutating method on the buffer takes `&mut self`, and by-value would consume a view the caller may still want. Each dispatch arm reborrows internally.
- The private helpers still take their view by value, which is what the recursion wants.

### Soundness

Bit reversal is a permutation used inside the NTT and FRI paths, so a wrong index corrupts a codeword silently rather than panicking. The existing tests are the guard, and they still run:

- Tiled-versus-naive equivalence across nine lengths, covering every tile branch: 0, 1, 3, 4, 7, 8, 9, 12, 13.
- A proptest that the tiled path matches the naive reference.
- A proptest that the permutation is an involution.
- The tile transpose against a scalar transpose.

The naive reference is untouched by this change, so it remains an independent oracle: the method under test is the permuting side, and a wrong index shows up as a mismatch.

### Verification

- `cargo check --workspace --all-targets --all-features` — clean.
- `cargo clippy -p binius-math -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-math` — 147 passed, plus 1 doctest. Same again with `--features rayon`, since the default build uses the hand-written no-rayon shim. Baseline is 147, and no test was added or removed.
- `cargo test -p binius-ip-prover` — 93 passed.
- `cargo check -p binius-math --benches` — clean, since the bench is a call site.
- `cargo doc -p binius-math --no-deps --all-features` — zero warnings.
- `cargo +nightly fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
