### PR TITLE
Let the serial chunk iterator take sub-word chunk sizes

### DIFF
--- a/crates/math/src/field_buffer/chunks.rs
+++ b/crates/math/src/field_buffer/chunks.rs
@@ -13,10 +13,11 @@
 //! chunk <  one packed word  ->  some lanes of one word
 //! ```
 //!
-//! The iterators here cover the first shape, where a chunk is a borrowed run of words.
-//! The second shape gets a type of its own, since locating those lanes is shared work.
+//! The shared iterator here covers both shapes, so any size up to the buffer's length works.
+//! The mutable one covers only the first, since a borrowed run of words is all it can lend out.
+//! Locating the lanes of the second shape is shared work, so it gets a type of its own.
 
-use std::{iter, marker::PhantomData, slice};
+use std::{iter, marker::PhantomData, ops::Range, slice};
 
 use binius_field::PackedField;
 
@@ -88,13 +89,31 @@ impl<P: PackedField> SubWordChunk<P> {
 	}
 }
 
+/// How a shared chunk iterator walks the store, settled by the chunk size before the first step.
+///
+/// ```text
+/// chunk >= one packed word  ->  Words, stepping runs of the store
+/// chunk <  one packed word  ->  Lanes, stepping chunk indices into one word each
+/// ```
+#[derive(Clone)]
+enum ChunkSource<'a, P: PackedField> {
+	/// Runs of words, one per chunk, cut off at the buffer's logical chunk count.
+	Words(iter::Take<slice::Chunks<'a, P>>),
+	/// Chunk indices to locate lanes with, alongside the store those lanes are repacked from.
+	Lanes {
+		words: &'a [P],
+		indices: Range<usize>,
+	},
+}
+
 /// Iterator over a buffer's chunks of a fixed size, each borrowed as a shared view.
 ///
 /// Yielded by asking a buffer for its chunks.
-/// The chunk size is at least one packed word, so every chunk is a borrowed run of words.
+/// A chunk of at least one packed word is a borrowed run of words.
+/// A smaller one is a copy of its lanes, repacked to start at lane 0.
 pub struct Chunks<'a, P: PackedField> {
-	/// Runs of words, one per chunk, cut off at the buffer's logical chunk count.
-	runs: iter::Take<slice::Chunks<'a, P>>,
+	/// Where the next chunk comes from, one shape or the other for the whole iteration.
+	source: ChunkSource<'a, P>,
 	/// Element count of each chunk, as a base-2 logarithm.
 	log_chunk_size: usize,
 }
