### PR TITLE
Adopt Plonky3's clippy and rustdoc lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,13 +101,30 @@ trybuild = "1.0"
 uninit = "0.6.2"
 ureq = "3.1"
 
+[workspace.lints]
+rust.rust_2018_idioms = { level = "deny", priority = -1 }
+rust.unused_must_use = "deny"
+rust.rust_2024_incompatible_pat = "warn"
+rustdoc.all = "warn"
+
 [workspace.lints.clippy]
-needless_range_loop = "allow"
-missing_const_for_fn = "warn"
-multiple_inherent_impl = "warn"
-needless_collect = "warn"
-redundant_clone = "warn"
+all = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+
+# Some pedantic lints
+semicolon_if_nothing_returned = "warn"
+match_bool = "warn"
 needless_pass_by_value = "warn"
+multiple_inherent_impl = "warn"
+
+needless_range_loop = "allow"
+redundant_pub_crate = "allow"
+too_long_first_doc_paragraph = "allow"
+unused_peekable = "allow"
+tuple_array_conversions = "allow"
+transmute_undefined_repr = "allow"
+cognitive_complexity = "allow"
+use_self = "allow"
 
 [workspace.metadata.typos]
 default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts" }

--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -58,7 +58,7 @@ fn run_google_mul_benchmark<U, R>(
 				x = mul_fn(y[j], x);
 			}
 			x
-		})
+		});
 	});
 }
 
@@ -100,7 +100,7 @@ fn run_mul_benchmark<T, R>(
 					batch[i] = mul_fn(batch[i], batch[(i + BATCH_SIZE / 2) % BATCH_SIZE]);
 				}
 			}
-		})
+		});
 	});
 }
 
@@ -138,7 +138,7 @@ fn run_unary_op_benchmark<T, R>(
 					batch[i] = op_fn(batch[i]);
 				}
 			}
-		})
+		});
 	});
 }
 
@@ -179,7 +179,7 @@ fn run_inner_product_benchmark<T, W, R>(
 			black_box(std::iter::zip(&a, &b).fold(W::ZERO, |acc, (&ai, &bi)| {
 				W::xor(acc, wide_mul(black_box(ai), black_box(bi)))
 			}))
-		})
+		});
 	});
 }
 
