### PR TITLE
BINIUS-529: Induce one sumcheck claim from a level's opened rows

### DIFF
--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -21,5 +21,7 @@ itertools.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+binius-compute = { path = "../compute" }
 binius-math = { path = "../math", features = ["test-utils"] }
 proptest.workspace = true
+rand.workspace = true

--- a/crates/iop/src/ligerito/induced_basis.rs
+++ b/crates/iop/src/ligerito/induced_basis.rs
@@ -1,0 +1,338 @@
+// Copyright 2026 The Binius Developers
+
+//! The weight vector a level's opened rows induce on its message.
+//!
+//! A Ligerito level opens `t` rows of a committed Reed-Solomon codeword.
+//! Row `q` is one row of the generator matrix, so opening it asserts
+//!
+//! ```text
+//!     <G_q, m> = y_q
+//! ```
+//!
+//! for the level's message `m`.
+//! That is `t` separate linear claims, and the protocol needs one.
+//!
+//! Batching them with the powers of a challenge `alpha` gives a single claim
+//!
+//! ```text
+//!     <w, m> = sum_i alpha^i * y_i,      w[j] = sum_i alpha^i * G_{q_i}[j]
+//! ```
+//!
+//! and `w` is what this module calls the *induced basis*.
+//! It is the weight vector of a sumcheck over `m`, which is the shape `mlecheck` already handles.
+//!
+//! # The verifier never builds it
+//!
+//! `w` has `2^log_dim` entries, which at production sizes is millions of field elements.
+//! A verifier only ever needs its multilinear extension at one point, and that has a closed form.
+//!
+//! Write `f_i[k]` for the `k`-th tensor factor of row `q_i`, so that
+//! `G_{q_i}[j] = prod_{k : bit_k(j) = 1} f_i[k]`.
+//! Expanding `eq` in characteristic 2, where `1 - x = 1 + x`:
+//!
+//! ```text
+//!     MLE(w)(p) = sum_j w[j] * prod_{k : j_k = 1} p_k * prod_{k : j_k = 0} (1 + p_k)
+//!               = sum_i alpha^i * prod_k ( (1 + p_k) + f_i[k] * p_k )
+//!               = sum_i alpha^i * prod_k ( 1 + p_k * (1 + f_i[k]) )
+//! ```
+//!
+//! The sum over `2^log_dim` terms collapsed into a product over `log_dim` of them.
+//! [`InducedBasis::evaluate`] costs `O(t * log_dim)` multiplications and no divisions, against
+//! `O(t * 2^log_dim)` to build the vector and read it.
+//!
+//! No division matters as much as the operation count.
+//! A verifier compiled into a circuit cannot invert a witness-dependent value.
+//! This path never asks it to.
+//! Its other input `f_i[k]` is a subset sum of precomputed constants.
+//! That is the gate shape the FRI fold already pays for its twiddles.
+//!
+//! [`InducedBasis::to_dense`] materializes `w` anyway, as the reference the closed form is tested
+//! against, and for a prover that genuinely needs every entry.
+
+use binius_field::{BinaryField, util::expand_subset_products};
+use binius_math::{
+	inner_product::inner_product_scalars,
+	ntt::{DomainContext, subspace_polys::evals_at_domain_index},
+};
+
+/// The weight vector `t` opened rows induce on a level's message.
+///
+/// Holds the per-row tensor factors rather than the vector itself.
+/// That is what lets [`Self::evaluate`] stay logarithmic in the message length.
+#[derive(Debug, Clone)]
+pub struct InducedBasis<F> {
+	/// `factors[i][k]` is the `k`-th tensor factor of the generator row at query `i`.
+	///
+	/// Entry `j` of that row is the product of the factors its set bits select.
+	/// So the row is `2^n_vars` values described by `n_vars` of them.
+	factors: Vec<Vec<F>>,
+	/// `alpha^0, .., alpha^{t-1}`, the coefficients the rows are batched with.
+	///
+	/// Held here so that no caller can batch the two halves of the claim with different values.
+	batching: Vec<F>,
+	/// The code's `log_dim`, and the number of variables the weight vector spans.
+	///
+	/// Stored rather than read off `factors`, which is empty when no rows are opened.
+	n_vars: usize,
+}
+
+impl<F: BinaryField> InducedBasis<F> {
+	/// Builds the basis induced by opening `indices` of a code of dimension `log_dim`.
+	///
+	/// `domain_context` must be the one the codeword was encoded over.
+	/// Its `log_domain_size` is therefore `log_dim + log_inv_rate`, not `log_dim`.
+	/// The generator row lives on the codeword domain.
+	/// The message dimension only says how much of that row to keep.
+	///
+	/// Truncating to `log_dim` factors drops the dimensions encoding zero-pads.
+	/// Reversing them applies the bit-reversal permutation `encode_batch` encodes under.
+	/// Both are pinned by tests in [`binius_math::ntt::subspace_polys`].
+	///
+	/// ## Preconditions
+	///
+	/// * `log_dim` is at most `domain_context.log_domain_size()`.
+	/// * every index is a codeword position, below `2^log_domain_size`.
+	///
+	/// The second is the channel's job, which masks what it samples to the domain.
+	/// An index past the end is a wiring bug rather than a dishonest prover, so it panics.
+	pub fn new<DC: DomainContext<Field = F>>(
+		domain_context: &DC,
+		log_dim: usize,
+		indices: &[usize],
+		alpha: F,
+	) -> Self {
+		let log_domain_size = domain_context.log_domain_size();
+		assert!(
+			log_dim <= log_domain_size,
+			"precondition: log_dim must be at most the domain's own dimension"
+		);
+		assert!(
+			indices.iter().all(|&index| index < 1 << log_domain_size),
+			"precondition: every index must be below 2^log_domain_size"
+		);
+
+		let factors = indices
+			.iter()
+			.map(|&index| {
+				let mut evals = evals_at_domain_index(domain_context, index);
+				evals.truncate(log_dim);
+				evals.reverse();
+				evals
+			})
+			.collect::<Vec<_>>();
+
+		// Powers of the batching challenge, one per opened row.
+		let batching = std::iter::successors(Some(F::ONE), |power| Some(*power * alpha))
+			.take(indices.len())
+			.collect();
+
+		Self {
+			factors,
+			batching,
+			n_vars: log_dim,
+		}
+	}
+
+	/// The number of variables the weighted multilinear spans, which is the code's `log_dim`.
+	pub const fn n_vars(&self) -> usize {
+		self.n_vars
+	}
+
+	/// The number of opened rows the basis batches.
+	pub const fn n_rows(&self) -> usize {
+		self.factors.len()
+	}
+
+	/// Evaluates the basis's multilinear extension at `point`, in `O(n_rows * n_vars)`.
+	///
+	/// This is the module documentation's closed form, and it is the verifier's only route.
+	/// Opening no rows induces the zero weight vector, whose extension is zero everywhere.
+	///
+	/// ## Preconditions
+	///
+	/// * `point` has [`Self::n_vars`] coordinates.
+	pub fn evaluate(&self, point: &[F]) -> F {
+		assert_eq!(point.len(), self.n_vars, "precondition: point must have n_vars coordinates");
+
+		let terms = self.factors.iter().map(|row| {
+			// One factor per variable: `1 + p_k * (1 + f[k])`, a multiplication and two additions.
+			std::iter::zip(row, point)
+				.map(|(&factor, &coordinate)| F::ONE + coordinate * (F::ONE + factor))
+				.product::<F>()
+		});
+		inner_product_scalars(self.batching.iter().copied(), terms)
+	}
+
+	/// The dense weight vector, `2^n_vars` entries.
+	///
+	/// This is the reference [`Self::evaluate`] is tested against, and the vector a prover folds.
+	/// A verifier must not call it.
+	/// The allocation alone defeats the point of the closed form.
+	/// In a recursion circuit it is not expressible at all.
+	pub fn to_dense(&self) -> Vec<F> {
+		let mut dense = vec![F::ZERO; 1 << self.n_vars];
+		for (row, &coefficient) in std::iter::zip(&self.factors, &self.batching) {
+			for (entry, weight) in std::iter::zip(&mut dense, expand_subset_products(row)) {
+				*entry += coefficient * weight;
+			}
+		}
+		dense
+	}
+
+	/// Batches the opened rows' own values into the claim [`Self::evaluate`] is checked against.
+	///
+	/// `row_values[i]` is row `q_i` folded by the level's challenges.
+	/// So this returns `sum_i alpha^i * row_values[i]`.
+	/// Pairing it with [`Self::evaluate`] turns the `t` row claims into one sumcheck claim.
+	///
+	/// ## Preconditions
+	///
+	/// * `row_values` has [`Self::n_rows`] entries.
+	pub fn enforced_sum(&self, row_values: &[F]) -> F {
+		assert_eq!(
+			row_values.len(),
+			self.n_rows(),
+			"precondition: row_values must have one entry per opened row"
+		);
+		inner_product_scalars(self.batching.iter().copied(), row_values.iter().copied())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_compute::GlobalAllocator;
+	use binius_field::{Field, Ghash128b as B128, Random};
+	use binius_math::{
+		multilinear::evaluate::evaluate_inplace_scalars,
+		ntt::{
+			NeighborsLastSingleThread,
+			domain_context::{GaoMateerOnTheFly, GaoMateerPreExpanded},
+		},
+		reed_solomon::ReedSolomonCode,
+		test_utils::random_field_buffer,
+	};
+	use proptest::prelude::*;
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	/// The codeword domain a `ReedSolomonCode` of this shape encodes over.
+	fn domain(log_dim: usize, log_inv_rate: usize) -> GaoMateerPreExpanded<B128> {
+		GaoMateerPreExpanded::generate(log_dim + log_inv_rate)
+	}
+
+	/// The identity the whole construction exists to provide.
+	///
+	/// Batching the opened rows by `alpha` must be the same claim as pairing the message with the
+	/// induced weight vector.
+	/// Were the two to disagree, prover and verifier would agree with each other and nothing else.
+	#[test]
+	fn the_induced_claim_is_the_batched_codeword_positions() {
+		for log_dim in 1..7 {
+			for log_inv_rate in 1..4 {
+				let code = ReedSolomonCode::<B128>::new(log_dim, log_inv_rate);
+				let ntt =
+					NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(code.log_len()));
+				let mut rng = StdRng::seed_from_u64(0);
+				let message = random_field_buffer::<B128>(&mut rng, log_dim);
+				let codeword = code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+
+				// Open every position, which is the strongest version of the check.
+				let indices = (0..1 << code.log_len()).collect::<Vec<_>>();
+				let alpha = B128::random(&mut rng);
+				let basis =
+					InducedBasis::new(&domain(log_dim, log_inv_rate), log_dim, &indices, alpha);
+
+				let opened = indices
+					.iter()
+					.map(|&index| codeword.as_ref()[index])
+					.collect::<Vec<_>>();
+				let paired =
+					inner_product_scalars(basis.to_dense(), message.as_ref().iter().copied());
+				assert_eq!(
+					paired,
+					basis.enforced_sum(&opened),
+					"log_dim={log_dim} log_inv_rate={log_inv_rate}"
+				);
+			}
+		}
+	}
+
+	#[test]
+	fn one_row_at_a_trivial_challenge_is_the_generator_row() {
+		let (log_dim, log_inv_rate) = (4, 2);
+		let code = ReedSolomonCode::<B128>::new(log_dim, log_inv_rate);
+		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(code.log_len()));
+		let mut rng = StdRng::seed_from_u64(1);
+		let message = random_field_buffer::<B128>(&mut rng, log_dim);
+		let codeword = code.encode_batch(&ntt, message.to_ref(), 0, &GlobalAllocator);
+
+		// A single row batched by alpha^0 = 1 is that row untouched, so pairing it with the
+		// message must reproduce exactly that codeword position.
+		for index in 0..1 << code.log_len() {
+			let basis =
+				InducedBasis::new(&domain(log_dim, log_inv_rate), log_dim, &[index], B128::ZERO);
+			let paired = inner_product_scalars(basis.to_dense(), message.as_ref().iter().copied());
+			assert_eq!(paired, codeword.as_ref()[index], "index={index}");
+		}
+	}
+
+	#[test]
+	fn opening_no_rows_induces_the_zero_vector() {
+		let basis = InducedBasis::new(&domain(5, 1), 5, &[], B128::ONE);
+		assert_eq!(basis.n_rows(), 0);
+		assert_eq!(basis.n_vars(), 5);
+		// Still a full-width vector of zeros, not an empty one.
+		assert_eq!(basis.to_dense(), vec![B128::ZERO; 32]);
+		assert_eq!(basis.evaluate(&[B128::ONE; 5]), B128::ZERO);
+		assert_eq!(basis.enforced_sum(&[]), B128::ZERO);
+	}
+
+	#[test]
+	#[should_panic(expected = "log_dim must be at most the domain's own dimension")]
+	fn a_dimension_past_the_domain_is_rejected() {
+		InducedBasis::new(&domain(3, 1), 5, &[0], B128::ONE);
+	}
+
+	#[test]
+	#[should_panic(expected = "every index must be below 2^log_domain_size")]
+	fn an_index_past_the_codeword_is_rejected() {
+		InducedBasis::new(&domain(3, 1), 3, &[16], B128::ONE);
+	}
+
+	#[test]
+	#[should_panic(expected = "point must have n_vars coordinates")]
+	fn a_point_of_the_wrong_width_is_rejected() {
+		InducedBasis::new(&domain(3, 1), 3, &[0], B128::ONE).evaluate(&[B128::ONE; 2]);
+	}
+
+	#[test]
+	#[should_panic(expected = "row_values must have one entry per opened row")]
+	fn a_row_count_mismatch_is_rejected() {
+		InducedBasis::new(&domain(3, 1), 3, &[0, 1], B128::ONE).enforced_sum(&[B128::ONE]);
+	}
+
+	proptest! {
+		/// The closed form is the verifier's only route.
+		/// So it must agree with the dense vector everywhere, not at points a fixed test picks.
+		#[test]
+		fn the_succinct_evaluation_matches_the_dense_vector(
+			seed: u64,
+			log_dim in 1usize..7,
+			log_inv_rate in 1usize..4,
+			n_rows in 0usize..6,
+		) {
+			let mut rng = StdRng::seed_from_u64(seed);
+			let log_len = log_dim + log_inv_rate;
+			let indices = (0..n_rows)
+				.map(|_| rng.random_range(0..1usize << log_len))
+				.collect::<Vec<_>>();
+			let alpha = B128::random(&mut rng);
+			let basis = InducedBasis::new(&domain(log_dim, log_inv_rate), log_dim, &indices, alpha);
+
+			let point = (0..log_dim).map(|_| B128::random(&mut rng)).collect::<Vec<_>>();
+			let reference = evaluate_inplace_scalars(basis.to_dense(), &point);
+			prop_assert_eq!(basis.evaluate(&point), reference);
+		}
+	}
+}