@@ -103,9 +122,17 @@ impl<'a, P: PackedField> Chunks<'a, P> {
 	/// Builds the iterator over `words`, whose length must be the buffer's live word count.
 	#[inline]
 	pub(super) fn new(words: &'a [P], log_chunk_size: usize, chunk_count: usize) -> Self {
-		let words_per_chunk = 1 << (log_chunk_size - P::LOG_WIDTH);
+		let source = if log_chunk_size >= P::LOG_WIDTH {
+			let words_per_chunk = 1 << (log_chunk_size - P::LOG_WIDTH);
+			ChunkSource::Words(words.chunks(words_per_chunk).take(chunk_count))
+		} else {
+			ChunkSource::Lanes {
+				words,
+				indices: 0..chunk_count,
+			}
+		};
 		Self {
-			runs: words.chunks(words_per_chunk).take(chunk_count),
+			source,
 			log_chunk_size,
 		}
 	}
@@ -116,15 +143,24 @@ impl<'a, P: PackedField> Iterator for Chunks<'a, P> {
 
 	#[inline]
 	fn next(&mut self) -> Option<Self::Item> {
-		self.runs.next().map(|run| FieldBuffer {
+		let values = match &mut self.source {
+			ChunkSource::Words(runs) => FieldSliceData::Slice(runs.next()?),
+			ChunkSource::Lanes { words, indices } => FieldSliceData::Single(
+				SubWordChunk::<P>::new(self.log_chunk_size, indices.next()?).repack(words),
+			),
+		};
+		Some(FieldBuffer {
 			log_len: self.log_chunk_size,
-			values: FieldSliceData::Slice(run),
+			values,
 		})
 	}
 
 	#[inline]
 	fn size_hint(&self) -> (usize, Option<usize>) {
-		self.runs.size_hint()
+		match &self.source {
+			ChunkSource::Words(runs) => runs.size_hint(),
+			ChunkSource::Lanes { indices, .. } => indices.size_hint(),
+		}
 	}
 }
 
@@ -133,7 +169,7 @@ impl<P: PackedField> ExactSizeIterator for Chunks<'_, P> {}
 impl<P: PackedField> Clone for Chunks<'_, P> {
 	fn clone(&self) -> Self {
 		Self {
-			runs: self.runs.clone(),
+			source: self.source.clone(),
 			log_chunk_size: self.log_chunk_size,
 		}
 	}
@@ -141,7 +177,7 @@ impl<P: PackedField> Clone for Chunks<'_, P> {
 
 /// Iterator over a buffer's chunks of a fixed size, each borrowed as a mutable view.
 ///
-/// The mutable counterpart of the shared chunk iterator.
+/// The mutable counterpart of the shared chunk iterator, restricted to chunks of whole words.
 /// The chunks are disjoint, so each is lent out for the whole iteration rather than one at a time.
 pub struct ChunksMut<'a, P: PackedField> {
 	/// Runs of words, one per chunk, cut off at the buffer's logical chunk count.

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -337,8 +337,6 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// A chunk's start offset is a multiple of its size.
 	/// So this yields the same chunk that stepping the shared iterator to that index would.
 	///
-	/// Unlike that iterator, this accepts a size below the packing width.
-	///
 	/// # Preconditions
 	///
 	/// * `log_chunk_size` must be at most `log_len`.
@@ -376,14 +374,18 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 
 	/// Split the buffer into chunks of size `2^log_chunk_size`.
 	///
+	/// Any size up to the buffer's length works, matching what the parallel iterator accepts.
+	/// A chunk of at least one packed word borrows a run of the store.
+	/// A smaller one arrives as a copy of its lanes, repacked to start at lane 0.
+	///
 	/// # Preconditions
 	///
-	/// * `log_chunk_size` must be at least `P::LOG_WIDTH` and at most `log_len`.
+	/// * `log_chunk_size` must be at most `log_len`.
 	#[track_caller]
 	pub fn chunks(&self, log_chunk_size: usize) -> Chunks<'_, P> {
 		assert!(
-			log_chunk_size >= P::LOG_WIDTH && log_chunk_size <= self.log_len,
-			"precondition: log_chunk_size must be in range [P::LOG_WIDTH, log_len]"
+			log_chunk_size <= self.log_len,
+			"precondition: log_chunk_size must be at most log_len"
 		);
 
 		let chunk_count = 1 << (self.log_len - log_chunk_size);
@@ -578,6 +580,16 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	}
 
 	/// Split the buffer into mutable chunks of size `2^log_chunk_size`.
+	///
+	/// A chunk must span whole words, unlike the shared iterator, which takes any size.
+	/// Chunks below the packing width share a word, so lending them out means lending copies.
+	/// Each copy live at once would need its own write-back into that word.
+	///
+	/// ```text
+	/// WIDTH = 4, log_chunk_size = 1  ->  word 0 = [chunk 0 | chunk 1]
+	/// ```
+	///
+	/// Reach for the single-chunk mutable accessor at such a size, which guards one copy.
 	///
 	/// # Preconditions
 	///
@@ -1224,12 +1236,30 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "precondition")]
-	fn chunks_invalid_size_too_small() {
+	fn chunks_below_packing_width() {
+		// A word holds 4 lanes, so pairs of elements share one:
+		//
+		//     word 0 = [s_0, s_1, s_2, s_3]  ->  chunks [s_0, s_1], [s_2, s_3]
 		let values: Vec<F> = (0..16).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
-		// P::LOG_WIDTH = 2, so chunks(0) should fail
-		let _ = buffer.chunks(0).collect::<Vec<_>>();
+
+		let chunks: Vec<_> = buffer.chunks(1).collect();
+		assert_eq!(chunks.len(), 8);
+
+		// Each chunk owns a repacked word, so its two elements sit at lanes 0 and 1.
+		for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
+			assert_eq!(chunk.len(), 2);
+			assert_eq!(chunk.get(0), F::new((chunk_idx * 2) as u128));
+			assert_eq!(chunk.get(1), F::new((chunk_idx * 2 + 1) as u128));
+		}
+
+		// A single-element chunk is the narrowest shape, one lane copied out on its own.
+		let singles: Vec<_> = buffer.chunks(0).collect();
+		assert_eq!(singles.len(), 16);
+		for (index, chunk) in singles.into_iter().enumerate() {
+			assert_eq!(chunk.len(), 1);
+			assert_eq!(chunk.get(0), F::new(index as u128));
+		}
 	}
 
 	#[test]
@@ -1550,6 +1580,32 @@ mod tests {
 
 			// Concatenating the chunks reproduces the buffer, in order and without gaps.
 			prop_assert_eq!(chunks.concat(), values);
+		}
+
+		#[test]
+		fn serial_and_parallel_chunks_agree(
+			(log_len, log_chunk_size) in (0usize..=8).prop_flat_map(|n| (Just(n), 0usize..=n)),
+		) {
+			// Invariant: both chunk iterators yield the same chunks, scalar for scalar.
+			// A packed word holds 4 lanes, so the sweep reaches sizes on both sides of it.
+			let values: Vec<F> = (0..1u128 << log_len).map(F::new).collect();
+			let buffer = FieldBuffer::<P>::from_values(&values);
+
+			let serial: Vec<Vec<F>> = buffer
+				.chunks(log_chunk_size)
+				.map(|chunk| chunk.iter_scalars().collect())
+				.collect();
+			let parallel: Vec<Vec<F>> = buffer
+				.chunks_par(log_chunk_size)
+				.map(|chunk| chunk.iter_scalars().collect())
+				.collect();
+
+			// The count follows the logical length, not the backing word count.
+			prop_assert_eq!(serial.len(), 1 << (log_len - log_chunk_size));
+			prop_assert_eq!(&serial, &parallel);
+
+			// Concatenating the chunks reproduces the buffer, in order and without gaps.
+			prop_assert_eq!(serial.concat(), values);
 		}
 	}
 }