@@ -302,6 +302,8 @@ fn bench_polyval(c: &mut Criterion) {
 
 /// Benchmark GF(2^128) GHASH multiplication using CLMUL instructions
 #[allow(unused_imports, unused_variables, unused_mut)]
+// The benchmark group lives until `finish()`, which is how criterion's API is meant to be used.
+#[allow(clippy::significant_drop_tightening)]
 fn bench_ghash(c: &mut Criterion) {
 	use binius_arith_bench::ghash::{mul_clmul, square_clmul};
 

--- a/crates/arith-bench/src/monbijou/aarch64.rs
+++ b/crates/arith-bench/src/monbijou/aarch64.rs
@@ -171,10 +171,13 @@ pub fn mul_wide_128b_schoolbook(x: poly64x2_t, y: poly64x2_t) -> [poly64x2_t; 3]
 /// Reduce the three raw schoolbook combinations from [`mul_wide_128b_schoolbook`] into a packed
 /// GF(2^128) element.
 ///
-/// The extension is `Y^2 = XY + 1`, so `coeff 0 = x0·y0 + x1·y1 = p00 + p11` and `coeff 1 = (x0·y1
-/// + x1·y0) + X·(x1·y1) = cross + X·p11`. The multiply-by-X on the unreduced `p11` (degree ≤ 126)
-/// is a plain 128-bit left shift; the two coefficient products are reduced together in one
-/// [`reduce`].
+/// The extension is `Y^2 = XY + 1`, so the two coefficients are
+///
+/// - `coeff 0 = x0·y0 + x1·y1 = p00 + p11`
+/// - `coeff 1 = (x0·y1 + x1·y0) + X·(x1·y1) = cross + X·p11`
+///
+/// The multiply-by-X on the unreduced `p11` (degree ≤ 126) is a plain 128-bit left shift; the two
+/// coefficient products are reduced together in one [`reduce`].
 #[inline]
 pub fn reduce_128b_schoolbook([p00, cross, p11]: [poly64x2_t; 3]) -> poly64x2_t {
 	unsafe {
@@ -222,8 +225,8 @@ pub fn reduce_sliced_128b([t0, t1, t2]: [Wide; 3]) -> [poly64x2_t; 2] {
 }
 
 /// Multiplies two elements of GF(2^128), the degree-2 extension of the Monbijou field, in the
-/// *sliced* representation. Same field product as [`mul_128b`], with the coefficients kept in
-/// separate registers. Composes [`mul_wide_sliced_128b`] with [`reduce_sliced_128b`].
+/// *sliced* representation. Same field product as [`mul_128b_schoolbook`], with the coefficients
+/// kept in separate registers. Composes [`mul_wide_sliced_128b`] with [`reduce_sliced_128b`].
 #[inline]
 pub fn mul_sliced_128b(x: [poly64x2_t; 2], y: [poly64x2_t; 2]) -> [poly64x2_t; 2] {
 	reduce_sliced_128b(mul_wide_sliced_128b(x, y))

--- a/crates/circuits/src/base64.rs
+++ b/crates/circuits/src/base64.rs
@@ -88,7 +88,7 @@ impl Base64UrlSafe {
 	///
 	/// * `w` - Witness filler to populate
 	/// * `length` - Actual length of decoded data in bytes
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
@@ -102,7 +102,7 @@ impl Base64UrlSafe {
 	/// # Panics
 	///
 	/// Panics if `data.len()` exceeds the maximum size specified during construction.
-	pub fn populate_decoded(&self, w: &mut WitnessFiller, data: &[u8]) {
+	pub fn populate_decoded(&self, w: &mut WitnessFiller<'_>, data: &[u8]) {
 		w.pack_bytes_le(&self.decoded, data);
 	}
 
@@ -116,7 +116,7 @@ impl Base64UrlSafe {
 	/// # Panics
 	///
 	/// Panics if `data.len()` exceeds the maximum size specified during construction.
-	pub fn populate_encoded(&self, w: &mut WitnessFiller, data: &[u8]) {
+	pub fn populate_encoded(&self, w: &mut WitnessFiller<'_>, data: &[u8]) {
 		w.pack_bytes_le(&self.encoded, data);
 	}
 }

--- a/crates/circuits/src/bignum/addsub.rs
+++ b/crates/circuits/src/bignum/addsub.rs
@@ -50,7 +50,7 @@ pub fn add_with_carry_out(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) ->
 		carry_out
 			.first()
 			.copied()
-			.unwrap_or(builder.add_constant(Word::ZERO)),
+			.unwrap_or_else(|| builder.add_constant(Word::ZERO)),
 	)
 }
 

--- a/crates/circuits/src/bignum/biguint.rs
+++ b/crates/circuits/src/bignum/biguint.rs
@@ -98,7 +98,7 @@ impl BigUint {
 	/// Populate the BigUint with the expected limb_values
 	///
 	/// Panics if limb_values.len() != self.limbs.len()
-	pub fn populate_limbs(&self, w: &mut WitnessFiller, limb_values: &[u64]) {
+	pub fn populate_limbs(&self, w: &mut WitnessFiller<'_>, limb_values: &[u64]) {
 		assert!(limb_values.len() == self.limbs.len());
 		for (&wire, &v) in iter::zip(&self.limbs, limb_values) {
 			w[wire] = Word::from_u64(v);

--- a/crates/circuits/src/bignum/mod_inverse.rs
+++ b/crates/circuits/src/bignum/mod_inverse.rs
@@ -63,12 +63,13 @@ impl Hint for ModInverseHint {
 		let modulus = num_biguint_from_u64_limbs(mod_limbs.iter().map(|w| w.as_u64()));
 
 		let zero = num_bigint::BigUint::ZERO;
-		let (quotient, inverse) = if let Some(inverse) = base.modinv(&modulus) {
-			let quotient = (base * &inverse - num_bigint::BigUint::from(1usize)) / &modulus;
-			(quotient, inverse)
-		} else {
-			(zero.clone(), zero)
-		};
+		let (quotient, inverse) = base.modinv(&modulus).map_or_else(
+			|| (zero.clone(), zero),
+			|inverse| {
+				let quotient = (base * &inverse - num_bigint::BigUint::from(1usize)) / &modulus;
+				(quotient, inverse)
+			},
+		);
 
 		assert_eq!(outputs.len(), 2 * *n_mod);
 		let (quotient_words, inverse_words) = outputs.split_at_mut(*n_mod);

--- a/crates/circuits/src/bignum/reduce.rs
+++ b/crates/circuits/src/bignum/reduce.rs
@@ -157,6 +157,6 @@ impl PseudoMersenneModReduce {
 
 	/// Apply the reduction constraint conditionally based on the value of boolean `mask` wire.
 	pub fn constrain_cond(self, builder: &CircuitBuilder, cond: Wire) {
-		assert_eq_cond(builder, "modred_pseudo_mersenne", &self.lhs, &self.rhs, cond)
+		assert_eq_cond(builder, "modred_pseudo_mersenne", &self.lhs, &self.rhs, cond);
 	}
 }

--- a/crates/circuits/src/bignum/tests.rs
+++ b/crates/circuits/src/bignum/tests.rs
@@ -21,7 +21,7 @@ use super::{num_biguint_from_u64_limbs as from_u64_limbs, *};
 ///
 /// # Returns
 /// The `BigUint` value as a `num_biguint::BigUint`
-pub fn biguint_to_num_biguint(w: &WitnessFiller, biguint: &BigUint) -> num_bigint::BigUint {
+pub fn biguint_to_num_biguint(w: &WitnessFiller<'_>, biguint: &BigUint) -> num_bigint::BigUint {
 	let limb_vals: Vec<_> = biguint.limbs.iter().map(|&l| w[l].as_u64()).collect();
 	from_u64_limbs(&limb_vals)
 }

--- a/crates/circuits/src/blake2b/circuit.rs
+++ b/crates/circuits/src/blake2b/circuit.rs
@@ -63,7 +63,7 @@ impl Blake2bCircuit {
 	}
 
 	/// Populate the message data into the witness
-	pub fn populate_message(&self, w: &mut WitnessFiller, message: &[u8]) {
+	pub fn populate_message(&self, w: &mut WitnessFiller<'_>, message: &[u8]) {
 		assert!(message.len() <= self.length, "Message exceeds circuit capacity");
 
 		// Pack message bytes into 64-bit words (little-endian)
@@ -82,7 +82,7 @@ impl Blake2bCircuit {
 	}
 
 	/// Populate the expected digest output for verification
-	pub fn populate_digest(&self, w: &mut WitnessFiller, digest: &[u8; 64]) {
+	pub fn populate_digest(&self, w: &mut WitnessFiller<'_>, digest: &[u8; 64]) {
 		// Pack digest bytes into 64-bit words (little-endian)
 		for i in 0..8 {
 			let mut word_value = 0u64;

--- a/crates/circuits/src/blake2s/mod.rs
+++ b/crates/circuits/src/blake2s/mod.rs
@@ -126,7 +126,7 @@ impl Blake2s {
 
 	/// Builds the constraints that verify the message hashes to the expected digest.
 	fn build_circuit(
-		builder: &mut CircuitBuilder,
+		builder: &CircuitBuilder,
 		length: usize,
 		message: &[Wire],
 		expected_digest: [Wire; 8],
@@ -306,7 +306,7 @@ impl Blake2s {
 	///
 	/// # Panics
 	/// * If `message.len()` does not equal the circuit's fixed message length.
-	pub fn populate_message(&self, witness: &mut WitnessFiller, message: &[u8]) {
+	pub fn populate_message(&self, witness: &mut WitnessFiller<'_>, message: &[u8]) {
 		assert!(
 			message.len() == self.length,
 			"Only messages of length {} supported while given {} bytes",
@@ -317,7 +317,7 @@ impl Blake2s {
 		for (i, bytes) in message.chunks(8).enumerate() {
 			let mut le_bytes = [0; 8];
 			le_bytes[..bytes.len()].copy_from_slice(bytes);
-			witness[self.message[i]] = Word(u64::from_le_bytes(le_bytes))
+			witness[self.message[i]] = Word(u64::from_le_bytes(le_bytes));
 		}
 	}
 
@@ -326,7 +326,7 @@ impl Blake2s {
 	/// # Arguments
 	/// * `witness` - Witness filler to populate.
 	/// * `digest` - The expected 32-byte BLAKE2s digest.
-	pub fn populate_digest(&self, witness: &mut WitnessFiller, digest: &[u8; 32]) {
+	pub fn populate_digest(&self, witness: &mut WitnessFiller<'_>, digest: &[u8; 32]) {
 		for i in 0..8 {
 			let word_bytes = &digest[i * 4..(i + 1) * 4];
 			let word = u32::from_le_bytes(word_bytes.try_into().unwrap());

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -244,10 +244,10 @@ fn blake3_parent_pair(
 ) -> ([Wire; 8], [Wire; 8]) {
 	// Both lanes start from the same chaining value, so each word is that word in both halves.
 	// The key's words carry zero high bits, so they pack by the same shift-and-XOR as a child.
-	let cv: [Wire; 8] = match key {
-		Some(key) => std::array::from_fn(|i| pack_lanes(builder, key[i], key[i])),
-		None => std::array::from_fn(|i| dup32(builder, IV[i])),
-	};
+	let cv: [Wire; 8] = key.map_or_else(
+		|| std::array::from_fn(|i| dup32(builder, IV[i])),
+		|key| std::array::from_fn(|i| pack_lanes(builder, key[i], key[i])),
+	);
 	let block: [Wire; 16] = std::array::from_fn(|i| {
 		if i < 8 {
 			pack_lanes(builder, a.0[i], b.0[i])

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -364,7 +364,7 @@ mod tests {
 	/// Build a concat over a mix of constant- and dynamic-length terms, populate, verify
 	/// constraints, and return the concatenated bytes. Lets tests drive the constant-offset /
 	/// constant-length branches that the `new_inout`-based `run_concat` never reaches.
-	fn run_concat_mixed(terms: &[Term]) -> Result<Vec<u8>> {
+	fn run_concat_mixed(terms: &[Term<'_>]) -> Result<Vec<u8>> {
 		let b = CircuitBuilder::new();
 		let inputs: Vec<ByteVec> = terms
 			.iter()
@@ -568,7 +568,7 @@ mod tests {
 					.enumerate()
 					.map(|(i, &n)| random_bytes(n, seed.wrapping_add(i as u64)))
 					.collect();
-				let terms: Vec<Term> = term_bytes.iter().map(|d| Term::Const(d.as_slice())).collect();
+				let terms: Vec<Term<'_>> = term_bytes.iter().map(|d| Term::Const(d.as_slice())).collect();
 				let expected: Vec<u8> = term_bytes.iter().flatten().copied().collect();
 				let bytes = run_concat_mixed(&terms).unwrap();
 				prop_assert_eq!(bytes, expected);

--- a/crates/circuits/src/fixed_byte_vec.rs
+++ b/crates/circuits/src/fixed_byte_vec.rs
@@ -119,7 +119,7 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// * If `len_bytes` lies outside `self.len_range`.
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		self.assert_len_in_range(len_bytes);
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
@@ -139,7 +139,7 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// * If bytes.len() exceeds self.max_len
-	pub fn populate_bytes_le(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_bytes_le(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.assert_len_in_range(bytes.len());
 		w.pack_bytes_le(&self.data, bytes);
 		w[self.len_bytes] = Word(bytes.len() as u64);
@@ -152,7 +152,7 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// Panics if `data_bytes.len()` > `self.max_len_bytes()`
-	pub fn populate_data(&self, w: &mut WitnessFiller, data_bytes: &[u8]) {
+	pub fn populate_data(&self, w: &mut WitnessFiller<'_>, data_bytes: &[u8]) {
 		assert!(
 			data_bytes.len() <= self.max_len_bytes(),
 			"vector data length {} exceeds maximum {}",

--- a/crates/circuits/src/hash_based_sig/aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/aggregate.rs
@@ -62,7 +62,7 @@ impl MultiSigWires {
 	/// If the number of pairs is not the number of signers the wires were allocated for.
 	pub fn populate(
 		&self,
-		w: &mut WitnessFiller,
+		w: &mut WitnessFiller<'_>,
 		message: &Message,
 		epoch: u32,
 		signatures: &[(XmssPublicKey, XmssSignature)],

--- a/crates/circuits/src/hash_based_sig/xmss.rs
+++ b/crates/circuits/src/hash_based_sig/xmss.rs
@@ -62,7 +62,7 @@ impl XmssSignatureWires {
 	}
 
 	/// Populates the wires from a signature.
-	pub fn populate(&self, w: &mut binius_frontend::WitnessFiller, signature: &XmssSignature) {
+	pub fn populate(&self, w: &mut binius_frontend::WitnessFiller<'_>, signature: &XmssSignature) {
 		w.pack_bytes_le(&self.randomness, &signature.randomness);
 		for (wires, tip) in iter::zip(&self.chain_tips, &signature.chain_tips) {
 			w.pack_bytes_le(wires, tip);

--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -15,7 +15,7 @@ pub struct Attribute {
 
 impl Attribute {
 	/// Populate the actual value length
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
@@ -23,7 +23,7 @@ impl Attribute {
 	///
 	/// # Panics
 	/// Panics if value.len() > max_value_size (determined by self.value.len() * 8)
-	pub fn populate_value(&self, w: &mut WitnessFiller, value: &[u8]) {
+	pub fn populate_value(&self, w: &mut WitnessFiller<'_>, value: &[u8]) {
 		w.pack_bytes_le(&self.value, value);
 	}
 }
@@ -204,7 +204,7 @@ impl JwtClaims {
 	}
 
 	/// Populate the len_bytes wire with the actual JSON size in bytes
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
@@ -212,7 +212,7 @@ impl JwtClaims {
 	///
 	/// # Panics
 	/// Panics if json.len() > max_len_json (the maximum size specified during construction)
-	pub fn populate_json(&self, w: &mut WitnessFiller, json: &[u8]) {
+	pub fn populate_json(&self, w: &mut WitnessFiller<'_>, json: &[u8]) {
 		w.pack_bytes_le(&self.json, json);
 	}
 }

--- a/crates/circuits/src/rs256.rs
+++ b/crates/circuits/src/rs256.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// This function converts a FixedByteVec with little-endian packed wires
 /// to a BigUint representing a big-endian number.
-fn fixedbytevec_le_to_biguint(builder: &mut CircuitBuilder, byte_vec: &ByteVec) -> BigUint {
+fn fixedbytevec_le_to_biguint(builder: &CircuitBuilder, byte_vec: &ByteVec) -> BigUint {
 	// With LE packing, each wire contains 8 bytes as: byte0 | byte1<<8 | ... | byte7<<56
 	// For a BE number, we need to both reverse wire order AND byte-swap within each wire
 	let limbs = byte_vec
@@ -192,19 +192,24 @@ impl Rs256Verify {
 	}
 
 	/// Populate the message length
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		self.message.populate_len_bytes(w, len_bytes);
 	}
 
 	/// Populate the RSA signature, modulus and intermediate computations
-	pub fn populate_rsa(&self, w: &mut WitnessFiller, signature: &[u8], modulus: &[u8]) {
+	pub fn populate_rsa(&self, w: &mut WitnessFiller<'_>, signature: &[u8], modulus: &[u8]) {
 		self.populate_signature(w, signature);
 		self.populate_modulus(w, modulus);
 		self.rsa_intermediates
 			.populate_witness(w, signature, modulus);
 	}
 
-	pub fn populate_intermediates(&self, w: &mut WitnessFiller, signature: &[u8], modulus: &[u8]) {
+	pub fn populate_intermediates(
+		&self,
+		w: &mut WitnessFiller<'_>,
+		signature: &[u8],
+		modulus: &[u8],
+	) {
 		self.rsa_intermediates
 			.populate_witness(w, signature, modulus);
 	}
@@ -213,7 +218,7 @@ impl Rs256Verify {
 	///
 	/// # Panics
 	/// Panics if message.len() > self.message.len() * 8
-	pub fn populate_message(&self, w: &mut WitnessFiller, message: &[u8]) {
+	pub fn populate_message(&self, w: &mut WitnessFiller<'_>, message: &[u8]) {
 		self.message.populate_data(w, message);
 	}
 
@@ -221,7 +226,7 @@ impl Rs256Verify {
 	///
 	/// # Panics
 	/// Panics if modulus_bytes.len() != 256
-	pub fn populate_modulus(&self, w: &mut WitnessFiller, modulus_bytes: &[u8]) {
+	pub fn populate_modulus(&self, w: &mut WitnessFiller<'_>, modulus_bytes: &[u8]) {
 		assert_eq!(modulus_bytes.len(), 256, "modulus must be exactly 256 bytes");
 		self.modulus.populate_bytes_le(w, modulus_bytes);
 	}
@@ -234,7 +239,7 @@ impl Rs256Verify {
 	///
 	/// # Panics
 	/// Panics if signature_bytes.len() != 256
-	pub fn populate_signature(&self, w: &mut WitnessFiller, signature_bytes: &[u8]) {
+	pub fn populate_signature(&self, w: &mut WitnessFiller<'_>, signature_bytes: &[u8]) {
 		assert_eq!(signature_bytes.len(), 256, "signature must be exactly 256 bytes");
 		self.signature.populate_bytes_le(w, signature_bytes);
 	}
@@ -315,7 +320,7 @@ impl RsaIntermediates {
 	/// # Arguments
 	/// * `signature` - The bytes of a RSA signature
 	/// * `modulus_limbs` - The bytes of a RSA modulus
-	pub fn populate_witness(&self, w: &mut WitnessFiller, signature: &[u8], modulus: &[u8]) {
+	pub fn populate_witness(&self, w: &mut WitnessFiller<'_>, signature: &[u8], modulus: &[u8]) {
 		assert_eq!(signature.len(), 256, "signature must be exactly 256 bytes");
 		assert_eq!(modulus.len(), 256, "modulus must be exactly 256 bytes");
 
@@ -361,7 +366,11 @@ impl RsaIntermediates {
 	///
 	/// # Panics
 	/// Panics if square_quotient_limbs.len() != 16 or if any quotient doesn't have 32 limbs.
-	fn populate_square_quotients(&self, w: &mut WitnessFiller, square_quotient_limbs: &[Vec<u64>]) {
+	fn populate_square_quotients(
+		&self,
+		w: &mut WitnessFiller<'_>,
+		square_quotient_limbs: &[Vec<u64>],
+	) {
 		assert_eq!(square_quotient_limbs.len(), 16, "must provide 16 square quotients");
 		for (i, q_limbs) in square_quotient_limbs.iter().enumerate() {
 			assert_eq!(
@@ -380,7 +389,7 @@ impl RsaIntermediates {
 	/// Panics if square_remainder_limbs.len() != 16 or if any remainder doesn't have 32 limbs
 	fn populate_square_remainders(
 		&self,
-		w: &mut WitnessFiller,
+		w: &mut WitnessFiller<'_>,
 		square_remainder_limbs: &[Vec<u64>],
 	) {
 		assert_eq!(square_remainder_limbs.len(), 16, "must provide 16 square remainders");
@@ -394,7 +403,7 @@ impl RsaIntermediates {
 	///
 	/// # Panics
 	/// Panics if mul_quotient_limbs.len() != 32
-	fn populate_mul_quotient(&self, w: &mut WitnessFiller, mul_quotient_limbs: &[u64]) {
+	fn populate_mul_quotient(&self, w: &mut WitnessFiller<'_>, mul_quotient_limbs: &[u64]) {
 		assert_eq!(
 			mul_quotient_limbs.len(),
 			self.mul_quotient.limbs.len(),
@@ -408,7 +417,7 @@ impl RsaIntermediates {
 	///
 	/// # Panics
 	/// Panics if mul_remainder_limbs.len() != 32
-	fn populate_mul_remainder(&self, w: &mut WitnessFiller, mul_remainder_limbs: &[u64]) {
+	fn populate_mul_remainder(&self, w: &mut WitnessFiller<'_>, mul_remainder_limbs: &[u64]) {
 		assert_eq!(mul_remainder_limbs.len(), 32, "mul_remainder must have 32 limbs");
 		self.mul_remainder.populate_limbs(w, mul_remainder_limbs);
 	}
@@ -448,7 +457,7 @@ mod tests {
 
 	fn populate_circuit(
 		circuit: &Rs256Verify,
-		w: &mut WitnessFiller,
+		w: &mut WitnessFiller<'_>,
 		signature_bytes: &[u8],
 		message_bytes: &[u8],
 		modulus_bytes: &[u8],

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -592,7 +592,7 @@ fn compress_inner(
 ///
 /// The bytes are packed big-endian into 16 32-bit words, one per wire, with the high 32 bits left
 /// zero — matching the precondition on `m` documented in [`sha256_compress`].
-pub fn populate_message_block(w: &mut WitnessFiller, m: &[Wire; 16], bytes: [u8; 64]) {
+pub fn populate_message_block(w: &mut WitnessFiller<'_>, m: &[Wire; 16], bytes: [u8; 64]) {
 	for (wire, chunk) in m.iter().zip(bytes.chunks_exact(4)) {
 		let word = u32::from_be_bytes(chunk.try_into().unwrap());
 		w[*wire] = Word(word as u64);

--- a/crates/compute/src/buffer_pool.rs
+++ b/crates/compute/src/buffer_pool.rs
@@ -229,7 +229,7 @@ impl<T> Drop for PoolVec<'_, T> {
 		// to the pool holds no live values.
 		data.clear();
 		let n_chunks = byte_len / BUFFER_ALIGN;
-		let ptr = data.as_ptr() as *mut AlignedChunk;
+		let ptr = data.as_mut_ptr().cast::<AlignedChunk>();
 		// Take the allocation away from the `Vec` so it is not freed, then rebuild the owning
 		// block.
 		mem::forget(data);

--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -253,7 +253,7 @@ impl ShiftVariant {
 	/// - `amount`: the shift amount in bits, below this variant's upper bound.
 	#[inline]
 	pub fn write_shifted(self, out: &mut [MaybeUninit<Word>], src: &[Word], amount: u32) {
-		self.dispatch(amount, WriteShiftedWords { out, src })
+		self.dispatch(amount, WriteShiftedWords { out, src });
 	}
 
 	/// Applies this shift to each source word and XORs the result into the matching output cell.
@@ -267,7 +267,7 @@ impl ShiftVariant {
 	/// - `amount`: the shift amount in bits, below this variant's upper bound.
 	#[inline]
 	pub fn xor_shifted(self, out: &mut [Word], src: &[Word], amount: u32) {
-		self.dispatch(amount, XorShiftedWords { out, src })
+		self.dispatch(amount, XorShiftedWords { out, src });
 	}
 }
 

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -358,15 +358,14 @@ impl ConstraintSystem {
 		constraint_index: usize,
 		operand_name: &'static str,
 	) -> Result<(), ConstraintSystemError> {
-		match self.operand_fault(operand) {
-			None => Ok(()),
-			Some(source) => Err(ConstraintSystemError::ConstraintOperand {
+		self.operand_fault(operand).map_or(Ok(()), |source| {
+			Err(ConstraintSystemError::ConstraintOperand {
 				constraint_kind,
 				constraint_index,
 				operand_name,
 				source,
-			}),
-		}
+			})
+		})
 	}
 
 	/// Returns the first way a term of an operand is malformed, or `None` when every term is

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -586,15 +586,9 @@ mod tests {
 
 			// Check sign bit is extended
 			let is_negative = (val as i64) < 0;
-			if is_negative {
-				// High bits should all be 1
-				let mask = !((1u64 << (64 - shift)) - 1);
-				assert_eq!(result.0 & mask, mask);
-			} else {
-				// High bits should all be 0
-				let mask = !((1u64 << (64 - shift)) - 1);
-				assert_eq!(result.0 & mask, 0);
-			}
+			// The high bits are all 1 for a negative input and all 0 otherwise.
+			let mask = !((1u64 << (64 - shift)) - 1);
+			assert_eq!(result.0 & mask, if is_negative { mask } else { 0 });
 		}
 
 		#[test]

--- a/crates/examples/benches/utils/independent_hashes.rs
+++ b/crates/examples/benches/utils/independent_hashes.rs
@@ -162,7 +162,7 @@ fn bench_witness_generation_and_proving<B>(
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 			ctx.prover.prove(&witness, &mut prover_transcript).unwrap();
 			prover_transcript
-		})
+		});
 	});
 
 	group.finish();

--- a/crates/examples/benches/utils/runner.rs
+++ b/crates/examples/benches/utils/runner.rs
@@ -168,7 +168,7 @@ pub fn run_cs_benchmark_with_extra_groups<B, F>(
 					.unwrap();
 				circuit.populate_wire_witness(&mut filler).unwrap();
 				filler.into_value_vec()
-			})
+			});
 		});
 
 		group.finish();
@@ -186,7 +186,7 @@ pub fn run_cs_benchmark_with_extra_groups<B, F>(
 				let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 				prover.prove(&witness, &mut prover_transcript).unwrap();
 				prover_transcript
-			})
+			});
 		});
 
 		group.finish();
@@ -221,8 +221,8 @@ pub fn run_cs_benchmark_with_extra_groups<B, F>(
 				verifier
 					.verify(witness.inout(), &mut verifier_transcript)
 					.unwrap();
-				verifier_transcript.finalize().unwrap()
-			})
+				verifier_transcript.finalize().unwrap();
+			});
 		});
 
 		group.finish();

--- a/crates/examples/src/bin/prover.rs
+++ b/crates/examples/src/bin/prover.rs
@@ -1,4 +1,7 @@
 // Copyright 2025 Irreducible Inc.
+
+//! Proves a constraint system read from disk, writing the proof out as a file.
+
 use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result};

--- a/crates/examples/src/bin/verifier.rs
+++ b/crates/examples/src/bin/verifier.rs
@@ -1,4 +1,7 @@
 // Copyright 2025 Irreducible Inc.
+
+//! Verifies a proof read from disk against the constraint system it was produced for.
+
 use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result, bail};

--- a/crates/examples/src/circuits/bip32.rs
+++ b/crates/examples/src/circuits/bip32.rs
@@ -228,7 +228,7 @@ impl ExampleCircuit for Bip32Example {
 		})
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		if instance.path.len() > self.max_depth {
 			bail!("path depth {} exceeds max_depth {}", instance.path.len(), self.max_depth);
 		}
@@ -279,10 +279,9 @@ impl ExampleCircuit for Bip32Example {
 /// Parse a single derivation-path child like "0", "44'", or "5h" into a 32-bit index with the
 /// hardened bit set when suffixed.
 fn parse_child(s: &str) -> Result<u32, String> {
-	let (digits, hardened) = match s.strip_suffix(['\'', 'h', 'H']) {
-		Some(rest) => (rest, true),
-		None => (s, false),
-	};
+	let (digits, hardened) = s
+		.strip_suffix(['\'', 'h', 'H'])
+		.map_or((s, false), |rest| (rest, true));
 	let idx: u32 = digits
 		.parse()
 		.map_err(|e| format!("invalid child index '{s}': {e}"))?;

--- a/crates/examples/src/circuits/bitcoin_header_chain.rs
+++ b/crates/examples/src/circuits/bitcoin_header_chain.rs
@@ -57,7 +57,7 @@ impl ExampleCircuit for BitcoinHeaderChainExample {
 	fn populate_witness(
 		&self,
 		instance: Self::Instance,
-		filler: &mut WitnessFiller,
+		filler: &mut WitnessFiller<'_>,
 	) -> anyhow::Result<()> {
 		let (headers_value, latest_digest_value) =
 			pull_headers(self.headers.len(), instance.to_block)?;
@@ -110,8 +110,6 @@ fn pull_headers(
 			.call()?
 			.body_mut()
 			.read_to_string()?;
-		let mut hash = hex::decode(hash)?;
-		hash.reverse();
 		let header = hex::decode(header)?;
 		headers.push(header);
 	}

--- a/crates/examples/src/circuits/bitcoin_p2pkh.rs
+++ b/crates/examples/src/circuits/bitcoin_p2pkh.rs
@@ -70,8 +70,10 @@ impl ExampleCircuit for BitcoinP2PKHExample {
 		})
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
-		// Generate or use provided private key
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
+		// Generate or use provided private key.
+		// The generating arm is much the longer one, so `map_or_else` would bury the common case.
+		#[allow(clippy::option_if_let_else)]
 		let private_key_bytes = match instance.private_key {
 			Some(key) => {
 				tracing::info!("Using provided private key");

--- a/crates/examples/src/circuits/blake2b.rs
+++ b/crates/examples/src/circuits/blake2b.rs
@@ -34,7 +34,7 @@ impl ExampleCircuit for Blake2bExample {
 		})
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 
 		// Compute digest using reference implementation

--- a/crates/examples/src/circuits/blake2s.rs
+++ b/crates/examples/src/circuits/blake2s.rs
@@ -36,7 +36,7 @@ impl ExampleCircuit for Blake2sExample {
 		})
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 
 		// Compute digest using reference implementation

--- a/crates/examples/src/circuits/blake3.rs
+++ b/crates/examples/src/circuits/blake3.rs
@@ -50,7 +50,7 @@ impl ExampleCircuit for Blake3Example {
 		})
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message_bytes = utils::resolve_hasher_message(&self.mode, &instance)?;
 
 		// Message: 32-bit little-endian words, 4 bytes per wire, high 32 bits zero.

--- a/crates/examples/src/circuits/blake3_compress.rs
+++ b/crates/examples/src/circuits/blake3_compress.rs
@@ -77,7 +77,7 @@ impl ExampleCircuit for Blake3CompressExample {
 		Ok(Self { initial_cv, pairs })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
 		let mut next = || Word(rng.next_u64());
 

--- a/crates/examples/src/circuits/ec_msm.rs
+++ b/crates/examples/src/circuits/ec_msm.rs
@@ -37,7 +37,7 @@ struct AffinePoint {
 }
 
 impl AffinePoint {
-	fn new_inout(builder: &mut CircuitBuilder) -> Self {
+	fn new_inout(builder: &CircuitBuilder) -> Self {
 		Self {
 			x: BigUint::new_inout(builder, N_LIMBS),
 			y: BigUint::new_inout(builder, N_LIMBS),
@@ -101,7 +101,7 @@ impl ExampleCircuit for EcMsmExample {
 		})
 	}
 
-	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(42);
 		let mut expected = ProjectivePoint::IDENTITY;
 
@@ -133,7 +133,7 @@ impl ExampleCircuit for EcMsmExample {
 }
 
 /// Populate the `x` and `y` limb wires from a k256 projective point's affine coordinates.
-fn populate_point(w: &mut WitnessFiller, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
+fn populate_point(w: &mut WitnessFiller<'_>, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
 	let bytes = p.to_affine().to_sec1_point(false).to_bytes();
 	// Uncompressed SEC1 encoding: `0x04 || x (32 bytes) || y (32 bytes)`.
 	x.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[1..33])));

--- a/crates/examples/src/circuits/ethsign.rs
+++ b/crates/examples/src/circuits/ethsign.rs
@@ -121,7 +121,7 @@ impl ExampleCircuit for EthSignExample {
 		})
 	}
 
-	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Generate random initial state with fixed seed for reproducibility
 		let mut rng = StdRng::seed_from_u64(42);
 

--- a/crates/examples/src/circuits/hashsign.rs
+++ b/crates/examples/src/circuits/hashsign.rs
@@ -52,7 +52,7 @@ impl ExampleCircuit for HashBasedSigExample {
 		})
 	}
 
-	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(SEED);
 
 		let mut message: Message = [0u8; MESSAGE_LEN];

--- a/crates/examples/src/circuits/independent_hashes.rs
+++ b/crates/examples/src/circuits/independent_hashes.rs
@@ -84,7 +84,7 @@ impl ExampleCircuit for IndependentSha256Compressions {
 		Ok(Self { compressions })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
 		for compression in &self.compressions {
 			let block_bytes = next_block(&mut rng);
@@ -155,7 +155,7 @@ impl ExampleCircuit for IndependentBlake3Compressions {
 		Ok(Self { compressions })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
 		for compression in &self.compressions {
 			let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
@@ -224,7 +224,7 @@ impl ExampleCircuit for IndependentKeccakPermutations {
 		Ok(Self { permutations })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
 		for permutation in &self.permutations {
 			let state: [u64; 25] = std::array::from_fn(|_| rng.next_u64());

--- a/crates/examples/src/circuits/keccak.rs
+++ b/crates/examples/src/circuits/keccak.rs
@@ -71,7 +71,7 @@ impl ExampleCircuit for KeccakExample {
 		Ok(Self { circuit, mode })
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 		let mut hasher = sha3::Keccak256::new();
 		hasher.update(&message);

--- a/crates/examples/src/circuits/sha256.rs
+++ b/crates/examples/src/circuits/sha256.rs
@@ -65,7 +65,7 @@ impl ExampleCircuit for Sha256Example {
 		Ok(Self { circuit, mode })
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 		let digest = sha2::Sha256::digest(&message);
 

--- a/crates/examples/src/circuits/sha3.rs
+++ b/crates/examples/src/circuits/sha3.rs
@@ -70,7 +70,7 @@ impl ExampleCircuit for Sha3Example {
 		Ok(Self { circuit, mode })
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 		let digest: [u8; 32] = sha3::Sha3_256::digest(&message).into();
 

--- a/crates/examples/src/circuits/sha3_512.rs
+++ b/crates/examples/src/circuits/sha3_512.rs
@@ -70,7 +70,7 @@ impl ExampleCircuit for Sha3_512Example {
 		Ok(Self { circuit, mode })
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 		let digest: [u8; 64] = sha3::Sha3_512::digest(&message).into();
 

--- a/crates/examples/src/circuits/sha512.rs
+++ b/crates/examples/src/circuits/sha512.rs
@@ -70,7 +70,7 @@ impl ExampleCircuit for Sha512Example {
 		Ok(Self { circuit, mode })
 	}
 
-	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: HasherInstance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let message = utils::resolve_hasher_message(&self.mode, &instance)?;
 		let digest = sha2::Sha512::digest(&message);
 

--- a/crates/examples/src/circuits/utils.rs
+++ b/crates/examples/src/circuits/utils.rs
@@ -119,15 +119,18 @@ pub fn resolve_hasher_mode(
 /// length `--random-message-len` (defaulting to `mode`'s capacity). The resulting length must be
 /// compatible with the circuit: exactly the fixed length, or at most the variable-length maximum.
 pub fn resolve_hasher_message(mode: &HasherMode, instance: &HasherInstance) -> Result<Vec<u8>> {
-	let message = if let Some(s) = &instance.message {
-		s.clone().into_bytes()
-	} else {
-		let len = instance.random_message_len.unwrap_or(mode.capacity_bytes());
-		let mut rng = StdRng::seed_from_u64(DEFAULT_RANDOM_SEED);
-		let mut bytes = vec![0u8; len];
-		rng.fill_bytes(&mut bytes);
-		bytes
-	};
+	let message = instance.message.as_ref().map_or_else(
+		|| {
+			let len = instance
+				.random_message_len
+				.unwrap_or_else(|| mode.capacity_bytes());
+			let mut rng = StdRng::seed_from_u64(DEFAULT_RANDOM_SEED);
+			let mut bytes = vec![0u8; len];
+			rng.fill_bytes(&mut bytes);
+			bytes
+		},
+		|s| s.clone().into_bytes(),
+	);
 
 	ensure!(!message.is_empty(), "Message length must be positive");
 	match mode {

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -317,96 +317,100 @@ impl ZkLogin {
 		}
 	}
 
-	pub fn populate_sub(&self, w: &mut WitnessFiller, sub_bytes: &[u8]) {
+	pub fn populate_sub(&self, w: &mut WitnessFiller<'_>, sub_bytes: &[u8]) {
 		self.sub.populate_bytes_le(w, sub_bytes);
 	}
 
-	pub fn populate_aud(&self, w: &mut WitnessFiller, aud_bytes: &[u8]) {
+	pub fn populate_aud(&self, w: &mut WitnessFiller<'_>, aud_bytes: &[u8]) {
 		self.aud.populate_bytes_le(w, aud_bytes);
 	}
 
-	pub fn populate_iss(&self, w: &mut WitnessFiller, iss_bytes: &[u8]) {
+	pub fn populate_iss(&self, w: &mut WitnessFiller<'_>, iss_bytes: &[u8]) {
 		self.iss.populate_bytes_le(w, iss_bytes);
 	}
 
-	pub fn populate_salt(&self, w: &mut WitnessFiller, salt_bytes: &[u8]) {
+	pub fn populate_salt(&self, w: &mut WitnessFiller<'_>, salt_bytes: &[u8]) {
 		self.salt.populate_bytes_le(w, salt_bytes);
 	}
 
-	pub fn populate_zkaddr(&self, w: &mut WitnessFiller, zkaddr_hash: &[u8; 32]) {
+	pub fn populate_zkaddr(&self, w: &mut WitnessFiller<'_>, zkaddr_hash: &[u8; 32]) {
 		for (i, chunk) in zkaddr_hash.chunks(8).enumerate() {
 			w[self.zkaddr[i]] = Word(u64::from_be_bytes(chunk.try_into().unwrap()));
 		}
 	}
 
-	pub fn populate_zkaddr_preimage(&self, w: &mut WitnessFiller, zkaddr_preimage: &[u8]) {
+	pub fn populate_zkaddr_preimage(&self, w: &mut WitnessFiller<'_>, zkaddr_preimage: &[u8]) {
 		self.zkaddr_sha256
 			.populate_len_bytes(w, zkaddr_preimage.len());
 		self.zkaddr_sha256.populate_data(w, zkaddr_preimage);
 	}
 
-	pub fn populate_jwt_header(&self, w: &mut WitnessFiller, header_bytes: &[u8]) {
+	pub fn populate_jwt_header(&self, w: &mut WitnessFiller<'_>, header_bytes: &[u8]) {
 		self.jwt_header.populate_bytes_le(w, header_bytes);
 	}
 
-	pub fn populate_jwt_payload(&self, w: &mut WitnessFiller, payload_bytes: &[u8]) {
+	pub fn populate_jwt_payload(&self, w: &mut WitnessFiller<'_>, payload_bytes: &[u8]) {
 		self.jwt_payload.populate_bytes_le(w, payload_bytes);
 	}
 
-	pub fn populate_jwt_signature(&self, w: &mut WitnessFiller, signature_bytes: &[u8]) {
+	pub fn populate_jwt_signature(&self, w: &mut WitnessFiller<'_>, signature_bytes: &[u8]) {
 		assert_eq!(signature_bytes.len(), 256, "RSA signature must be 256 bytes");
 		self.jwt_signature.populate_bytes_le(w, signature_bytes);
 	}
 
-	pub fn populate_base64_jwt_header(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_base64_jwt_header(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.base64_jwt_header.populate_bytes_le(w, bytes);
 	}
 
-	pub fn populate_base64_jwt_payload(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_base64_jwt_payload(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.base64_jwt_payload.populate_bytes_le(w, bytes);
 	}
 
-	pub fn populate_base64_jwt_signature(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_base64_jwt_signature(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.base64_jwt_signature.populate_bytes_le(w, bytes);
 	}
 
-	pub fn populate_rsa_modulus(&self, w: &mut WitnessFiller, modulus_bytes: &[u8]) {
+	pub fn populate_rsa_modulus(&self, w: &mut WitnessFiller<'_>, modulus_bytes: &[u8]) {
 		self.jwt_signature_verify
 			.modulus
 			.populate_bytes_le(w, modulus_bytes);
 	}
 
-	pub fn populate_jwt_header_attributes(&self, w: &mut WitnessFiller) {
+	pub fn populate_jwt_header_attributes(&self, w: &mut WitnessFiller<'_>) {
 		// Populate the expected lengths for "alg" and "typ" attributes
 		self.jwt_claims_header.attributes[0].populate_len_bytes(w, 5); // "RS256" is 5 bytes
 		self.jwt_claims_header.attributes[1].populate_len_bytes(w, 3); // "JWT" is 3 bytes
 	}
 
-	pub fn populate_nonce(&self, w: &mut WitnessFiller, nonce_hash: &[u8; 32]) {
+	pub fn populate_nonce(&self, w: &mut WitnessFiller<'_>, nonce_hash: &[u8; 32]) {
 		for (i, chunk) in nonce_hash.chunks(8).enumerate() {
 			w[self.nonce[i]] = Word(u64::from_be_bytes(chunk.try_into().unwrap()));
 		}
 	}
 
-	pub fn populate_nonce_preimage(&self, w: &mut WitnessFiller, nonce_preimage: &[u8]) {
+	pub fn populate_nonce_preimage(&self, w: &mut WitnessFiller<'_>, nonce_preimage: &[u8]) {
 		self.nonce_sha256
 			.populate_len_bytes(w, nonce_preimage.len());
 		self.nonce_sha256.populate_data(w, nonce_preimage);
 	}
 
-	pub fn populate_vk_u(&self, w: &mut WitnessFiller, vk_u_bytes: &[u8; 32]) {
+	pub fn populate_vk_u(&self, w: &mut WitnessFiller<'_>, vk_u_bytes: &[u8; 32]) {
 		w.pack_bytes_le(&self.vk_u, vk_u_bytes);
 	}
 
-	pub fn populate_t_max(&self, w: &mut WitnessFiller, t_max_bytes: &[u8]) {
+	pub fn populate_t_max(&self, w: &mut WitnessFiller<'_>, t_max_bytes: &[u8]) {
 		self.t_max.populate_bytes_le(w, t_max_bytes);
 	}
 
-	pub fn populate_nonce_r(&self, w: &mut WitnessFiller, nonce_r_bytes: &[u8]) {
+	pub fn populate_nonce_r(&self, w: &mut WitnessFiller<'_>, nonce_r_bytes: &[u8]) {
 		self.nonce_r.populate_bytes_le(w, nonce_r_bytes);
 	}
 
-	pub fn populate_base64_jwt_payload_nonce(&self, w: &mut WitnessFiller, base64_nonce: &[u8]) {
+	pub fn populate_base64_jwt_payload_nonce(
+		&self,
+		w: &mut WitnessFiller<'_>,
+		base64_nonce: &[u8],
+	) {
 		// The base64 nonce is 43 characters, but we need to pad to 48 bytes (6 wires)
 		let mut padded = vec![0u8; 48];
 		padded[..base64_nonce.len()].copy_from_slice(&base64_nonce[..base64_nonce.len()]);
@@ -575,7 +579,7 @@ impl ExampleCircuit for ZkLoginExample {
 		Ok(Self { zklogin })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(42);
 
 		// Generate JWT and related data

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,6 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+//! Example circuits and the harness that runs them.
+//!
+//! Each module under [`circuits`] builds one circuit and knows how to fill its witness; [`cli`]
+//! turns that into a runnable binary and [`snapshot`] records the circuit's statistics so a change
+//! in size shows up as a diff.
+
 pub mod circuits;
 pub mod cli;
 pub mod snapshot;
@@ -310,7 +316,11 @@ pub trait ExampleCircuit: Sized {
 	/// - Process the instance data (e.g., parse inputs, compute hashes)
 	/// - Fill all witness values using the provided filler
 	/// - Validate that instance data is compatible with circuit parameters
-	fn populate_witness(&self, instance: Self::Instance, filler: &mut WitnessFiller) -> Result<()>;
+	fn populate_witness(
+		&self,
+		instance: Self::Instance,
+		filler: &mut WitnessFiller<'_>,
+	) -> Result<()>;
 
 	/// Generate a concise parameter summary for perfetto trace filenames.
 	///

--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -18,7 +18,7 @@ fn bench_function<F: Field, M: Measurement, R>(
 	let a: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 	let b: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 	c.bench_function(id, |bench| {
-		bench.iter(|| array::from_fn::<_, BATCH_SIZE, _>(|i| func(a[i], b[i])))
+		bench.iter(|| array::from_fn::<_, BATCH_SIZE, _>(|i| func(a[i], b[i])));
 	});
 }
 

--- a/crates/field/benches/ghash_invert.rs
+++ b/crates/field/benches/ghash_invert.rs
@@ -29,7 +29,7 @@ fn bench_width<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: 
 				acc += black_box(x).invert_or_zero();
 			}
 			black_box(acc)
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/ghash_widening.rs
+++ b/crates/field/benches/ghash_widening.rs
@@ -27,7 +27,7 @@ fn bench_at_n<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: &
 				acc += black_box(a_vals[i]) * black_box(b_vals[i]);
 			}
 			black_box(acc)
-		})
+		});
 	});
 
 	group.bench_function(format!("wide_mul/{label}/n={n}"), |b| {
@@ -37,7 +37,7 @@ fn bench_at_n<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: &
 				acc += P::wide_mul(black_box(a_vals[i]), black_box(b_vals[i]));
 			}
 			black_box(P::reduce(acc))
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_element_access.rs
+++ b/crates/field/benches/packed_field_element_access.rs
@@ -38,7 +38,7 @@ fn benchmark_set_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, 
 			}
 
 			value
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_init.rs
+++ b/crates/field/benches/packed_field_init.rs
@@ -26,7 +26,7 @@ fn benchmark_get_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, 
 				let values = &values[j];
 				P::from_fn(|i| values[i])
 			})
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_spread.rs
+++ b/crates/field/benches/packed_field_spread.rs
@@ -28,7 +28,7 @@ fn benchmark_get_impl<P: PackedField>(
 			array::from_fn::<_, BATCH_SIZE, _>(|j| {
 				values[j].spread(log_block_len, (j % 1) << (P::LOG_WIDTH - log_block_len))
 			})
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -3,7 +3,7 @@
 use criterion::{BenchmarkGroup, measurement::WallTime};
 
 pub fn run_benchmark<R>(
-	group: &mut BenchmarkGroup<WallTime>,
+	group: &mut BenchmarkGroup<'_, WallTime>,
 	name: &str,
 	func: impl Fn() -> Batch<R>,
 ) {
@@ -22,7 +22,7 @@ macro_rules! benchmark_packed_operation {
 		paste::paste! {
             #[allow(non_snake_case)]
 			#[inline(never)]
-			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
                 a: &$crate::packed_field_utils::Batch<$packed_field>,
                 b: &$crate::packed_field_utils::Batch<$packed_field>) {
 				#[allow(unused)]
@@ -60,7 +60,7 @@ macro_rules! benchmark_packed_operation {
 		paste::paste! {
             #[allow(non_snake_case)]
 			#[inline(never)]
-			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
                 a: &$crate::packed_field_utils::Batch<$packed_field>,
                 _b: &$crate::packed_field_utils::Batch<$packed_field>) {
 				#[allow(unused)]

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -136,7 +136,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_square_8(a in any::<u8>()) {
-			check_square(AESTowerField8b::from(a))
+			check_square(AESTowerField8b::from(a));
 		}
 	}
 
@@ -152,7 +152,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_invert_8(a in any::<u8>()) {
-			check_invert(AESTowerField8b::from(a))
+			check_invert(AESTowerField8b::from(a));
 		}
 	}
 
@@ -190,7 +190,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_mul_8(a in any::<u8>(), b in any::<u8>(), c in any::<u8>()) {
-			check_mul(AESTowerField8b::from(a), AESTowerField8b::from(b), AESTowerField8b::from(c))
+			check_mul(AESTowerField8b::from(a), AESTowerField8b::from(b), AESTowerField8b::from(c));
 		}
 	}
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -99,7 +99,7 @@ impl From<M128> for u128 {
 		let mut result = 0u128;
 		unsafe {
 			// Safety: u128 is 16-byte aligned, as the const assertion above checks.
-			_mm_store_si128(&raw mut result as *mut __m128i, value.0)
+			_mm_store_si128(&raw mut result as *mut __m128i, value.0);
 		};
 		result
 	}
@@ -157,7 +157,7 @@ impl BitAnd for M128 {
 impl BitAndAssign for M128 {
 	#[inline(always)]
 	fn bitand_assign(&mut self, rhs: Self) {
-		*self = *self & rhs
+		*self = *self & rhs;
 	}
 }
 
@@ -173,7 +173,7 @@ impl BitOr for M128 {
 impl BitOrAssign for M128 {
 	#[inline(always)]
 	fn bitor_assign(&mut self, rhs: Self) {
-		*self = *self | rhs
+		*self = *self | rhs;
 	}
 }
 
@@ -779,7 +779,7 @@ mod tests {
 
 		#[test]
 		fn test_negate(a in any::<u128>()) {
-			assert_eq!(M128::from(!a), !M128::from(a))
+			assert_eq!(M128::from(!a), !M128::from(a));
 		}
 
 		#[test]

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -193,7 +193,7 @@ impl BitAnd for M256 {
 impl BitAndAssign for M256 {
 	#[inline(always)]
 	fn bitand_assign(&mut self, rhs: Self) {
-		*self = *self & rhs
+		*self = *self & rhs;
 	}
 }
 
@@ -209,7 +209,7 @@ impl BitOr for M256 {
 impl BitOrAssign for M256 {
 	#[inline(always)]
 	fn bitor_assign(&mut self, rhs: Self) {
-		*self = *self | rhs
+		*self = *self | rhs;
 	}
 }
 
@@ -256,7 +256,7 @@ impl Shr<usize> for M256 {
 					high = 0;
 				} else {
 					low = (low >> rhs) + (high << (128usize - rhs));
-					high >>= rhs
+					high >>= rhs;
 				}
 				[low, high].into()
 			}
@@ -279,7 +279,7 @@ impl Shl<usize> for M256 {
 					low = 0;
 				} else {
 					high = (high << rhs) + (low >> (128usize - rhs));
-					low <<= rhs
+					low <<= rhs;
 				}
 				[low, high].into()
 			}
@@ -1065,7 +1065,7 @@ mod tests {
 		#[test]
 		#[allow(clippy::tuple_array_conversions)] // false positive
 		fn test_negate(a in any::<u128>(), b in any::<u128>()) {
-			assert_eq!(M256::from([!a, ! b]), !M256::from([a, b]))
+			assert_eq!(M256::from([!a, ! b]), !M256::from([a, b]));
 		}
 
 		#[test]

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -158,7 +158,7 @@ impl BitAnd for M512 {
 impl BitAndAssign for M512 {
 	#[inline(always)]
 	fn bitand_assign(&mut self, rhs: Self) {
-		*self = *self & rhs
+		*self = *self & rhs;
 	}
 }
 
@@ -174,7 +174,7 @@ impl BitOr for M512 {
 impl BitOrAssign for M512 {
 	#[inline(always)]
 	fn bitor_assign(&mut self, rhs: Self) {
-		*self = *self | rhs
+		*self = *self | rhs;
 	}
 }
 
@@ -1120,7 +1120,7 @@ mod tests {
 
 		#[test]
 		fn test_negate(a in any::<[u128; 4]>()) {
-			assert_eq!(M512::from([!a[0], !a[1], !a[2], !a[3]]), !M512::from(a))
+			assert_eq!(M512::from([!a[0], !a[1], !a[2], !a[3]]), !M512::from(a));
 		}
 
 		#[test]

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -154,6 +154,6 @@ impl<F: Field> FieldOps for F {
 	where
 		F: ExtensionField<FSub>,
 	{
-		<F as ExtensionField<FSub>>::square_transpose(elems)
+		<F as ExtensionField<FSub>>::square_transpose(elems);
 	}
 }

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -109,7 +109,7 @@ pub trait PackedField:
 		for i in (0..64).rev() {
 			res = Square::square(res);
 			if ((exp >> i) & 1) == 1 {
-				res.mul_assign(self)
+				res.mul_assign(self);
 			}
 		}
 		res
@@ -247,7 +247,7 @@ pub unsafe fn set_packed_slice_unchecked<P: PackedField>(
 	unsafe {
 		packed
 			.get_unchecked_mut(i >> P::LOG_WIDTH)
-			.set_unchecked(i % P::WIDTH, scalar)
+			.set_unchecked(i % P::WIDTH, scalar);
 	}
 }
 

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -341,7 +341,7 @@ mod tests {
 
 	fn test_mul_packed_random<P: PackedField>() {
 		let mut rng = StdRng::seed_from_u64(0);
-		test_mul_packed(P::random(&mut rng), P::random(&mut rng))
+		test_mul_packed(P::random(&mut rng), P::random(&mut rng));
 	}
 
 	fn test_set_then_get<P: PackedField>() {
@@ -411,33 +411,33 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_add_packed_128x1b(a_val in any::<u128>(), b_val in any::<u128>()) {
-			test_add_packed::<PackedBinaryField128x1b>(a_val, b_val)
+			test_add_packed::<PackedBinaryField128x1b>(a_val, b_val);
 		}
 
 		#[test]
 		fn test_add_packed_16x8b(a_val in any::<u128>(), b_val in any::<u128>()) {
-			test_add_packed::<PackedAESBinaryField16x8b>(a_val, b_val)
+			test_add_packed::<PackedAESBinaryField16x8b>(a_val, b_val);
 		}
 
 		#[test]
 		fn test_add_packed_1x128b(a_val in any::<u128>(), b_val in any::<u128>()) {
-			test_add_packed::<PackedBinaryGhash1x128b>(a_val, b_val)
+			test_add_packed::<PackedBinaryGhash1x128b>(a_val, b_val);
 		}
 	}
 
 	#[test]
 	fn test_mul_packed_256x1b() {
-		test_mul_packed_random::<PackedBinaryField256x1b>()
+		test_mul_packed_random::<PackedBinaryField256x1b>();
 	}
 
 	#[test]
 	fn test_mul_packed_32x8b() {
-		test_mul_packed_random::<PackedAESBinaryField32x8b>()
+		test_mul_packed_random::<PackedAESBinaryField32x8b>();
 	}
 
 	#[test]
 	fn test_mul_packed_2x128b() {
-		test_mul_packed_random::<PackedBinaryGhash2x128b>()
+		test_mul_packed_random::<PackedBinaryGhash2x128b>();
 	}
 
 	#[test]

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -31,7 +31,7 @@ fn test_field_text_debug() {
 	assert_eq!(
 		format!("{:?}", PackedAESBinaryField16x8b::broadcast(AESTowerField8b::new(123))),
 		"Packed16x8([0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b])"
-	)
+	);
 }
 
 fn basic_spread<P>(packed: P, log_block_len: usize, block_idx: usize) -> P

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -113,7 +113,7 @@ where
 	F: BinaryField,
 	FE: PackedExtension<F>,
 {
-	transpose_square_blocks(FE::Scalar::LOG_DEGREE, FE::cast_bases_mut(values))
+	transpose_square_blocks(FE::Scalar::LOG_DEGREE, FE::cast_bases_mut(values));
 }
 
 #[cfg(test)]

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -21,7 +21,7 @@ pub(crate) fn single_element_mask_bits<T: UnderlierType + Shl<usize, Output = T>
 	} else {
 		let mut result = T::ONE;
 		for height in 0..checked_log_2(bits_count) {
-			result |= result << (1usize << height)
+			result |= result << (1usize << height);
 		}
 
 		result

--- a/crates/frontend/src/artifact/circuit.rs
+++ b/crates/frontend/src/artifact/circuit.rs
@@ -173,7 +173,7 @@ impl Circuit {
 	/// [`CircuitBuilder::add_inout`]: crate::CircuitBuilder::add_inout
 	/// [`CircuitBuilder::add_witness`]: crate::CircuitBuilder::add_witness
 	/// [`CircuitBuilder::mark_inout`]: crate::CircuitBuilder::mark_inout
-	pub fn populate_wire_witness(&self, w: &mut WitnessFiller) -> Result<(), PopulateError> {
+	pub fn populate_wire_witness(&self, w: &mut WitnessFiller<'_>) -> Result<(), PopulateError> {
 		// Fill the constant part from the witness.
 		for (index, constant) in self.constraint_system.constants.iter().enumerate() {
 			w.value_vec[ValueIndex::constant(index as u32)] = *constant;

--- a/crates/frontend/src/artifact/stat.rs
+++ b/crates/frontend/src/artifact/stat.rs
@@ -139,7 +139,7 @@ impl CircuitStat {
 }
 
 impl fmt::Display for CircuitStat {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		// Helper to format numbers with commas
 		fn fmt_num(n: usize) -> String {
 			let s = n.to_string();
@@ -189,7 +189,7 @@ impl fmt::Display for CircuitStat {
 		// allocation of `0` rather than a power of two — unlike AND, which is always padded to at
 		// least one row.
 		fn constraint_line(
-			f: &mut fmt::Formatter,
+			f: &mut fmt::Formatter<'_>,
 			name: &str,
 			used: usize,
 			allocated: usize,

--- a/crates/frontend/src/ir/hints.rs
+++ b/crates/frontend/src/ir/hints.rs
@@ -88,7 +88,7 @@ impl<T: Hint> ErasedHint for T {
 	}
 
 	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
-		<T as Hint>::execute(self, dimensions, inputs, outputs)
+		<T as Hint>::execute(self, dimensions, inputs, outputs);
 	}
 }
 

--- a/crates/frontend/src/pass/fusion/commit_set.rs
+++ b/crates/frontend/src/pass/fusion/commit_set.rs
@@ -562,9 +562,8 @@ mod tests {
 				// Identity links are legal anywhere and must not sway the answer.
 				amounts
 					.into_iter()
-					.map(|amount| match amount {
-						Some(amount) => KINDS[kind](amount as usize),
-						None => Shift::IDENTITY,
+					.map(|amount| {
+						amount.map_or(Shift::IDENTITY, |amount| KINDS[kind](amount as usize))
 					})
 					.collect()
 			},

--- a/crates/frontend/src/pass/fusion/patch.rs
+++ b/crates/frontend/src/pass/fusion/patch.rs
@@ -75,7 +75,7 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 			AddedConstraint::Bmul(bmul_constraint) => new_bmul_constraints.push(bmul_constraint),
 			AddedConstraint::Zero(zero_constraint) => new_zero_constraints.push(zero_constraint),
 			AddedConstraint::Linear(linear_constraint) => {
-				new_linear_constraints.push(linear_constraint)
+				new_linear_constraints.push(linear_constraint);
 			}
 		}
 	}
@@ -582,7 +582,7 @@ mod tests {
 			for term in cb.operand_terms(inner) {
 				match push_inner(shift_seq, term.sole_shift(), LOWERED_SHIFT_SLOTS) {
 					PushInner::Seq(composed) => {
-						expand_term_recursive(cb, leg, result, term.wire, composed)
+						expand_term_recursive(cb, leg, result, term.wire, composed);
 					}
 					// A term the shifts clear contributes nothing to the XOR.
 					PushInner::Zero => {}

--- a/crates/hash/benches/blake3_portable.rs
+++ b/crates/hash/benches/blake3_portable.rs
@@ -70,7 +70,7 @@ fn bench_portable(c: &mut Criterion) {
 			&batch_size,
 			|b, &bs| {
 				b.iter(|| {
-					run(&portable4, &elements, bs, &mut digests.spare_capacity_mut()[..n_leaves])
+					run(&portable4, &elements, bs, &mut digests.spare_capacity_mut()[..n_leaves]);
 				});
 			},
 		);
@@ -79,7 +79,7 @@ fn bench_portable(c: &mut Criterion) {
 			&batch_size,
 			|b, &bs| {
 				b.iter(|| {
-					run(&portable8, &elements, bs, &mut digests.spare_capacity_mut()[..n_leaves])
+					run(&portable8, &elements, bs, &mut digests.spare_capacity_mut()[..n_leaves]);
 				});
 			},
 		);
@@ -88,7 +88,7 @@ fn bench_portable(c: &mut Criterion) {
 			&batch_size,
 			|b, &bs| {
 				b.iter(|| {
-					run(&portable16, &elements, bs, &mut digests.spare_capacity_mut()[..n_leaves])
+					run(&portable16, &elements, bs, &mut digests.spare_capacity_mut()[..n_leaves]);
 				});
 			},
 		);

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -143,7 +143,7 @@ impl<D: MultiDigest<N, Digest: Send> + Send + Sync, const N: usize> ParallelDige
 					buf.clear();
 					for item in chunk {
 						item.serialize(&mut buf)
-							.expect("pre-condition: items must serialize without error")
+							.expect("pre-condition: items must serialize without error");
 					}
 				}
 				let data = array::from_fn(|i| buffers[i].as_ref());
@@ -200,7 +200,7 @@ where
 					let mut buffer = HashBuffer::new(hasher);
 					for item in items {
 						item.serialize(&mut buffer)
-							.expect("pre-condition: items must serialize without error")
+							.expect("pre-condition: items must serialize without error");
 					}
 				}
 				out.write(hasher.finalize_reset());

--- a/crates/hash/src/serialization.rs
+++ b/crates/hash/src/serialization.rs
@@ -60,7 +60,7 @@ unsafe impl<D: Digest + BlockSizeUser> BufMut for HashBuffer<'_, D> {
 
 impl<D: Digest + BlockSizeUser> Drop for HashBuffer<'_, D> {
 	fn drop(&mut self) {
-		self.flush()
+		self.flush();
 	}
 }
 

--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -69,7 +69,7 @@ where
 	group.bench_function(format!("{case} pooled"), |b| {
 		b.iter(|| pooled_prover.commit_field_buffer(buffer.as_view(), LOG_ELEMS_IN_LEAF));
 	});
-	group.finish()
+	group.finish();
 }
 
 fn bench_sha256_merkle_tree(c: &mut Criterion) {

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -465,8 +465,8 @@ where
 ///
 /// * `src.log_len() <= log_block <= dst.log_len()`
 fn place_repeated<P: PackedField>(
-	mut dst: FieldSliceMut<P>,
-	src: FieldSlice<P>,
+	mut dst: FieldSliceMut<'_, P>,
+	src: FieldSlice<'_, P>,
 	scalar: P::Scalar,
 	log_block: usize,
 ) {
@@ -503,8 +503,8 @@ fn place_repeated<P: PackedField>(
 }
 
 fn accumulate_scaled_buffer<P: PackedField>(
-	mut dst: FieldSliceMut<P>,
-	src: FieldSlice<P>,
+	mut dst: FieldSliceMut<'_, P>,
+	src: FieldSlice<'_, P>,
 	scalar_broadcast: P,
 ) {
 	if src.log_len() >= P::LOG_WIDTH {
@@ -593,7 +593,7 @@ where
 		&self.oracle_specs[self.queue.len()..]
 	}
 
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
 		let remaining = self.remaining_oracle_specs();
 		assert!(!remaining.is_empty(), "send_oracle called but no remaining oracle specs");
 
@@ -1148,7 +1148,7 @@ mod tests {
 			assert!(
 				PackedBinaryGhash4x128b::LOG_WIDTH > 1,
 				"the fixture needs a packed element wider than the `[0, 1]` batch's lift block"
-			)
+			);
 		};
 		for sizes in [[0, 1], [1, 2]] {
 			assert!(

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -38,7 +38,7 @@ pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Sca
 	///
 	/// * `remaining_oracle_specs()` must be non-empty.
 	/// * `buffer.log_len()` must match the expected length from the next oracle spec.
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle;
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle;
 
 	/// Generates an opening proof for one oracle linear relation.
 	///

--- a/crates/iop-prover/src/channel/naive.rs
+++ b/crates/iop-prover/src/channel/naive.rs
@@ -124,7 +124,7 @@ where
 		&self.oracle_specs[self.next_oracle_index..]
 	}
 
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
 		let index = self.next_oracle_index;
 		assert!(
 			index < self.oracle_specs.len(),

--- a/crates/iop-prover/src/commit_pipeline.rs
+++ b/crates/iop-prover/src/commit_pipeline.rs
@@ -48,7 +48,7 @@ pub type PipelinedCommit<P, H, A> = (
 pub fn encode_and_commit_pipelined<F, P, DC, H, N, A>(
 	rs_code: &ReedSolomonCode<F>,
 	ntt: &NeighborsLastMultiThread<DC>,
-	message: FieldSlice<P>,
+	message: FieldSlice<'_, P>,
 	log_batch_size: usize,
 	log_leaf_len: usize,
 	alloc: &A,

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -37,7 +37,7 @@ pub fn encode_interleaved<F, P, NTT, A>(
 	params: &FRIParams<F>,
 	oracle_index: usize,
 	ntt: &NTT,
-	message: FieldSlice<P>,
+	message: FieldSlice<'_, P>,
 	alloc: &A,
 ) -> FieldBuffer<P, A::Vec<P>>
 where
@@ -108,7 +108,7 @@ pub fn encode_masked<F, P, NTT, A>(
 	params: &FRIParams<F>,
 	oracle_index: usize,
 	ntt: &NTT,
-	message: FieldSlice<P>,
+	message: FieldSlice<'_, P>,
 	mut rng: impl CryptoRng,
 	alloc: &A,
 ) -> MaskedCodeword<P, A::Vec<P>>

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -387,7 +387,7 @@ where
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 #[instrument(skip_all, level = "debug")]
-fn fold_codeword<F, NTT>(ntt: &NTT, codeword: FieldSlice<F>, challenges: &[F]) -> FieldBuffer<F>
+fn fold_codeword<F, NTT>(ntt: &NTT, codeword: FieldSlice<'_, F>, challenges: &[F]) -> FieldBuffer<F>
 where
 	F: BinaryField,
 	NTT: AdditiveNTT<Field = F> + Sync,

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -74,7 +74,7 @@ where
 	pub fn commit<NTT, Channel>(
 		level: LigeritoLevel,
 		ntt: &NTT,
-		message: FieldSlice<P>,
+		message: FieldSlice<'_, P>,
 		channel: &mut Channel,
 	) -> Self
 	where
@@ -108,7 +108,7 @@ where
 	/// * `eval_point` has `level.log_msg_len()` coordinates, in low-to-high variable order.
 	pub fn prove<A, Channel>(
 		&self,
-		message: FieldSlice<P>,
+		message: FieldSlice<'_, P>,
 		eval_point: &[F],
 		eval_claim: F,
 		alloc: &A,

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -45,7 +45,7 @@ pub trait MerkleIPProverChannel<F: Field>: WordIPProverChannel<F> {
 	///   power of two.
 	fn send_merkle_commitment<P: PackedField<Scalar = F>>(
 		&mut self,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 		leaf_size: usize,
 	) -> Self::Commitment;
 
@@ -60,7 +60,7 @@ pub trait MerkleIPProverChannel<F: Field>: WordIPProverChannel<F> {
 	fn send_openings<P: PackedField<Scalar = F>>(
 		&mut self,
 		commitment: &Self::Commitment,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 		indices: &[Self::Word],
 	);
 
@@ -72,7 +72,7 @@ pub trait MerkleIPProverChannel<F: Field>: WordIPProverChannel<F> {
 	fn send_committed_vector<P: PackedField<Scalar = F>>(
 		&mut self,
 		commitment: &Self::Commitment,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 	);
 }
 
@@ -141,19 +141,19 @@ where
 	A: Allocator,
 {
 	fn send_one(&mut self, elem: F) {
-		self.transcript.borrow_mut().send_one(elem)
+		self.transcript.borrow_mut().send_one(elem);
 	}
 
 	fn send_many(&mut self, elems: &[F]) {
-		self.transcript.borrow_mut().send_many(elems)
+		self.transcript.borrow_mut().send_many(elems);
 	}
 
 	fn observe_one(&mut self, val: F) {
-		self.transcript.borrow_mut().observe_one(val)
+		self.transcript.borrow_mut().observe_one(val);
 	}
 
 	fn observe_many(&mut self, vals: &[F]) {
-		self.transcript.borrow_mut().observe_many(vals)
+		self.transcript.borrow_mut().observe_many(vals);
 	}
 
 	fn sample(&mut self) -> F {
@@ -195,7 +195,7 @@ where
 
 	fn send_merkle_commitment<P: PackedField<Scalar = F>>(
 		&mut self,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 		leaf_size: usize,
 	) -> Self::Commitment {
 		assert!(leaf_size.is_power_of_two(), "precondition: leaf_size must be a power of two");
@@ -215,7 +215,7 @@ where
 	fn send_openings<P: PackedField<Scalar = F>>(
 		&mut self,
 		commitment: &Self::Commitment,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 		indices: &[Word],
 	) {
 		let tree_depth = commitment.depth;
@@ -248,7 +248,7 @@ where
 	fn send_committed_vector<P: PackedField<Scalar = F>>(
 		&mut self,
 		commitment: &Self::Commitment,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 	) {
 		debug_assert_eq!(commitment.depth, data.log_len() - commitment.log_leaf_size);
 

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -63,7 +63,7 @@ pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 	/// * `log_leaf_len` must be at most the buffer's log length.
 	fn commit_field_buffer<P>(
 		&self,
-		buffer: FieldSlice<P>,
+		buffer: FieldSlice<'_, P>,
 		log_leaf_len: usize,
 	) -> (Commitment<ProverDigest<T, Self>>, Self::Committed)
 	where
@@ -118,6 +118,6 @@ pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 		committed: &Self::Committed,
 		layer_depth: usize,
 		index: usize,
-		proof: &mut TranscriptWriter<B>,
+		proof: &mut TranscriptWriter<'_, B>,
 	);
 }

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -72,7 +72,7 @@ where
 		committed: &Self::Committed,
 		layer_depth: usize,
 		index: usize,
-		proof: &mut TranscriptWriter<B>,
+		proof: &mut TranscriptWriter<'_, B>,
 	) {
 		let branch = committed
 			.branch(index, layer_depth)

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -83,7 +83,7 @@ where
 				(chunk_index << (log_size - 1)) | index_offset,
 				pair,
 				challenge,
-			)
+			);
 		}
 
 		log_len -= 1;

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -96,6 +96,6 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 		layer_depth: usize,
 		tree_depth: usize,
 		layer_digests: &[Self::Digest],
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<(), Error>;
 }

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -230,7 +230,7 @@ where
 		layer_depth: usize,
 		tree_depth: usize,
 		layer_digests: &[Self::Digest],
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<(), Error> {
 		// A layer that many levels below the root holds exactly that many digests.
 		assert_eq!(

--- a/crates/iop/src/soundness.rs
+++ b/crates/iop/src/soundness.rs
@@ -104,6 +104,10 @@
 //! [DP24]: <https://eprint.iacr.org/2024/504>
 //! [ABF26]: <https://eprint.iacr.org/2026/680>
 
+// The expressions here are theorem statements copied term for term, so they stay readable against
+// the papers rather than folded into `mul_add`.
+#![allow(clippy::suboptimal_flops)]
+
 use binius_transcript::MAX_GRINDING_BITS;
 
 use crate::fri::calculate_n_test_queries;

--- a/crates/ip-prover/src/fracaddcheck/circuit.rs
+++ b/crates/ip-prover/src/fracaddcheck/circuit.rs
@@ -119,8 +119,8 @@ where
 			//     spare capacity:  >= out_len   allocated for at least that many
 			//     sibling halves:  == out_len   halves of two equal-length buffers
 			debug_assert!(
-				num_data.spare_capacity_mut().len() >= out_len
-					&& den_data.spare_capacity_mut().len() >= out_len,
+				num_data.capacity() - num_data.len() >= out_len
+					&& den_data.capacity() - den_data.len() >= out_len,
 				"allocated buffers must hold every claimed slot"
 			);
 			debug_assert!(

--- a/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
+++ b/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
@@ -287,7 +287,7 @@ impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for ZeroPadMleCheckPr
 		match &mut self.phase {
 			Phase::Real(inner) => inner.fold(challenge),
 			Phase::Padding { bound_eq, .. } => {
-				*bound_eq *= Hypercube::One.eq_one_var(F::ZERO, challenge)
+				*bound_eq *= Hypercube::One.eq_one_var(F::ZERO, challenge);
 			}
 		}
 		self.round += 1;

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -151,7 +151,7 @@ pub fn prove_reduction<A, F, P>(
 	gamma: F,
 	tables: &[TableLookup<'_, P>],
 	numerators: Vec<Vec<FieldVec<P, A>>>,
-	pushforwards: &[FieldSlice<P>],
+	pushforwards: &[FieldSlice<'_, P>],
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
 where

--- a/crates/ip-prover/src/prodcheck/one_pad_mle.rs
+++ b/crates/ip-prover/src/prodcheck/one_pad_mle.rs
@@ -236,7 +236,7 @@ impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for OnePadMleCheckPro
 		match &mut self.phase {
 			Phase::Real(inner) => inner.fold(challenge),
 			Phase::Padding { bound_eq, .. } => {
-				*bound_eq *= Hypercube::One.eq_one_var(F::ZERO, challenge)
+				*bound_eq *= Hypercube::One.eq_one_var(F::ZERO, challenge);
 			}
 		}
 		self.round += 1;

--- a/crates/ip-prover/src/sumcheck/common.rs
+++ b/crates/ip-prover/src/sumcheck/common.rs
@@ -70,7 +70,7 @@ where
 	}
 
 	fn fold(&mut self, challenge: F) {
-		either::for_both!(self, inner => inner.fold(challenge))
+		either::for_both!(self, inner => inner.fold(challenge));
 	}
 
 	fn finish(self) -> Vec<F> {
@@ -167,7 +167,7 @@ where
 	}
 
 	fn fold(&mut self, challenge: F) {
-		either::for_both!(self, inner => inner.fold(challenge))
+		either::for_both!(self, inner => inner.fold(challenge));
 	}
 
 	fn finish(self) -> Vec<F> {

--- a/crates/ip-prover/src/sumcheck/drive.rs
+++ b/crates/ip-prover/src/sumcheck/drive.rs
@@ -90,7 +90,7 @@ impl<F: Field, Prover: SumcheckProver<F>> RoundProver<F> for SumcheckRounds<Prov
 	}
 
 	fn fold(&mut self, challenge: F) {
-		self.0.fold(challenge)
+		self.0.fold(challenge);
 	}
 
 	fn finish(self) -> Vec<F> {
@@ -116,7 +116,7 @@ impl<F: Field, Prover: MleCheckProver<F>> RoundProver<F> for MleCheckRounds<Prov
 	}
 
 	fn fold(&mut self, challenge: F) {
-		self.0.fold(challenge)
+		self.0.fold(challenge);
 	}
 
 	fn finish(self) -> Vec<F> {

--- a/crates/ip-prover/src/sumcheck/eq_tracker.rs
+++ b/crates/ip-prover/src/sumcheck/eq_tracker.rs
@@ -145,7 +145,7 @@ impl<F: Field, P: PackedField<Scalar = F>> EqTracker<P> {
 	pub fn fold(&mut self, challenge: F) {
 		// Summing the two halves marginalises out the highest variable.
 		self.advance(challenge, |expansion, shrunk| {
-			expansion.eq_ind_truncate_low(Hypercube::One, shrunk)
+			expansion.eq_ind_truncate_low(Hypercube::One, shrunk);
 		});
 	}
 

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -483,7 +483,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 					*column = Column::Owned(
 						dst.take()
 							.expect("borrowed columns get a destination buffer"),
-					)
+					);
 				}
 				Column::Owned(buffer) => buffer.truncate(n_vars),
 				Column::SplitHalf(_) => {}

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -66,7 +66,7 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 		let alpha = self.mlecheck_prover.eval_point()[self.n_vars() - 1];
 		self.eq_prefix_eval *= Hypercube::One.eq_one_var(challenge, alpha);
 
-		self.mlecheck_prover.fold(challenge)
+		self.mlecheck_prover.fold(challenge);
 	}
 
 	fn finish(self) -> Vec<F> {
@@ -121,7 +121,7 @@ where
 
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
 		self.inner
-			.accumulate(chunk, chunk.eq(self.eq_tracker).as_view(), accum)
+			.accumulate(chunk, chunk.eq(self.eq_tracker).as_view(), accum);
 	}
 
 	fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P], claim: F) -> RoundCoeffs<F> {

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -93,18 +93,19 @@ where
 		assert!(bit_offset < self.n_multilinears);
 		assert_eq!(scratchpad.len(), 1 << chunk_vars);
 
-		if let Some(folded) = &self.folded {
-			folded[bit_offset].chunk(chunk_vars, chunk_index)
-		} else {
-			get_binary_chunk(
-				scratchpad,
-				&self.tensor,
-				&BitSelector::new(bit_offset, self.bitmasks),
-				chunk_vars,
-				chunk_index,
-			);
-			scratchpad.as_view()
-		}
+		self.folded.as_ref().map_or_else(
+			|| {
+				get_binary_chunk(
+					scratchpad,
+					&self.tensor,
+					&BitSelector::new(bit_offset, self.bitmasks),
+					chunk_vars,
+					chunk_index,
+				);
+				scratchpad.as_view()
+			},
+			|folded| folded[bit_offset].chunk(chunk_vars, chunk_index),
+		)
 	}
 
 	pub fn fold(&mut self, challenge: F) {

--- a/crates/ip/src/sumcheck/verify.rs
+++ b/crates/ip/src/sumcheck/verify.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// The [`verify`] function reduces a claim about the sum of a multivariate polynomial over the
 /// boolean hypercube to its evaluation at a challenge point.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SumcheckOutput<F> {
 	/// The evaluation of the sumcheck multivariate at the challenge point.
 	pub eval: F,

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -434,7 +434,7 @@ impl<'a> ValueWords<'a> {
 			// * the row holds one word per instance, so it is exactly as long as the stripe;
 			// * `MaybeUninit<Word>` has the same memory representation as `Word`.
 			TermWords::Plain(row) => unsafe {
-				ptr::copy_nonoverlapping(row.as_ptr(), out.as_mut_ptr() as *mut Word, out.len())
+				ptr::copy_nonoverlapping(row.as_ptr(), out.as_mut_ptr() as *mut Word, out.len());
 			},
 			TermWords::Shifted {
 				row,

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -56,12 +56,10 @@ const LOG_INV_RATE: usize = 1;
 ///
 /// Panics if `var` is set but does not parse as a `usize`.
 fn log_size_from_env(var: &str, default: usize) -> usize {
-	match std::env::var(var) {
-		Ok(val) => val
-			.parse()
-			.unwrap_or_else(|_| panic!("{var} must be a non-negative integer, got {val:?}")),
-		Err(_) => default,
-	}
+	std::env::var(var).map_or(default, |val| {
+		val.parse()
+			.unwrap_or_else(|_| panic!("{var} must be a non-negative integer, got {val:?}"))
+	})
 }
 
 /// Installs a timing-tree tracing subscriber, once per test binary.

--- a/crates/math/benches/batch_invert.rs
+++ b/crates/math/benches/batch_invert.rs
@@ -18,7 +18,7 @@ fn bench_batch_inversion_scalar(c: &mut Criterion) {
 		group.bench_function(format!("{n}"), |b| {
 			b.iter(|| {
 				inverter.invert_or_zero(&mut elements);
-			})
+			});
 		});
 	}
 
@@ -38,7 +38,7 @@ fn bench_batch_inversion_packed(c: &mut Criterion) {
 			.collect();
 		let mut inverter = BatchInversion::<OptimalPackedB128>::new(n);
 		group.bench_function(format!("{n}x{}", OptimalPackedB128::WIDTH), |b| {
-			b.iter(|| inverter.invert_nonzero(&mut elements))
+			b.iter(|| inverter.invert_nonzero(&mut elements));
 		});
 	}
 

--- a/crates/math/benches/bit_reverse.rs
+++ b/crates/math/benches/bit_reverse.rs
@@ -22,7 +22,7 @@ fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
 
 		group.bench_function(BenchmarkId::new("bit_reverse", &parameter), |b| {
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| data.as_mut_view().bit_reverse())
+			b.iter(|| data.as_mut_view().bit_reverse());
 		});
 	}
 

--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -36,7 +36,7 @@ enum ThroughputVariant {
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::single_element_loop)]
 fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
-	group: &mut BenchmarkGroup<WallTime>,
+	group: &mut BenchmarkGroup<'_, WallTime>,
 	throughput_var: ThroughputVariant,
 	log_d: usize,
 	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
@@ -65,7 +65,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 			};
 
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late))
+			b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late));
 		});
 	}
 
@@ -74,7 +74,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 		let ntt = NeighborsLastBreadthFirst { domain_context };
 
 		let mut data = random_field_buffer::<P>(&mut rng, log_d);
-		b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late))
+		b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late));
 	});
 
 	for log_num_shares in [0, 3] {
@@ -97,8 +97,8 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 					.build()
 					.unwrap();
 				thread_pool.install(|| {
-					b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late))
-				})
+					b.iter(|| ntt.forward_transform(data.as_mut_view(), skip_early, skip_late));
+				});
 			});
 		}
 	}

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -117,7 +117,9 @@ impl<P: PackedField> FieldSliceMut<'_, P> {
 /// # Preconditions
 ///
 /// * `buffer.log_len() >= 2 * (P::LOG_WIDTH + LOG_TILE_PACKED)`
-fn bit_reverse_tiled<P: PackedField, const LOG_TILE_PACKED: usize>(mut buffer: FieldSliceMut<P>) {
+fn bit_reverse_tiled<P: PackedField, const LOG_TILE_PACKED: usize>(
+	mut buffer: FieldSliceMut<'_, P>,
+) {
 	// Tile width in scalars, and the middle index field the two ends leave over.
 	let log_tile = P::LOG_WIDTH + LOG_TILE_PACKED;
 	let log_len = buffer.log_len();
@@ -272,7 +274,7 @@ fn transpose_tile<P: PackedField, const LOG_TILE_PACKED: usize>(tile: &mut [P], 
 /// # Arguments
 ///
 /// * `buffer` - Mutable slice of packed field elements to permute
-fn bit_reverse_packed_naive<P: PackedField>(mut buffer: FieldSliceMut<P>) {
+fn bit_reverse_packed_naive<P: PackedField>(mut buffer: FieldSliceMut<'_, P>) {
 	let bits = buffer.log_len() as u32;
 	for i in 0..buffer.len() {
 		let i_rev = reverse_bits(i, bits);

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -181,7 +181,7 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	/// Copies a borrowed buffer into memory drawn from `alloc`.
 	///
 	/// Whole packed words are copied, dead lanes and all, so the copy is bit-identical.
-	pub fn from_view_in<A>(alloc: &A, src: FieldSlice<P>) -> Self
+	pub fn from_view_in<A>(alloc: &A, src: FieldSlice<'_, P>) -> Self
 	where
 		A: Allocator<Vec<P> = Data>,
 	{

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -126,7 +126,7 @@ impl<F: BinaryField> GenericPreExpanded<F> {
 				}
 			}
 			assert_eq!(expanded_i.len(), 1 << (basis.len() - 1));
-			expanded.push(expanded_i)
+			expanded.push(expanded_i);
 		}
 		assert_eq!(expanded.len(), evals.len());
 
@@ -351,7 +351,7 @@ mod tests {
 				assert_eq!(dc_1.twiddle(i, block), dc_2.twiddle(i, block));
 			}
 		}
-		assert_eq!(dc_1.subspace(log_domain_size), dc_2.subspace(log_domain_size))
+		assert_eq!(dc_1.subspace(log_domain_size), dc_2.subspace(log_domain_size));
 	}
 
 	#[test]

--- a/crates/math/src/ntt/mod.rs
+++ b/crates/math/src/ntt/mod.rs
@@ -74,7 +74,7 @@ pub trait AdditiveNTT {
 	/// [DP24]: <https://eprint.iacr.org/2024/504>
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		data: FieldSliceMut<P>,
+		data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	);
@@ -89,7 +89,7 @@ pub trait AdditiveNTT {
 	/// - same as [`Self::forward_transform`]
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		data: FieldSliceMut<P>,
+		data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	);
@@ -124,7 +124,7 @@ pub trait AdditiveNTT {
 	/// - same as [`Self::forward_transform`]
 	fn transpose_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -403,7 +403,7 @@ where
 
 	fn forward_transform<P: PackedField<Scalar = F>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -429,7 +429,7 @@ where
 
 	fn inverse_transform<P: PackedField<Scalar = F>>(
 		&self,
-		_data: FieldSliceMut<P>,
+		_data: FieldSliceMut<'_, P>,
 		_skip_early: usize,
 		_skip_late: usize,
 	) {
@@ -474,7 +474,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastSingleThread<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -502,7 +502,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastSingleThread<DC> {
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		_data_orig: FieldSliceMut<P>,
+		_data_orig: FieldSliceMut<'_, P>,
 		_skip_early: usize,
 		_skip_late: usize,
 	) {
@@ -566,7 +566,7 @@ impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
 	/// There, `on_chunk_ready` runs once for block 0, after the fallback transform completes.
 	pub fn forward_transform_with_callback<P: PackedField<Scalar = DC::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 		on_chunk_ready: impl Fn(usize, &[P]) + Sync,
@@ -638,7 +638,7 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		data: FieldSliceMut<P>,
+		data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -647,7 +647,7 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		_data_orig: FieldSliceMut<P>,
+		_data_orig: FieldSliceMut<'_, P>,
 		_skip_early: usize,
 		_skip_late: usize,
 	) {

--- a/crates/math/src/ntt/reference.rs
+++ b/crates/math/src/ntt/reference.rs
@@ -19,7 +19,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -48,7 +48,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -234,7 +234,7 @@ fn novel_basis<DC: DomainContext>(domain_context: &DC) -> Vec<Polynomial<DC::Fie
 	novel_basis.push(Polynomial::one());
 	for i in 0..log_d {
 		for j in 0..novel_basis.len() {
-			novel_basis.push(&novel_basis[j] * &w_hat[i])
+			novel_basis.push(&novel_basis[j] * &w_hat[i]);
 		}
 	}
 

--- a/crates/math/src/ntt/tests_reference.rs
+++ b/crates/math/src/ntt/tests_reference.rs
@@ -21,8 +21,8 @@ use crate::{
 
 fn test_transform_equivalence<P: PackedField>(
 	mut rng: impl Rng,
-	reference: impl Fn(FieldSliceMut<P>, usize, usize),
-	transform: impl Fn(FieldSliceMut<P>, usize, usize),
+	reference: impl Fn(FieldSliceMut<'_, P>, usize, usize),
+	transform: impl Fn(FieldSliceMut<'_, P>, usize, usize),
 	log_n: usize,
 ) {
 	let half_rounds = log_n / 2;

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -111,7 +111,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 	pub fn encode_batch<P, NTT, A>(
 		&self,
 		ntt: &NTT,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 		log_batch_size: usize,
 		alloc: &A,
 	) -> FieldBuffer<P, A::Vec<P>>
@@ -188,7 +188,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 	pub fn encode_batch_with_callback<P, DC, A>(
 		&self,
 		ntt: &NeighborsLastMultiThread<DC>,
-		data: FieldSlice<P>,
+		data: FieldSlice<'_, P>,
 		log_batch_size: usize,
 		alloc: &A,
 		on_chunk_ready: impl Fn(usize, &[P]) + Sync,
@@ -270,7 +270,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 /// * `msg` holds at least one whole word, and `total` is a multiple of its word count
 /// * `run` is a power of two, and at most the message's word count
 fn repeated_message_buffer<P: PackedField, A: Allocator>(
-	msg: FieldSlice<P>,
+	msg: FieldSlice<'_, P>,
 	total: usize,
 	run: usize,
 	alloc: &A,
@@ -478,7 +478,7 @@ mod tests {
 	// One serial copy of the message, one permutation, then a chain of doublings.
 	// That is the plain form of the same construction, so it pins the run-split form.
 	fn repeated_message_buffer_reference<P: PackedField>(
-		msg: FieldSlice<P>,
+		msg: FieldSlice<'_, P>,
 		total: usize,
 	) -> Vec<P> {
 		let mut output = Vec::with_capacity(total);

--- a/crates/prover/benches/fold_across_words.rs
+++ b/crates/prover/benches/fold_across_words.rs
@@ -32,10 +32,10 @@ fn bench_single_column(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(n_words as u64));
 
 		group.bench_with_input(BenchmarkId::new("sequential", n_words), &n_words, |b, _| {
-			b.iter(|| folder.fold(&words))
+			b.iter(|| folder.fold(&words));
 		});
 		group.bench_with_input(BenchmarkId::new("parallel", n_words), &n_words, |b, _| {
-			b.iter(|| folder.fold_par(&words))
+			b.iter(|| folder.fold_par(&words));
 		});
 	}
 
@@ -75,7 +75,7 @@ fn bench_shared_point_columns(c: &mut Criterion) {
 						.iter()
 						.map(|col| folder.fold(col))
 						.collect::<Vec<_>>()
-				})
+				});
 			},
 		);
 		group.bench_with_input(
@@ -87,7 +87,7 @@ fn bench_shared_point_columns(c: &mut Criterion) {
 						.iter()
 						.map(|col| folder.fold_par(col))
 						.collect::<Vec<_>>()
-				})
+				});
 			},
 		);
 	}

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -133,7 +133,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 					intmul_prover.prove(witness.take().expect("set in setup"));
 				},
 				BatchSize::SmallInput,
-			)
+			);
 		},
 	);
 
@@ -156,7 +156,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 					intmul_prover.prove(witness);
 				},
 				BatchSize::SmallInput,
-			)
+			);
 		},
 	);
 

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -163,7 +163,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					},
 					&subspace,
 				)
-			})
+			});
 		});
 
 		// Pre-run the prover to get the transcript for verifier benchmarking
@@ -220,7 +220,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					&mut verifier_transcript,
 				)
 				.unwrap();
-			})
+			});
 		});
 	}
 }

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -114,9 +114,9 @@ where
 	///
 	/// This method consumes a `Witness` in order to reduce integer multiplication statement to
 	/// evaluation claims on 1-bit multilinears. More formally:
-	///  * `witness` contains po2-sized integer arrays  `a`, `b`, `c_lo` and `c_hi` that satisfy `a
-	///    * b = c_lo | c_hi << Word::BITS`, as well as the layers of the constant- and
-	///      variable-base GKR product check circuits
+	///  * `witness` contains po2-sized integer arrays `a`, `b`, `c_lo` and `c_hi` that satisfy `a *
+	///    b = c_lo | c_hi << Word::BITS`, as well as the layers of the constant- and variable-base
+	///    GKR product check circuits
 	///  * The proving consists of five phases:
 	///    - Phase 1: GKR tree roots for B & C are evaluated at a sampled point, after which
 	///      reductions are performed to obtain evaluation claims on $(b * (G^{a_i} - 1) + 1)^{2^i}$
@@ -234,7 +234,7 @@ where
 		a_exponents: &[Word],
 		c_lo_exponents: &[Word],
 		c_hi_exponents: &[Word],
-		table: FieldSlice<P>,
+		table: FieldSlice<'_, P>,
 	) -> IntMulOutput<F> {
 		let alloc = self.alloc;
 		let n_vars = b_eval_point.len();
@@ -431,7 +431,7 @@ where
 		&mut self,
 		eval_point: &[F],
 		b_prover: ProdcheckProver<'alloc, A, P>,
-		b_leaves: FieldSlice<P>,
+		b_leaves: FieldSlice<'_, P>,
 		b_root_eval: F,
 	) -> Phase1Output<F> {
 		let n_vars = eval_point.len();

--- a/crates/prover/src/protocols/shift/key_collection/operation.rs
+++ b/crates/prover/src/protocols/shift/key_collection/operation.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, BufMut};
 
 /// The constraint kind a key names.
 /// Every constraint in a Binius64 system reduces to one of these four checks over 64-bit words.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Operation {
 	/// A single word equals zero.
 	///

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -175,7 +175,7 @@ impl<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator> ShiftIndSumcheck<
 	/// # Panics
 	///
 	/// Panics unless the weights hold one entry per bit position of a word.
-	pub fn new(alloc: &A, weights: &[F], point: &ShiftChallengePoint<F>, g_eval: F) -> Self {
+	pub fn new(alloc: &A, weights: &[F], point: &ShiftChallengePoint<'_, F>, g_eval: F) -> Self {
 		assert_eq!(weights.len(), Word::BITS, "the weights are indexed by bit position");
 
 		let shift_ind = point.indicator();

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -285,7 +285,7 @@ pub struct RingSwitchOutput<A: Allocator, P: PackedField> {
 ///   log of the extension degree of B128 over B1 (= 7)
 pub fn prove<A, P, Channel>(
 	alloc: &A,
-	packed_witness: FieldSlice<P>,
+	packed_witness: FieldSlice<'_, P>,
 	eval_point: &[B128],
 	channel: &mut Channel,
 ) -> RingSwitchOutput<A, P>

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -359,26 +359,20 @@ fn test_shift_prove_and_verify() {
 		// — mirroring the prover/verifier skip of the IntMul reduction in `binius_prover` /
 		// `binius_verifier`.
 		let intmul_is_empty = cs.imul_constraints.is_empty();
-		let r_x_prime_intmul = if let Some(log_intmul_constraint_count) = cs.log_imul_constraints()
-		{
-			(0..log_intmul_constraint_count as u128)
-				.map(F::new)
-				.collect::<Vec<_>>()
-		} else {
-			Vec::new()
-		};
+		let r_x_prime_intmul = cs
+			.log_imul_constraints()
+			.map_or_else(Vec::new, |log_count| {
+				(0..log_count as u128).map(F::new).collect::<Vec<_>>()
+			});
 
 		// A constraint system may equally have zero BMUL constraints, and the BinMul operator is
 		// then empty for the same reason.
 		let binmul_is_empty = cs.bmul_constraints.is_empty();
-		let r_x_prime_binmul = if let Some(log_binmul_constraint_count) = cs.log_bmul_constraints()
-		{
-			(0..log_binmul_constraint_count as u128)
-				.map(F::new)
-				.collect::<Vec<_>>()
-		} else {
-			Vec::new()
-		};
+		let r_x_prime_binmul = cs
+			.log_bmul_constraints()
+			.map_or_else(Vec::new, |log_count| {
+				(0..log_count as u128).map(F::new).collect::<Vec<_>>()
+			});
 
 		// Sample univariate eval point — the bitand and intmul operators share
 		// `r_zhat_prime` so the verifier can compute `h_op_evals` once for both.

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -136,23 +136,19 @@ impl Binius64BuilderChannel {
 	}
 
 	/// Allocates the `(lo, hi)` pair one field element occupies, as circuit inputs.
-	fn input_element(&mut self, kind: &'static str) -> Element {
+	fn input_element(&self, kind: &'static str) -> Element {
 		array::from_fn(|_| self.shared.input_wire(kind))
 	}
 
 	/// Allocates the wires one digest occupies, as circuit inputs.
-	fn input_digest(&mut self, kind: &'static str) -> Digest {
+	fn input_digest(&self, kind: &'static str) -> Digest {
 		array::from_fn(|_| self.shared.input_wire(kind))
 	}
 
 	/// Allocates the input wires one query's opening occupies: its leaf, then its branch.
 	///
 	/// The tape carries an opening in this order, so a replay fills the wires in it too.
-	fn input_opening(
-		&mut self,
-		leaf_size: usize,
-		branch_len: usize,
-	) -> (Vec<Element>, Vec<Digest>) {
+	fn input_opening(&self, leaf_size: usize, branch_len: usize) -> (Vec<Element>, Vec<Digest>) {
 		let leaf = (0..leaf_size)
 			.map(|_| self.input_element("opening"))
 			.collect();

--- a/crates/recursion/src/merkle.rs
+++ b/crates/recursion/src/merkle.rs
@@ -184,7 +184,7 @@ pub fn digest_words(bytes: &[u8; 32]) -> [u64; DIGEST_WORDS] {
 }
 
 /// Writes a 32-byte digest into the wires that carry it.
-pub fn populate_digest(w: &mut WitnessFiller, digest: &Digest, bytes: &[u8; 32]) {
+pub fn populate_digest(w: &mut WitnessFiller<'_>, digest: &Digest, bytes: &[u8; 32]) {
 	// One wire per eight digest bytes, in the packed order the digest convention fixes.
 	for (wire, value) in digest.iter().zip(digest_words(bytes)) {
 		w[*wire] = Word(value);
@@ -200,7 +200,7 @@ pub const fn element_words(value: u128) -> [u64; ELEMENT_WORDS] {
 }
 
 /// Writes a field element into the wires that carry it.
-pub fn populate_element(w: &mut WitnessFiller, element: &Element, value: u128) {
+pub fn populate_element(w: &mut WitnessFiller<'_>, element: &Element, value: u128) {
 	// Two wires per element, low serialized half first.
 	for (wire, word) in element.iter().zip(element_words(value)) {
 		w[*wire] = Word(word);

--- a/crates/recursion/src/merkle/tests.rs
+++ b/crates/recursion/src/merkle/tests.rs
@@ -56,7 +56,7 @@ fn digest_wires(builder: &CircuitBuilder, n: usize) -> Vec<Digest> {
 }
 
 /// Writes one field element into each element's pair of wires.
-fn fill_elements(w: &mut WitnessFiller, wires: &[Element], values: &[B128]) {
+fn fill_elements(w: &mut WitnessFiller<'_>, wires: &[Element], values: &[B128]) {
 	// A count mismatch would leave wires unwritten, which reads later as a wrong value.
 	assert_eq!(wires.len(), values.len(), "one element per value");
 	// Splitting a value across its two wires is the packing convention, not a choice here.
@@ -66,7 +66,7 @@ fn fill_elements(w: &mut WitnessFiller, wires: &[Element], values: &[B128]) {
 }
 
 /// Writes one 32-byte digest into each digest's wires.
-fn fill_digests(w: &mut WitnessFiller, wires: &[Digest], bytes: &[[u8; 32]]) {
+fn fill_digests(w: &mut WitnessFiller<'_>, wires: &[Digest], bytes: &[[u8; 32]]) {
 	// As with elements, an unwritten wire would masquerade as a corrupted digest.
 	assert_eq!(wires.len(), bytes.len(), "one digest per byte string");
 	// The byte order each wire holds is fixed by the digest convention.

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -176,7 +176,7 @@ fn record(proved: &Proved) -> Recording {
 }
 
 /// Replays the verifier over the real transcript, filling every wire the build recorded.
-fn replay(proved: &Proved, recorded: &Recorded, filler: &mut WitnessFiller) {
+fn replay(proved: &Proved, recorded: &Recorded, filler: &mut WitnessFiller<'_>) {
 	let mut transcript = VerifierTranscript::new(StdChallenger::default(), proved.proof.clone());
 	let filler_channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
 		&mut transcript,

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -272,7 +272,7 @@ impl<F: Field> CircuitBuilder for ConstraintBuilder<F> {
 	type Field = F;
 
 	fn assert_zero(&mut self, wire: Self::Wire) {
-		self.ir.zero_constraints.push(wire.into())
+		self.ir.zero_constraints.push(wire.into());
 	}
 
 	fn assert_eq(&mut self, lhs: Self::Wire, rhs: Self::Wire) {

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -428,8 +428,8 @@ where
 fn prove_mulcheck<F, P, Channel, A>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
-	precommit_packed: FieldSlice<P>,
-	private_packed: FieldSlice<P>,
+	precommit_packed: FieldSlice<'_, P>,
+	private_packed: FieldSlice<'_, P>,
 	mask: zk_mlecheck::Mask<P, impl Deref<Target = [P]>>,
 	channel: &mut Channel,
 	alloc: &A,

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -154,8 +154,8 @@ pub struct MulCheckWitness<A: Allocator, P: PackedField> {
 /// Evaluates an operand by XORing witness values at the specified indices.
 fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 	public: &[F],
-	precommit_packed: &FieldSlice<P>,
-	private_packed: &FieldSlice<P>,
+	precommit_packed: &FieldSlice<'_, P>,
+	private_packed: &FieldSlice<'_, P>,
 	operand: &Operand<WitnessIndex>,
 ) -> F {
 	operand
@@ -179,8 +179,8 @@ pub fn build_mulcheck_witness<A: Allocator, F: Field, P: PackedField<Scalar = F>
 	alloc: &A,
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
-	precommit_packed: FieldSlice<P>,
-	private_packed: FieldSlice<P>,
+	precommit_packed: FieldSlice<'_, P>,
+	private_packed: FieldSlice<'_, P>,
 ) -> MulCheckWitness<A, P> {
 	const fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.a

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -310,7 +310,7 @@ where
 		&remaining[..n_inner_remaining]
 	}
 
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"send_oracle called but no inner oracle specs remaining"
@@ -331,10 +331,10 @@ where
 		self.interaction.push(claim);
 
 		self.inner_channel
-			.prove_oracle_relation(oracle, transparent, claim)
+			.prove_oracle_relation(oracle, transparent, claim);
 	}
 
 	fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>) {
-		self.inner_channel.finalize_oracle(oracle, buffer)
+		self.inner_channel.finalize_oracle(oracle, buffer);
 	}
 }

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -74,7 +74,7 @@ pub fn evaluate_wiring_mle_public<F: FieldOps>(
 				.wires()
 				.iter()
 				.flat_map(|index| {
-					if let WitnessSegment::Public = index.segment {
+					if index.segment == WitnessSegment::Public {
 						Some(public[index.index as usize].clone())
 					} else {
 						None

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -105,6 +105,9 @@ where
 	/// Combine `elems` under an operation. If every input is a `Constant`, fold at the `F` level
 	/// via `f_op` (no builder is touched). Otherwise convert constants to wires on the shared
 	/// builder and run `builder_op` over the wires.
+	// The two arms are long and the wire arm is the one the doc comment leads with, so
+	// `map_or_else` would put them in the wrong order.
+	#[allow(clippy::option_if_let_else)]
 	pub fn combine<const IN: usize, const OUT: usize>(
 		elems: [&Self; IN],
 		f_op: impl Fn([F; IN]) -> [F; OUT],
@@ -154,6 +157,7 @@ where
 	///
 	/// `f_op` and `builder_op` must return a `Vec` of length `n_out`; checked via
 	/// `debug_assert_eq!`.
+	#[allow(clippy::option_if_let_else)]
 	pub fn combine_varlen(
 		elems: &[&Self],
 		n_out: usize,

--- a/crates/transcript/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/transcript/src/fiat_shamir/hasher_challenger.rs
@@ -116,7 +116,7 @@ where
 		Digest::update(&mut self.hasher, &digest);
 
 		self.buffer = digest;
-		self.index = 0
+		self.index = 0;
 	}
 }
 
@@ -140,7 +140,7 @@ where
 {
 	fn flush(&mut self) {
 		self.hasher.update(&self.buffer[..self.index]);
-		self.index = 0
+		self.index = 0;
 	}
 }
 

--- a/crates/transcript/src/fiat_shamir/sampling.rs
+++ b/crates/transcript/src/fiat_shamir/sampling.rs
@@ -41,10 +41,6 @@ pub fn sample_bits_reader<Reader: Buf>(mut reader: Reader, bits: usize) -> u32 {
 	reader.copy_to_slice(&mut bytes[..bytes_to_sample]);
 
 	let unmasked = u32::from_le_bytes(bytes);
-	let mask = 1u32.checked_shl(bits as u32);
-	let mask = match mask {
-		Some(x) => x - 1,
-		None => u32::MAX,
-	};
+	let mask = 1u32.checked_shl(bits as u32).map_or(u32::MAX, |x| x - 1);
 	mask & unmasked
 }

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -145,7 +145,7 @@ impl<Challenger> Drop for VerifierTranscript<Challenger> {
 			tracing::warn!(
 				"Transcript reader is not fully read out: {:?} bytes left",
 				self.combined.buffer.remaining()
-			)
+			);
 		}
 	}
 }
@@ -280,11 +280,8 @@ impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 				let test_name = current_thread.name().unwrap_or("unknown");
 				// Adjust "./" to "../../" to ensure files are saved in the project root rather than
 				// the package root.
-				let path = if let Some(stripped) = path.strip_prefix("./") {
-					format!("../../{stripped}",)
-				} else {
-					path
-				};
+				let rebased = path.strip_prefix("./").map(|s| format!("../../{s}"));
+				let path = rebased.unwrap_or(path);
 				std::fs::create_dir_all(&path)
 					.unwrap_or_else(|_| panic!("Failed to create directories for path: {path}",));
 				format!("{path}/{test_name}.bin")
@@ -481,7 +478,7 @@ impl<B: BufMut> TranscriptWriter<'_, B> {
 
 	pub fn write_debug(&mut self, msg: &str) {
 		if self.options.debug_assertions {
-			self.write_bytes(msg.as_bytes())
+			self.write_bytes(msg.as_bytes());
 		}
 	}
 

--- a/crates/utils/build.rs
+++ b/crates/utils/build.rs
@@ -14,17 +14,7 @@ fn main() {
 		.replace('\x1f', " "); // CARGO_ENCODED_RUSTFLAGS uses 0x1f as separator
 	println!("cargo:rustc-env=BUILD_RUSTFLAGS={rustflags}");
 
-	// Collect target features
-	let target_features = if let Ok(features) = env::var("CARGO_CFG_TARGET_FEATURE") {
-		if features.is_empty() {
-			Vec::new()
-		} else {
-			features.split(',').map(|s| s.to_string()).collect()
-		}
-	} else {
-		Vec::new()
-	};
-
-	// Pass target features as comma-separated list
-	println!("cargo:rustc-env=COMPILE_TIME_FEATURES={}", target_features.join(","));
+	// Cargo already sets this as a comma-separated list, which is the form we forward.
+	let target_features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+	println!("cargo:rustc-env=COMPILE_TIME_FEATURES={target_features}");
 }

--- a/crates/utils/src/checked_arithmetics.rs
+++ b/crates/utils/src/checked_arithmetics.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright (c) 2024 The Plonky3 Authors
 
-/// Division implementation that fails in case when `a`` isn't divisible by `b`
+/// Division implementation that fails in case when `a` isn't divisible by `b`
 pub const fn checked_int_div(a: usize, b: usize) -> usize {
 	let result = a / b;
 	assert!(b * result == a);
@@ -105,7 +105,7 @@ mod tests {
 	#[test]
 	#[should_panic]
 	const fn test_checked_log2_fail() {
-		_ = checked_log_2(6)
+		_ = checked_log_2(6);
 	}
 
 	#[test]

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -291,9 +291,10 @@ impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
 	where
 		Self: Sized,
 	{
-		Ok(match bool::deserialize(&mut read_buf)? {
-			true => Some(T::deserialize(&mut read_buf)?),
-			false => None,
+		Ok(if bool::deserialize(&mut read_buf)? {
+			Some(T::deserialize(&mut read_buf)?)
+		} else {
+			None
 		})
 	}
 }

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -122,7 +122,7 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 					// Safety: different instances of StridedArray2DViewMut created with the same
 					// data slice do not access overlapping indices.
 					data: unsafe {
-						slice::from_raw_parts_mut(self.data.as_ptr() as *mut T, self.data.len())
+						slice::from_raw_parts_mut(self.data.as_ptr().cast_mut(), self.data.len())
 					},
 					data_width: self.data_width,
 					height: self.height,

--- a/crates/verifier/src/protocols/bitand.rs
+++ b/crates/verifier/src/protocols/bitand.rs
@@ -16,7 +16,7 @@ pub const SKIPPED_VARS: usize = binius_core::Word::LOG_BITS;
 pub const ROWS_PER_HYPERCUBE_VERTEX: usize = 1 << SKIPPED_VARS;
 
 /// Output from the AND constraint reduction protocol verification.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AndCheckOutput<F> {
 	pub a_eval: F,
 	pub b_eval: F,

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -7,7 +7,7 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, field::FieldOps};
 use itertools::iterate;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntMulOutput<F> {
 	pub eval_point: Vec<F>,
 	pub a_evals: [F; Word::BITS],

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -697,20 +697,14 @@ impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 		let bitand =
 			OperationEvalFn::new(&cs.and_constraints, cs.n_const(), cs.n_inout, cs.n_private)
 				.call::<E>(&bitand_input);
-		let intmul = match intmul_input {
-			Some(input) => {
-				OperationEvalFn::new(&cs.imul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-					.call::<E>(&input)
-			}
-			None => E::zero(),
-		};
-		let binmul = match binmul_input {
-			Some(input) => {
-				OperationEvalFn::new(&cs.bmul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-					.call::<E>(&input)
-			}
-			None => E::zero(),
-		};
+		let intmul = intmul_input.map_or_else(E::zero, |input| {
+			OperationEvalFn::new(&cs.imul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
+				.call::<E>(&input)
+		});
+		let binmul = binmul_input.map_or_else(E::zero, |input| {
+			OperationEvalFn::new(&cs.bmul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
+				.call::<E>(&input)
+		});
 
 		zero + bitand + intmul + binmul
 	}
@@ -740,20 +734,14 @@ impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 		let bitand =
 			OperationEvalFn::new(&cs.and_constraints, cs.n_const(), cs.n_inout, cs.n_private)
 				.call_native(&bitand_input);
-		let intmul = match intmul_input {
-			Some(input) => {
-				OperationEvalFn::new(&cs.imul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-					.call_native(&input)
-			}
-			None => F::ZERO,
-		};
-		let binmul = match binmul_input {
-			Some(input) => {
-				OperationEvalFn::new(&cs.bmul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-					.call_native(&input)
-			}
-			None => F::ZERO,
-		};
+		let intmul = intmul_input.map_or(F::ZERO, |input| {
+			OperationEvalFn::new(&cs.imul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
+				.call_native(&input)
+		});
+		let binmul = binmul_input.map_or(F::ZERO, |input| {
+			OperationEvalFn::new(&cs.bmul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
+				.call_native(&input)
+		});
 
 		zero + bitand + intmul + binmul
 	}

--- a/crates/verifier/src/protocols/zero.rs
+++ b/crates/verifier/src/protocols/zero.rs
@@ -50,10 +50,7 @@ pub fn reduction_point<F: Clone>(
 	// The ZERO and AND sets are padded to power-of-two row counts independently, so a ZERO set
 	// with more rows than the AND set runs past the BitAnd point and samples the rest.
 	(0..log_zero_constraints)
-		.map(|i| match bitand_eval_point.get(i) {
-			Some(coord) => coord.clone(),
-			None => sample(),
-		})
+		.map(|i| bitand_eval_point.get(i).map_or_else(&mut sample, F::clone))
 		.collect()
 }
 

--- a/crates/verifier/src/signature.rs
+++ b/crates/verifier/src/signature.rs
@@ -73,7 +73,7 @@ use digest::Digest;
 ///
 /// The `writer` must be an *observing* writer (obtained from `transcript.observe()`), so the
 /// digest is mixed into the Fiat-Shamir state without being written to the proof tape.
-pub fn observe_message<H, B>(writer: &mut TranscriptWriter<B>, message: &[u8])
+pub fn observe_message<H, B>(writer: &mut TranscriptWriter<'_, B>, message: &[u8])
 where
 	H: HashSuite,
 	B: BufMut,


### PR DESCRIPTION
Adopts the clippy and rustdoc lint configuration Plonky3 uses, and fixes everything it finds.

Pure lint-and-cleanup change — no behavior change, and the circuit-statistics snapshots are unchanged.

### The problem

The workspace lints six clippy lints by name:

```toml
[workspace.lints.clippy]
needless_range_loop = "allow"
missing_const_for_fn = "warn"
multiple_inherent_impl = "warn"
needless_collect = "warn"
redundant_clone = "warn"
needless_pass_by_value = "warn"
```

Four of those five `warn`s are already members of `clippy::nursery`, so the list is really "nursery, but only these four".
Everything else nursery and `clippy::all` would say goes unheard, and `rustdoc::all` is off entirely — so allow-by-default rustdoc lints like `unescaped_backticks` never run.

### The idea

Turn on the groups and keep a short allow list for the ones that fight this codebase, exactly as Plonky3 does:

```toml
[workspace.lints]
rust.rust_2018_idioms = { level = "deny", priority = -1 }
rust.unused_must_use = "deny"
rust.rust_2024_incompatible_pat = "warn"
rustdoc.all = "warn"

[workspace.lints.clippy]
all = { level = "warn", priority = -1 }
nursery = { level = "warn", priority = -1 }

# Some pedantic lints
semicolon_if_nothing_returned = "warn"
match_bool = "warn"
needless_pass_by_value = "warn"
multiple_inherent_impl = "warn"

needless_range_loop = "allow"
redundant_pub_crate = "allow"
too_long_first_doc_paragraph = "allow"
unused_peekable = "allow"
tuple_array_conversions = "allow"
transmute_undefined_repr = "allow"
cognitive_complexity = "allow"
use_self = "allow"
```

`use_self` is the one addition to Plonky3's list — it is left off deliberately.

The three lints dropped from the old block (`missing_const_for_fn`, `needless_collect`, `redundant_clone`) are all nursery members, so `nursery = "warn"` keeps them on.
`multiple_inherent_impl` is a restriction lint and no group covers it, so it stays named.

### What the groups found

| lint | count |
|---|---|
| `elided_lifetimes_in_paths` (via `rust_2018_idioms`) | 141 |
| `clippy::option_if_let_else` | 21 |
| `clippy::needless_pass_by_ref_mut` | 5 |
| `clippy::as_ptr_cast_mut` | 2 |
| `clippy::or_fun_call` | 2 |
| `clippy::significant_drop_tightening` | 1 |
| `clippy::branches_sharing_code` | 1 |
| `clippy::debug_assert_with_mut_call` | 1 |
| `clippy::collection_is_never_read` | 1 |
| `clippy::semicolon_if_nothing_returned` / `match_bool` | ~40 |
| `rustdoc::unescaped_backticks` | 2 |
| `rustdoc::broken_intra_doc_links` | 1 |
| `rustdoc::missing_crate_level_docs` | 3 |

### Two of them were real defects

**Dead code in the header-chain fetch loop.** `collection_is_never_read` on `crates/examples/src/circuits/bitcoin_header_chain.rs`:

```
 let header = ureq::get(...).read_to_string()?;
-let mut hash = hex::decode(hash)?;
-hash.reverse();
 let header = hex::decode(header)?;
```

The decoded, byte-reversed hash was never used. The `latest_digest` the function returns is computed separately, above the loop, from the tip height.

**Two doc comments rendered a stray bullet list.** A code span was wrapped onto a continuation line that starts with `+ ` or `* `, which markdown reads as a list marker — so the span never closed and the paragraph broke into a list:

```
/// ... and `coeff 1 = (x0·y1
/// + x1·y0) + X·(x1·y1) = cross + X·p11`.
      ^ markdown sees a list item here
```

`rustdoc::unescaped_backticks` flagged both (`monbijou/aarch64.rs` and `intmul/prove.rs`); they are reflowed so no continuation line can start with a marker.
The same pass fixed a stale intra-doc link to `mul_128b` (the item is `mul_128b_schoolbook`) and a stray double backtick in `checked_arithmetics.rs`.

### The rest is mechanical

- 141 elided lifetimes spelled out: `&mut WitnessFiller` → `&mut WitnessFiller<'_>`, `FieldSlice<P>` → `FieldSlice<'_, P>`, and so on.
- Semicolons on statement-position calls whose value is `()`.
- `if let Some(x) = … else …` → `map_or` / `map_or_else`.
- Five `&mut` parameters that were never used mutably — three `&mut CircuitBuilder` that the rest of the repo already passes as `&CircuitBuilder` (329 sites vs 34), and two `&mut self` methods on the recursion channel.
- `as_ptr() as *mut T` → `as_mut_ptr()` / `as_ptr().cast_mut()`.
- `debug_assert!` no longer calls `spare_capacity_mut()` (a `&mut` method) inside the assertion; it compares `capacity() - len()` instead.
- `binius-examples` and its two binaries gained crate-level docs.

### Three local allows

Kept where the lint's rewrite reads worse than the code:

- `CircuitElem::combine` and `combine_varlen` — the two arms are 30–45 lines and `map_or_else` would put the all-constants arm first, inverting the order the doc comment leads with.
- `bitcoin_p2pkh`'s key branch — same shape, the generating arm is much the longer one.
- `bench_ghash` — criterion's `BenchmarkGroup` is meant to live until `finish()`, which is exactly what `significant_drop_tightening` objects to.

### Scope

- **changed:** `Cargo.toml` lint block, 135 source files
- **left untouched:** CI workflows — the existing `clippy --workspace --all-targets --all-features -- -D warnings` and `rust-doc` jobs already gate this
- **not adopted from Plonky3:** `use_self`, and the non-clippy parts of its lint job (`cargo sort`, `taplo`)

### Verification

Run on `aarch64-apple-darwin`:

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` — clean
- `cargo doc --no-deps --all-features` (the `Documentation` workflow) — clean
- `cargo nextest run --workspace` — 1821 passed, 13 skipped
- `cargo nextest run --workspace --features rayon` — 1808 passed, 13 skipped
- `cargo test --doc --workspace` — clean
- all 13 circuit-statistics snapshots — unchanged
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos`, copyright check — clean

The aarch64 leg matters here: `monbijou/aarch64.rs` and its broken doc link are invisible to CI's x86-only `rust-doc` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
