### PR TITLE
Bench the fused BitAnd fold on its own

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -57,6 +57,10 @@ name = "and_reduction"
 harness = false
 
 [[bench]]
+name = "fold_bitand_operands"
+harness = false
+
+[[bench]]
 name = "shift_reduction"
 harness = false
 

--- a/crates/prover/benches/fold_bitand_operands.rs
+++ b/crates/prover/benches/fold_bitand_operands.rs
@@ -1,0 +1,68 @@
+// Copyright 2026 The Binius Developers
+use binius_compute::BufferPool;
+use binius_core::word::Word;
+use binius_field::arch::OptimalPackedB128;
+use binius_math::test_utils::random_scalars;
+use binius_prover::fold_word::BitAxisFolder;
+use binius_verifier::config::B128;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::prelude::*;
+
+/// Columns the AND zerocheck folds from two stored ones.
+///
+/// The constraint is `A & B == C`, and on a satisfying witness the third column is the AND of the
+/// first two. So two columns are read and three are produced.
+const N_COLUMNS: u64 = 3;
+
+/// The fused fold, against the three separate folds it replaces.
+///
+/// The zerocheck stores only the two operand columns, so a caller folding them separately has to
+/// materialize the third first. The fused one derives it in registers instead, and never writes it.
+/// Both produce the same three folded columns, so the pair measures what the fusion is worth.
+fn bench_fold_bitand_operands(c: &mut Criterion) {
+	let mut group = c.benchmark_group("fold_bitand_operands");
+
+	for log_n_words in [16, 20] {
+		let n_words = 1 << log_n_words;
+		let mut rng = rand::rng();
+
+		// Two random operand columns, and the third the constraint derives from them.
+		let a_words = (0..n_words)
+			.map(|_| Word::from_u64(rng.random()))
+			.collect::<Vec<_>>();
+		let b_words = (0..n_words)
+			.map(|_| Word::from_u64(rng.random()))
+			.collect::<Vec<_>>();
+		let weights = random_scalars::<B128>(&mut rng, Word::BITS);
+		let folder = BitAxisFolder::new(&weights);
+		let pool = BufferPool::new();
+		let alloc = &pool;
+
+		// Words across all three output columns, so throughput counts the whole phase.
+		group.throughput(Throughput::Elements(N_COLUMNS * n_words as u64));
+
+		group.bench_with_input(BenchmarkId::new("fused", n_words), &n_words, |b, _| {
+			b.iter(|| {
+				folder.fold_bitand_operands::<OptimalPackedB128, _>(&alloc, &a_words, &b_words)
+			})
+		});
+		group.bench_with_input(BenchmarkId::new("separate", n_words), &n_words, |b, _| {
+			b.iter(|| {
+				// The derived column is not stored, so folding separately pays to build it.
+				let c_words = std::iter::zip(&a_words, &b_words)
+					.map(|(&a, &b)| a & b)
+					.collect::<Vec<_>>();
+				[
+					folder.fold::<OptimalPackedB128, _>(&alloc, &a_words),
+					folder.fold::<OptimalPackedB128, _>(&alloc, &b_words),
+					folder.fold::<OptimalPackedB128, _>(&alloc, &c_words),
+				]
+			})
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_fold_bitand_operands);
+criterion_main!(benches);


### PR DESCRIPTION
Adds a bench for the fold that is roughly a fifth of AND-reduction prove time, and which until now could only be measured by running the whole reduction. Bench-only — no production code changes.

### The problem

The AND zerocheck proves `A & B == C`. On a satisfying witness the third column is the AND of the first two, so only two are stored and the fold derives the third in registers:

```
    stream A --+--> fold --> folded A
    stream B --+--> fold --> folded B
               +--> A & B --> fold --> folded C   (no third input stream)
```

That fold is **about 18% of AND-reduction prove time at 2^21 words**, measured through `benches/and_reduction.rs`, where it shows up as one line of a four-stage total.

So a change to it could only be defended by running the whole reduction and watching a number that three other stages also move. That is not a measurement you can act on.

### What the bench compares

The fused fold, against the three separate folds it replaces.

The comparison only means something if the separate side pays what a real caller would. The derived column **is not stored**, so a caller folding separately has to build it first:

```
// The derived column is not stored, so folding separately pays to build it.
let c_words = zip(&a_words, &b_words).map(|(&a, &b)| a & b).collect::<Vec<_>>();
[folder.fold(&alloc, &a_words), folder.fold(&alloc, &b_words), folder.fold(&alloc, &c_words)]
```

Materializing it outside the timed loop was the first thing I got wrong here, and it flattered the separate side by a whole pass over the input.

Throughput counts all three output columns, so the two sides compare directly.

### What it already shows

At 2^16 words the fusion is worth about **1.9x**:

| variant | 2^16 words |
|---|---|
| fused | 136 us |
| separate, including building the third column | 260 us |

The 2^20 case could not be resolved on the machine available: with it loaded, the baseline itself moved by more than the effect, and the two sides swapped order between runs. That is exactly the ambiguity a dedicated bench exists to settle, and it is worth someone re-running on a quiet machine — the fusion's premise is that two input streams beat three, and at 2^20 the outputs alone are 48 MB, so it is not obvious that it holds there.

### Scope

- **new:** one bench and its entry in the manifest
- nothing else touched

### Verification

- `cargo check -p binius-prover --all-targets` — clean
- `cargo clippy -p binius-prover --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt` — clean
- the bench runs and reports both variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)