### PR TITLE
Bring the field buffer's names up to std convention

### DIFF
--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -58,7 +58,7 @@ where
 		packing_name.as_ref()
 	);
 	group.bench_function(&case, |b| {
-		b.iter(|| merkle_prover.commit_field_buffer(buffer.to_ref(), LOG_ELEMS_IN_LEAF));
+		b.iter(|| merkle_prover.commit_field_buffer(buffer.as_view(), LOG_ELEMS_IN_LEAF));
 	});
 
 	// The same commitment out of a pool the prover holds across iterations, which is how a real
@@ -67,7 +67,7 @@ where
 	let pool = BufferPool::new();
 	let pooled_prover = BinaryMerkleTreeProver::<B128, H, _>::with_allocator(&pool);
 	group.bench_function(format!("{case} pooled"), |b| {
-		b.iter(|| pooled_prover.commit_field_buffer(buffer.to_ref(), LOG_ELEMS_IN_LEAF));
+		b.iter(|| pooled_prover.commit_field_buffer(buffer.as_view(), LOG_ELEMS_IN_LEAF));
 	});
 	group.finish()
 }
@@ -126,9 +126,9 @@ fn bench_commit_pipeline(c: &mut Criterion) {
 
 	group.bench_function("sequential", |b| {
 		b.iter(|| {
-			let codeword = rs_code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+			let codeword = rs_code.encode_batch(&ntt, message.as_view(), 0, &GlobalAllocator);
 			BinaryMerkleTreeProver::<B128, Sha256HashSuite>::new()
-				.commit_field_buffer(codeword.to_ref(), LOG_ELEMS_IN_LEAF)
+				.commit_field_buffer(codeword.as_view(), LOG_ELEMS_IN_LEAF)
 		});
 	});
 
@@ -137,7 +137,7 @@ fn bench_commit_pipeline(c: &mut Criterion) {
 			encode_and_commit_pipelined::<B128, OptimalPackedB128, _, Sha256HashSuite, _, _>(
 				&rs_code,
 				&ntt,
-				message.to_ref(),
+				message.as_view(),
 				0,
 				LOG_ELEMS_IN_LEAF,
 				&GlobalAllocator,

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -306,7 +306,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 			};
 
 			let mut store = MleStore::new(n_i, alloc);
-			let message_col = store.push(message.to_ref());
+			let message_col = store.push(message.as_view());
 			let transparent_col = store.push_owned(transparent);
 			let inner = SharedSumcheckProver::new(
 				store,
@@ -364,7 +364,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 			// 2^{log_repeat} chunks of size 2^{n_i + log_lift}.
 			// Borrow as a slice before the closure: the allocator's buffer type is only `Send`, so
 			// a closure capturing the owned buffer would not be `Sync` as `for_each` requires.
-			place_repeated(combined.to_mut(), witness_prime.to_ref(), eq_i, n_i + log_lift);
+			place_repeated(combined.as_mut_view(), witness_prime.as_view(), eq_i, n_i + log_lift);
 
 			// Repeat dims contribute 1; only the lift dims contribute an eq-to-zero factor.
 			s_prime += eq_i * alpha_i * Hypercube::One.eq_ind_zero(&point[n_i..][..log_lift]);
@@ -437,8 +437,8 @@ where
 				assert_eq!(relation.transparent.log_len(), batched.transparent.log_len());
 
 				accumulate_scaled_buffer(
-					batched.transparent.to_mut(),
-					relation.transparent.to_ref(),
+					batched.transparent.as_mut_view(),
+					relation.transparent.as_view(),
 					P::broadcast(coeff),
 				);
 				batched.claim += coeff * relation.claim;
@@ -478,7 +478,7 @@ fn place_repeated<P: PackedField>(
 		let chunk_packed = 1usize << (log_block - P::LOG_WIDTH);
 		dst.as_mut().par_chunks_mut(chunk_packed).for_each(|chunk| {
 			let chunk_buf = FieldSliceMut::from_slice(log_block, chunk);
-			accumulate_scaled_buffer(chunk_buf, src.to_ref(), scalar_broadcast);
+			accumulate_scaled_buffer(chunk_buf, src.as_view(), scalar_broadcast);
 		});
 	} else {
 		// Lane `k` of every element sits at position `k % 2^log_block` of its block, and carries
@@ -616,7 +616,7 @@ where
 				&self.fri_params,
 				index,
 				self.ntt,
-				buffer.to_ref(),
+				buffer.as_view(),
 				&mut self.rng,
 				&self.alloc,
 			);
@@ -627,7 +627,7 @@ where
 					&self.fri_params,
 					index,
 					self.ntt,
-					buffer.to_ref(),
+					buffer.as_view(),
 					&self.alloc,
 				),
 				None,
@@ -639,7 +639,7 @@ where
 		let leaf_size = 1 << self.fri_params.input_oracles()[index].log_batch_size();
 		let commitment = self
 			.channel
-			.send_merkle_commitment(codeword.to_ref(), leaf_size);
+			.send_merkle_commitment(codeword.as_view(), leaf_size);
 		drop(merkle_scope);
 
 		self.committed_oracles.push(CommittedOracleData {
@@ -781,7 +781,7 @@ mod tests {
 				GlobalAllocator,
 			);
 
-		let oracle = prover_channel.send_oracle(buffer.to_ref());
+		let oracle = prover_channel.send_oracle(buffer.as_view());
 		assert_eq!(oracle.index, 0);
 
 		prover_channel.prove_oracle_relation(oracle, transparent_poly.clone(), eval_claim);
@@ -850,8 +850,8 @@ mod tests {
 				GlobalAllocator,
 			);
 
-		let oracle_1 = prover_channel.send_oracle(buffer_1.to_ref());
-		let oracle_2 = prover_channel.send_oracle(buffer_2.to_ref());
+		let oracle_1 = prover_channel.send_oracle(buffer_1.as_view());
+		let oracle_2 = prover_channel.send_oracle(buffer_2.as_view());
 
 		prover_channel.prove_oracle_relation(oracle_1, transparent_poly_1.clone(), eval_claim_1);
 		prover_channel.prove_oracle_relation(oracle_2, transparent_poly_2.clone(), eval_claim_2);
@@ -938,7 +938,7 @@ mod tests {
 
 		let oracles: Vec<_> = data
 			.iter()
-			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
+			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.as_view()))
 			.collect();
 		for (oracle, (buffer, transparent, claim)) in iter::zip(oracles, &data) {
 			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
@@ -1027,7 +1027,7 @@ mod tests {
 
 		let oracles: Vec<_> = data
 			.iter()
-			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
+			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.as_view()))
 			.collect();
 		for (oracle, (buffer, transparent, claim)) in iter::zip(oracles, &data) {
 			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
@@ -1114,7 +1114,7 @@ mod tests {
 			}
 
 			let mut actual = initial;
-			place_repeated(actual.to_mut(), src.to_ref(), scalar, log_block);
+			place_repeated(actual.as_mut_view(), src.as_view(), scalar, log_block);
 
 			for index in 0..1usize << log_dst {
 				assert_eq!(
@@ -1279,7 +1279,7 @@ mod tests {
 
 		let oracles = data
 			.iter()
-			.map(|(buffer, _)| prover_channel.send_oracle(buffer.to_ref()))
+			.map(|(buffer, _)| prover_channel.send_oracle(buffer.as_view()))
 			.collect::<Vec<_>>();
 		for &(index, round) in &arrivals {
 			let (transparent, claim) = &data[index].1[round];

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -181,7 +181,7 @@ mod test {
 			&fri_params,
 			0,
 			&ntt,
-			witness.to_ref(),
+			witness.as_view(),
 			&mut commit_rng,
 			&GlobalAllocator,
 		);
@@ -192,7 +192,7 @@ mod test {
 				&mut prover_transcript,
 				merkle_prover,
 			);
-		let codeword_commitment = prover_channel.send_merkle_commitment(codeword.to_ref(), 2);
+		let codeword_commitment = prover_channel.send_merkle_commitment(codeword.as_view(), 2);
 
 		// Sample the masking challenge γ and form π' = (1-γ)·witness + γ·mask.
 		let batch_challenge: F = IPProverChannel::sample(&mut prover_channel);

--- a/crates/iop-prover/src/commit_pipeline.rs
+++ b/crates/iop-prover/src/commit_pipeline.rs
@@ -133,13 +133,14 @@ mod tests {
 			encode_and_commit_pipelined::<B128, P, _, Sha256HashSuite, _, _>(
 				&rs_code,
 				&ntt,
-				message.to_ref(),
+				message.as_view(),
 				0,
 				log_leaf_len,
 				&GlobalAllocator,
 			);
 
-		let sequential_codeword = rs_code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+		let sequential_codeword =
+			rs_code.encode_batch(&ntt, message.as_view(), 0, &GlobalAllocator);
 		let sequential_tree = BinaryMerkleTree::<_, GlobalAllocator>::new::<B128, Sha256HashSuite>(
 			&sequential_codeword.iter_scalars().collect::<Vec<_>>(),
 			1 << log_leaf_len,

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -73,7 +73,7 @@ where
 	)
 	.entered();
 
-	rs_code.encode_batch(ntt, message.to_ref(), log_batch_size, alloc)
+	rs_code.encode_batch(ntt, message.as_view(), log_batch_size, alloc)
 }
 
 /// Output of [`encode_masked`]: the interleaved (message ‖ mask) codeword and the generated mask.
@@ -167,7 +167,7 @@ where
 	};
 	let combined = FieldBuffer::new(log_len + 1, combined_values);
 
-	let codeword = encode_interleaved(params, oracle_index, ntt, combined.to_ref(), alloc);
+	let codeword = encode_interleaved(params, oracle_index, ntt, combined.as_view(), alloc);
 
 	MaskedCodeword { codeword, mask }
 }
@@ -219,7 +219,7 @@ mod tests {
 		let message = random_field_buffer::<P>(&mut rng, log_dim);
 
 		let output: MaskedCodeword<P> =
-			encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng, &GlobalAllocator);
+			encode_masked(&params, 0, &ntt, message.as_view(), &mut rng, &GlobalAllocator);
 
 		// Verify mask has correct dimensions.
 		assert_eq!(output.mask.log_len(), log_dim);

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -242,7 +242,7 @@ where
 				// reduced dimension and rate.
 				let challenges = mem::take(&mut self.unprocessed_challenges);
 				let fri_fold_span = tracing::debug_span!("FRI Fold").entered();
-				let folded_codeword = fold_codeword(self.ntt, last_codeword.to_ref(), &challenges);
+				let folded_codeword = fold_codeword(self.ntt, last_codeword.as_view(), &challenges);
 				drop(fri_fold_span);
 				// The fold consuming `last_codeword` has arity `challenges.len()`, which is the
 				// coset size its commitment was built with.
@@ -288,7 +288,7 @@ where
 
 		let _merkle_tree_span = tracing::debug_span!("Merkle Tree").entered();
 		let commitment =
-			channel.send_merkle_commitment(folded_codeword.to_ref(), 1 << log_coset_size);
+			channel.send_merkle_commitment(folded_codeword.as_view(), 1 << log_coset_size);
 
 		// The next commitment lands `next_arity` rounds after the current one. Once there is no
 		// next arity, this is the terminal codeword and no further commitments are made.
@@ -370,7 +370,7 @@ where
 
 		// Send the per-oracle batched query openings, then the terminal codeword in full.
 		query_prover.prove_queries(&indices, channel);
-		channel.send_committed_vector(&terminal_commitment, terminate_codeword.to_ref());
+		channel.send_committed_vector(&terminal_commitment, terminate_codeword.as_view());
 	}
 }
 
@@ -628,13 +628,13 @@ mod tests {
 
 		// Encode the message over the large domain.
 		let mut codeword = msg;
-		ntt.forward_transform(codeword.to_mut(), 0, 0);
+		ntt.forward_transform(codeword.as_mut_view(), 0, 0);
 
 		// Fold the encoded message using FRI folding.
-		let folded_codeword = fold_codeword(&ntt, codeword.to_ref(), &challenges);
+		let folded_codeword = fold_codeword(&ntt, codeword.as_view(), &challenges);
 
 		// Encode the folded message.
-		ntt.forward_transform(folded_msg.to_mut(), 0, 0);
+		ntt.forward_transform(folded_msg.as_mut_view(), 0, 0);
 
 		// Check that folding and encoding commute.
 		assert_eq!(folded_codeword, folded_msg);

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -400,7 +400,7 @@ where
 	// For each coset of size `2^chunk_size` in the codeword, fold it with the folding challenges.
 	let chunk_size = 1 << challenges.len();
 	let values: Vec<F> = codeword
-		.chunks_par(challenges.len())
+		.par_chunks(challenges.len())
 		.enumerate()
 		.map_init(
 			|| vec![F::default(); chunk_size],
@@ -556,7 +556,7 @@ impl<F: Field, P: PackedField<Scalar = F>, C, Data: Deref<Target = [P]>>
 			if index == 0 {
 				values.spare_capacity_mut()[..code_len]
 					.par_chunks_mut(1 << log_lift)
-					.zip(codeword.chunks_par(log_batch_size))
+					.zip(codeword.par_chunks(log_batch_size))
 					.for_each(|(copies, chunk)| {
 						let value = chunk.inner_product(&tensor);
 						for acc in copies {
@@ -569,7 +569,7 @@ impl<F: Field, P: PackedField<Scalar = F>, C, Data: Deref<Target = [P]>>
 			} else {
 				values
 					.par_chunks_mut(1 << log_lift)
-					.zip(codeword.chunks_par(log_batch_size))
+					.zip(codeword.par_chunks(log_batch_size))
 					.for_each(|(copies, chunk)| {
 						let value = chunk.inner_product(&tensor);
 						for acc in copies {

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -76,7 +76,7 @@ where
 			.iter()
 			.map(|index| index.clone() >> self.log_lift as u32)
 			.collect::<Vec<_>>();
-		channel.send_openings(&self.commitment, self.codeword.to_ref(), &lifted_indices);
+		channel.send_openings(&self.commitment, self.codeword.as_view(), &lifted_indices);
 	}
 }
 
@@ -167,7 +167,7 @@ where
 	where
 		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
 	{
-		channel.send_openings(&self.commitment, self.codeword.to_ref(), indices);
+		channel.send_openings(&self.commitment, self.codeword.as_view(), indices);
 	}
 }
 

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -53,7 +53,7 @@ fn test_commit_prove_verify_success<F, P>(
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());
 
 	// Prover encodes the message and commits the codeword over a Merkle channel.
-	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
+	let codeword = encode_interleaved(&params, 0, &ntt, msg.as_view(), &GlobalAllocator);
 
 	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
 	let mut prover_channel =
@@ -61,7 +61,7 @@ fn test_commit_prove_verify_success<F, P>(
 			&mut prover_challenger,
 		);
 	let codeword_commitment =
-		prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
+		prover_channel.send_merkle_commitment(codeword.as_view(), 1 << log_batch_size);
 
 	// Run the prover to generate the proximity proof
 	let mut round_prover = FRIFoldProver::new(&params, &ntt, codeword, codeword_commitment);
@@ -256,9 +256,9 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 		let oracle_params =
 			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.as_view(), &GlobalAllocator);
 		let commitment =
-			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
+			prover_channel.send_merkle_commitment(codeword.as_view(), 1 << log_batch_size);
 		messages.push(msg);
 		committed_codewords.push((codeword, commitment));
 	}
@@ -391,9 +391,9 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 		let oracle_params =
 			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.as_view(), &GlobalAllocator);
 		let commitment =
-			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
+			prover_channel.send_merkle_commitment(codeword.as_view(), 1 << log_batch_size);
 		messages.push(msg);
 		committed_codewords.push((codeword, commitment));
 	}
@@ -546,9 +546,9 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
 		let oracle_params = FRIParams::new(rs_code, log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.as_view(), &GlobalAllocator);
 		let commitment =
-			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
+			prover_channel.send_merkle_commitment(codeword.as_view(), 1 << log_batch_size);
 		messages.push(msg);
 		committed_codewords.push((codeword, commitment));
 	}
@@ -666,7 +666,7 @@ where
 
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());
 
-	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref(), &GlobalAllocator);
+	let codeword = encode_interleaved(&params, 0, &ntt, msg.as_view(), &GlobalAllocator);
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	let mut prover_channel =
@@ -674,7 +674,7 @@ where
 			&mut prover_transcript,
 		);
 	let codeword_commitment =
-		prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
+		prover_channel.send_merkle_commitment(codeword.as_view(), 1 << log_batch_size);
 
 	let mut round_prover = FRIFoldProver::new(&params, &ntt, codeword, codeword_commitment);
 

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -92,7 +92,7 @@ where
 	let oracles = tracing::debug_span!("Commit pushforwards").in_scope(|| {
 		pushforwards
 			.iter()
-			.map(|pushforward| channel.send_oracle(pushforward.to_ref()))
+			.map(|pushforward| channel.send_oracle(pushforward.as_view()))
 			.collect::<Vec<_>>()
 	});
 
@@ -100,7 +100,7 @@ where
 	// IP.
 	let pushforward_slices = pushforwards
 		.iter()
-		.map(FieldBuffer::to_ref)
+		.map(FieldBuffer::as_view)
 		.collect::<Vec<_>>();
 	let output =
 		reduction::prove_reduction(alloc, gamma, &tables, numerators, &pushforward_slices, channel);
@@ -293,7 +293,7 @@ mod tests {
 		tables
 			.iter()
 			.map(|table| TableLookup {
-				table: table.values.to_ref(),
+				table: table.values.as_view(),
 				lookers: table
 					.lookers
 					.iter()

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -299,10 +299,10 @@ mod tests {
 		// Prover side: commit, sample query indices, open them, then send the vector in full.
 		let mut prover_channel =
 			ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
-		let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+		let commitment = prover_channel.send_merkle_commitment(data.as_view(), LEAF_SIZE);
 		let indices = sample_indices(&mut prover_channel);
-		prover_channel.send_openings(&commitment, data.to_ref(), &indices);
-		prover_channel.send_committed_vector(&commitment, data.to_ref());
+		prover_channel.send_openings(&commitment, data.as_view(), &indices);
+		prover_channel.send_committed_vector(&commitment, data.as_view());
 
 		// Verifier side: mirror the interaction and check the opened values against the data.
 		let transcript = prover_channel.into_transcript().into_verifier();
@@ -340,9 +340,9 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		{
 			let mut prover_channel = ProverChannel::new(&mut prover_transcript);
-			let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+			let commitment = prover_channel.send_merkle_commitment(data.as_view(), LEAF_SIZE);
 			let indices = sample_indices(&mut prover_channel);
-			prover_channel.send_openings(&commitment, data.to_ref(), &indices);
+			prover_channel.send_openings(&commitment, data.as_view(), &indices);
 		}
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -374,9 +374,9 @@ mod tests {
 
 		let mut prover_channel =
 			ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
-		let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+		let commitment = prover_channel.send_merkle_commitment(data.as_view(), LEAF_SIZE);
 		let indices = sample_indices(&mut prover_channel);
-		prover_channel.send_openings(&commitment, data.to_ref(), &indices);
+		prover_channel.send_openings(&commitment, data.as_view(), &indices);
 
 		let transcript = prover_channel.into_transcript().into_verifier();
 		let mut verifier_channel = VerifierChannel::new(transcript);
@@ -414,11 +414,11 @@ mod tests {
 		// Commit one buffer but open the other, so the openings do not match the commitment.
 		let mut prover_channel =
 			ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
-		let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+		let commitment = prover_channel.send_merkle_commitment(data.as_view(), LEAF_SIZE);
 		let other_commitment =
-			prover_channel.send_merkle_commitment(other_data.to_ref(), LEAF_SIZE);
+			prover_channel.send_merkle_commitment(other_data.as_view(), LEAF_SIZE);
 		let indices = sample_indices(&mut prover_channel);
-		prover_channel.send_openings(&other_commitment, other_data.to_ref(), &indices);
+		prover_channel.send_openings(&other_commitment, other_data.as_view(), &indices);
 		let _ = commitment;
 
 		let transcript = prover_channel.into_transcript().into_verifier();

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -141,7 +141,7 @@ fn check_commit_field_buffer_matches_commit<P: PackedField<Scalar = B128>>() {
 
 		for log_leaf_len in 0..=log_len {
 			let (reference, _) = prover.commit(&scalars, 1 << log_leaf_len);
-			let (packed, _) = prover.commit_field_buffer(buffer.to_ref(), log_leaf_len);
+			let (packed, _) = prover.commit_field_buffer(buffer.as_view(), log_leaf_len);
 
 			assert_eq!(packed.root, reference.root, "log_len {log_len}, leaf {log_leaf_len}");
 			assert_eq!(packed.depth, reference.depth, "log_len {log_len}, leaf {log_leaf_len}");
@@ -169,7 +169,7 @@ fn test_commit_field_buffer_rejects_oversized_leaf() {
 	let buffer = FieldBuffer::<PackedBinaryGhash4x128b, _>::from_values(&random_scalars::<B128>(
 		&mut rng, 4,
 	));
-	let _ = prover.commit_field_buffer(buffer.to_ref(), 3);
+	let _ = prover.commit_field_buffer(buffer.as_view(), 3);
 }
 
 #[test]

--- a/crates/iop-prover/tests/merkle_pool_allocations.rs
+++ b/crates/iop-prover/tests/merkle_pool_allocations.rs
@@ -154,8 +154,8 @@ fn a_pooled_encode_stops_allocating_the_codeword_globally() {
 
 	// Warm both paths, so neither count includes one-off setup unrelated to the allocator.
 	let pool = BufferPool::new();
-	drop(fri::encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng, &GlobalAllocator));
-	drop(fri::encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng, &&pool));
+	drop(fri::encode_masked(&params, 0, &ntt, message.as_view(), &mut rng, &GlobalAllocator));
+	drop(fri::encode_masked(&params, 0, &ntt, message.as_view(), &mut rng, &&pool));
 
 	let global_allocs = count_large_allocs(|| {
 		for _ in 0..COMMITS {
@@ -163,7 +163,7 @@ fn a_pooled_encode_stops_allocating_the_codeword_globally() {
 				&params,
 				0,
 				&ntt,
-				message.to_ref(),
+				message.as_view(),
 				&mut rng,
 				&GlobalAllocator,
 			));
@@ -171,7 +171,7 @@ fn a_pooled_encode_stops_allocating_the_codeword_globally() {
 	});
 	let pooled_allocs = count_large_allocs(|| {
 		for _ in 0..COMMITS {
-			drop(fri::encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng, &&pool));
+			drop(fri::encode_masked(&params, 0, &ntt, message.as_view(), &mut rng, &&pool));
 		}
 	});
 

--- a/crates/iop/src/channel/naive.rs
+++ b/crates/iop/src/channel/naive.rs
@@ -198,7 +198,7 @@ where
 
 		// Verify the inner product claim directly
 		let stored_poly = &self.stored_polynomials[index];
-		let witness_poly = stored_poly.to_ref();
+		let witness_poly = stored_poly.as_view();
 		let actual_inner_product: F = witness_poly.inner_product(&transparent_poly);
 
 		assert_eq!(

--- a/crates/iop/src/ligerito/induced_basis.rs
+++ b/crates/iop/src/ligerito/induced_basis.rs
@@ -306,7 +306,7 @@ mod tests {
 					NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(code.log_len()));
 				let mut rng = StdRng::seed_from_u64(0);
 				let message = random_field_buffer::<B128>(&mut rng, log_dim);
-				let codeword = code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+				let codeword = code.encode_batch(&ntt, message.as_view(), 0, &GlobalAllocator);
 
 				// Open every position, which is the strongest version of the check.
 				let indices = (0..1 << code.log_len()).collect::<Vec<_>>();
@@ -336,7 +336,7 @@ mod tests {
 		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(code.log_len()));
 		let mut rng = StdRng::seed_from_u64(1);
 		let message = random_field_buffer::<B128>(&mut rng, log_dim);
-		let codeword = code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+		let codeword = code.encode_batch(&ntt, message.as_view(), 0, &GlobalAllocator);
 
 		// A single row batched by alpha^0 = 1 is that row untouched, so pairing it with the
 		// message must reproduce exactly that codeword position.

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -75,8 +75,8 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 				|| {
 					(
 						transcript.clone(),
-						FieldBuffer::clone_from_slice(&alloc, a_buffer.as_view()),
-						FieldBuffer::clone_from_slice(&alloc, b_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, a_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, b_buffer.as_view()),
 					)
 				},
 				|(mut transcript, a, b)| {
@@ -119,8 +119,8 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 				|| {
 					(
 						transcript.clone(),
-						FieldBuffer::clone_from_slice(&alloc, a_buffer.as_view()),
-						FieldBuffer::clone_from_slice(&alloc, b_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, a_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, b_buffer.as_view()),
 						eval_point.clone(),
 					)
 				},

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -75,8 +75,8 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 				|| {
 					(
 						transcript.clone(),
-						FieldBuffer::clone_from_slice(&alloc, a_buffer.to_ref()),
-						FieldBuffer::clone_from_slice(&alloc, b_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, a_buffer.as_view()),
+						FieldBuffer::clone_from_slice(&alloc, b_buffer.as_view()),
 					)
 				},
 				|(mut transcript, a, b)| {
@@ -119,8 +119,8 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 				|| {
 					(
 						transcript.clone(),
-						FieldBuffer::clone_from_slice(&alloc, a_buffer.to_ref()),
-						FieldBuffer::clone_from_slice(&alloc, b_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, a_buffer.as_view()),
+						FieldBuffer::clone_from_slice(&alloc, b_buffer.as_view()),
 						eval_point.clone(),
 					)
 				},

--- a/crates/ip-prover/src/fracaddcheck/circuit.rs
+++ b/crates/ip-prover/src/fracaddcheck/circuit.rs
@@ -85,8 +85,8 @@ where
 			let Fraction { num, den } = prev_layer;
 			let num_log_len = num.log_len() - 1;
 			let den_log_len = den.log_len() - 1;
-			let (num_0, num_1) = num.split_half_ref();
-			let (den_0, den_1) = den.split_half_ref();
+			let (num_0, num_1) = num.split_half();
+			let (den_0, den_1) = den.split_half();
 
 			// One packed word of the next layer from the sibling halves, written straight into
 			// the pooled buffers:

--- a/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
+++ b/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
@@ -357,8 +357,8 @@ mod tests {
 
 	/// The fractional-addition MLE-check claims on the two buffers' halves at `eval_point`.
 	fn split_half_claims(num: &FieldBuffer<P>, den: &FieldBuffer<P>, eval_point: &[F]) -> [F; 2] {
-		let (num_0, num_1) = num.split_half_ref();
-		let (den_0, den_1) = den.split_half_ref();
+		let (num_0, num_1) = num.split_half();
+		let (den_0, den_1) = den.split_half();
 		let composite = |compose: fn(F, F, F, F) -> F| {
 			let values = (0..num_0.len())
 				.map(|i| compose(num_0.get(i), num_1.get(i), den_0.get(i), den_1.get(i)))

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -219,7 +219,7 @@ where
 		let (table_prover, table_root) = FracAddCircuit::build(
 			table.log_len(),
 			alloc,
-			Fraction::new(FieldBuffer::clone_from_slice(alloc, pushforward.as_view()), table_den),
+			Fraction::new(FieldBuffer::from_view_in(alloc, pushforward.as_view()), table_den),
 		);
 		provers.push(table_prover);
 		roots.push(table_root.as_ref().map(|buffer| buffer.get(0)));

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -112,7 +112,7 @@ where
 	// It runs the reduction over the witnesses directly.
 	let pushforward_slices = pushforwards
 		.iter()
-		.map(FieldBuffer::to_ref)
+		.map(FieldBuffer::as_view)
 		.collect::<Vec<_>>();
 	prove_reduction(alloc, gamma, &tables, numerators, &pushforward_slices, channel)
 }
@@ -219,7 +219,7 @@ where
 		let (table_prover, table_root) = FracAddCircuit::build(
 			table.log_len(),
 			alloc,
-			Fraction::new(FieldBuffer::clone_from_slice(alloc, pushforward.to_ref()), table_den),
+			Fraction::new(FieldBuffer::clone_from_slice(alloc, pushforward.as_view()), table_den),
 		);
 		provers.push(table_prover);
 		roots.push(table_root.as_ref().map(|buffer| buffer.get(0)));
@@ -472,7 +472,7 @@ mod tests {
 		let prover_tables = tables
 			.iter()
 			.map(|table| TableLookup {
-				table: table.values.to_ref(),
+				table: table.values.as_view(),
 				lookers: table
 					.lookers
 					.iter()
@@ -650,7 +650,7 @@ mod tests {
 			&alloc,
 			gamma,
 			[TableLookup {
-				table: table.values.to_ref(),
+				table: table.values.as_view(),
 				lookers: vec![Looker {
 					index: &looker.index,
 					eval_point: &looker.eval_point,
@@ -693,7 +693,7 @@ mod tests {
 			gamma,
 			[
 				TableLookup {
-					table: tables[0].values.to_ref(),
+					table: tables[0].values.as_view(),
 					lookers: vec![Looker {
 						index: &tables[0].lookers[0].index,
 						eval_point: &tables[0].lookers[0].eval_point,
@@ -701,7 +701,7 @@ mod tests {
 					}],
 				},
 				TableLookup {
-					table: tables[1].values.to_ref(),
+					table: tables[1].values.as_view(),
 					lookers: vec![Looker {
 						index: &looker.index,
 						eval_point: &looker.eval_point,
@@ -751,7 +751,7 @@ mod tests {
 			&alloc,
 			gamma,
 			[TableLookup {
-				table: table.to_ref(),
+				table: table.as_view(),
 				lookers: vec![Looker {
 					index: &[0],
 					eval_point: &[],
@@ -776,7 +776,7 @@ mod tests {
 			&alloc,
 			gamma,
 			[TableLookup {
-				table: table.to_ref(),
+				table: table.as_view(),
 				lookers: Vec::new(),
 			}],
 			&mut transcript,
@@ -798,7 +798,7 @@ mod tests {
 			&alloc,
 			gamma,
 			[TableLookup {
-				table: table.to_ref(),
+				table: table.as_view(),
 				lookers: vec![Looker {
 					index: &[0, 1, 2],
 					eval_point: &eval_point,
@@ -825,7 +825,7 @@ mod tests {
 			&alloc,
 			gamma,
 			[TableLookup {
-				table: table.to_ref(),
+				table: table.as_view(),
 				lookers: vec![Looker {
 					index: &[0, 4],
 					eval_point: &eval_point,

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -144,7 +144,7 @@ where
 	for table in tables {
 		let (mine, rest) = remaining.split_at(table.lookers.len());
 		remaining = rest;
-		grouped_slices.push(mine.iter().map(FieldBuffer::to_ref).collect::<Vec<_>>());
+		grouped_slices.push(mine.iter().map(FieldBuffer::as_view).collect::<Vec<_>>());
 	}
 	let pushforwards = iter::zip(tables, &grouped_slices)
 		.map(|(table, numerators)| {
@@ -371,7 +371,7 @@ where
 	// One accumulator slot per table position, all starting empty.
 	let mut buckets = vec![F::ZERO; 1usize << table_n_vars];
 	// Add each row's numerator value into the position it indexes into.
-	scatter_add(&mut buckets, &eq_r.to_ref(), index);
+	scatter_add(&mut buckets, &eq_r.as_view(), index);
 	// Repack the scalar accumulator into the packed table buffer.
 	FieldBuffer::from_values(&buckets)
 }
@@ -464,7 +464,7 @@ mod tests {
 		let index_slices = indices.iter().map(Vec::as_slice).collect::<Vec<_>>();
 		let numerator_slices = numerators
 			.iter()
-			.map(FieldBuffer::to_ref)
+			.map(FieldBuffer::as_view)
 			.collect::<Vec<_>>();
 		let got =
 			combined_pushforward::<_, F, P>(&GlobalAllocator, &numerator_slices, &index_slices, m)

--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -83,7 +83,7 @@ where
 		for _ in 0..k {
 			let prev_layer = layers.last().expect("layers is non-empty");
 			let next_log_len = prev_layer.log_len() - 1;
-			let (half_0, half_1) = prev_layer.split_half_ref();
+			let (half_0, half_1) = prev_layer.split_half();
 
 			// Each layer is half the width of the one below it, down to a single word.
 			// The last layers are too small to be worth splitting.

--- a/crates/ip-prover/src/prodcheck/one_pad_mle.rs
+++ b/crates/ip-prover/src/prodcheck/one_pad_mle.rs
@@ -296,7 +296,7 @@ mod tests {
 
 	/// The bivariate-product MLE-check claim on a buffer's two halves at `eval_point`.
 	fn split_half_claim(buffer: &FieldBuffer<P>, eval_point: &[F]) -> F {
-		let (low, high) = buffer.split_half_ref();
+		let (low, high) = buffer.split_half();
 		let products = (0..low.len())
 			.map(|i| low.get(i) * high.get(i))
 			.collect::<Vec<_>>();

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -257,8 +257,8 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 		let mut index = id.index();
 		for column in &self.columns {
 			match column {
-				Column::Borrowed(slice) if index == 0 => return slice.to_ref(),
-				Column::Owned(buffer) if index == 0 => return buffer.to_ref(),
+				Column::Borrowed(slice) if index == 0 => return slice.as_view(),
+				Column::Owned(buffer) if index == 0 => return buffer.as_view(),
 				Column::SplitHalf(buffer) if index < 2 => {
 					// The buffer holds the two columns as its low and high halves; each column is
 					// the front `2^n_vars` scalars of one half, so read it as that half's chunk 0.
@@ -281,8 +281,8 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 		let mut slices = Vec::with_capacity(self.n_cols);
 		for column in &self.columns {
 			match column {
-				Column::Borrowed(slice) => slices.push(slice.to_ref()),
-				Column::Owned(buffer) => slices.push(buffer.to_ref()),
+				Column::Borrowed(slice) => slices.push(slice.as_view()),
+				Column::Owned(buffer) => slices.push(buffer.as_view()),
 				Column::SplitHalf(buffer) => {
 					// The buffer holds the two columns as its low and high halves; each column is
 					// the front `2^n_vars` scalars of one half, so read it as that half's
@@ -345,7 +345,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 				ColumnChunk { lo, hi }
 			})
 			.collect();
-		let eqs = self.eq_expansions().iter().map(|eq| eq.to_ref()).collect();
+		let eqs = self.eq_expansions().iter().map(|eq| eq.as_view()).collect();
 		let chunk = EvaluationChunk {
 			n_vars: self.n_vars - 1,
 			cols,
@@ -853,7 +853,7 @@ mod tests {
 		// logical columns in one step to reach the last id.
 		let borrowed = random_field_buffer::<P>(&mut rng, n_vars);
 		let mut store = MleStore::<GlobalAllocator, P>::new(n_vars, &alloc);
-		let mut col_ids = vec![store.push(borrowed.to_ref())];
+		let mut col_ids = vec![store.push(borrowed.as_view())];
 		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
 		col_ids.extend(store.push_split_half(random_field_buffer::<P>(&mut rng, n_vars + 1)));
 		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
@@ -888,7 +888,7 @@ mod tests {
 		let mut store = MleStore::<GlobalAllocator, P>::new(n_vars, &alloc);
 		let mut col_ids = borrowed
 			.iter()
-			.map(|col| store.push(col.to_ref()))
+			.map(|col| store.push(col.as_view()))
 			.collect::<Vec<_>>();
 		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
 		col_ids.extend(store.push_split_half(random_field_buffer::<P>(&mut rng, n_vars + 1)));
@@ -949,7 +949,7 @@ mod tests {
 			let mut store = MleStore::<GlobalAllocator, P>::new(n_vars, &alloc);
 			let mut col_ids = borrowed
 				.iter()
-				.map(|col| store.push(col.to_ref()))
+				.map(|col| store.push(col.as_view()))
 				.collect::<Vec<_>>();
 			col_ids.push(store.push_owned(owned.clone()));
 			col_ids.extend(store.push_split_half(split.clone()));
@@ -968,7 +968,7 @@ mod tests {
 			let eqs = store
 				.eq_expansions()
 				.iter()
-				.flat_map(|eq| scalars(&eq.to_ref()))
+				.flat_map(|eq| scalars(&eq.as_view()))
 				.collect_vec();
 			(store.n_vars(), cols, eqs)
 		};

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -341,7 +341,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 		let cols = col_slices
 			.iter()
 			.map(|col| {
-				let (lo, hi) = col.split_half_ref();
+				let (lo, hi) = col.split_half();
 				ColumnChunk { lo, hi }
 			})
 			.collect();
@@ -744,12 +744,12 @@ impl<'c, P: PackedField> EvaluationChunk<'c, P> {
 		let (cols_0, cols_1) = cols
 			.iter()
 			.map(|ColumnChunk { lo, hi }| {
-				let (lo_0, lo_1) = lo.split_half_ref();
-				let (hi_0, hi_1) = hi.split_half_ref();
+				let (lo_0, lo_1) = lo.split_half();
+				let (hi_0, hi_1) = hi.split_half();
 				(ColumnChunk { lo: lo_0, hi: hi_0 }, ColumnChunk { lo: lo_1, hi: hi_1 })
 			})
 			.unzip();
-		let (eqs_0, eqs_1) = eqs.iter().map(|col| col.split_half_ref()).unzip();
+		let (eqs_0, eqs_1) = eqs.iter().map(|col| col.split_half()).unzip();
 		[
 			EvaluationChunk {
 				n_vars: n_vars - 1,

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -121,7 +121,7 @@ where
 
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
 		self.inner
-			.accumulate(chunk, chunk.eq(self.eq_tracker).to_ref(), accum)
+			.accumulate(chunk, chunk.eq(self.eq_tracker).as_view(), accum)
 	}
 
 	fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P], claim: F) -> RoundCoeffs<F> {

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -539,7 +539,7 @@ where
 			for evaluator in evaluators {
 				let (slots, tail) = rest.split_at_mut(evaluator.degree());
 				rest = tail;
-				evaluator.accumulate(&chunk, eq_chunk.to_ref(), slots);
+				evaluator.accumulate(&chunk, eq_chunk.as_view(), slots);
 			}
 			debug_assert!(rest.is_empty(), "the runs must tile the accumulator exactly");
 			// Reduce the wide accumulators so the eq-weighted `reduce` can linearly extrapolate on
@@ -666,7 +666,7 @@ mod tests {
 		claims: [F; 2],
 	) -> SharedMleCheckProver<'a, GlobalAllocator, F, P, Box<dyn MleCheckRoundEvaluator<F, P>>> {
 		let mut store = MleStore::new(eval_point.len(), alloc);
-		let col_ids = cols.each_ref().map(|col| store.push(col.to_ref()));
+		let col_ids = cols.each_ref().map(|col| store.push(col.as_view()));
 		let (num_ev, den_ev) = frac_add_mle::evaluators(col_ids);
 		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] =
 			[(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
@@ -764,7 +764,7 @@ mod tests {
 			let alloc = GlobalAllocator;
 			let mut store = MleStore::new(m - 1, &alloc);
 			let [y_0_col, y_1_col, d_0_col, d_1_col, t_0_col, t_1_col] =
-				[&y_0, &y_1, &d_0, &d_1, &t_0, &t_1].map(|col| store.push(col.to_ref()));
+				[&y_0, &y_1, &d_0, &d_1, &t_0, &t_1].map(|col| store.push(col.as_view()));
 
 			// The eq-weighted fractional evaluators, wrapped so they emit sumcheck round
 			// polynomials. The wrappers, driven by a plain sumcheck prover, hold the shared eq

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -622,7 +622,7 @@ mod tests {
 
 	// Split a multilinear on its highest variable into owned low and high halves.
 	fn owned_halves(buffer: &FieldBuffer<P>) -> [FieldBuffer<P>; 2] {
-		let (lo, hi) = buffer.split_half_ref();
+		let (lo, hi) = buffer.split_half();
 		[
 			FieldBuffer::new(lo.log_len(), lo.as_ref().into()),
 			FieldBuffer::new(hi.log_len(), hi.as_ref().into()),

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -128,7 +128,7 @@ where
 
 		// The fold below reads both halves concurrently from many rayon tasks.
 		// Borrowed halves cross that boundary for any backing store the buffer is built on.
-		let (selected_0, selected_1) = self.selected.split_half_ref();
+		let (selected_0, selected_1) = self.selected.split_half();
 
 		let packed_prime_evals = (0..chunk_count)
 			.into_par_iter()

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -103,7 +103,7 @@ where
 				chunk_vars,
 				chunk_index,
 			);
-			scratchpad.to_ref()
+			scratchpad.as_view()
 		}
 	}
 
@@ -120,9 +120,9 @@ where
 			// Prepend the new variable via bit-reverse + append + bit-reverse. This does not need
 			// to be fast: it runs once per pre-switchover round on a small tensor (see
 			// BINIUS-327).
-			tensor.to_mut().bit_reverse();
+			tensor.as_mut_view().bit_reverse();
 			let mut tensor = Hypercube::One.expand(&[challenge]).append_to(tensor);
-			tensor.to_mut().bit_reverse();
+			tensor.as_mut_view().bit_reverse();
 			self.tensor = tensor;
 
 			if self.tensor.log_len() == self.switchover {

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -450,7 +450,7 @@ mod tests {
 		let eval_point: Vec<B128> = random_scalars(&mut rng, n_vars);
 
 		// Compute the MLE of the mask polynomial at eval_point
-		let mask = Mask::new(n_vars, degree, buffer.to_ref());
+		let mask = Mask::new(n_vars, degree, buffer.as_view());
 		let eval_claim = mask.evaluate_mle(&eval_point);
 
 		// Create the prover (takes ownership of a borrowed mask view)
@@ -487,7 +487,7 @@ mod tests {
 		challenge_point.reverse();
 
 		// Check that the final evaluation matches direct computation
-		let mask = Mask::new(n_vars, degree, buffer.to_ref());
+		let mask = Mask::new(n_vars, degree, buffer.as_view());
 		let expected_eval = evaluate_mask_polynomial(&mask, &challenge_point);
 		assert_eq!(output.multilinear_evals[0], expected_eval);
 	}
@@ -516,7 +516,7 @@ mod tests {
 		let buffer = random_field_buffer::<B128>(&mut rng, m_n + m_d);
 
 		let eval_point: Vec<B128> = random_scalars(&mut rng, 1);
-		let mask = Mask::new(1, 2, buffer.to_ref());
+		let mask = Mask::new(1, 2, buffer.as_view());
 		let eval_claim = mask.evaluate_mle(&eval_point);
 
 		let prover = MleCheckMaskProver::new(mask, eval_point.clone(), eval_claim);
@@ -535,7 +535,7 @@ mod tests {
 		let mut challenge_point = sumcheck_output.challenges;
 		challenge_point.reverse();
 
-		let mask = Mask::new(1, 2, buffer.to_ref());
+		let mask = Mask::new(1, 2, buffer.as_view());
 		let expected_eval = evaluate_mask_polynomial(&mask, &challenge_point);
 		assert_eq!(output.multilinear_evals[0], expected_eval);
 	}
@@ -559,14 +559,14 @@ mod tests {
 		let eval_point: Vec<B128> = random_scalars(&mut rng, n_vars);
 
 		// Compute the MLE of the main polynomial at eval_point
-		let main_mask = Mask::new(n_vars, main_degree, main_buffer.to_ref());
+		let main_mask = Mask::new(n_vars, main_degree, main_buffer.as_view());
 		let main_eval_claim = main_mask.evaluate_mle(&eval_point);
 
 		// Create the main prover (using MleCheckMaskProver as a simple MleCheckProver)
 		let main_prover = MleCheckMaskProver::new(main_mask, eval_point.clone(), main_eval_claim);
 
 		// Run the ZK proving protocol
-		let zk_mask = Mask::new(n_vars, mask_degree, zk_buffer.to_ref());
+		let zk_mask = Mask::new(n_vars, mask_degree, zk_buffer.as_view());
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let output = prove(main_prover, zk_mask, &mut prover_transcript);
 
@@ -600,12 +600,12 @@ mod tests {
 		challenge_point.reverse();
 
 		// Check that the final main evaluation matches direct computation
-		let main_mask = Mask::new(n_vars, main_degree, main_buffer.to_ref());
+		let main_mask = Mask::new(n_vars, main_degree, main_buffer.as_view());
 		let expected_main_eval = evaluate_mask_polynomial(&main_mask, &challenge_point);
 		assert_eq!(output.multilinear_evals[0], expected_main_eval);
 
 		// Check that the mask evaluation matches the zk_mask evaluation at the challenge point
-		let zk_mask = Mask::new(n_vars, mask_degree, zk_buffer.to_ref());
+		let zk_mask = Mask::new(n_vars, mask_degree, zk_buffer.as_view());
 		let expected_mask_eval = evaluate_mask_polynomial(&zk_mask, &challenge_point);
 		assert_eq!(mask_eval, expected_mask_eval);
 	}
@@ -627,7 +627,7 @@ mod tests {
 		let challenge_point: Vec<B128> = random_scalars(&mut rng, n_vars);
 
 		// Compute g(r) using direct computation.evaluate()
-		let mask = Mask::new(n_vars, degree, mask_buffer.to_ref());
+		let mask = Mask::new(n_vars, degree, mask_buffer.as_view());
 		let direct_eval: B128 = (0..n_vars)
 			.map(|i| mask.evaluate_univariate(i, challenge_point[i]))
 			.sum();

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -132,7 +132,7 @@ impl IOPProver {
 		};
 		let trace_oracle = {
 			let _scope = tracing::debug_span!("Commit trace").entered();
-			channel.send_oracle(trace_packed.to_ref())
+			channel.send_oracle(trace_packed.as_view())
 		};
 
 		// One base domain shared by the AND-check and the shift, consistent by construction.
@@ -352,7 +352,7 @@ impl IOPProver {
 			// The point is `r_j || r_rho || r_y`.
 			// Its instance coordinates fold the trace at `r_rho`.
 			let trace_point = [r_j, r_rho.as_slice(), r_y].concat();
-			ring_switch::prove(alloc, trace_packed.to_ref(), &trace_point, channel)
+			ring_switch::prove(alloc, trace_packed.as_view(), &trace_point, channel)
 		};
 
 		// Queue the trace opening against the ring-switch's transparent multilinear.

--- a/crates/math/benches/bit_reverse.rs
+++ b/crates/math/benches/bit_reverse.rs
@@ -22,7 +22,7 @@ fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
 
 		group.bench_function(BenchmarkId::new("bit_reverse", &parameter), |b| {
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| data.to_mut().bit_reverse())
+			b.iter(|| data.as_mut_view().bit_reverse())
 		});
 	}
 

--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -65,7 +65,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 			};
 
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late))
+			b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late))
 		});
 	}
 
@@ -74,7 +74,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 		let ntt = NeighborsLastBreadthFirst { domain_context };
 
 		let mut data = random_field_buffer::<P>(&mut rng, log_d);
-		b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late))
+		b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late))
 	});
 
 	for log_num_shares in [0, 3] {
@@ -97,7 +97,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 					.build()
 					.unwrap();
 				thread_pool.install(|| {
-					b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late))
+					b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late))
 				})
 			});
 		}

--- a/crates/math/benches/reed_solomon.rs
+++ b/crates/math/benches/reed_solomon.rs
@@ -46,7 +46,7 @@ fn bench_encode_by_rate(c: &mut Criterion) {
 					format!("log_dim={log_dim}"),
 					format!("log_inv_rate={log_inv_rate}"),
 				),
-				|b| b.iter(|| rs_code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator)),
+				|b| b.iter(|| rs_code.encode_batch(&ntt, message.as_view(), 0, &GlobalAllocator)),
 			);
 		}
 	}

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -52,7 +52,7 @@ impl<P: PackedField> FieldSliceMut<'_, P> {
 		// A buffer shorter than a square of packed elements leaves the two passes below no room.
 		let log_len = self.log_len();
 		if log_len < 2 * P::LOG_WIDTH {
-			return bit_reverse_packed_naive(self.to_mut());
+			return bit_reverse_packed_naive(self.as_mut_view());
 		}
 
 		// Scalars covering one cache line, which is the granularity a permutation is charged at.
@@ -79,11 +79,11 @@ impl<P: PackedField> FieldSliceMut<'_, P> {
 		// A run-time bound lowers the moves of a one-element tile to a call.
 		// That call is most of the work at that width.
 		match log_tile - P::LOG_WIDTH {
-			0 => bit_reverse_tiled::<P, 0>(self.to_mut()),
-			1 => bit_reverse_tiled::<P, 1>(self.to_mut()),
-			2 => bit_reverse_tiled::<P, 2>(self.to_mut()),
+			0 => bit_reverse_tiled::<P, 0>(self.as_mut_view()),
+			1 => bit_reverse_tiled::<P, 1>(self.as_mut_view()),
+			2 => bit_reverse_tiled::<P, 2>(self.as_mut_view()),
 			// The clamp caps the tile at the widest instance, which answers every larger value.
-			_ => bit_reverse_tiled::<P, MAX_LOG_TILE_PACKED>(self.to_mut()),
+			_ => bit_reverse_tiled::<P, MAX_LOG_TILE_PACKED>(self.as_mut_view()),
 		}
 	}
 }
@@ -384,8 +384,8 @@ mod tests {
 		let mut naive = data_orig;
 
 		// Invariant: moving whole tiles lands every element where the definition puts it.
-		blocked.to_mut().bit_reverse();
-		bit_reverse_packed_naive(naive.to_mut());
+		blocked.as_mut_view().bit_reverse();
+		bit_reverse_packed_naive(naive.as_mut_view());
 
 		assert_eq!(blocked, naive, "mismatch at log_d={log_d}");
 	}
@@ -432,8 +432,8 @@ mod tests {
 			// Invariant: reversing the bits of an index twice is the identity.
 			// So a buffer permuted twice has to come back exactly as it went in.
 			let mut twice = orig.clone();
-			twice.to_mut().bit_reverse();
-			twice.to_mut().bit_reverse();
+			twice.as_mut_view().bit_reverse();
+			twice.as_mut_view().bit_reverse();
 
 			prop_assert_eq!(twice, orig);
 		}

--- a/crates/math/src/field_buffer/chunks.rs
+++ b/crates/math/src/field_buffer/chunks.rs
@@ -143,7 +143,7 @@ impl<'a, P: PackedField> Iterator for Chunks<'a, P> {
 
 	#[inline]
 	fn next(&mut self) -> Option<Self::Item> {
-		let values = match &mut self.source {
+		let words = match &mut self.source {
 			ChunkSource::Words(runs) => FieldSliceData::Slice(runs.next()?),
 			ChunkSource::Lanes { words, indices } => FieldSliceData::Single(
 				SubWordChunk::<P>::new(self.log_chunk_size, indices.next()?).repack(words),
@@ -151,7 +151,7 @@ impl<'a, P: PackedField> Iterator for Chunks<'a, P> {
 		};
 		Some(FieldBuffer {
 			log_len: self.log_chunk_size,
-			values,
+			words,
 		})
 	}
 
@@ -205,7 +205,7 @@ impl<'a, P: PackedField> Iterator for ChunksMut<'a, P> {
 	fn next(&mut self) -> Option<Self::Item> {
 		self.runs.next().map(|run| FieldBuffer {
 			log_len: self.log_chunk_size,
-			values: run,
+			words: run,
 		})
 	}
 

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -296,7 +296,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	}
 
 	/// Borrows the whole buffer as a shared view.
-	pub fn to_ref(&self) -> FieldSlice<'_, P> {
+	pub fn as_view(&self) -> FieldSlice<'_, P> {
 		FieldSlice::from_slice(self.log_len, self.as_ref())
 	}
 
@@ -546,7 +546,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 
 impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// Borrows the whole buffer as a mutable view.
-	pub fn to_mut(&mut self) -> FieldSliceMut<'_, P> {
+	pub fn as_mut_view(&mut self) -> FieldSliceMut<'_, P> {
 		FieldSliceMut::from_slice(self.log_len, self.as_mut())
 	}
 
@@ -645,7 +645,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// * `self.log_len()` must be greater than 0.
 	#[track_caller]
 	pub fn split_half_mut(&mut self) -> FieldBufferSplitMut<P, &'_ mut [P]> {
-		self.to_mut().split_half()
+		self.as_mut_view().split_half()
 	}
 }
 
@@ -754,15 +754,15 @@ mod tests {
 		let src = FieldBuffer::<P>::from_values(&scalars);
 
 		// A copy drawn from the allocator carries over both the length and the scalars.
-		let cloned: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.to_ref());
+		let cloned: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.as_view());
 		assert_eq!(cloned.log_len(), 4);
-		assert_eq!(cloned.to_ref(), src.to_ref());
+		assert_eq!(cloned.as_view(), src.as_view());
 
 		// Copying a source shorter than one packed word keeps the two live lanes, not four.
 		let small = FieldBuffer::<P>::from_values(&scalars[..2]);
-		let cloned_small: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.to_ref());
+		let cloned_small: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.as_view());
 		assert_eq!(cloned_small.log_len(), 1);
-		assert_eq!(cloned_small.to_ref(), small.to_ref());
+		assert_eq!(cloned_small.as_view(), small.as_view());
 
 		// 32 elements requested, 32 zeros readable: the buffer arrives at full length, not empty.
 		let mut zeros: FieldVec<P, A> = FieldBuffer::zeros_in(alloc, 5);
@@ -785,7 +785,7 @@ mod tests {
 		//
 		// Under a pool the target may sit on memory a prior buffer dirtied.
 		// So the zeros above the copied words have to be written, never assumed.
-		let src_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.to_ref());
+		let src_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.as_view());
 		let extended = src_vec.zero_extend_in(alloc, 5);
 		assert_eq!(extended.log_len(), 5);
 		for i in 0..16 {
@@ -794,10 +794,10 @@ mod tests {
 		assert!((16..32).all(|i| extended.get(i) == F::ZERO));
 
 		// An already-wide-enough buffer comes back unchanged, with no copy taken.
-		let same: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.to_ref());
+		let same: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.as_view());
 		let same = same.zero_extend_in(alloc, 4);
 		assert_eq!(same.log_len(), 4);
-		assert_eq!(same.to_ref(), src.to_ref());
+		assert_eq!(same.as_view(), src.as_view());
 
 		// A source narrower than one packed word pads out of that word's dead lanes.
 		//
@@ -805,7 +805,7 @@ mod tests {
 		//     result (log_len 3)    [0, 1 | 0, 0] [0, 0 | 0, 0]
 		//
 		// The two dead lanes become live, so they read back as zeros, not stale scalars.
-		let small_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.to_ref());
+		let small_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.as_view());
 		let widened = small_vec.zero_extend_in(alloc, 3);
 		assert_eq!(widened.log_len(), 3);
 		assert_eq!(widened.get(0), F::new(0));
@@ -974,17 +974,17 @@ mod tests {
 	}
 
 	#[test]
-	fn to_ref_to_mut() {
+	fn borrowed_views() {
 		let mut buffer = FieldBuffer::<P>::zeros(3);
 
-		// Test to_ref
-		let slice_ref = buffer.to_ref();
+		// Test the shared view
+		let slice_ref = buffer.as_view();
 		assert_eq!(slice_ref.len(), buffer.len());
 		assert_eq!(slice_ref.log_len(), buffer.log_len());
 		assert_eq!(slice_ref.as_ref().len(), 1 << slice_ref.log_len().saturating_sub(P::LOG_WIDTH));
 
-		// Test to_mut
-		let mut slice_mut = buffer.to_mut();
+		// Test the mutable view
+		let mut slice_mut = buffer.as_mut_view();
 		slice_mut.set(0, F::new(123));
 		assert_eq!(slice_mut.as_mut().len(), 1 << slice_mut.log_len().saturating_sub(P::LOG_WIDTH));
 		assert_eq!(buffer.get(0), F::new(123));

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -398,7 +398,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `log_chunk_size` must be at most `log_len`.
 	#[track_caller]
-	pub fn chunks_par(
+	pub fn par_chunks(
 		&self,
 		log_chunk_size: usize,
 	) -> impl IndexedParallelIterator<Item = FieldSlice<'_, P>> {
@@ -1263,12 +1263,12 @@ mod tests {
 	}
 
 	#[test]
-	fn chunks_par() {
+	fn par_chunks() {
 		let values: Vec<F> = (0..16).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
 
 		// Split into 4 chunks of size 4
-		let chunks: Vec<_> = buffer.chunks_par(2).collect();
+		let chunks: Vec<_> = buffer.par_chunks(2).collect();
 		assert_eq!(chunks.len(), 4);
 
 		for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
@@ -1280,9 +1280,9 @@ mod tests {
 		}
 
 		// Test small chunk sizes (below P::LOG_WIDTH)
-		// P::LOG_WIDTH = 2, so chunks_par(0) and chunks_par(1) should work
+		// P::LOG_WIDTH = 2, so par_chunks(0) and par_chunks(1) should work
 		// Split into 8 chunks of size 2 (log_chunk_size = 1)
-		let chunks: Vec<_> = buffer.chunks_par(1).collect();
+		let chunks: Vec<_> = buffer.par_chunks(1).collect();
 		assert_eq!(chunks.len(), 8);
 		for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
 			assert_eq!(chunk.len(), 2);
@@ -1293,7 +1293,7 @@ mod tests {
 		}
 
 		// Split into 16 chunks of size 1 (log_chunk_size = 0)
-		let chunks: Vec<_> = buffer.chunks_par(0).collect();
+		let chunks: Vec<_> = buffer.par_chunks(0).collect();
 		assert_eq!(chunks.len(), 16);
 		for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
 			assert_eq!(chunk.len(), 1);
@@ -1320,10 +1320,10 @@ mod tests {
 
 	#[test]
 	#[should_panic(expected = "precondition")]
-	fn chunks_par_invalid_size() {
+	fn par_chunks_invalid_size() {
 		let values: Vec<F> = (0..16).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
-		let _ = buffer.chunks_par(5).collect::<Vec<_>>();
+		let _ = buffer.par_chunks(5).collect::<Vec<_>>();
 	}
 
 	#[test]
@@ -1596,7 +1596,7 @@ mod tests {
 				.map(|chunk| chunk.iter_scalars().collect())
 				.collect();
 			let parallel: Vec<Vec<F>> = buffer
-				.chunks_par(log_chunk_size)
+				.par_chunks(log_chunk_size)
 				.map(|chunk| chunk.iter_scalars().collect())
 				.collect();
 

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -54,7 +54,7 @@ use chunks::SubWordChunk;
 pub use chunks::{Chunks, ChunksMut};
 pub use scalars::Scalars;
 pub use view::{FieldSlice, FieldSliceData, FieldSliceMut, FieldVec};
-pub use write_back::FieldBufferSplitMut;
+pub use write_back::SplitMut;
 
 /// A power-of-two-sized buffer containing field elements, stored in packed fields.
 ///
@@ -616,7 +616,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `self.log_len()` must be greater than 0.
 	#[track_caller]
-	pub fn split_half(self) -> FieldBufferSplitMut<P, Data> {
+	pub fn split_half(self) -> SplitMut<P, Data> {
 		assert!(self.log_len > 0, "precondition: cannot split a buffer of length 1");
 
 		let new_log_len = self.log_len - 1;
@@ -629,7 +629,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 			None
 		};
 
-		FieldBufferSplitMut {
+		SplitMut {
 			log_len: new_log_len,
 			singles,
 			data: self.values,
@@ -644,7 +644,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `self.log_len()` must be greater than 0.
 	#[track_caller]
-	pub fn split_half_mut(&mut self) -> FieldBufferSplitMut<P, &'_ mut [P]> {
+	pub fn split_half_mut(&mut self) -> SplitMut<P, &'_ mut [P]> {
 		self.as_mut_view().split_half()
 	}
 }

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -281,7 +281,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	}
 
 	/// Consumes the buffer and returns its backing data store.
-	pub fn take_data(self) -> Data {
+	pub fn into_inner(self) -> Data {
 		self.values
 	}
 
@@ -1060,7 +1060,7 @@ mod tests {
 		assert_eq!(buffer.get(0), F::new(9));
 
 		// The one word packed keeps zeros in the 3 lanes past the element.
-		let data = buffer.take_data();
+		let data = buffer.into_inner();
 		assert_eq!(data.len(), 1);
 		assert!((1..P::WIDTH).all(|lane| get_packed_slice(&data[..], lane) == F::ZERO));
 	}
@@ -1133,7 +1133,7 @@ mod tests {
 		for i in 0..8 {
 			assert_eq!(buffer.get(i), F::new(i as u128));
 		}
-		assert_eq!(buffer.take_data().len(), 2);
+		assert_eq!(buffer.into_inner().len(), 2);
 
 		// Sub-packing-width result: one word retained, live prefix kept, dead lanes zeroed.
 		let mut buffer = make();
@@ -1141,7 +1141,7 @@ mod tests {
 		assert_eq!(buffer.len(), 2);
 		assert_eq!(buffer.get(0), F::new(0));
 		assert_eq!(buffer.get(1), F::new(1));
-		let data = buffer.take_data();
+		let data = buffer.into_inner();
 		assert_eq!(data.len(), 1);
 		assert_eq!(get_packed_slice(&data[..], 2), F::new(0));
 		assert_eq!(get_packed_slice(&data[..], 3), F::new(0));
@@ -1150,7 +1150,7 @@ mod tests {
 		let mut buffer = FieldBuffer::<P>::from_values(&(0..4).map(F::new).collect::<Vec<_>>());
 		buffer.truncate(5);
 		assert_eq!(buffer.log_len(), 2);
-		assert_eq!(buffer.take_data().len(), 1);
+		assert_eq!(buffer.into_inner().len(), 1);
 	}
 
 	#[test]
@@ -1167,7 +1167,7 @@ mod tests {
 		assert_eq!(buffer.get(0), F::new(0));
 		assert_eq!(buffer.get(1), F::new(1));
 
-		let data = buffer.take_data();
+		let data = buffer.into_inner();
 		assert_eq!(data.len(), 1);
 		assert_eq!(get_packed_slice(&data[..], 2), F::new(0));
 		assert_eq!(get_packed_slice(&data[..], 3), F::new(0));

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -502,7 +502,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `self.log_len()` must be greater than 0.
 	#[track_caller]
-	pub fn split_half_ref(&self) -> (FieldSlice<'_, P>, FieldSlice<'_, P>) {
+	pub fn split_half(&self) -> (FieldSlice<'_, P>, FieldSlice<'_, P>) {
 		assert!(self.log_len > 0, "precondition: cannot split a buffer of length 1");
 
 		let new_log_len = self.log_len - 1;
@@ -616,7 +616,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `self.log_len()` must be greater than 0.
 	#[track_caller]
-	pub fn split_half(self) -> SplitMut<P, Data> {
+	pub fn into_split_half(self) -> SplitMut<P, Data> {
 		assert!(self.log_len > 0, "precondition: cannot split a buffer of length 1");
 
 		let new_log_len = self.log_len - 1;
@@ -645,7 +645,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// * `self.log_len()` must be greater than 0.
 	#[track_caller]
 	pub fn split_half_mut(&mut self) -> SplitMut<P, &'_ mut [P]> {
-		self.as_mut_view().split_half()
+		self.as_mut_view().into_split_half()
 	}
 }
 
@@ -1362,7 +1362,7 @@ mod tests {
 		let values: Vec<F> = (0..16).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
 
-		let (first, second) = buffer.split_half_ref();
+		let (first, second) = buffer.split_half();
 		assert_eq!(first.len(), 8);
 		assert_eq!(second.len(), 8);
 
@@ -1377,7 +1377,7 @@ mod tests {
 		let values: Vec<F> = (0..4).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
 
-		let (first, second) = buffer.split_half_ref();
+		let (first, second) = buffer.split_half();
 		assert_eq!(first.len(), 2);
 		assert_eq!(second.len(), 2);
 
@@ -1401,7 +1401,7 @@ mod tests {
 		let values: Vec<F> = vec![F::new(10), F::new(20)];
 		let buffer = FieldBuffer::<P>::from_values(&values);
 
-		let (first, second) = buffer.split_half_ref();
+		let (first, second) = buffer.split_half();
 		assert_eq!(first.len(), 1);
 		assert_eq!(second.len(), 1);
 
@@ -1421,10 +1421,10 @@ mod tests {
 
 	#[test]
 	#[should_panic(expected = "precondition")]
-	fn split_half_ref_size_one() {
+	fn split_half_size_one() {
 		let values = vec![F::new(42)];
 		let buffer = FieldBuffer::<P>::from_values(&values);
-		let _ = buffer.split_half_ref();
+		let _ = buffer.split_half();
 	}
 
 	#[test]

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -61,7 +61,7 @@ pub use write_back::SplitMut;
 /// The backing store length is fully determined by `log_len`:
 ///
 /// ```text
-/// values.len() == 1 << log_len.saturating_sub(P::LOG_WIDTH)
+/// words.len() == 1 << log_len.saturating_sub(P::LOG_WIDTH)
 /// ```
 ///
 /// A buffer shorter than one packed word still occupies a whole word.
@@ -83,8 +83,8 @@ pub use write_back::SplitMut;
 pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Vec<P>> {
 	/// log2 the number over elements in the buffer.
 	log_len: usize,
-	/// The packed values.
-	values: Data,
+	/// The packed words.
+	words: Data,
 }
 
 impl<P: PackedField, Data: Deref<Target = [P]> + Copy> Copy for FieldBuffer<P, Data> {}
@@ -103,13 +103,13 @@ impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Dat
 		}
 		if self.log_len < P::LOG_WIDTH {
 			let iter_1 = self
-				.values
+				.words
 				.first()
 				.expect("len >= 1")
 				.iter()
 				.take(1 << self.log_len);
 			let iter_2 = other
-				.values
+				.words
 				.first()
 				.expect("len >= 1")
 				.iter()
@@ -117,7 +117,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Dat
 			iter_1.eq(iter_2)
 		} else {
 			let prefix = 1 << (self.log_len - P::LOG_WIDTH);
-			self.values[..prefix] == other.values[..prefix]
+			self.words[..prefix] == other.words[..prefix]
 		}
 	}
 }
@@ -134,24 +134,21 @@ impl<P: PackedField> FieldBuffer<P> {
 			strict_log_2(values.len()).expect("precondition: values.len() must be a power of two");
 
 		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		let mut packed_values = Vec::with_capacity(packed_len);
-		packed_values.extend(
+		let mut words = Vec::with_capacity(packed_len);
+		words.extend(
 			values
 				.chunks(P::WIDTH)
 				.map(|chunk| P::from_scalars(chunk.iter().copied())),
 		);
 
-		Self {
-			log_len,
-			values: packed_values,
-		}
+		Self { log_len, words }
 	}
 
 	/// Builds a buffer of `2^log_len` zeros.
 	pub fn zeros(log_len: usize) -> Self {
 		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		let values = zeroed_vec(packed_len);
-		Self { log_len, values }
+		let words = zeroed_vec(packed_len);
+		Self { log_len, words }
 	}
 
 	/// Builds a one-element buffer holding `value`, with room reserved to grow.
@@ -159,9 +156,9 @@ impl<P: PackedField> FieldBuffer<P> {
 	/// The store is sized for `2^log_capacity` elements up front.
 	/// Growing the buffer to that many therefore never reallocates.
 	pub fn scalar_with_capacity(value: P::Scalar, log_capacity: usize) -> Self {
-		let mut values = Vec::with_capacity(1 << log_capacity.saturating_sub(P::LOG_WIDTH));
-		values.push(P::from_scalars([value]));
-		Self { log_len: 0, values }
+		let mut words = Vec::with_capacity(1 << log_capacity.saturating_sub(P::LOG_WIDTH));
+		words.push(P::from_scalars([value]));
+		Self { log_len: 0, words }
 	}
 }
 
@@ -176,9 +173,9 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	{
 		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 		// An allocator hands out an empty buffer, so the words are both created and zeroed here.
-		let mut values = alloc.alloc::<P>(packed_len);
-		values.resize(packed_len, P::default());
-		FieldBuffer::new(log_len, values)
+		let mut words = alloc.alloc::<P>(packed_len);
+		words.resize(packed_len, P::default());
+		FieldBuffer::new(log_len, words)
 	}
 
 	/// Copies a borrowed buffer into memory drawn from `alloc`.
@@ -188,9 +185,9 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	where
 		A: Allocator<Vec<P> = Data>,
 	{
-		let mut values = alloc.alloc::<P>(src.as_ref().len());
-		values.extend_from_slice(src.as_ref());
-		FieldBuffer::new(src.log_len(), values)
+		let mut words = alloc.alloc::<P>(src.as_ref().len());
+		words.extend_from_slice(src.as_ref());
+		FieldBuffer::new(src.log_len(), words)
 	}
 
 	/// Builds a buffer from scalar values, directly into memory drawn from `alloc`.
@@ -211,14 +208,14 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 			strict_log_2(values.len()).expect("precondition: values.len() must be a power of two");
 
 		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		let mut packed_values = alloc.alloc::<P>(packed_len);
-		packed_values.extend(
+		let mut words = alloc.alloc::<P>(packed_len);
+		words.extend(
 			values
 				.chunks(P::WIDTH)
 				.map(|chunk| P::from_scalars(chunk.iter().copied())),
 		);
 
-		FieldBuffer::new(log_len, packed_values)
+		FieldBuffer::new(log_len, words)
 	}
 
 	/// Grows the buffer to span `log_len` variables, padding the new positions with zeros.
@@ -264,25 +261,25 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 
 #[allow(clippy::len_without_is_empty)]
 impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
-	/// Create a new FieldBuffer from a slice of packed values.
+	/// Create a new FieldBuffer from a slice of packed words.
 	///
 	/// # Preconditions
 	///
-	/// * `values.len()` must equal the expected packed length for `log_len`.
+	/// * `words.len()` must equal the expected packed length for `log_len`.
 	#[track_caller]
-	pub fn new(log_len: usize, values: Data) -> Self {
+	pub fn new(log_len: usize, words: Data) -> Self {
 		let expected_packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 		assert!(
-			values.len() == expected_packed_len,
-			"precondition: values.len() must equal expected packed length"
+			words.len() == expected_packed_len,
+			"precondition: words.len() must equal expected packed length"
 		);
 
-		Self { log_len, values }
+		Self { log_len, words }
 	}
 
 	/// Consumes the buffer and returns its backing data store.
 	pub fn into_inner(self) -> Data {
-		self.values
+		self.words
 	}
 
 	/// Returns log2 the number of field elements.
@@ -315,7 +312,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 
 		// Safety: bound check on index performed above. The buffer length is at least
 		// `self.len() >> P::LOG_WIDTH` by struct invariant.
-		unsafe { get_packed_slice_unchecked(&self.values, index) }
+		unsafe { get_packed_slice_unchecked(&self.words, index) }
 	}
 
 	/// Returns an iterator over the scalar elements in the buffer.
@@ -355,20 +352,20 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 			"precondition: chunk_index must be less than chunk_count"
 		);
 
-		let values = if log_chunk_size >= P::LOG_WIDTH {
+		let words = if log_chunk_size >= P::LOG_WIDTH {
 			// A whole run of words, borrowed straight from the store.
 			let words_per_chunk = 1 << (log_chunk_size - P::LOG_WIDTH);
-			FieldSliceData::Slice(&self.values[chunk_index * words_per_chunk..][..words_per_chunk])
+			FieldSliceData::Slice(&self.words[chunk_index * words_per_chunk..][..words_per_chunk])
 		} else {
 			// Lanes inside one word, copied out so the chunk starts at lane 0.
 			FieldSliceData::Single(
-				SubWordChunk::new(log_chunk_size, chunk_index).repack(&self.values),
+				SubWordChunk::new(log_chunk_size, chunk_index).repack(&self.words),
 			)
 		};
 
 		FieldBuffer {
 			log_len: log_chunk_size,
-			values,
+			words,
 		}
 	}
 
@@ -415,7 +412,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 					.par_chunks(packed_chunk_size)
 					.map(move |chunk| FieldBuffer {
 						log_len: log_chunk_size,
-						values: FieldSliceData::Slice(chunk),
+						words: FieldSliceData::Slice(chunk),
 					}),
 			)
 		} else {
@@ -427,7 +424,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 					.into_par_iter()
 					.map(move |chunk_index| FieldBuffer {
 						log_len: log_chunk_size,
-						values: FieldSliceData::Single(
+						words: FieldSliceData::Single(
 							SubWordChunk::new(log_chunk_size, chunk_index).repack(words),
 						),
 					}),
@@ -509,34 +506,34 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 		if new_log_len < P::LOG_WIDTH {
 			// The result will be two Single variants
 			// We have exactly one packed element that needs to be split
-			let packed = self.values[0];
+			let packed = self.words[0];
 			let zeros = P::default();
 
 			let (first_half, second_half) = packed.interleave(zeros, new_log_len);
 
 			let first = FieldBuffer {
 				log_len: new_log_len,
-				values: FieldSliceData::Single(first_half),
+				words: FieldSliceData::Single(first_half),
 			};
 			let second = FieldBuffer {
 				log_len: new_log_len,
-				values: FieldSliceData::Single(second_half),
+				words: FieldSliceData::Single(second_half),
 			};
 
 			(first, second)
 		} else {
-			// Split the packed values slice in half
+			// Split the packed word slice in half
 			let half_len = 1 << (new_log_len - P::LOG_WIDTH);
-			let (first_half, second_half) = self.values.split_at(half_len);
+			let (first_half, second_half) = self.words.split_at(half_len);
 			let second_half = &second_half[..half_len];
 
 			let first = FieldBuffer {
 				log_len: new_log_len,
-				values: FieldSliceData::Slice(first_half),
+				words: FieldSliceData::Slice(first_half),
 			};
 			let second = FieldBuffer {
 				log_len: new_log_len,
-				values: FieldSliceData::Slice(second_half),
+				words: FieldSliceData::Slice(second_half),
 			};
 
 			(first, second)
@@ -565,7 +562,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 
 		// Safety: bound check on index performed above. The buffer length is at least
 		// `self.len() >> P::LOG_WIDTH` by struct invariant.
-		unsafe { set_packed_slice_unchecked(&mut self.values, index, value) };
+		unsafe { set_packed_slice_unchecked(&mut self.words, index, value) };
 	}
 
 	/// Returns a mutable iterator over the packed words the elements occupy.
@@ -621,7 +618,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 
 		let new_log_len = self.log_len - 1;
 		let singles = if new_log_len < P::LOG_WIDTH {
-			let packed = self.values[0];
+			let packed = self.words[0];
 			let zeros = P::default();
 			let (lo_half, hi_half) = packed.interleave(zeros, new_log_len);
 			Some([lo_half, hi_half])
@@ -632,7 +629,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 		SplitMut {
 			log_len: new_log_len,
 			singles,
-			data: self.values,
+			data: self.words,
 		}
 	}
 
@@ -666,11 +663,11 @@ impl<P: PackedField, Data: BufferData<P>> FieldBuffer<P, Data> {
 		// result carries no stale scalars. Wider results drop whole words and need no masking.
 		if new_log_len < P::LOG_WIDTH {
 			for i in 1 << new_log_len..P::WIDTH {
-				self.values[0].set(i, <P::Scalar as Field>::ZERO);
+				self.words[0].set(i, <P::Scalar as Field>::ZERO);
 			}
 		}
 
-		self.values
+		self.words
 			.truncate(1 << new_log_len.saturating_sub(P::LOG_WIDTH));
 	}
 }
@@ -678,14 +675,14 @@ impl<P: PackedField, Data: BufferData<P>> FieldBuffer<P, Data> {
 impl<P: PackedField, Data: Deref<Target = [P]>> AsRef<[P]> for FieldBuffer<P, Data> {
 	#[inline]
 	fn as_ref(&self) -> &[P] {
-		&self.values[..1 << self.log_len.saturating_sub(P::LOG_WIDTH)]
+		&self.words[..1 << self.log_len.saturating_sub(P::LOG_WIDTH)]
 	}
 }
 
 impl<P: PackedField, Data: DerefMut<Target = [P]>> AsMut<[P]> for FieldBuffer<P, Data> {
 	#[inline]
 	fn as_mut(&mut self) -> &mut [P] {
-		&mut self.values[..1 << self.log_len.saturating_sub(P::LOG_WIDTH)]
+		&mut self.words[..1 << self.log_len.saturating_sub(P::LOG_WIDTH)]
 	}
 }
 
@@ -701,7 +698,7 @@ impl<P: PackedField> FromIterator<P::Scalar> for FieldBuffer<P> {
 	fn from_iter<I: IntoIterator<Item = P::Scalar>>(iter: I) -> Self {
 		let iter = iter.into_iter();
 		// The lower bound is the whole count whenever the iterator knows its own length.
-		let mut values = Vec::with_capacity(iter.size_hint().0 >> P::LOG_WIDTH);
+		let mut words = Vec::with_capacity(iter.size_hint().0 >> P::LOG_WIDTH);
 
 		let mut word = P::default();
 		let mut len = 0usize;
@@ -712,7 +709,7 @@ impl<P: PackedField> FromIterator<P::Scalar> for FieldBuffer<P> {
 
 			// A word fills up at its last lane, and a zeroed one takes over from there.
 			if lane == P::WIDTH - 1 {
-				values.push(word);
+				words.push(word);
 				word = P::default();
 			}
 		}
@@ -723,10 +720,10 @@ impl<P: PackedField> FromIterator<P::Scalar> for FieldBuffer<P> {
 		// A count below the packing width never reaches a last lane.
 		// So the one word it filled is still in hand, its lanes past the count still zero.
 		if log_len < P::LOG_WIDTH {
-			values.push(word);
+			words.push(word);
 		}
 
-		Self { log_len, values }
+		Self { log_len, words }
 	}
 }
 
@@ -1382,11 +1379,11 @@ mod tests {
 		assert_eq!(second.len(), 2);
 
 		// Verify we got Single variants
-		match &first.values {
+		match &first.words {
 			FieldSliceData::Single(_) => {}
 			_ => panic!("Expected Single variant for first half"),
 		}
-		match &second.values {
+		match &second.words {
 			FieldSliceData::Single(_) => {}
 			_ => panic!("Expected Single variant for second half"),
 		}
@@ -1406,11 +1403,11 @@ mod tests {
 		assert_eq!(second.len(), 1);
 
 		// Verify we got Single variants
-		match &first.values {
+		match &first.words {
 			FieldSliceData::Single(_) => {}
 			_ => panic!("Expected Single variant for first half"),
 		}
-		match &second.values {
+		match &second.words {
 			FieldSliceData::Single(_) => {}
 			_ => panic!("Expected Single variant for second half"),
 		}

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -184,7 +184,7 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	/// Copies a borrowed buffer into memory drawn from `alloc`.
 	///
 	/// Whole packed words are copied, dead lanes and all, so the copy is bit-identical.
-	pub fn clone_from_slice<A>(alloc: &A, src: FieldSlice<P>) -> Self
+	pub fn from_view_in<A>(alloc: &A, src: FieldSlice<P>) -> Self
 	where
 		A: Allocator<Vec<P> = Data>,
 	{
@@ -754,13 +754,13 @@ mod tests {
 		let src = FieldBuffer::<P>::from_values(&scalars);
 
 		// A copy drawn from the allocator carries over both the length and the scalars.
-		let cloned: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.as_view());
+		let cloned: FieldVec<P, A> = FieldBuffer::from_view_in(alloc, src.as_view());
 		assert_eq!(cloned.log_len(), 4);
 		assert_eq!(cloned.as_view(), src.as_view());
 
 		// Copying a source shorter than one packed word keeps the two live lanes, not four.
 		let small = FieldBuffer::<P>::from_values(&scalars[..2]);
-		let cloned_small: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.as_view());
+		let cloned_small: FieldVec<P, A> = FieldBuffer::from_view_in(alloc, small.as_view());
 		assert_eq!(cloned_small.log_len(), 1);
 		assert_eq!(cloned_small.as_view(), small.as_view());
 
@@ -785,7 +785,7 @@ mod tests {
 		//
 		// Under a pool the target may sit on memory a prior buffer dirtied.
 		// So the zeros above the copied words have to be written, never assumed.
-		let src_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.as_view());
+		let src_vec: FieldVec<P, A> = FieldBuffer::from_view_in(alloc, src.as_view());
 		let extended = src_vec.zero_extend_in(alloc, 5);
 		assert_eq!(extended.log_len(), 5);
 		for i in 0..16 {
@@ -794,7 +794,7 @@ mod tests {
 		assert!((16..32).all(|i| extended.get(i) == F::ZERO));
 
 		// An already-wide-enough buffer comes back unchanged, with no copy taken.
-		let same: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.as_view());
+		let same: FieldVec<P, A> = FieldBuffer::from_view_in(alloc, src.as_view());
 		let same = same.zero_extend_in(alloc, 4);
 		assert_eq!(same.log_len(), 4);
 		assert_eq!(same.as_view(), src.as_view());
@@ -805,7 +805,7 @@ mod tests {
 		//     result (log_len 3)    [0, 1 | 0, 0] [0, 0 | 0, 0]
 		//
 		// The two dead lanes become live, so they read back as zeros, not stale scalars.
-		let small_vec: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.as_view());
+		let small_vec: FieldVec<P, A> = FieldBuffer::from_view_in(alloc, small.as_view());
 		let widened = small_vec.zero_extend_in(alloc, 3);
 		assert_eq!(widened.log_len(), 3);
 		assert_eq!(widened.get(0), F::new(0));

--- a/crates/math/src/field_buffer/scalars.rs
+++ b/crates/math/src/field_buffer/scalars.rs
@@ -128,7 +128,7 @@ mod tests {
 		);
 
 		// A borrowed store iterates the same way an owned one does.
-		let slice = buffer.to_ref();
+		let slice = buffer.as_view();
 		assert_eq!(IntoIterator::into_iter(&slice).collect::<Vec<_>>(), values);
 	}
 }

--- a/crates/math/src/field_buffer/view.rs
+++ b/crates/math/src/field_buffer/view.rs
@@ -44,7 +44,7 @@ impl<'a, P: PackedField, Data: Deref<Target = [P]>> From<&'a FieldBuffer<P, Data
 	for FieldSlice<'a, P>
 {
 	fn from(buffer: &'a FieldBuffer<P, Data>) -> Self {
-		buffer.to_ref()
+		buffer.as_view()
 	}
 }
 
@@ -64,7 +64,7 @@ impl<'a, P: PackedField, Data: DerefMut<Target = [P]>> From<&'a mut FieldBuffer<
 	for FieldSliceMut<'a, P>
 {
 	fn from(buffer: &'a mut FieldBuffer<P, Data>) -> Self {
-		buffer.to_mut()
+		buffer.as_mut_view()
 	}
 }
 

--- a/crates/math/src/field_buffer/view.rs
+++ b/crates/math/src/field_buffer/view.rs
@@ -29,7 +29,7 @@ pub type FieldSlice<'a, P> = FieldBuffer<P, FieldSliceData<'a, P>>;
 pub type FieldSliceMut<'a, P> = FieldBuffer<P, &'a mut [P]>;
 
 impl<'a, P: PackedField> FieldSlice<'a, P> {
-	/// Create a new FieldSlice from a slice of packed values.
+	/// Create a new FieldSlice from a slice of packed words.
 	///
 	/// # Preconditions
 	///
@@ -49,7 +49,7 @@ impl<'a, P: PackedField, Data: Deref<Target = [P]>> From<&'a FieldBuffer<P, Data
 }
 
 impl<'a, P: PackedField> FieldSliceMut<'a, P> {
-	/// Create a new FieldSliceMut from a mutable slice of packed values.
+	/// Create a new FieldSliceMut from a mutable slice of packed words.
 	///
 	/// # Preconditions
 	///

--- a/crates/math/src/field_buffer/write_back.rs
+++ b/crates/math/src/field_buffer/write_back.rs
@@ -22,13 +22,13 @@ use super::{FieldBuffer, FieldSliceMut};
 ///
 /// Holds the parent store, and lends each half out as a mutable view.
 #[derive(Debug)]
-pub struct FieldBufferSplitMut<P: PackedField, Data: DerefMut<Target = [P]>> {
+pub struct SplitMut<P: PackedField, Data: DerefMut<Target = [P]>> {
 	pub(super) log_len: usize,
 	pub(super) singles: Option<[P; 2]>,
 	pub(super) data: Data,
 }
 
-impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBufferSplitMut<P, Data> {
+impl<P: PackedField, Data: DerefMut<Target = [P]>> SplitMut<P, Data> {
 	/// Lends the two halves out as mutable views, the low half first.
 	///
 	/// A half of whole words is a view straight onto the store, so edits land at once.
@@ -63,7 +63,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBufferSplitMut<P, Data> 
 	}
 }
 
-impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for FieldBufferSplitMut<P, Data> {
+impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for SplitMut<P, Data> {
 	fn drop(&mut self) {
 		// Detached halves are the only shape with anything to write back.
 		if let Some([lo_half, hi_half]) = self.singles {

--- a/crates/math/src/field_buffer/write_back.rs
+++ b/crates/math/src/field_buffer/write_back.rs
@@ -38,11 +38,11 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> SplitMut<P, Data> {
 			Some([lo_half, hi_half]) => (
 				FieldBuffer {
 					log_len: self.log_len,
-					values: slice::from_mut(lo_half),
+					words: slice::from_mut(lo_half),
 				},
 				FieldBuffer {
 					log_len: self.log_len,
-					values: slice::from_mut(hi_half),
+					words: slice::from_mut(hi_half),
 				},
 			),
 			None => {
@@ -51,11 +51,11 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> SplitMut<P, Data> {
 				(
 					FieldBuffer {
 						log_len: self.log_len,
-						values: lo_half,
+						words: lo_half,
 					},
 					FieldBuffer {
 						log_len: self.log_len,
-						values: hi_half,
+						words: hi_half,
 					},
 				)
 			}

--- a/crates/math/src/multilinear/ext.rs
+++ b/crates/math/src/multilinear/ext.rs
@@ -190,7 +190,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> Multilinear<P> for FieldBuffer<P
 		// Otherwise each chunk pairs with the expansion, and the resulting scalars are the
 		// residual multilinear over the coordinates not yet used.
 		let scalars = self
-			.chunks_par(first_half_len)
+			.par_chunks(first_half_len)
 			.map(|chunk| chunk.inner_product(&eq_tensor))
 			.collect::<Vec<_>>();
 

--- a/crates/math/src/multilinear/ext.rs
+++ b/crates/math/src/multilinear/ext.rs
@@ -380,7 +380,7 @@ mod tests {
 		// A shared view carries no store of its own, so this pins the read impl's bound.
 		let buffer = random_field_buffer::<P>(&mut rng, 5);
 		let point = random_scalars::<F>(&mut rng, 5);
-		let view: FieldSlice<'_, P> = buffer.to_ref();
+		let view: FieldSlice<'_, P> = buffer.as_view();
 
 		assert_eq!(view.n_vars(), 5);
 		assert_eq!(view.evaluate(&point), buffer.evaluate(&point));
@@ -398,11 +398,11 @@ mod tests {
 		expected.fold_highest_var(scalar);
 
 		let mut owned = original;
-		let mut slice = owned.to_mut();
+		let mut slice = owned.as_mut_view();
 		slice.fold_highest_var(scalar);
 
 		assert_eq!(slice.n_vars(), 4);
-		assert_eq!(slice, expected.to_mut());
+		assert_eq!(slice, expected.as_mut_view());
 	}
 
 	#[test]
@@ -509,7 +509,7 @@ mod tests {
 			prop_assert_eq!(a.par_inner_product(&b), reference);
 
 			// A view passed straight through must reach the same computation.
-			prop_assert_eq!(a.inner_product(b.to_ref()), reference);
+			prop_assert_eq!(a.inner_product(b.as_view()), reference);
 		}
 
 		#[test]

--- a/crates/math/src/multilinear/ext.rs
+++ b/crates/math/src/multilinear/ext.rs
@@ -231,7 +231,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> Multilinear<P> for FieldBuffer<P
 
 		// The two halves are the multilinear specialized to 0 and to 1 on the highest variable.
 		let broadcast_scalar = P::broadcast(scalar);
-		let (lo, hi) = self.split_half_ref();
+		let (lo, hi) = self.split_half();
 
 		// Interpolate the line through each pair at the challenge directly into a fresh buffer
 		// drawn from the allocator, writing the uninitialized spare capacity in parallel rather

--- a/crates/math/src/multilinear/hypercube/expansion.rs
+++ b/crates/math/src/multilinear/hypercube/expansion.rs
@@ -467,9 +467,9 @@ mod tests {
 
 		let mut tensor = FieldBuffer::<P>::from_values(&[F::ONE]);
 		for &r in point.iter().rev() {
-			tensor.to_mut().bit_reverse();
+			tensor.as_mut_view().bit_reverse();
 			tensor = Hypercube::One.expand(&[r]).append_to::<P>(tensor);
-			tensor.to_mut().bit_reverse();
+			tensor.as_mut_view().bit_reverse();
 		}
 
 		assert_eq!(tensor, Hypercube::One.expand(&point).build::<P>());

--- a/crates/math/src/multilinear/hypercube/expansion.rs
+++ b/crates/math/src/multilinear/hypercube/expansion.rs
@@ -170,7 +170,7 @@ impl<'a, F: Field> Expansion<'a, F> {
 	) -> FieldBuffer<P, Vec<P>> {
 		let start_log_len = values.log_len();
 		let final_log_len = start_log_len + self.point.len();
-		let mut data = values.take_data();
+		let mut data = values.into_inner();
 
 		// Reserve the whole final capacity once, so no round reallocates.
 		// Each round then writes its new coefficients straight into the reserved spare capacity,
@@ -199,7 +199,7 @@ impl<'a, F: Field> Expansion<'a, F> {
 	) -> FieldBuffer<P, Data> {
 		let start_log_len = values.log_len();
 		let final_log_len = start_log_len + self.point.len();
-		let mut data = values.take_data();
+		let mut data = values.into_inner();
 
 		// precondition
 		debug_assert!(data.capacity() >= Self::packed_words::<P>(final_log_len));
@@ -529,11 +529,11 @@ mod tests {
 				//
 				// The one-lane store is exactly the scalars, so the two must agree there too.
 				prop_assert_eq!(
-					cube.expand(&point).build::<F>().take_data(),
+					cube.expand(&point).build::<F>().into_inner(),
 					cube.expand(&point).build_scalars()
 				);
 				prop_assert_eq!(
-					cube.expand(&point).scaled_by(scale).build::<F>().take_data(),
+					cube.expand(&point).scaled_by(scale).build::<F>().into_inner(),
 					cube.expand(&point).scaled_by(scale).build_scalars()
 				);
 			}

--- a/crates/math/src/ntt/mod.rs
+++ b/crates/math/src/ntt/mod.rs
@@ -302,10 +302,10 @@ mod tests {
 		let m = random_field_buffer::<P>(&mut rng, log_n);
 
 		let mut transposed = a.clone();
-		ntt.transpose_transform(transposed.to_mut(), skip_early, skip_late);
+		ntt.transpose_transform(transposed.as_mut_view(), skip_early, skip_late);
 
 		let mut forward = m.clone();
-		ntt.forward_transform(forward.to_mut(), skip_early, skip_late);
+		ntt.forward_transform(forward.as_mut_view(), skip_early, skip_late);
 
 		assert_eq!(
 			inner_product_scalars(transposed.iter_scalars(), m.iter_scalars()),

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -576,7 +576,7 @@ impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
 			let fallback_ntt = NeighborsLastReference {
 				domain_context: &self.domain_context,
 			};
-			fallback_ntt.forward_transform(data.to_mut(), skip_early, skip_late);
+			fallback_ntt.forward_transform(data.as_mut_view(), skip_early, skip_late);
 			on_chunk_ready(0, data.as_ref());
 			return;
 		}

--- a/crates/math/src/ntt/subspace_polys.rs
+++ b/crates/math/src/ntt/subspace_polys.rs
@@ -318,7 +318,7 @@ mod tests {
 
 		let mut transformed = coeffs.clone();
 		let ntt = NeighborsLastSingleThread::new(dc);
-		ntt.forward_transform(transformed.to_mut(), 0, 0);
+		ntt.forward_transform(transformed.as_mut_view(), 0, 0);
 
 		for index in 0..1 << log_d {
 			// Row `index` of the transform matrix is the tensor of W_hat_k at that domain point.
@@ -373,7 +373,7 @@ mod tests {
 				));
 				let mut rng = StdRng::seed_from_u64(7);
 				let msg = random_field_buffer::<F>(&mut rng, log_dim);
-				let codeword = code.encode_batch(&ntt, msg.to_ref(), 0, &GlobalAllocator);
+				let codeword = code.encode_batch(&ntt, msg.as_view(), 0, &GlobalAllocator);
 
 				for (index, row) in generator_rows(&code).into_iter().enumerate() {
 					let dot = inner_product_scalars(msg.as_ref().iter().copied(), row);
@@ -399,7 +399,7 @@ mod tests {
 					let mut rng = StdRng::seed_from_u64(11);
 					let msg = random_field_buffer::<F>(&mut rng, log_dim + log_batch);
 					let codeword =
-						code.encode_batch(&ntt, msg.to_ref(), log_batch, &GlobalAllocator);
+						code.encode_batch(&ntt, msg.as_view(), log_batch, &GlobalAllocator);
 					let rows = generator_rows(&code);
 
 					for lane in 0..1 << log_batch {

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -264,7 +264,7 @@ fn test_equivalence<F: BinaryField, NTT: AdditiveNTT<Field = F>>(ntt: &NTT) {
 
 	// way 2 to compute evaluations: use NTT
 	let mut ntt_data = novel_coeffs;
-	ntt.forward_transform(ntt_data.to_mut(), 0, 0);
+	ntt.forward_transform(ntt_data.as_mut_view(), 0, 0);
 
 	// check equivalence
 	assert_eq!(ntt_data.as_ref(), &evals);

--- a/crates/math/src/ntt/tests_reference.rs
+++ b/crates/math/src/ntt/tests_reference.rs
@@ -35,8 +35,8 @@ fn test_transform_equivalence<P: PackedField>(
 			let mut data_a = random_field_buffer::<P>(&mut rng, log_n);
 			let mut data_b = data_a.clone();
 
-			reference(data_a.to_mut(), skip_early, skip_late);
-			transform(data_b.to_mut(), skip_early, skip_late);
+			reference(data_a.as_mut_view(), skip_early, skip_late);
+			transform(data_b.as_mut_view(), skip_early, skip_late);
 			assert_eq!(data_a, data_b);
 		}
 	}
@@ -197,7 +197,7 @@ fn test_forward_transform_is_identity(#[case] ntt_factory: impl NTTFactory<B128>
 		let data = random_field_buffer::<P>(&mut rng, 0);
 		let mut data_clone = data.clone();
 
-		ntt.forward_transform(data_clone.to_mut(), 0, 0);
+		ntt.forward_transform(data_clone.as_mut_view(), 0, 0);
 
 		assert_eq!(data, data_clone);
 	}
@@ -242,8 +242,8 @@ where
 				continue;
 			}
 
-			ntt.forward_transform(data.to_mut(), skip_early, skip_late);
-			ntt.inverse_transform(data.to_mut(), skip_early, skip_late);
+			ntt.forward_transform(data.as_mut_view(), skip_early, skip_late);
+			ntt.inverse_transform(data.as_mut_view(), skip_early, skip_late);
 			assert_eq!(data, data_orig);
 		}
 	}

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -169,7 +169,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		};
 		let mut output = FieldBuffer::new(log_output_len, output_data);
 
-		ntt.forward_transform(output.to_mut(), self.log_inv_rate, log_batch_size);
+		ntt.forward_transform(output.as_mut_view(), self.log_inv_rate, log_batch_size);
 		output
 	}
 
@@ -238,7 +238,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		let mut output = FieldBuffer::new(log_output_len, output_data);
 
 		ntt.forward_transform_with_callback(
-			output.to_mut(),
+			output.as_mut_view(),
 			self.log_inv_rate,
 			log_batch_size,
 			on_chunk_ready,
@@ -364,7 +364,7 @@ mod tests {
 
 		// Test the new encode_batch interface
 		let encoded_buffer =
-			rs_code.encode_batch(&ntt, message.to_ref(), log_batch_size, &GlobalAllocator);
+			rs_code.encode_batch(&ntt, message.as_view(), log_batch_size, &GlobalAllocator);
 
 		// Method 2: Reference implementation - apply NTT with zero-padded coefficients to the
 		// bit-reversal permuted message.
@@ -375,7 +375,7 @@ mod tests {
 		}
 
 		// Perform large NTT with zero-padded coefficients.
-		ntt.forward_transform(reference_buffer.to_mut(), 0, log_batch_size);
+		ntt.forward_transform(reference_buffer.as_mut_view(), 0, log_batch_size);
 
 		// Compare results
 		assert_eq!(
@@ -446,8 +446,8 @@ mod tests {
 			msg_large.set(i, val);
 		}
 
-		let enc_small = rs_small.encode_batch(&ntt, msg_small.to_ref(), 0, &GlobalAllocator);
-		let enc_large = rs_large.encode_batch(&ntt, msg_large.to_ref(), 0, &GlobalAllocator);
+		let enc_small = rs_small.encode_batch(&ntt, msg_small.as_view(), 0, &GlobalAllocator);
+		let enc_large = rs_large.encode_batch(&ntt, msg_large.as_view(), 0, &GlobalAllocator);
 
 		let small_scalars = enc_small.iter_scalars().collect::<Vec<_>>();
 		let large_scalars = enc_large.iter_scalars().collect::<Vec<_>>();
@@ -501,14 +501,14 @@ mod tests {
 			for log_copies in 0..4 {
 				let msg = random_field_buffer::<PackedBinaryGhash1x128b>(&mut rng, log_msg);
 				let total = (1 << log_msg) << log_copies;
-				let expected = repeated_message_buffer_reference(msg.to_ref(), total);
+				let expected = repeated_message_buffer_reference(msg.as_view(), total);
 
 				// Every run width a caller can pass, from one word up to the whole message.
 				// A run under the message length is what splits a fill across workers.
 				// The encoder only reaches that on a message above one mebibyte.
 				for log_run in 0..=log_msg {
 					let built = repeated_message_buffer(
-						msg.to_ref(),
+						msg.as_view(),
 						total,
 						1 << log_run,
 						&GlobalAllocator,

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -117,9 +117,9 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 			b.iter_batched(
 				|| {
 					(
-						multilinears.each_ref().map(|multilin| {
-							FieldBuffer::clone_from_slice(&alloc, multilin.as_view())
-						}),
+						multilinears
+							.each_ref()
+							.map(|multilin| FieldBuffer::from_view_in(&alloc, multilin.as_view())),
 						eval_point.clone(),
 					)
 				},

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -118,7 +118,7 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 				|| {
 					(
 						multilinears.each_ref().map(|multilin| {
-							FieldBuffer::clone_from_slice(&alloc, multilin.to_ref())
+							FieldBuffer::clone_from_slice(&alloc, multilin.as_view())
 						}),
 						eval_point.clone(),
 					)

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -36,8 +36,8 @@ fn bench_fracaddcheck_build(c: &mut Criterion) {
 			b.iter_batched(
 				|| {
 					(
-						FieldBuffer::clone_from_slice(&alloc, num_buffer.to_ref()),
-						FieldBuffer::clone_from_slice(&alloc, den_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, num_buffer.as_view()),
+						FieldBuffer::clone_from_slice(&alloc, den_buffer.as_view()),
 					)
 				},
 				|(witness_num, witness_den)| {

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -36,8 +36,8 @@ fn bench_fracaddcheck_build(c: &mut Criterion) {
 			b.iter_batched(
 				|| {
 					(
-						FieldBuffer::clone_from_slice(&alloc, num_buffer.as_view()),
-						FieldBuffer::clone_from_slice(&alloc, den_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, num_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, den_buffer.as_view()),
 					)
 				},
 				|(witness_num, witness_den)| {

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -187,7 +187,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
-		prover.phase1(&initial_eval_point, w.b_prodcheck, witness.b_leaves.to_ref(), exp_eval)
+		prover.phase1(&initial_eval_point, w.b_prodcheck, witness.b_leaves.as_view(), exp_eval)
 	};
 	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 	let phase3 = {
@@ -229,7 +229,12 @@ fn bench_intmul_phases(c: &mut Criterion) {
 			|b_prodcheck| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
-				prover.phase1(&initial_eval_point, b_prodcheck, witness.b_leaves.to_ref(), exp_eval)
+				prover.phase1(
+					&initial_eval_point,
+					b_prodcheck,
+					witness.b_leaves.as_view(),
+					exp_eval,
+				)
 			},
 			BatchSize::SmallInput,
 		);
@@ -311,7 +316,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 					witness.a_exponents,
 					witness.c_lo_exponents,
 					witness.c_hi_exponents,
-					witness.tables[0].to_ref(),
+					witness.tables[0].as_view(),
 				)
 			},
 			BatchSize::SmallInput,
@@ -342,14 +347,14 @@ fn bench_intmul_components(c: &mut Criterion) {
 	// exponents).
 	group.bench_function("b_leaves", |bencher| {
 		bencher.iter(|| {
-			compute_b_leaves::<_, F, P>(&alloc, witness.a_root.to_ref(), witness.b_exponents)
+			compute_b_leaves::<_, F, P>(&alloc, witness.a_root.as_view(), witness.b_exponents)
 		});
 	});
 
 	// Computing a product tree over the leaves.
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
-			|| FieldBuffer::clone_from_slice(&alloc, witness.b_leaves.to_ref()),
+			|| FieldBuffer::clone_from_slice(&alloc, witness.b_leaves.as_view()),
 			|b_leaves| ProdcheckProver::<_, P>::new(Word::LOG_BITS, &alloc, b_leaves),
 			BatchSize::SmallInput,
 		);
@@ -367,7 +372,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
-		prover.phase1(&initial_eval_point, w.b_prodcheck, witness.b_leaves.to_ref(), exp_eval)
+		prover.phase1(&initial_eval_point, w.b_prodcheck, witness.b_leaves.as_view(), exp_eval)
 	};
 	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -354,7 +354,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 	// Computing a product tree over the leaves.
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
-			|| FieldBuffer::clone_from_slice(&alloc, witness.b_leaves.as_view()),
+			|| FieldBuffer::from_view_in(&alloc, witness.b_leaves.as_view()),
 			|b_leaves| ProdcheckProver::<_, P>::new(Word::LOG_BITS, &alloc, b_leaves),
 			BatchSize::SmallInput,
 		);

--- a/crates/prover/benches/prodcheck.rs
+++ b/crates/prover/benches/prodcheck.rs
@@ -33,7 +33,7 @@ fn bench_prodcheck_new(c: &mut Criterion) {
 			let alloc = &pool;
 
 			b.iter_batched(
-				|| FieldBuffer::clone_from_slice(&alloc, witness_buffer.to_ref()),
+				|| FieldBuffer::clone_from_slice(&alloc, witness_buffer.as_view()),
 				|witness| ProdcheckProver::<_, P>::new(k, &alloc, witness),
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/prodcheck.rs
+++ b/crates/prover/benches/prodcheck.rs
@@ -33,7 +33,7 @@ fn bench_prodcheck_new(c: &mut Criterion) {
 			let alloc = &pool;
 
 			b.iter_batched(
-				|| FieldBuffer::clone_from_slice(&alloc, witness_buffer.as_view()),
+				|| FieldBuffer::from_view_in(&alloc, witness_buffer.as_view()),
 				|witness| ProdcheckProver::<_, P>::new(k, &alloc, witness),
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -41,7 +41,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			b.iter_batched(
 				|| {
 					[multilinear_a.as_view(), multilinear_b.as_view()]
-						.map(|multilin| FieldBuffer::clone_from_slice(&alloc, multilin))
+						.map(|multilin| FieldBuffer::from_view_in(&alloc, multilin))
 				},
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(
@@ -88,7 +88,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 						multilinear_b.as_view(),
 						multilinear_c.as_view(),
 					]
-					.map(|multilin| FieldBuffer::clone_from_slice(&alloc, multilin))
+					.map(|multilin| FieldBuffer::from_view_in(&alloc, multilin))
 				},
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -40,7 +40,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			// Benchmark only the proving phase
 			b.iter_batched(
 				|| {
-					[multilinear_a.to_ref(), multilinear_b.to_ref()]
+					[multilinear_a.as_view(), multilinear_b.as_view()]
 						.map(|multilin| FieldBuffer::clone_from_slice(&alloc, multilin))
 				},
 				|multilinears| {
@@ -84,9 +84,9 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			b.iter_batched(
 				|| {
 					[
-						multilinear_a.to_ref(),
-						multilinear_b.to_ref(),
-						multilinear_c.to_ref(),
+						multilinear_a.as_view(),
+						multilinear_b.as_view(),
+						multilinear_c.as_view(),
 					]
 					.map(|multilin| FieldBuffer::clone_from_slice(&alloc, multilin))
 				},

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -207,7 +207,8 @@ where
 		}
 
 		// Forward NTT the zero-padded coefficients.
-		self.extrapolation.forward_transform(values.to_mut(), 0, 0);
+		self.extrapolation
+			.forward_transform(values.as_mut_view(), 0, 0);
 
 		values
 	}

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -169,7 +169,7 @@ where
 		let Phase1Output {
 			eval_point: phase1_eval_point,
 			b_leaves_evals,
-		} = self.phase1(&initial_eval_point, b_prodcheck, b_leaves.to_ref(), exp_eval);
+		} = self.phase1(&initial_eval_point, b_prodcheck, b_leaves.as_view(), exp_eval);
 
 		// Phase 2
 		let Phase2Output {
@@ -216,7 +216,7 @@ where
 			a_exponents,
 			c_lo_exponents,
 			c_hi_exponents,
-			tables[0].to_ref(),
+			tables[0].as_view(),
 		)
 	}
 

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -456,7 +456,7 @@ where
 		let leaf_guard = tracing::debug_span!("Compute base layer partial evals").entered();
 		let x_tensor = Hypercube::One.expand(x_point).build();
 		let b_leaves_evals = b_leaves
-			.chunks_par(n_vars)
+			.par_chunks(n_vars)
 			.map(|b_leaf| b_leaf.inner_product(&x_tensor))
 			.collect::<Vec<_>>();
 		drop(leaf_guard);

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -197,7 +197,7 @@ where
 		let (b_prodcheck, b_root) = ProdcheckProver::new(
 			Word::LOG_BITS,
 			alloc,
-			FieldBuffer::clone_from_slice(alloc, b_leaves.as_view()),
+			FieldBuffer::from_view_in(alloc, b_leaves.as_view()),
 		);
 		drop(variable_base_tree_scope);
 

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -191,13 +191,13 @@ where
 		// Compute b_leaves as concatenated leaves for prodcheck; the variable base is the `a` root.
 		let variable_base_tree_scope =
 			tracing::debug_span!("Compute variable-base prodcheck layers").entered();
-		let b_leaves = compute_b_leaves(alloc, a_root.to_ref(), b);
+		let b_leaves = compute_b_leaves(alloc, a_root.as_view(), b);
 		// The prodcheck prover folds its leaf layer in place, and phase 1 reads the leaves again
 		// afterwards, so the prover gets a clone.
 		let (b_prodcheck, b_root) = ProdcheckProver::new(
 			Word::LOG_BITS,
 			alloc,
-			FieldBuffer::clone_from_slice(alloc, b_leaves.to_ref()),
+			FieldBuffer::clone_from_slice(alloc, b_leaves.as_view()),
 		);
 		drop(variable_base_tree_scope);
 
@@ -531,7 +531,7 @@ mod tests {
 		// (`c_lo_root * c_hi_root`); this equality is what lets the prover reuse `b_root` in place
 		// of a separately stored `c_root`.
 		let c_root = buffer_bivariate_product(witness.c_lo_root(), witness.c_hi_root());
-		assert_eq!(witness.b_root().to_ref(), c_root.to_ref());
+		assert_eq!(witness.b_root().as_view(), c_root.as_view());
 	}
 
 	#[test]
@@ -611,7 +611,7 @@ mod tests {
 				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 
-			let leaves = compute_b_leaves::<_, F, P>(&GlobalAllocator, bases.to_ref(), &exponents);
+			let leaves = compute_b_leaves::<_, F, P>(&GlobalAllocator, bases.as_view(), &exponents);
 
 			for (i, &base0) in base_scalars.iter().enumerate() {
 				let mut base = base0;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -115,7 +115,7 @@ impl IOPProver {
 		let witness_commit_guard = tracing::info_span!("Commit witness").entered();
 
 		// Commit witness via channel
-		let trace_oracle = channel.send_oracle(witness_packed.to_ref());
+		let trace_oracle = channel.send_oracle(witness_packed.as_view());
 
 		drop(witness_commit_guard);
 
@@ -329,7 +329,7 @@ impl IOPProver {
 		let ring_switch::RingSwitchOutput {
 			rs_eq_ind,
 			sumcheck_claim,
-		} = ring_switch::prove(alloc, witness_packed.to_ref(), witness_point, &mut *channel);
+		} = ring_switch::prove(alloc, witness_packed.as_view(), witness_point, &mut *channel);
 
 		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
 		// relation, when the IntMul reduction ran, was already queued inside phase 5.

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -380,7 +380,7 @@ pub fn prove_public_eval<A, P, Channel>(
 	let RingSwitchOutput {
 		rs_eq_ind,
 		sumcheck_claim,
-	} = prove(alloc, packed.to_ref(), &[r_j, r_y_public].concat(), channel);
+	} = prove(alloc, packed.as_view(), &[r_j, r_y_public].concat(), channel);
 
 	// The reduced claim is the sum of the two multilinears' product over the hypercube, which is
 	// what the trace's opening hands to BaseFold. Here it is discharged by the sumcheck alone: the

--- a/crates/recursion/tests/basefold_opening.rs
+++ b/crates/recursion/tests/basefold_opening.rs
@@ -196,7 +196,7 @@ fn prove(shape: &Shape, setup: &Setup, seed: u64) -> Opening {
 		&setup.fri_params,
 		0,
 		&setup.ntt,
-		witness.to_ref(),
+		witness.as_view(),
 		&mut rng,
 		&GlobalAllocator,
 	);
@@ -215,7 +215,7 @@ fn prove(shape: &Shape, setup: &Setup, seed: u64) -> Opening {
 		.collect::<Vec<_>>();
 	WordIPProverChannel::<B128>::observe_words(&mut channel, &point_words);
 
-	let commitment = channel.send_merkle_commitment(codeword.to_ref(), LEAF_ELEMENTS);
+	let commitment = channel.send_merkle_commitment(codeword.as_view(), LEAF_ELEMENTS);
 
 	// Fold the interleaved (pi || omega) codeword to pi' = (1 - gamma) pi + gamma omega.
 	let gamma: B128 = IPProverChannel::sample(&mut channel);

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -160,7 +160,7 @@ impl<F: Field> IOPProver<F> {
 			&precommit_blinding,
 			rng,
 		);
-		let precommit_oracle = channel.send_oracle(precommit_packed.to_ref());
+		let precommit_oracle = channel.send_oracle(precommit_packed.as_view());
 		(precommit_oracle, precommit_packed)
 	}
 
@@ -252,7 +252,7 @@ impl<F: Field> IOPProver<F> {
 		};
 
 		let mulcheck_mask =
-			zk_mlecheck::Mask::new(log_mul_constraints, mask_degree, masks_buffer.to_ref());
+			zk_mlecheck::Mask::new(log_mul_constraints, mask_degree, masks_buffer.as_view());
 
 		// Pack private witness into field elements and add blinding
 		let blinding_info = cs.blinding_info();
@@ -267,15 +267,15 @@ impl<F: Field> IOPProver<F> {
 
 		// Send the private and mask oracles to the channel. The precommit oracle was committed
 		// by the caller via `commit_precommit` and passed in as `precommit_oracle`.
-		let private_oracle = channel.send_oracle(private_packed.to_ref());
-		let mask_oracle = channel.send_oracle(masks_buffer.to_ref());
+		let private_oracle = channel.send_oracle(private_packed.as_view());
+		let mask_oracle = channel.send_oracle(masks_buffer.as_view());
 
 		// Prove the multiplication constraints
 		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _, _>(
 			cs.mul_constraints(),
 			witness.public(),
-			precommit_packed.to_ref(),
-			private_packed.to_ref(),
+			precommit_packed.as_view(),
+			private_packed.as_view(),
 			mulcheck_mask,
 			&mut *channel,
 			alloc,

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -451,8 +451,8 @@ mod tests {
 			&GlobalAllocator,
 			&constraints,
 			&public,
-			precommit_buf.to_ref(),
-			private_buf.to_ref(),
+			precommit_buf.as_view(),
+			private_buf.as_view(),
 		);
 
 		// Sample r_x (sumcheck evaluation point for constraint axis)
@@ -478,7 +478,7 @@ mod tests {
 			NaiveProverChannel::<B128, _>::new(&mut prover_transcript, oracle_specs.clone());
 
 		// Send private witness oracle
-		let witness_oracle = prover_channel.send_oracle(private_buf.to_ref());
+		let witness_oracle = prover_channel.send_oracle(private_buf.as_view());
 
 		// Sample lambda
 		let lambda: B128 = prover_channel.sample();

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -172,7 +172,7 @@ where
 			&precommit_blinding,
 			&mut rng,
 		);
-		let precommit_oracle = inner_channel.send_oracle(precommit_packed.to_ref());
+		let precommit_oracle = inner_channel.send_oracle(precommit_packed.as_view());
 		(keys, precommit_oracle, precommit_packed)
 	}
 

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -730,7 +730,7 @@ impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 				.expand(point)
 				.scaled_by(scale)
 				.build::<F>()
-				.take_data()
+				.into_inner()
 		});
 		let cs = &self.constraint_system;
 


### PR DESCRIPTION
Renames seven pieces of the field buffer's surface to match `std` convention, and establishes one vocabulary rule. Pure refactor — no behaviour change, no signature change beyond the names.

### The problem

Several names said something the code does not do.

- **`to_ref` / `to_mut`.** In `std`, `to_*` is a **clone-producing** conversion — `to_owned`, `to_vec`, `to_string`. A cheap borrow is `as_*`. Worse, `Cow::to_mut` genuinely clones, so `to_mut` actively reads as "may allocate" on a method that only borrows.
- **`take_data`.** In `std`, `take` means "replace with `Default` and return" — `Option::take`, `mem::take`. This consumes `self`, which is `into_inner`.
- **`clone_from_slice`.** Collides head-on with `slice::clone_from_slice`, which copies *into* an existing slice. This is a constructor.
- **`chunks_par`.** Its sibling is `par_chunk_scalars`, and rayon's convention is the `par_` prefix. Two orderings for one idea.
- **`FieldBufferSplitMut`.** The prefix restates the module: `field_buffer::FieldBufferSplitMut`.
- **`split_half_ref` / `split_half` / `split_half_mut`.** Three names where `_ref` marks the `&self` method, inverting the `std` convention that the bare name *is* the shared one.
- **The `values` field.** The store holds packed words. `values` is what the scalar constructors take.

### The vocabulary rule this settles

The obvious rename of `to_ref` is `as_slice`, and it is **wrong** — that was caught during review rather than after.

`FieldBuffer` already implements `AsRef<[P]>`, so `as_ref()` returns `&[P]`. An `as_slice()` returning a `FieldSlice` would put two different return types behind one word, and break `std`'s promise that `as_slice` yields `&[T]`. The rename would have read *less* `std`-like than what it replaced, while appearing to fix it. The same collision showed up a second time: `from_slice_in(alloc, src: FieldSlice)` next to `FieldSlice::from_slice(log_len, &[P])`, where "slice" means a view in one and raw words in the other.

So the rule is: **"slice" always means a raw `&[P]`; "view" always means a `FieldSlice`.** No name means both.

```
to_ref()            ->  as_view()          returns FieldSlice
to_mut()            ->  as_mut_view()      returns FieldSliceMut
as_ref()            ->  unchanged          returns &[P]
clone_from_slice()  ->  from_view_in()     takes a FieldSlice
FieldSlice::from_slice()  ->  unchanged    takes a raw &[P]

take_data()         ->  into_inner()
chunks_par()        ->  par_chunks()
FieldBufferSplitMut ->  SplitMut
values (field)      ->  words

split_half_ref(&self)     ->  split_half(&self)
split_half(self)          ->  into_split_half(self)
split_half_mut(&mut self) ->  unchanged
```

The rule is now visible in the code: one line reads `FieldBuffer::new(4, packed_values.as_slice())` — a `Vec<P>` handing over raw words — a few hundred lines from `buffer.as_mut_view()` handing over a borrowed buffer. Those used to look like the same operation.

### The halving trio, and how the risky rename was fenced

Renaming `split_half_ref` to `split_half` while a consuming `split_half` still exists means calls can silently resolve to the wrong method. Rather than one simultaneous edit, the order does the policing:

1. Rename the **consuming** method first. That leaves *no* inherent `split_half` on the buffer at all, so the compiler must flag the one remaining call site — inside `split_half_mut`.
2. `cargo check --workspace --all-targets --all-features` at that intermediate point. Clean.
3. Then rename the borrowing method into the freed name.

Same guarantee as an atomic edit, with a machine check in the middle.

**A textual count would have been misleading.** `split_half` appears on three unrelated types in the sumcheck store, plus two `split_half_claim` helpers. The discriminator is the signature: the buffer's method returns a tuple destructured `(a, b)`, while all three foreign ones return `[Self; 2]` destructured `[a, b]`. Final tally at the intermediate point — 9 foreign mentions, 2 pre-existing intra-doc links, 1 test name, and zero buffer ones, which is what forced the compiler's hand.

### One rename deliberately skipped

The plan also proposed `chunk(log_size, i)` -> `chunk_at(i, log_size)`, renaming **and** swapping the argument order. Not done, on purpose.

Both parameters are `usize`, so a swapped call compiles and silently returns the wrong chunk — a wrong witness, not a panic. Putting the one change that can fail silently inside ~270 mechanical changes that cannot makes it invisible to review. If the argument order is worth fixing, it deserves a PR where it is the only thing under review.

`pub fn chunk(&self, log_chunk_size: usize, chunk_index: usize)` is untouched, and no diff line touches its signature.

### Scope

Seven commits, one rename group each, 56 files, +327/−323. Every commit compiles and is individually `fmt`-clean; the rustfmt reflows a longer name causes sit in the commit that causes them.

The `values` -> `words` rename was *almost* module-private: the field and its locals are, but the name also appeared in a public constructor's parameter, its rustdoc, and two panic messages, so those moved too. `values` is deliberately kept wherever it genuinely names a scalar slice — `from_values`, `from_values_in` — since that contrast is what makes the pair readable.

### Verifying that no rename is half-applied

Combined hits for every removed name — `to_ref`, `to_mut`, `clone_from_slice`, `from_slice_in`, `take_data`, `chunks_par`, `FieldBufferSplitMut`, `split_half_ref`: **zero**.

`as_slice` and `as_mut_slice` cannot be zero, since `Vec::as_slice` predates this work. So the stronger property was checked instead: their workspace counts are byte-identical to base, and the diff touches **zero** lines containing either token. No pre-existing `Vec` caller was collateral damage.

Each new name has exactly one definition, all three on the buffer, and none existed at base.

### Verification

- `cargo clippy` with `--all-targets --all-features -- -D warnings` across the nine touched crates — clean.
- `cargo test -p binius-math` — 150 passed, plus 1 doctest; same with `--features rayon`, since the default build uses the hand-written no-rayon shim. Matches the baseline exactly.
- The other eight touched crates — all green.
- `cargo check --workspace --all-targets --all-features` — clean. Justified here, since public method names change workspace-wide.
- `cargo test -p binius-math --target wasm32-wasip1 --no-run` — compiles. CI runs wasm with default features, which an `--all-features` gate misses.
- `cargo +nightly fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