--- a/crates/iop/src/ligerito/mod.rs
+++ b/crates/iop/src/ligerito/mod.rs
@@ -18,6 +18,7 @@
 //! It holds only:
 //!
 //! - [`LigeritoParams`] and its invariants;
+//! - [`InducedBasis`], the weight vector a level's opened rows put on its message;
 //! - [`LigeritoParams::proof_size`], the byte-exact estimate;
 //! - [`LigeritoParams::optimal_ladder`], the search that minimizes it subject to a security target.
 //!
@@ -28,7 +29,9 @@
 //! [NA25]: <https://eprint.iacr.org/2025/1187>
 
 mod common;
+mod induced_basis;
 mod size_estimation;
 
 pub use common::*;
+pub use induced_basis::InducedBasis;
 pub use size_estimation::{MAX_LOG_INV_RATE, MAX_LOG_LANES};


### PR DESCRIPTION
Closes [BINIUS-529](https://linear.app/jimpo/issue/BINIUS-529).

### In one line

Turn the `t` linear claims a level's opened rows make into the one sumcheck claim the protocol needs, without ever building the million-element vector that names them.

### The problem

A Ligerito level commits a Reed–Solomon codeword and then opens some rows of it. Opening row `q` tells the verifier one number: the codeword at position `q`.

That number is a *linear claim about the message*. A codeword position is one row of the generator matrix dotted with the message:

```
    <G_q, m> = y_q
```

Open `t` rows and you have `t` such claims. What comes next is a single sumcheck, which takes one.

### The idea

Take a random challenge `alpha` and add the claims up weighted by its powers. The `t` claims collapse into

```
    <w, m> = sum_i alpha^i * y_i        with    w[j] = sum_i alpha^i * G_{q_i}[j]
```

A prover who cheated on any one row now has to have cheated in a way that survives a random combination, which it won't.

`w` is the *induced basis*: the weight vector the opened rows put on the message.

The catch: `w` has one entry per message coefficient. At `log_dim = 21` that's two million field elements. A verifier can't build that, and a verifier compiled into a circuit *really* can't.

### It doesn't have to

The verifier never needs all of `w`. It needs `w`'s multilinear extension at one point. And that has a closed form.

Each generator row is a tensor — that's what [BINIUS-514](https://linear.app/jimpo/issue/BINIUS-514) established. Write `f_i[k]` for the `k`-th factor of row `q_i`, so entry `j` of that row is the product of the factors its set bits pick out.

Now expand `eq` in characteristic 2, where `1 - x` is just `1 + x`:

```
    MLE(w)(p) = sum_j w[j] * prod_{k : j_k = 1} p_k * prod_{k : j_k = 0} (1 + p_k)
              = sum_i alpha^i * prod_k ( (1 + p_k) + f_i[k] * p_k )
              = sum_i alpha^i * prod_k ( 1 + p_k * (1 + f_i[k]) )
```

The sum over `2^log_dim` terms became a product over `log_dim` of them.

### Walk through it

Two variables, so four message coefficients and four entries in a row. Open one row, at a position where the two factors happen to be `a` and `b`.

That row is:

```
    j = 00  ->  1        j = 01  ->  b
    j = 10  ->  a        j = 11  ->  a*b
```

Evaluate its extension at `p = (p_0, p_1)` the slow way — four terms:

```
    1*(1+p_0)(1+p_1) + b*p_0(1+p_1) + a*(1+p_0)p_1 + a*b*p_0*p_1
```

Now the fast way — two factors, multiplied:

```
    (1 + p_0*(1 + b)) * (1 + p_1*(1 + a))
```

Expand it and the four terms above fall out. Four entries read as two numbers. At `log_dim = 21` it is two million entries read as 21 numbers.

### Why the shape matters, not just the count

Two things about that expression are load-bearing for `crates/recursion`.

**No division.** A circuit cannot invert a witness-dependent value cheaply, and this never asks it to — just multiplications and additions.

**The inputs are subset sums of constants.** `f_i[k]` comes from evaluating a subspace polynomial at a domain index, and those are `F_2`-linear, so the value is an XOR of precomputed constants selected by the bits of the index. That is the same gate shape `fri::batch::fold_coset` already pays for its twiddles.

So a verifier built on this costs the recursion circuit what FRI's fold already costs. That was a hard constraint on this PR from the plan, and it is met.

### The change

New `crates/iop/src/ligerito/induced_basis.rs`.

```
InducedBasis::new(domain_context, log_dim, indices, alpha)
    .evaluate(point)       -> the closed form, O(t * log_dim), the verifier's only route
    .to_dense()            -> the materialized vector, prover and test only
    .enforced_sum(rows)    -> sum_i alpha^i * y_i, the claim `evaluate` is checked against
    .n_vars() / .n_rows()
```

The batching challenge lives inside the type, so nothing can batch `evaluate` with one value and `enforced_sum` with another.

The row factors come from the **codeword** domain, truncated to `log_dim`, then reversed — the pairing [BINIUS-514](https://linear.app/jimpo/issue/BINIUS-514) pinned against `ReedSolomonCode::encode_batch`. Getting that wrong is exactly the failure mode where a prover and a verifier agree with each other and with nothing else, so the headline test closes the loop: encode a real message, open every position, and check the induced claim against the batched codeword positions.

`to_dense` stays public and is documented as prover-and-test-only. It is the reference the closed form is proven against, and PR 5's prover will fold it.

### Deliberately not here

The transposed-NTT fast path for the dense build, which the plan bundles into this PR.

The repo has no transposed additive NTT. `inverse_transform` is the *inverse* map, not the transpose, so this needs a new primitive in `binius-math` with its own correctness argument. And there is no prover yet to benchmark it against — the dense build is a prover cost, and the prover is PR 5. Building it now would be an unmeasured optimization for a caller that doesn't exist. It belongs with the prover.

### Scope

- **new:** `crates/iop/src/ligerito/induced_basis.rs`
- **changed:** two lines in `crates/iop/src/ligerito/mod.rs`; `binius-compute` and `rand` added as dev-dependencies for the encode round-trip test
- no protocol code, no existing signature touched, no caller migrated

### Verification

- `cargo test -p binius-iop` — 52 passed
- `cargo clippy -p binius-iop --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-iop --document-private-items` — clean
- `typos` and the copyright hook — clean

Tests: the induced claim against a real `encode_batch` codeword with every position opened, across dimensions 1..7 and rates 1/2 to 1/8; a single row at `alpha^0 = 1` reproducing that codeword position exactly; the closed form against the dense vector by proptest over random shapes, row counts and points; the empty case giving a full-width zero vector rather than an empty one; and each precondition rejecting its own violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
