### PR TITLE
Rename FracAddCheckProver to FracAddCircuit and move it to circuit.rs

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/circuit.rs
+++ b/crates/ip-prover/src/fracaddcheck/circuit.rs
@@ -1,0 +1,333 @@
+// Copyright 2025-2026 The Binius Developers
+
+//! The materialized layers of a fractional-addition circuit, and the driver that proves them.
+
+use binius_compute::Allocator;
+use binius_field::{Field, PackedField};
+use binius_ip::fracaddcheck::FracAddEvalClaim;
+use binius_math::{FieldBuffer, FieldVec, line::extrapolate_line};
+use binius_utils::{
+	buffer::VecLike,
+	rayon::{
+		iter::{IntoParallelIterator, ParallelIterator},
+		task_size::{IndexedParallelIteratorExt, WorkPerItem},
+	},
+};
+
+use super::{LayerProver, fraction::Fraction};
+use crate::{
+	channel::IPProverChannel,
+	sumcheck::{batch::batch_prove_mle, frac_add_mle},
+};
+
+/// The materialized layers of a fractional addition circuit.
+///
+/// Each layer holds the numerator and denominator of one fractional term per node.
+/// A layer is half the width of the one below it, each node adding its two children:
+/// $$\frac{a_0}{b_0} + \frac{a_1}{b_1} = \frac{a_0b_1 + a_1b_0}{b_0b_1}$$
+pub struct FracAddCircuit<'a, A: Allocator, P: PackedField> {
+	layers: Vec<Fraction<FieldVec<P, A>>>,
+	/// Allocator the layer buffers are drawn from.
+	pub(crate) alloc: &'a A,
+}
+
+impl<A: Allocator, P: PackedField> Clone for FracAddCircuit<'_, A, P>
+where
+	A::Vec<P>: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			layers: self.layers.clone(),
+			alloc: self.alloc,
+		}
+	}
+}
+
+impl<'a, A, F, P> FracAddCircuit<'a, A, P>
+where
+	A: Allocator,
+	F: Field,
+	P: PackedField<Scalar = F>,
+{
+	/// Materializes every layer of the circuit from `witness`.
+	///
+	/// Returns the circuit beside `sums`, its root layer.
+	/// `sums` holds the fractional addition over all `k` reduced variables.
+	///
+	/// # Arguments
+	/// * `k` - How many variables to reduce, one sibling fractional addition per step.
+	/// * `witness` - The witness numerator/denominator layers
+	///
+	/// # Preconditions
+	/// * `witness.num.log_len() >= k`
+	pub fn build(
+		k: usize,
+		alloc: &'a A,
+		witness: Fraction<FieldVec<P, A>>,
+	) -> (Self, Fraction<FieldVec<P, A>>) {
+		let Fraction {
+			num: witness_num,
+			den: witness_den,
+		} = witness;
+		assert_eq!(
+			witness_num.log_len(),
+			witness_den.log_len(),
+			"numerator and denominator witnesses must have equal length"
+		);
+		assert!(witness_num.log_len() >= k);
+
+		let mut layers = Vec::with_capacity(k + 1);
+		layers.push(Fraction::new(witness_num, witness_den));
+
+		for _ in 0..k {
+			let prev_layer = layers.last().expect("layers is non-empty");
+
+			let Fraction { num, den } = prev_layer;
+			let num_log_len = num.log_len() - 1;
+			let den_log_len = den.log_len() - 1;
+			let (num_0, num_1) = num.split_half_ref();
+			let (den_0, den_1) = den.split_half_ref();
+
+			// One packed word of the next layer from the sibling halves, written straight into
+			// the pooled buffers:
+			//     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
+			// Workers each take a contiguous run of words.
+			// One word is three multiplies and an add, a few nanoseconds of work.
+			// A run must therefore be long enough to pay back handing it off.
+			let out_len = num_0.as_ref().len();
+			let mut num_data = alloc.alloc::<P>(out_len);
+			let mut den_data = alloc.alloc::<P>(out_len);
+			(
+				num_data.spare_capacity_mut(),
+				den_data.spare_capacity_mut(),
+				num_0.as_ref(),
+				den_0.as_ref(),
+				num_1.as_ref(),
+				den_1.as_ref(),
+			)
+				.into_par_iter()
+				.with_min_task(WorkPerItem::FieldMuls)
+				.for_each(|(num_out, den_out, &num_0, &den_0, &num_1, &den_1)| {
+					num_out.write(num_0 * den_1 + num_1 * den_0);
+					den_out.write(den_0 * den_1);
+				});
+			// Invariant: every zip input holds at least `out_len` words.
+			//
+			// A parallel zip yields as many items as its shortest input holds.
+			// A shorter input would leave trailing slots uninitialized.
+			//
+			//     spare capacity:  >= out_len   allocated for at least that many
+			//     sibling halves:  == out_len   halves of two equal-length buffers
+			debug_assert!(
+				num_data.spare_capacity_mut().len() >= out_len
+					&& den_data.spare_capacity_mut().len() >= out_len,
+				"allocated buffers must hold every claimed slot"
+			);
+			debug_assert!(
+				[den_0.as_ref(), num_1.as_ref(), den_1.as_ref()]
+					.iter()
+					.all(|half| half.len() == out_len),
+				"the four sibling halves must hold exactly one word per claimed slot"
+			);
+			// Safety: both length claims cover only initialized slots.
+			// - The assertions above bound every zip input below by `out_len`.
+			// - So the loop ran `out_len` items.
+			// - Each item wrote one numerator slot and one denominator slot.
+			unsafe {
+				num_data.set_len(out_len);
+				den_data.set_len(out_len);
+			}
+			let next_layer = Fraction::new(
+				FieldBuffer::new(num_log_len, num_data),
+				FieldBuffer::new(den_log_len, den_data),
+			);
+
+			layers.push(next_layer);
+		}
+
+		let sums = layers.pop().expect("layers has k+1 elements");
+		(Self { layers, alloc }, sums)
+	}
+
+	/// Returns the number of remaining layers to prove.
+	pub const fn n_layers(&self) -> usize {
+		self.layers.len()
+	}
+
+	/// Pops the widest remaining layer as the MLE-check prover that reduces it.
+	///
+	/// The returned prover owns the popped buffers and borrows only the allocator.
+	/// So it outlives this borrow, and the circuit stays in place while a caller drives it.
+	///
+	/// # Preconditions
+	/// * `self.n_layers() >= 1`
+	pub fn pop_layer(&mut self, claim: FracAddEvalClaim<F>) -> LayerProver<'a, A, F, P> {
+		let Fraction { num, den } = self
+			.layers
+			.pop()
+			.expect("precondition: self.n_layers() >= 1");
+
+		// The MLE-check reduces four multilinears: the low and high halves of the numerator buffer
+		// and of the denominator buffer. The store takes ownership of the two popped buffers and
+		// shares each between its halves, so the prover is self-contained with no up-front copy of
+		// the popped layer.
+		frac_add_mle::new_split_half(
+			self.alloc,
+			num,
+			den,
+			claim.point,
+			[claim.num_eval, claim.den_eval],
+		)
+	}
+
+	/// Runs the fractional addition check protocol and returns the final evaluation claims.
+	///
+	/// This consumes the circuit, reducing from the smallest layer back to the largest.
+	///
+	/// # Arguments
+	/// * `claim` - The numerator and denominator claims at their shared evaluation point.
+	/// * `channel` - The channel for sending prover messages and sampling challenges.
+	///
+	/// # Preconditions
+	/// * `claim.point.len() == witness.log_len() - k`, for `k` the number of reduction layers.
+	pub fn prove(
+		self,
+		claim: FracAddEvalClaim<F>,
+		channel: &mut impl IPProverChannel<F>,
+	) -> FracAddEvalClaim<F> {
+		// Proving the full circuit runs every layer, so delegate and drop the leftover circuit.
+		let n_layers = self.n_layers();
+		let (remaining, claim) = self.prove_layers(n_layers, claim, channel);
+		debug_assert_eq!(remaining.n_layers(), 0, "proving every layer leaves none unproved");
+		claim
+	}
+
+	/// Runs the first `n_layers` fractional-addition layers from a claim, returning the remainder.
+	///
+	/// Each layer adds one variable via a sumcheck and a line-fold.
+	/// So starting from a claim over `d` variables, the returned claim is over `d + n_layers`.
+	///
+	/// This is the layer loop of [`Self::prove`], which runs every layer.
+	/// The returned circuit still holds the layers that were not proved.
+	///
+	/// # Arguments
+	/// * `n_layers` - The number of layers to prove, at most [`Self::n_layers`].
+	/// * `claim` - The numerator and denominator claims at their shared evaluation point.
+	/// * `channel` - The channel for sending prover messages and sampling challenges.
+	///
+	/// # Returns
+	/// * the circuit, holding whatever layers were not proved,
+	/// * the reduced numerator/denominator claims after `n_layers` layers.
+	///
+	/// # Preconditions
+	/// * `n_layers <= self.n_layers()`.
+	fn prove_layers(
+		mut self,
+		n_layers: usize,
+		claim: FracAddEvalClaim<F>,
+		channel: &mut impl IPProverChannel<F>,
+	) -> (Self, FracAddEvalClaim<F>) {
+		let mut claim = claim;
+
+		for _ in 0..n_layers {
+			let sumcheck_prover = self.pop_layer(claim);
+
+			// The driver draws the batching coefficient and Horner-folds the layer's two claims,
+			// which is the polynomial the verifier's `batch_verify_mle` reconstructs.
+			let output = batch_prove_mle(vec![sumcheck_prover], channel);
+			output.send_evals(channel);
+
+			let mut multilinear_evals = output.multilinear_evals;
+			let evals = multilinear_evals.pop().expect("batch contains one prover");
+
+			let [num_0, num_1, den_0, den_1] = evals
+				.try_into()
+				.expect("prover evaluates four multilinears");
+
+			// Fold the highest variable to combine the two halves into the next layer's claim.
+			let r = channel.sample();
+
+			let next_num = extrapolate_line(num_0, num_1, r);
+			let next_den = extrapolate_line(den_0, den_1, r);
+
+			// Sumcheck binds variables high-to-low; reverse to low-to-high for the claim point.
+			let mut next_point = output.challenges;
+			next_point.reverse();
+			next_point.push(r);
+
+			claim = FracAddEvalClaim {
+				num_eval: next_num,
+				den_eval: next_den,
+				point: next_point,
+			};
+		}
+
+		(self, claim)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter;
+
+	use binius_compute::GlobalAllocator;
+	use binius_math::test_utils::{Packed128b, random_field_buffer};
+	use proptest::prelude::*;
+	use rand::prelude::*;
+
+	use super::*;
+
+	fn check_all_layers<P: PackedField>(n: usize, k: usize, seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let alloc = GlobalAllocator;
+
+		// Create random witness with log_len = n + k
+		let witness_num = random_field_buffer::<P>(&mut rng, n + k);
+		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
+
+		// Create prover (computes fractional-add layers)
+		let (prover, sums) = FracAddCircuit::build(
+			k,
+			&alloc,
+			Fraction::new(witness_num.clone(), witness_den.clone()),
+		);
+
+		// `build` pops the root off as `sums`, so the circuit is `layers` followed by it.
+		for (j, layer) in prover.layers.iter().chain(iter::once(&sums)).enumerate() {
+			// Entry i of layer j is the fractional sum of the 2^j witness values strided by that
+			// layer's own width (strided access, not contiguous).
+			let width = 1 << (n + k - j);
+			let num_terms = 1 << j;
+			for i in 0..width {
+				let mut expected_num = witness_num.get(i);
+				let mut expected_den = witness_den.get(i);
+				for z in 1..num_terms {
+					let idx = i + z * width;
+					let num_z = witness_num.get(idx);
+					let den_z = witness_den.get(idx);
+					expected_num = expected_num * den_z + num_z * expected_den;
+					expected_den *= den_z;
+				}
+				let actual_num = layer.num.get(i);
+				let actual_den = layer.den.get(i);
+				assert_eq!(actual_num, expected_num, "layer {j} numerator mismatch at index {i}");
+				assert_eq!(actual_den, expected_den, "layer {j} denominator mismatch at index {i}");
+			}
+		}
+	}
+
+	proptest! {
+		// Invariant: every layer of the circuit is the fractional-addition fold of the witness.
+		//
+		// Pinning each layer to that fold pins the sibling recurrence the layers are built from.
+		// Only an end-to-end proof failure notices if `build` folds the wrong pairs.
+		#[test]
+		fn frac_add_check_layers_fold_the_witness(
+			seed in any::<u64>(),
+			n in 0usize..=4,
+			k in 0usize..=4,
+		) {
+			check_all_layers::<Packed128b>(n, k, seed);
+		}
+	}
+}