### PR DESCRIPTION
Makes the serial chunk iterator accept the chunk sizes the parallel one already accepts. Removes a runtime panic that had no compile-time warning and no documentation.

### The problem

The buffer's chunk accessors disagreed about which sizes are legal, and nothing said so:

```
chunk(log_chunk_size, i)      log_chunk_size <= log_len                    sub-word OK
chunks(log_chunk_size)        P::LOG_WIDTH <= log_chunk_size <= log_len    sub-word PANICS
chunks_par(log_chunk_size)    log_chunk_size <= log_len                    sub-word OK
par_chunk_scalars(..)         log_chunk_size <= log_len                    sub-word OK
chunks_mut(log_chunk_size)    P::LOG_WIDTH <= log_chunk_size <= log_len    sub-word PANICS
```

So the serial iterator panicked on inputs the parallel one handled. Develop against the parallel iterator, switch to the serial one for a small instance, and you get a runtime panic — not a type error. Neither doc comment mentioned the difference.

### The idea

The serial iterator's items are shared buffer views, and that type can already hold an owned repacked word. So it *can* express a sub-word chunk; it simply never learned how.

The obstacle was arithmetic, not representation. The constructor computed

```
words_per_chunk = 1 << (log_chunk_size - P::LOG_WIDTH)
```

which **underflows** when the size is below the packing width. So the fix is to choose a shape before doing any arithmetic, not to relax an assertion:

```rust
enum ChunkSource<'a, P: PackedField> {
    /// Runs of words, one per chunk, cut off at the buffer's logical chunk count.
    Words(iter::Take<slice::Chunks<'a, P>>),
    /// Chunk indices to locate lanes with, alongside the store those lanes are repacked from.
    Lanes { words: &'a [P], indices: Range<usize> },
}
```

The constructor picks a variant once, so the subtraction is only ever evaluated on the branch where it is valid.

**No new index arithmetic was written.** The lane path repacks through the same helper the parallel iterator already uses, so both paths share one implementation of the sub-word index split. `size_hint` dispatches to whichever inner iterator is live, so the exact-size guarantee still holds.

### Why `chunks_mut` keeps its restriction

It cannot be fixed the same way, and the reason is worth stating rather than leaving as an asymmetry. Sub-word chunks share a word, so lending several out at once means lending *copies*, and every copy alive simultaneously would need its own write-back into that word. The guard that did exactly that for a single chunk was just deleted as dead code, and resurrecting it for a whole iterator is a worse trade.

So the restriction stays and is now documented, with the layout that makes it obvious:

```
WIDTH = 4, log_chunk_size = 1  ->  word 0 = [chunk 0 | chunk 1]
```

The doc points a caller at the single-chunk mutable accessor for that case, which guards one copy at a time.

### Soundness — the proptest was verified by breaking the code

Relaxing an assertion widens what the type accepts, so the failure mode is a *wrong chunk*, not a panic. The new proptest sweeps `log_len` in 0 to 8 and every chunk size within it against a 4-lane packing, asserting three things: the chunk count, serial equals parallel scalar-for-scalar, and the chunks concatenate back to the buffer.

That was checked by injecting a fault rather than by inspection. Swapping adjacent chunks within a word — `indices.next()? ^ 1`, the classic wrong high/low split — fails both new tests. The three assertions cover different flavours: a wrong index in the serial path alone diverges from the parallel path, while an off-by-one *shared* by both paths still fails the concatenation and count checks, because the buffer is filled with distinct ascending values so every misplacement is observable.

One honest negative: flipping the shape boundary from `>=` to `>` fails nothing. That is correct, not a coverage gap — at exactly the packing width the lane path repacks a whole word lane-for-lane, which is the identity, so the two branches genuinely agree there.

### Scope

- **changed:** `field_buffer/chunks.rs` — the two-variant source and the lane-path `next`.
- **changed:** `field_buffer/mod.rs` — the assertion on the shared iterator now matches the parallel ones; the mutable iterator gains its documented restriction.
- **deleted:** a sentence on the single-chunk accessor claiming it is the only one accepting sub-word sizes. No longer true.
- **replaced:** the `#[should_panic]` test for a sub-word size, which is now wrong by construction, became a positive test of that case.

### Verification

- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p binius-math` — 157 passed, plus 1 doctest. Same again with `--features rayon`, since the default build uses the hand-written no-rayon shim.
- `cargo test -p binius-math --target wasm32-wasip1 --no-run` — builds. CI runs wasm with default features, which an `--all-features` gate misses.
- `cargo +nightly fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
