### PR TITLE
Name the word-axis folder after the axis it contracts

### DIFF
--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -9,7 +9,7 @@ use binius_core::{ValueTable, word::Word};
 use binius_field::{BinaryField, PackedField};
 use binius_math::{FieldVec, inner_product::inner_product};
 pub use binius_prover::fold_word::FoldedWord;
-use binius_prover::fold_word::WordFolder;
+use binius_prover::fold_word::WordAxisFolder;
 use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 /// The committed witness of a batch, with its instance axis collapsed at a point.
@@ -72,7 +72,7 @@ impl<F: BinaryField, A: Allocator> FoldedWitness<F, A> {
 
 		// The bit lookup tables and per-chunk weights depend only on the point.
 		// Build them once here, then share them across every word position.
-		let folder = WordFolder::<F>::new(r_rho);
+		let folder = WordAxisFolder::<F>::new(r_rho);
 		let n_words = table.n_hidden_words();
 
 		// Invariant: the stored words split evenly into one chunk per committed word.

--- a/crates/prover/benches/fold_across_words.rs
+++ b/crates/prover/benches/fold_across_words.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 use binius_core::word::Word;
 use binius_math::test_utils::random_scalars;
-use binius_prover::fold_word::WordFolder;
+use binius_prover::fold_word::WordAxisFolder;
 use binius_verifier::config::B128;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
@@ -26,7 +26,7 @@ fn bench_single_column(c: &mut Criterion) {
 			.map(|_| Word::from_u64(rng.random()))
 			.collect::<Vec<_>>();
 		let point = random_scalars::<B128>(&mut rng, log_n_words);
-		let folder = WordFolder::<B128>::new(&point);
+		let folder = WordAxisFolder::<B128>::new(&point);
 
 		// Words per second, so the two drivers compare directly across sizes.
 		group.throughput(Throughput::Elements(n_words as u64));
@@ -61,7 +61,7 @@ fn bench_shared_point_columns(c: &mut Criterion) {
 			})
 			.collect::<Vec<_>>();
 		let point = random_scalars::<B128>(&mut rng, log_n_words);
-		let folder = WordFolder::<B128>::new(&point);
+		let folder = WordAxisFolder::<B128>::new(&point);
 
 		// All six columns' words, so throughput counts the whole phase.
 		group.throughput(Throughput::Elements((N_COLUMNS * n_words) as u64));

--- a/crates/prover/src/fold_word/mod.rs
+++ b/crates/prover/src/fold_word/mod.rs
@@ -39,7 +39,7 @@ mod word_axis;
 
 use binius_core::word::Word;
 pub use bit_axis::BitAxisFolder;
-pub use word_axis::WordFolder;
+pub use word_axis::WordAxisFolder;
 
 use crate::bit_matrix::WEIGHTS_PER_TABLE;
 

--- a/crates/prover/src/fold_word/word_axis.rs
+++ b/crates/prover/src/fold_word/word_axis.rs
@@ -25,7 +25,8 @@ use crate::bit_matrix::{ColumnSums, RowFoldTables, WEIGHTS_PER_TABLE};
 ///
 /// Sixteen chunks is 1024 words, which is the setting that loses at neither end.
 const MIN_CHUNKS_PER_TASK: usize = 16;
-/// A reusable [Method of Four Russians] folder over a fixed evaluation point.
+/// A reusable [Method of Four Russians] folder over a fixed evaluation point, contracting the
+/// word axis.
 ///
 /// Many word-lists often share one point, so the tables are built once here and reused.
 /// The batched instance fold is that case: every committed word folds against the same point.
@@ -36,7 +37,7 @@ const MIN_CHUNKS_PER_TASK: usize = 16;
 ///
 /// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
 #[derive(Debug)]
-pub struct WordFolder<F: BinaryField> {
+pub struct WordAxisFolder<F: BinaryField> {
 	/// One 256-entry subset-sum table per byte of a word, from the prefix expansion.
 	///
 	/// Table `s` folds the words at positions `s * WEIGHTS_PER_TABLE + t` within a chunk.
@@ -51,7 +52,7 @@ pub struct WordFolder<F: BinaryField> {
 	log_n_words: usize,
 }
 
-impl<F: BinaryField> WordFolder<F> {
+impl<F: BinaryField> WordAxisFolder<F> {
 	/// Builds the folding tables for `point`.
 	///
 	/// Each later fold takes a list of at most `2^point.len()` words, folded against
@@ -260,7 +261,7 @@ mod tests {
 			let point = random_scalars::<B128>(&mut rng, log2_ceil_usize(words.len()));
 
 			prop_assert_eq!(
-				WordFolder::new(&point).fold_par(&words),
+				WordAxisFolder::new(&point).fold_par(&words),
 				reference_fold_word_axis(&words, &point),
 			);
 		}
@@ -273,7 +274,7 @@ mod tests {
 			let mut rng = StdRng::seed_from_u64(seed ^ 3);
 			let point = random_scalars::<B128>(&mut rng, log2_ceil_usize(words.len()));
 
-			let folder = WordFolder::new(&point);
+			let folder = WordAxisFolder::new(&point);
 			prop_assert_eq!(folder.fold_par(&words), folder.fold(&words));
 		}
 
@@ -293,8 +294,8 @@ mod tests {
 			padded.resize(1 << log_rows, Word::ZERO);
 			let expected = reference_fold_word_axis(&padded, &point);
 
-			prop_assert_eq!(WordFolder::new(&point).fold(&words), expected);
-			prop_assert_eq!(WordFolder::new(&point).fold_par(&words), expected);
+			prop_assert_eq!(WordAxisFolder::new(&point).fold(&words), expected);
+			prop_assert_eq!(WordAxisFolder::new(&point).fold_par(&words), expected);
 		}
 	}
 }

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -13,7 +13,7 @@ use binius_math::{FieldVec, field_buffer::FieldBuffer};
 use binius_utils::{buffer::VecLike, checked_arithmetics::log2_ceil_usize};
 pub use binius_verifier::protocols::binmul::BinMulOutput;
 
-use crate::fold_word::WordFolder;
+use crate::fold_word::WordAxisFolder;
 
 /// Build a packed GHASH-field multilinear table from a `(lo, hi)` pair of word columns.
 ///
@@ -130,7 +130,7 @@ where
 	//
 	// Six columns cannot fill a machine on their own, so each column divides its own chunk axis
 	// rather than the six being run against each other.
-	let folder = WordFolder::<F>::new(&eval_point);
+	let folder = WordAxisFolder::<F>::new(&eval_point);
 	let a_lo_evals = folder.fold_par(a_lo);
 	let a_hi_evals = folder.fold_par(a_hi);
 	let b_lo_evals = folder.fold_par(b_lo);

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -40,7 +40,7 @@ use super::{
 	error::Error,
 	witness::{Witness, limb_index, two_valued_field_buffer},
 };
-use crate::fold_word::{BitAxisFolder, WordFolder};
+use crate::fold_word::{BitAxisFolder, WordAxisFolder};
 
 /// Proves the integer multiplication (IntMul) reduction over the four operand columns.
 ///
@@ -397,7 +397,7 @@ where
 		let output_guard = tracing::debug_span!("Compute output bit evals").entered();
 		// All four columns fold against the same point, so the lookup tables and the per-chunk
 		// weights are built once and shared.
-		let folder = WordFolder::<F>::new(r_out);
+		let folder = WordAxisFolder::<F>::new(r_out);
 		let a_evals = folder.fold_par(a_exponents);
 		let c_lo_evals = folder.fold_par(c_lo_exponents);
 		let c_hi_evals = folder.fold_par(c_hi_exponents);


### PR DESCRIPTION
Renames one type so the two folders are named on the same principle. Pure rename — no behavior change.

### The problem

A word list is a matrix over GF(2), and the module contracts one axis of it or the other. The two folders that do that were named differently:

| type | named after | contracts |
|---|---|---|
| `BitAxisFolder` | the axis it contracts | the bit axis |
| `WordFolder` | what it consumes | the **word** axis |

Every fold in the module consumes words, so naming one of them for that says nothing, and reading the pair suggests they do unrelated things. They do the same thing along opposite axes.

The module split made this plainer rather than fixing it. The two now live in `bit_axis.rs` and `word_axis.rs`, and one of them still carried the old name:

```
pub use bit_axis::BitAxisFolder;
pub use word_axis::WordFolder;      // named on a different principle
```

### The change

```
- WordFolder
+ WordAxisFolder
```

Sixteen sites across two crates, all mechanical.

### Scope

- **renamed:** one type
- **untouched:** every body, every signature otherwise, every test's meaning
- this is the last piece of the naming cleanup the module's reorganization opened with

### Verification

- `cargo check -p binius-prover -p binius-m4-prover --all-targets` — clean
- `cargo clippy -p binius-prover -p binius-m4-prover --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt` — clean
- `cargo test -p binius-prover --lib` — 79 passed, and again with `--features rayon`
- `cargo test -p binius-m4-prover --lib` — 42 passed

The no-rayon shim is the default test path in this repo, so the prover tests were run in both configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)