--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -4,25 +4,18 @@ use std::iter;
 
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
-use binius_ip::{fracaddcheck::FracAddEvalClaim, mlecheck, sumcheck::RoundCoeffs};
+use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_math::{
 	FieldBuffer, FieldVec,
 	line::extrapolate_line,
 	multilinear::hypercube::{Hypercube, OneCube},
 };
-use binius_utils::{
-	buffer::VecLike,
-	rayon::{
-		iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
-		task_size::{IndexedParallelIteratorExt, WorkPerItem},
-	},
-};
+use binius_utils::rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use itertools::izip;
 
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
-		batch::batch_prove_mle,
 		common::MleCheckProver,
 		frac_add_mle,
 		mle_store::MleStore,
@@ -30,263 +23,17 @@ use crate::{
 	},
 };
 
+mod circuit;
 pub mod fraction;
 pub mod padding;
 pub mod zero_pad_mle;
 
+pub use circuit::FracAddCircuit;
 use fraction::Fraction;
 use padding::layer_provers;
 pub use padding::unpad_leaf_claim;
 
 pub use crate::sumcheck::frac_add_mle::LayerProver;
-
-/// Prover for the fractional addition protocol.
-///
-/// Each layer is a double of the numerator and denominator values of fractional terms. Each layer
-/// represents the addition of siblings with respect to the fractional addition rule:
-/// $$\frac{a_0}{b_0} + \frac{a_1}{b_1} = \frac{a_0b_1 + a_1b_0}{b_0b_1}$
-pub struct FracAddCheckProver<'a, A: Allocator, P: PackedField> {
-	layers: Vec<Fraction<FieldVec<P, A>>>,
-	/// Allocator the layer buffers are drawn from.
-	pub(crate) alloc: &'a A,
-}
-
-impl<A: Allocator, P: PackedField> Clone for FracAddCheckProver<'_, A, P>
-where
-	A::Vec<P>: Clone,
-{
-	fn clone(&self) -> Self {
-		Self {
-			layers: self.layers.clone(),
-			alloc: self.alloc,
-		}
-	}
-}
-
-impl<'a, A, F, P> FracAddCheckProver<'a, A, P>
-where
-	A: Allocator,
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	/// Creates a new [`FracAddCheckProver`].
-	///
-	/// Returns `(prover, sums)` where `sums` is the final layer containing the
-	/// fractional additions over all `k` variables.
-	///
-	/// # Arguments
-	/// * `k` - The number of variables over which the reduction is taken. Each reduction step
-	///   reduces one variable by computing fractional additions of sibling terms.
-	/// * `witness` - The witness numerator/denominator layers
-	///
-	/// # Preconditions
-	/// * `witness.num.log_len() >= k`
-	pub fn new(
-		k: usize,
-		alloc: &'a A,
-		witness: Fraction<FieldVec<P, A>>,
-	) -> (Self, Fraction<FieldVec<P, A>>) {
-		let Fraction {
-			num: witness_num,
-			den: witness_den,
-		} = witness;
-		assert_eq!(
-			witness_num.log_len(),
-			witness_den.log_len(),
-			"numerator and denominator witnesses must have equal length"
-		);
-		assert!(witness_num.log_len() >= k);
-
-		let mut layers = Vec::with_capacity(k + 1);
-		layers.push(Fraction::new(witness_num, witness_den));
-
-		for _ in 0..k {
-			let prev_layer = layers.last().expect("layers is non-empty");
-
-			let Fraction { num, den } = prev_layer;
-			let num_log_len = num.log_len() - 1;
-			let den_log_len = den.log_len() - 1;
-			let (num_0, num_1) = num.split_half_ref();
-			let (den_0, den_1) = den.split_half_ref();
-
-			// One packed word of the next layer from the sibling halves, written straight into
-			// the pooled buffers:
-			//     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
-			// Workers each take a contiguous run of words.
-			// One word is three multiplies and an add, a few nanoseconds of work.
-			// A run must therefore be long enough to pay back handing it off.
-			let out_len = num_0.as_ref().len();
-			let mut num_data = alloc.alloc::<P>(out_len);
-			let mut den_data = alloc.alloc::<P>(out_len);
-			(
-				num_data.spare_capacity_mut(),
-				den_data.spare_capacity_mut(),
-				num_0.as_ref(),
-				den_0.as_ref(),
-				num_1.as_ref(),
-				den_1.as_ref(),
-			)
-				.into_par_iter()
-				.with_min_task(WorkPerItem::FieldMuls)
-				.for_each(|(num_out, den_out, &num_0, &den_0, &num_1, &den_1)| {
-					num_out.write(num_0 * den_1 + num_1 * den_0);
-					den_out.write(den_0 * den_1);
-				});
-			// Invariant: every zip input holds at least `out_len` words.
-			//
-			// A parallel zip yields as many items as its shortest input holds.
-			// A shorter input would leave trailing slots uninitialized.
-			//
-			//     spare capacity:  >= out_len   allocated for at least that many
-			//     sibling halves:  == out_len   halves of two equal-length buffers
-			debug_assert!(
-				num_data.spare_capacity_mut().len() >= out_len
-					&& den_data.spare_capacity_mut().len() >= out_len,
-				"allocated buffers must hold every claimed slot"
-			);
-			debug_assert!(
-				[den_0.as_ref(), num_1.as_ref(), den_1.as_ref()]
-					.iter()
-					.all(|half| half.len() == out_len),
-				"the four sibling halves must hold exactly one word per claimed slot"
-			);
-			// Safety: both length claims cover only initialized slots.
-			// - The assertions above bound every zip input below by `out_len`.
-			// - So the loop ran `out_len` items.
-			// - Each item wrote one numerator slot and one denominator slot.
-			unsafe {
-				num_data.set_len(out_len);
-				den_data.set_len(out_len);
-			}
-			let next_layer = Fraction::new(
-				FieldBuffer::new(num_log_len, num_data),
-				FieldBuffer::new(den_log_len, den_data),
-			);
-
-			layers.push(next_layer);
-		}
-
-		let sums = layers.pop().expect("layers has k+1 elements");
-		(Self { layers, alloc }, sums)
-	}
-
-	/// Returns the number of remaining layers to prove.
-	pub const fn n_layers(&self) -> usize {
-		self.layers.len()
-	}
-
-	/// Pops the widest remaining layer as the MLE-check prover that reduces it.
-	///
-	/// The returned prover owns the popped buffers and borrows only the allocator, so it outlives
-	/// this borrow: a caller drives one layer at a time and keeps the circuit in place.
-	///
-	/// # Preconditions
-	/// * `self.n_layers() >= 1`
-	pub fn pop_layer(&mut self, claim: FracAddEvalClaim<F>) -> LayerProver<'a, A, F, P> {
-		let Fraction { num, den } = self
-			.layers
-			.pop()
-			.expect("precondition: self.n_layers() >= 1");
-
-		// The MLE-check reduces four multilinears: the low and high halves of the numerator buffer
-		// and of the denominator buffer. The store takes ownership of the two popped buffers and
-		// shares each between its halves, so the prover is self-contained with no up-front copy of
-		// the popped layer.
-		frac_add_mle::new_split_half(
-			self.alloc,
-			num,
-			den,
-			claim.point,
-			[claim.num_eval, claim.den_eval],
-		)
-	}
-
-	/// Runs the fractional addition check protocol and returns the final evaluation claims.
-	///
-	/// This consumes the prover and runs sumcheck reductions from the smallest layer back to
-	/// the largest.
-	///
-	/// # Arguments
-	/// * `claim` - The numerator and denominator claims at their shared evaluation point.
-	/// * `channel` - The channel for sending prover messages and sampling challenges.
-	///
-	/// # Preconditions
-	/// * `claim.point.len() == witness.log_len() - k`, for `k` the number of reduction layers.
-	pub fn prove(
-		self,
-		claim: FracAddEvalClaim<F>,
-		channel: &mut impl IPProverChannel<F>,
-	) -> FracAddEvalClaim<F> {
-		// Proving the full circuit runs every layer, so delegate and drop the leftover prover.
-		let n_layers = self.n_layers();
-		let (remaining, claim) = self.prove_layers(n_layers, claim, channel);
-		debug_assert_eq!(remaining.n_layers(), 0, "proving every layer leaves none unproved");
-		claim
-	}
-
-	/// Runs the first `n_layers` fractional-addition layers from a claim, returning the remainder.
-	///
-	/// Each layer adds one variable via a sumcheck and a line-fold.
-	/// So starting from a claim over `d` variables, the returned claim is over `d + n_layers`.
-	///
-	/// This is the layer loop of [`Self::prove`], which runs every layer.
-	/// The returned prover still holds the layers that were not proved.
-	///
-	/// # Arguments
-	/// * `n_layers` - The number of layers to prove, at most [`Self::n_layers`].
-	/// * `claim` - The numerator and denominator claims at their shared evaluation point.
-	/// * `channel` - The channel for sending prover messages and sampling challenges.
-	///
-	/// # Returns
-	/// * the circuit, holding whatever layers were not proved,
-	/// * the reduced numerator/denominator claims after `n_layers` layers.
-	///
-	/// # Preconditions
-	/// * `n_layers <= self.n_layers()`.
-	fn prove_layers(
-		mut self,
-		n_layers: usize,
-		claim: FracAddEvalClaim<F>,
-		channel: &mut impl IPProverChannel<F>,
-	) -> (Self, FracAddEvalClaim<F>) {
-		let mut claim = claim;
-
-		for _ in 0..n_layers {
-			let sumcheck_prover = self.pop_layer(claim);
-
-			// The driver draws the batching coefficient and Horner-folds the layer's two claims,
-			// which is the polynomial the verifier's `batch_verify_mle` reconstructs.
-			let output = batch_prove_mle(vec![sumcheck_prover], channel);
-			output.send_evals(channel);
-
-			let mut multilinear_evals = output.multilinear_evals;
-			let evals = multilinear_evals.pop().expect("batch contains one prover");
-
-			let [num_0, num_1, den_0, den_1] = evals
-				.try_into()
-				.expect("prover evaluates four multilinears");
-
-			// Fold the highest variable to combine the two halves into the next layer's claim.
-			let r = channel.sample();
-
-			let next_num = extrapolate_line(num_0, num_1, r);
-			let next_den = extrapolate_line(den_0, den_1, r);
-
-			// Sumcheck binds variables high-to-low; reverse to low-to-high for the claim point.
-			let mut next_point = output.challenges;
-			next_point.reverse();
-			next_point.push(r);
-
-			claim = FracAddEvalClaim {
-				num_eval: next_num,
-				den_eval: next_den,
-				point: next_point,
-			};
-		}
-
-		(self, claim)
-	}
-}
 
 /// Output of [`batch_prove_unequal_depths`].
 ///
@@ -611,7 +358,7 @@ fn finalize_layer<F: Field>(
 /// Those leaf claims are on the *padded* witnesses.
 /// [`unpad_leaf_claim`] reduces one to the claims on the tree's own witness.
 pub fn batch_prove_unequal_depths<'a, A, F, P>(
-	provers: Vec<FracAddCheckProver<'a, A, P>>,
+	provers: Vec<FracAddCircuit<'a, A, P>>,
 	claimed_fractions: Vec<Fraction<F>>,
 	selector_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
@@ -631,7 +378,7 @@ where
 	let mut provers = provers;
 	let n_layers = provers
 		.iter()
-		.map(FracAddCheckProver::n_layers)
+		.map(FracAddCircuit::n_layers)
 		.max()
 		.expect("provers is non-empty");
 	assert!(n_layers >= 1); // precondition
@@ -674,7 +421,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_field::{FieldOps, PackedField};
-	use binius_ip::fracaddcheck;
+	use binius_ip::fracaddcheck::{self, FracAddEvalClaim};
 	use binius_math::{
 		inner_product::inner_product,
 		multilinear::evaluate::evaluate,
@@ -700,7 +447,7 @@ mod tests {
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// 2. Create prover (computes fractional-add layers)
-		let (prover, sums) = FracAddCheckProver::new(
+		let (prover, sums) = FracAddCircuit::build(
 			k,
 			&alloc,
 			Fraction::new(witness_num.clone(), witness_den.clone()),
@@ -747,60 +494,6 @@ mod tests {
 		test_frac_add_check_prove_verify_helper::<Packed128b>(0, 4);
 	}
 
-	fn check_all_layers<P: PackedField>(n: usize, k: usize, seed: u64) {
-		let mut rng = StdRng::seed_from_u64(seed);
-		let alloc = GlobalAllocator;
-
-		// Create random witness with log_len = n + k
-		let witness_num = random_field_buffer::<P>(&mut rng, n + k);
-		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
-
-		// Create prover (computes fractional-add layers)
-		let (prover, sums) = FracAddCheckProver::new(
-			k,
-			&alloc,
-			Fraction::new(witness_num.clone(), witness_den.clone()),
-		);
-
-		// `new` pops the root off as `sums`, so the circuit is `layers` followed by it.
-		for (j, layer) in prover.layers.iter().chain(iter::once(&sums)).enumerate() {
-			// Entry i of layer j is the fractional sum of the 2^j witness values strided by that
-			// layer's own width (strided access, not contiguous).
-			let width = 1 << (n + k - j);
-			let num_terms = 1 << j;
-			for i in 0..width {
-				let mut expected_num = witness_num.get(i);
-				let mut expected_den = witness_den.get(i);
-				for z in 1..num_terms {
-					let idx = i + z * width;
-					let num_z = witness_num.get(idx);
-					let den_z = witness_den.get(idx);
-					expected_num = expected_num * den_z + num_z * expected_den;
-					expected_den *= den_z;
-				}
-				let actual_num = layer.num.get(i);
-				let actual_den = layer.den.get(i);
-				assert_eq!(actual_num, expected_num, "layer {j} numerator mismatch at index {i}");
-				assert_eq!(actual_den, expected_den, "layer {j} denominator mismatch at index {i}");
-			}
-		}
-	}
-
-	proptest! {
-		// Invariant: every layer of the circuit is the fractional-addition fold of the witness.
-		//
-		// Pinning each layer to that fold pins the sibling recurrence the layers are built from.
-		// Only an end-to-end proof failure notices if `new` folds the wrong pairs.
-		#[test]
-		fn frac_add_check_layers_fold_the_witness(
-			seed in any::<u64>(),
-			n in 0usize..=4,
-			k in 0usize..=4,
-		) {
-			check_all_layers::<Packed128b>(n, k, seed);
-		}
-	}
-
 	// ==================== batch_prove_unequal_depths tests ====================
 
 	/// A numerator/denominator witness pair.
@@ -812,17 +505,13 @@ mod tests {
 		rng: &mut impl rand::Rng,
 		alloc: &'a GlobalAllocator,
 		depths: &[usize],
-	) -> (
-		Vec<Witness<P>>,
-		Vec<FracAddCheckProver<'a, GlobalAllocator, P>>,
-		Vec<Fraction<P::Scalar>>,
-	) {
+	) -> (Vec<Witness<P>>, Vec<FracAddCircuit<'a, GlobalAllocator, P>>, Vec<Fraction<P::Scalar>>) {
 		itertools::multiunzip(depths.iter().map(|&depth| {
 			let witness = Fraction::new(
 				random_field_buffer::<P>(&mut *rng, depth),
 				random_field_buffer::<P>(&mut *rng, depth),
 			);
-			let (prover, sums) = FracAddCheckProver::new(depth, alloc, witness.clone());
+			let (prover, sums) = FracAddCircuit::build(depth, alloc, witness.clone());
 			assert_eq!(sums.num.log_len(), 0);
 			(witness, prover, sums.as_ref().map(|buffer| buffer.get(0)))
 		}))

--- a/crates/ip-prover/src/fracaddcheck/padding.rs
+++ b/crates/ip-prover/src/fracaddcheck/padding.rs
@@ -39,7 +39,7 @@ use either::Either;
 use itertools::izip;
 
 use super::{
-	FracAddCheckProver, LayerProver,
+	FracAddCircuit, LayerProver,
 	fraction::Fraction,
 	zero_pad_mle::{self, ConstantFraction, ZeroPadMleCheckProver},
 };
@@ -54,7 +54,7 @@ pub(super) type PaddedLayerProver<'a, A, F, P> =
 /// The provers come back in input order, one per tree, so they stay aligned with `pad_lens` and
 /// `claims`. A tree the batch has not reached yet keeps every layer it has.
 pub(super) fn layer_provers<'a, A, F, P>(
-	provers: &mut [FracAddCheckProver<'a, A, P>],
+	provers: &mut [FracAddCircuit<'a, A, P>],
 	pad_lens: &[usize],
 	claims: &[Fraction<F>],
 	node_point: &[F],

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::{
 	channel::IPProverChannel,
-	fracaddcheck::{self, FracAddCheckProver, fraction::Fraction, unpad_leaf_claim},
+	fracaddcheck::{self, FracAddCircuit, fraction::Fraction, unpad_leaf_claim},
 };
 
 /// One looker's column and claim: `(I^* T)(eval_point) = eval_claim` against the table it reads.
@@ -201,7 +201,7 @@ where
 		.map(|(&(looker, c), numerator)| {
 			let den = witness::looker_denominator::<A, F, P>(alloc, c, looker.index);
 			// Lookers may differ in length, so each circuit is built at its own depth.
-			let (prover, root) = FracAddCheckProver::new(
+			let (prover, root) = FracAddCircuit::build(
 				looker.eval_point.len(),
 				alloc,
 				Fraction::new(numerator, den),
@@ -216,7 +216,7 @@ where
 		let table_den = witness::table_denominator::<A, F, P>(alloc, c, table.log_len());
 		// The pushforward is borrowed — a committing caller keeps it for the oracle opening — so
 		// the table circuit's leaf layer, which it folds in place, is a clone drawn from `alloc`.
-		let (table_prover, table_root) = FracAddCheckProver::new(
+		let (table_prover, table_root) = FracAddCircuit::build(
 			table.log_len(),
 			alloc,
 			Fraction::new(FieldBuffer::clone_from_slice(alloc, pushforward.to_ref()), table_den),
@@ -232,7 +232,7 @@ where
 	//     sum_j num_j / den_j  -  sum_t num_t / den_t
 	//
 	// which is zero exactly when the logUp identities hold.
-	let (top_prover, top_root) = FracAddCheckProver::new(k, alloc, {
+	let (top_prover, top_root) = FracAddCircuit::build(k, alloc, {
 		let (mut root_nums, mut root_dens): (Vec<_>, Vec<_>) =
 			roots.iter().map(|&root| (root.num, root.den)).unzip();
 		// The slots past the last instance hold the zero fraction, which the sum ignores.

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -3,7 +3,7 @@
 use binius_compute::BufferPool;
 use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::fracaddcheck::FracAddEvalClaim;
-use binius_ip_prover::fracaddcheck::{FracAddCheckProver, fraction::Fraction};
+use binius_ip_prover::fracaddcheck::{FracAddCircuit, fraction::Fraction};
 use binius_math::{
 	FieldBuffer,
 	multilinear::evaluate::evaluate,
@@ -16,8 +16,8 @@ use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_mai
 type P = OptimalPackedB128;
 type F = <P as FieldOps>::Scalar;
 
-fn bench_fracaddcheck_new(c: &mut Criterion) {
-	let mut group = c.benchmark_group("fracaddcheck/new");
+fn bench_fracaddcheck_build(c: &mut Criterion) {
+	let mut group = c.benchmark_group("fracaddcheck/build");
 
 	for n_vars in [12, 16, 20] {
 		// Full reduction: k = n_vars, so sums layer has log_len = 0.
@@ -41,7 +41,7 @@ fn bench_fracaddcheck_new(c: &mut Criterion) {
 					)
 				},
 				|(witness_num, witness_den)| {
-					FracAddCheckProver::<_, P>::new(
+					FracAddCircuit::<_, P>::build(
 						k,
 						&alloc,
 						Fraction::new(witness_num, witness_den),
@@ -72,7 +72,7 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 			let alloc = &pool;
 
 			// Build the prover once, then clone it per iteration (untimed setup).
-			let (prover, sums) = FracAddCheckProver::new(
+			let (prover, sums) = FracAddCircuit::build(
 				k,
 				&alloc,
 				Fraction::new(
@@ -101,5 +101,5 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 	group.finish();
 }
 
-criterion_group!(fracaddcheck, bench_fracaddcheck_new, bench_fracaddcheck_prove);
+criterion_group!(fracaddcheck, bench_fracaddcheck_build, bench_fracaddcheck_prove);
 criterion_main!(fracaddcheck);


### PR DESCRIPTION
The transcript is byte-identical — verified, see below. No behaviour change, no performance change.

### The problem

`FracAddCheckProver` proves nothing.

It holds `layers: Vec<Fraction<FieldVec<P, A>>>` and an allocator, and its substantial method materialises every layer of the GKR circuit from the witness. The things that *prove* are `LayerProver` and the driver functions.

A type whose job is "hold the materialised layers", with a name ending in `Prover`, sends a reader looking for round logic that is not there.

### The change

```
- FracAddCheckProver::new(k, alloc, witness)   ->  (Self, Fraction<..>)
+ FracAddCircuit::build(k, alloc, witness)     ->  (Self, Fraction<..>)
```

`new` becomes `build` because it **does not return `Self`** — it returns the circuit beside its root layer. Rust reserves `new` for constructors returning `Self`, and this is exactly the case that convention exists to catch.

Both move into a new `fracaddcheck/circuit.rs`, together with `n_layers`, `pop_layer`, `prove` and `prove_layers` — the circuit and driving it end to end.

`reduce_layer`, `BatchProveOutput`, `combine_claims` and `batch_prove_unequal_depths` stay in `mod.rs`, untouched apart from the type name in one signature and one `.map()`.

### The public path

`mod circuit;` is **private**, with `pub use circuit::FracAddCircuit;` in `mod.rs`.

So `fracaddcheck::FracAddCircuit` is the single canonical path, with no deeper `fracaddcheck::circuit::FracAddCircuit` for call sites to drift to. That matches how `LayerProver` and `unpad_leaf_claim` are already surfaced.

### Call sites

A census over the whole repo — all file types, no Markdown or Typst references anywhere:

| file | hits | kind |
|---|---:|---|
| `fracaddcheck/mod.rs` | 10 | definition, `Clone`, impl, doc link, `batch_prove_unequal_depths`, 3 test uses |
| `fracaddcheck/padding.rs` | 2 | import, `layer_provers` parameter |
| `logup_star/prove.rs` | 4 | import, 3 × `::new(` — looker, table, top |
| `prover/benches/fracaddcheck.rs` | 3 | import, 2 × `::new(` |

### Soundness: the transcript is byte-identical

A throwaway harness dumped `transcript.finalize()` plus the returned `eval_point` and `fractions` for depths `[2,4,5]`, `[4,4,4]`, `[0,3]`, before and after:

```
83cc802a27a70475b741e6d783d38013c98b57caab29377a395f022feaf814b3  baseline.txt
83cc802a27a70475b741e6d783d38013c98b57caab29377a395f022feaf814b3  after.txt
```

Transcript lengths were 960 / 704 / 384 bytes for the three shapes. `reduce_layer` and its call site are byte-identical to before; no `MleStore` consolidation and no change to the parallel decomposition, both of which are measured performance decisions.

### Two judgement calls worth surfacing

**The bench group id moved too.** `bench_fracaddcheck_new` became `bench_fracaddcheck_build`, and I also moved its criterion group id from `"fracaddcheck/new"` to `"fracaddcheck/build"` so the id agrees with the method it measures. That orphans any stored criterion baseline for that group — the right trade while no performance work depends on one, but say the word if you would rather keep the id stable.

**Five wrapped doc paragraphs are rewritten.** They had a sentence spanning two `///` lines, against the house rule. Four are prose carried over unchanged; one is from the `pop_layer` doc added recently, so it is my own. A new file should not ship with them. This is the only change in the PR that is not a name, a location, or an import that follows from one.

### Scope

- **new:** `crates/ip-prover/src/fracaddcheck/circuit.rs`
- **changed:** `mod.rs` (−281), `padding.rs`, `logup_star/prove.rs`, the bench
- **untouched:** every reduction, the padding algebra, the verifier

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean, and re-audited afterwards for sentences wrapping across `///` lines
- `cargo test -p binius-ip-prover` — 93 passed, and again with `--features rayon` — 93 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --no-deps` — clean

### Rebased onto #2282 and #2286, and the predicted hazard resolved

Both have merged, so this is rebased onto them. Three things had to be fixed, and only the first was a textual conflict:

**1. The `_prover` binding.** #2282 needs the binding named (it reads `prover.layers`); this branch had `_prover`. Resolved by keeping the binding and taking the new name: `let (prover, sums) = FracAddCircuit::build(..)`.

**2. `FieldVec` had to come back to `mod.rs`.** This branch removed it, because the type that used it moved out — but #2286's `finish_and_transpose` and `prove_selector_rounds` *stayed* in `mod.rs` and build `FieldVec` columns. Git saw no conflict here at all; it surfaced only as a compile error.

**3. The layer proptest moved into `circuit.rs`.** This is the hazard flagged when #2282 opened: its strengthened test reads the private `layers` field, legal only while the test lives in the module owning the type. Moving the type moves the field out of reach. So `check_all_layers` and `frac_add_check_layers_fold_the_witness` now live in a `#[cfg(test)] mod tests` in `circuit.rs` — the natural home, since they test the circuit's construction.

Test count is unchanged at 94, and the moved test still bites: perturbing the production fold (`den_out.write(den_0 * den_1)` -> `+ den_0`) fails it with "layer 1 denominator mismatch at index 0". Reverted, and the `proptest-regressions` artifact deleted.

Points 2 and 3 produced no merge conflict — the same class of failure that broke the merge queue on #2273. Worth noting that this repo's green tick on a PR page does not imply the merge compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
