### PR TITLE
BINIUS-530: Add a transcript proof of work, and count grinding in the soundness budget

### DIFF
--- a/crates/iop/src/soundness.rs
+++ b/crates/iop/src/soundness.rs
@@ -8,8 +8,8 @@
 //! ```text
 //!     bits    = min(algebra, queries)
 //!
-//!     algebra = -log2(eps_ca)                  <- fixed by the code and the field
-//!     queries = -n_queries * log2(1 - delta)   <- bought one query at a time
+//!     algebra = -log2(eps_ca)                + challenge_grind   <- code, field, proof of work
+//!     queries = -n_queries * log2(1 - delta) + query_grind       <- one query at a time
 //! ```
 //!
 //! The right-hand term is the one everybody counts.
@@ -80,10 +80,9 @@
 //! reference implementations disagree on how much: one charges a factor `l`, the other `2^(l-1)`.
 //! [`crate::ligerito::LigeritoParams::correlated_agreement_bits`] charges the pessimistic one.
 //!
-//! Proof-of-work grinding is also absent, and it is what both references use to close the last
-//! few bits.
-//! Grinding is a transcript-level device rather than a property of the code, so it belongs to
-//! whichever protocol adopts it.
+//! Proof-of-work grinding *is* counted, through [`Grinding`].
+//! It is the one lever that moves the left-hand term.
+//! It does that without touching the code, by making a re-rolled challenge cost a fresh search.
 //!
 //! One warning is *stronger* in characteristic 2 than elsewhere.
 //! [BCHKS25] Theorem 1.6 and Cor. 1.7 show proximity gaps past the Johnson radius fail, and they
@@ -105,7 +104,70 @@
 //! [DP24]: <https://eprint.iacr.org/2024/504>
 //! [ABF26]: <https://eprint.iacr.org/2026/680>
 
+use binius_transcript::MAX_GRINDING_BITS;
+
 use crate::fri::calculate_n_test_queries;
+
+/// Proof-of-work bits ground into a transcript, split by the term each one buys back.
+///
+/// Grinding does not change the code, so it cannot move a proximity bound on its own.
+/// What it changes is the cost of *retrying*.
+/// A prover that dislikes a challenge must redo a `2^bits` search to see another one.
+/// Every term derived from that challenge therefore gains `bits`.
+///
+/// The two fields are not interchangeable.
+/// Charging one where the other belongs overstates the security reached.
+///
+/// - [`Self::challenge_bits`] is ground before the fold or batching challenge.
+/// - [`Self::query_bits`] is ground after the commitment, before query positions are drawn.
+///
+/// The first raises the ceiling that no query count can touch.
+/// The second lets the query phase reach the same target with fewer rows opened.
+///
+/// Both reference Ligerito implementations carry both kinds, at 16 and 17 bits.
+/// [`binius_transcript::ProverTranscript::grind`] is the primitive that produces them.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Grinding {
+	/// Bits ground before the challenge the algebraic terms depend on.
+	challenge_bits: usize,
+	/// Bits ground after the commitment and before query positions are drawn.
+	query_bits: usize,
+}
+
+impl Grinding {
+	/// No proof of work at all, which is what an unmodified protocol does.
+	pub const NONE: Self = Self {
+		challenge_bits: 0,
+		query_bits: 0,
+	};
+
+	/// Grinding of the given depth on each of the two challenges.
+	///
+	/// The prover pays about `2^challenge_bits + 2^query_bits` hashes per level for this.
+	pub const fn new(challenge_bits: usize, query_bits: usize) -> Self {
+		// A budget that claims more grinding than the transcript can deliver would report a
+		// security level nothing produces: `sample_bits_reader` masks to 32, so a larger
+		// difficulty silently weakens to that one.
+		assert!(
+			challenge_bits <= MAX_GRINDING_BITS && query_bits <= MAX_GRINDING_BITS,
+			"precondition: each grind must be within what the transcript can express"
+		);
+		Self {
+			challenge_bits,
+			query_bits,
+		}
+	}
+
+	/// Bits ground before the challenge the algebraic terms depend on.
+	pub const fn challenge_bits(self) -> usize {
+		self.challenge_bits
+	}
+
+	/// Bits ground after the commitment and before query positions are drawn.
+	pub const fn query_bits(self) -> usize {
+		self.query_bits
+	}
+}
 
 /// Which proximity-testing regime a code's parameters are derived in.
 ///
@@ -293,9 +355,12 @@ impl SoundnessRegime {
 		log_inv_rate: usize,
 		log_field_size: usize,
 		n_queries: usize,
+		grinding: Grinding,
 	) -> f64 {
-		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size);
-		let queries = n_queries as f64 * self.bits_per_query(log_inv_rate);
+		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size)
+			+ grinding.challenge_bits() as f64;
+		let queries =
+			n_queries as f64 * self.bits_per_query(log_inv_rate) + grinding.query_bits() as f64;
 		algebra.min(queries)
 	}
 
@@ -303,8 +368,11 @@ impl SoundnessRegime {
 	///
 	/// A `None` is not a parameter that needs more queries.
 	/// It is a configuration that cannot reach the target at all, because
-	/// [`Self::correlated_agreement_bits`] is already under it.
-	/// Widen the field, grind, or lower the target.
+	/// [`Self::correlated_agreement_bits`] plus `grinding`'s challenge side is still under it.
+	/// Widen the field, grind harder, or lower the target.
+	///
+	/// Grinding past `security_bits` on the query side returns zero queries.
+	/// That is a misconfiguration rather than a protocol.
 	///
 	/// # Panics
 	/// Those of [`Self::proximity_parameter`].
@@ -314,12 +382,38 @@ impl SoundnessRegime {
 		log_msg_len: usize,
 		log_inv_rate: usize,
 		log_field_size: usize,
+		grinding: Grinding,
 	) -> Option<usize> {
-		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size);
+		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size)
+			+ grinding.challenge_bits() as f64;
 		if algebra < security_bits as f64 {
 			return None;
 		}
-		Some(self.n_queries(security_bits, log_inv_rate))
+		// Query grinding closes part of the target on its own, so the rows only cover the rest.
+		let from_queries = security_bits.saturating_sub(grinding.query_bits());
+		Some(self.n_queries(from_queries, log_inv_rate))
+	}
+
+	/// Proof-of-work bits that would lift the algebraic term to `security_bits`.
+	///
+	/// Zero when the term already clears the target.
+	/// This is the ceiling read backwards.
+	/// Rather than what a configuration reaches, it says what reaching a given target would take.
+	///
+	/// Only the challenge side is returned, because only that side is ever *required*.
+	/// Query grinding trades proof size against prover time, so it is a choice, not a deficit.
+	///
+	/// # Panics
+	/// Those of [`Self::proximity_parameter`].
+	pub fn required_challenge_grinding(
+		self,
+		security_bits: usize,
+		log_msg_len: usize,
+		log_inv_rate: usize,
+		log_field_size: usize,
+	) -> usize {
+		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size);
+		(security_bits as f64 - algebra).max(0.0).ceil() as usize
 	}
 
 	/// The [`Self::Johnson`] slack minimizing queries at `security_bits`, with the count it
@@ -356,6 +450,7 @@ impl SoundnessRegime {
 					log_msg_len,
 					log_inv_rate,
 					log_field_size,
+					Grinding::NONE,
 				)?;
 				Some((regime, queries))
 			})
@@ -397,6 +492,7 @@ impl SoundnessRegime {
 					log_msg_len,
 					log_inv_rate,
 					log_field_size,
+					Grinding::NONE,
 				)?;
 				Some((regime, queries))
 			})
@@ -503,10 +599,21 @@ mod tests {
 			assert!((ceiling - expected).abs() < 0.01, "log_msg_len={log_msg_len} {ceiling}");
 
 			// The query count clears the target, and the algebra clears it too, so 96 holds.
-			let queries = SoundnessRegime::UniqueDecoding.plan_queries(96, log_msg_len, 1, B128);
+			let queries = SoundnessRegime::UniqueDecoding.plan_queries(
+				96,
+				log_msg_len,
+				1,
+				B128,
+				Grinding::NONE,
+			);
 			assert_eq!(queries, Some(232));
-			let achieved =
-				SoundnessRegime::UniqueDecoding.achieved_security_bits(log_msg_len, 1, B128, 232);
+			let achieved = SoundnessRegime::UniqueDecoding.achieved_security_bits(
+				log_msg_len,
+				1,
+				B128,
+				232,
+				Grinding::NONE,
+			);
 			assert!(achieved >= 96.0, "log_msg_len={log_msg_len} achieved={achieved}");
 		}
 	}
@@ -542,7 +649,8 @@ mod tests {
 						128,
 						log_msg_len,
 						log_inv_rate,
-						B128
+						B128,
+						Grinding::NONE,
 					),
 					None,
 				);
@@ -606,7 +714,7 @@ mod tests {
 		for log_msg_len in [24, 28, 30] {
 			assert!(
 				SoundnessRegime::UniqueDecoding
-					.plan_queries(128, log_msg_len, 1, 256)
+					.plan_queries(128, log_msg_len, 1, 256, Grinding::NONE)
 					.is_some()
 			);
 			assert!(SoundnessRegime::optimal_johnson(128, log_msg_len, 1, 256).is_some());
@@ -667,5 +775,94 @@ mod tests {
 	#[should_panic(expected = "eta must be less than 1 - sqrt(rho)")]
 	fn a_slack_past_the_johnson_radius_is_rejected() {
 		SoundnessRegime::Johnson { eta: 0.5 }.bits_per_query(1);
+	}
+	/// The slack that maximizes the lossy unique-decoding ceiling at the shape used below.
+	fn best_lossy() -> SoundnessRegime {
+		(1..4096)
+			.map(|i| SoundnessRegime::UniqueDecodingWithLoss {
+				loss: 0.25 * f64::from(i) / 4096.0,
+			})
+			.max_by(|a, b| {
+				a.correlated_agreement_bits(24, 1, B128)
+					.total_cmp(&b.correlated_agreement_bits(24, 1, B128))
+			})
+			.expect("the sweep is non-empty")
+	}
+
+	#[test]
+	fn no_grinding_is_the_default_and_changes_nothing() {
+		assert_eq!(Grinding::default(), Grinding::NONE);
+		assert_eq!(Grinding::NONE.challenge_bits(), 0);
+		assert_eq!(Grinding::NONE.query_bits(), 0);
+
+		// The shipped configuration reads the same with an explicit empty grind as without one.
+		let regime = SoundnessRegime::UniqueDecoding;
+		let bare = regime.correlated_agreement_bits(24, 1, B128);
+		let with_none = regime.achieved_security_bits(24, 1, B128, 1 << 30, Grinding::NONE);
+		assert!((with_none - bare).abs() < 1e-9);
+	}
+
+	#[test]
+	fn challenge_grinding_lifts_the_ceiling_that_queries_cannot() {
+		let regime = best_lossy();
+
+		// Over B128 the lossy ceiling stops at 124.5 bits, so 128 is out of reach unaided.
+		assert!((regime.correlated_agreement_bits(24, 1, B128) - 124.457).abs() < 0.01);
+		assert_eq!(regime.plan_queries(128, 24, 1, B128, Grinding::NONE), None);
+
+		// Four bits of proof of work close that gap, and the function says so before the fact.
+		assert_eq!(regime.required_challenge_grinding(128, 24, 1, B128), 4);
+		let ground = Grinding::new(4, 0);
+		assert!(regime.plan_queries(128, 24, 1, B128, ground).is_some());
+
+		// Nothing is owed once the term already clears the target.
+		assert_eq!(regime.required_challenge_grinding(124, 24, 1, B128), 0);
+		assert_eq!(regime.required_challenge_grinding(96, 24, 1, B128), 0);
+	}
+
+	#[test]
+	fn query_grinding_buys_rows_and_leaves_the_ceiling_alone() {
+		let regime = SoundnessRegime::UniqueDecoding;
+
+		// Seventeen bits is what one reference implementation grinds before drawing positions.
+		// The rows then only have to close the remaining target.
+		let bare = regime
+			.plan_queries(96, 24, 1, B128, Grinding::NONE)
+			.expect("96 bits is reachable");
+		let ground = regime
+			.plan_queries(96, 24, 1, B128, Grinding::new(0, 17))
+			.expect("grinding does not make it unreachable");
+		assert_eq!(bare, 232);
+		assert_eq!(ground, 191);
+
+		// But it does not touch the ceiling, so an out-of-reach target stays out of reach.
+		let lossy = best_lossy();
+		// Even the largest query grind the transcript can express leaves it out of reach.
+		let most = Grinding::new(0, MAX_GRINDING_BITS);
+		assert_eq!(lossy.plan_queries(128, 24, 1, B128, most), None);
+	}
+
+	#[test]
+	fn the_two_grinds_do_not_substitute_for_each_other() {
+		let regime = SoundnessRegime::UniqueDecoding;
+
+		// Challenge grinding raises the algebraic term and leaves the row count where it was.
+		let rows = regime
+			.plan_queries(96, 24, 1, B128, Grinding::new(17, 0))
+			.expect("96 bits is reachable");
+		assert_eq!(rows, regime.n_queries(96, 1));
+
+		// And it shows up in the achieved figure exactly once, on the side it belongs to.
+		let queries = 1 << 30;
+		let bare = regime.achieved_security_bits(24, 1, B128, queries, Grinding::NONE);
+		let ground = regime.achieved_security_bits(24, 1, B128, queries, Grinding::new(17, 0));
+		assert!((ground - bare - 17.0).abs() < 1e-9);
+	}
+	#[test]
+	#[should_panic(expected = "each grind must be within what the transcript can express")]
+	fn a_budget_past_what_the_transcript_can_deliver_is_rejected() {
+		// The sampler masks to 32 bits, so 40 would silently become 32 and the budget would claim
+		// eight bits nothing produces.
+		Grinding::new(MAX_GRINDING_BITS + 1, 0);
 	}
 }

--- a/crates/transcript/src/error.rs
+++ b/crates/transcript/src/error.rs
@@ -8,4 +8,12 @@ pub enum Error {
 	NotEnoughBytes,
 	#[error("Serialization error: {0}")]
 	Serialization(#[from] binius_utils::SerializationError),
+	/// A proof of work in the transcript does not meet the difficulty the verifier asked for.
+	#[error("proof of work is short: {bits} zero bits required, transcript sampled {sampled}")]
+	InsufficientWork {
+		/// Number of zero bits the verifier required.
+		bits: usize,
+		/// Bits the transcript actually sampled after observing the prover's nonce.
+		sampled: u32,
+	},
 }

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -12,6 +12,13 @@ use super::{
 };
 use crate::fiat_shamir::{CanSample, CanSampleBits, sample_bits_reader};
 
+/// Largest proof-of-work difficulty the transcript accepts, in bits.
+///
+/// The sampler masks what it returns to 32 bits.
+/// A larger difficulty could not be expressed, and would silently weaken to this one.
+/// A 32-bit grind already costs about four billion hashes, so the cap never binds in practice.
+pub const MAX_GRINDING_BITS: usize = 32;
+
 /// Configuration options for transcript behavior
 #[derive(Debug, Clone, Copy)]
 pub struct Options {
@@ -99,6 +106,35 @@ impl<Challenger_: Challenger> VerifierTranscript<Challenger_> {
 			buffer: &mut self.combined,
 			options: self.options,
 		}
+	}
+
+	/// Checks the proof of work that [`ProverTranscript::grind`] wrote, returning its nonce.
+	///
+	/// Reads the nonce as a message, so the challenger observes the same bytes the prover fed it.
+	/// Then samples `bits` and requires every one of them to be zero.
+	/// Both transcripts consume the same challenger state either way.
+	/// So a caller may keep going after an error without the two sides drifting apart.
+	///
+	/// ## Errors
+	///
+	/// Returns [`Error::InsufficientWork`] when the sampled bits are not all zero.
+	/// Returns a deserialization error when the tape holds no nonce.
+	///
+	/// ## Preconditions
+	///
+	/// * `bits` must be at most 32, which is the width the sampler masks to.
+	pub fn verify_grind(&mut self, bits: usize) -> Result<u64, Error> {
+		assert!(
+			bits <= MAX_GRINDING_BITS,
+			"precondition: bits must be at most {MAX_GRINDING_BITS}"
+		);
+
+		let nonce = self.message().read::<u64>()?;
+		let sampled = CanSampleBits::<u32>::sample_bits(self, bits);
+		if sampled != 0 {
+			return Err(Error::InsufficientWork { bits, sampled });
+		}
+		Ok(nonce)
 	}
 }
 
@@ -304,6 +340,53 @@ impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 			buffer: &mut self.combined,
 			options: self.options,
 		}
+	}
+
+	/// Grinds a proof of work into the transcript, returning the nonce it found.
+	///
+	/// Searches for a nonce whose observation drives the next `bits` sampled bits to zero.
+	/// The nonce goes out as a message, and those bits are then sampled so the challenger advances.
+	/// [`VerifierTranscript::verify_grind`] is the matching check.
+	///
+	/// A prover that wants to re-roll whatever challenge comes next must redo this search first.
+	/// Every term derived from that challenge therefore gains `bits` of soundness.
+	/// That is how a protocol buys back a term no query count can touch.
+	/// `binius_iop::soundness::Grinding` is where that credit enters a security budget.
+	///
+	/// The search is the obvious one: try nonces in order until one lands.
+	/// A trial is one challenger observation plus one sample, and lands with probability `2^-bits`.
+	/// The expected cost is therefore `2^bits` trials.
+	/// The search is serial, so a caller pays that in wall clock.
+	///
+	/// ## Preconditions
+	///
+	/// * `bits` must be at most 32, which is the width the sampler masks to.
+	pub fn grind(&mut self, bits: usize) -> u64
+	where
+		Challenger_: Clone,
+	{
+		assert!(
+			bits <= MAX_GRINDING_BITS,
+			"precondition: bits must be at most {MAX_GRINDING_BITS}"
+		);
+
+		// Trial on a clone so a failed nonce leaves the real challenger untouched. Observing the
+		// nonce's little-endian bytes is what `write::<u64>` feeds the challenger, so the two
+		// agree.
+		let mut nonce = 0u64;
+		loop {
+			let mut trial = self.combined.challenger.clone();
+			trial.observer().put_slice(&nonce.to_le_bytes());
+			if sample_bits_reader(trial.sampler(), bits) == 0 {
+				break;
+			}
+			nonce += 1;
+		}
+
+		self.message().write(&nonce);
+		let sampled = CanSampleBits::<u32>::sample_bits(self, bits);
+		debug_assert_eq!(sampled, 0, "the nonce search only exits on a landing nonce");
+		nonce
 	}
 }
 
@@ -525,5 +608,80 @@ mod tests {
 			.into_verifier()
 			.message()
 			.read_debug("test_transcript_debug_should_fail");
+	}
+	#[test]
+	fn grinding_round_trips_and_keeps_both_challengers_in_step() {
+		const BITS: usize = 12;
+
+		let mut prover = ProverTranscript::new(HasherChallenger::<Sha256>::default());
+		prover.message().write_scalar(B128::new(7));
+		let nonce = prover.grind(BITS);
+		// A difficulty this high is not met by the first nonce tried, so the search really ran.
+		assert!(nonce > 0);
+		let prover_challenge: B128 = prover.sample();
+
+		let mut verifier = prover.into_verifier();
+		let echoed: B128 = verifier.message().read_scalar().unwrap();
+		assert_eq!(echoed, B128::new(7));
+		assert_eq!(verifier.verify_grind(BITS).unwrap(), nonce);
+
+		// The nonce and its sample advance both challengers identically, so what follows agrees.
+		let verifier_challenge: B128 = verifier.sample();
+		assert_eq!(verifier_challenge, prover_challenge);
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn zero_difficulty_is_met_by_the_first_nonce() {
+		let mut prover = ProverTranscript::new(HasherChallenger::<Sha256>::default());
+		// Every nonce satisfies an empty condition, so the search stops immediately.
+		assert_eq!(prover.grind(0), 0);
+
+		// It still consumes a sample, which is what keeps the verifier in step.
+		let mut verifier = prover.into_verifier();
+		assert_eq!(verifier.verify_grind(0).unwrap(), 0);
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn a_tampered_nonce_is_rejected() {
+		const BITS: usize = 12;
+
+		let mut prover = ProverTranscript::new(HasherChallenger::<Sha256>::default());
+		prover.grind(BITS);
+		let mut tape = prover.finalize();
+
+		// Flip a bit of the written nonce. It is the first thing on the tape, and the challenger
+		// observes it, so the sampled bits move off zero.
+		tape[0] ^= 1;
+
+		let mut verifier =
+			VerifierTranscript::new(HasherChallenger::<Sha256>::default(), tape.clone());
+		let err = verifier.verify_grind(BITS).unwrap_err();
+		let Error::InsufficientWork { bits, sampled } = err else {
+			panic!("expected InsufficientWork, got {err:?}");
+		};
+		assert_eq!(bits, BITS);
+		assert_ne!(sampled, 0);
+		// The masked sample never exceeds the difficulty it was masked to.
+		assert!(sampled < 1 << BITS);
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn an_empty_tape_has_no_nonce_to_read() {
+		let mut verifier = VerifierTranscript::new(HasherChallenger::<Sha256>::default(), vec![]);
+		let err = verifier.verify_grind(8).unwrap_err();
+		let Error::Serialization(inner) = err else {
+			panic!("expected Serialization, got {err:?}");
+		};
+		assert!(matches!(inner, binius_utils::SerializationError::NotEnoughBytes));
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	#[should_panic(expected = "bits must be at most 32")]
+	fn a_difficulty_past_the_sampler_width_is_rejected() {
+		ProverTranscript::new(HasherChallenger::<Sha256>::default()).grind(MAX_GRINDING_BITS + 1);
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-530](https://linear.app/jimpo/issue/BINIUS-530).

### In one line

Make the prover burn hashes before it sees a challenge, so it cannot keep re-rolling one it does not like — and count that in the security budget.

### The problem

A proximity test's soundness is the worse of two independent numbers.

One is the **query term**. Open `t` random rows, and a cheating prover survives with probability `(1 - delta)^t`. Want more security? Open more rows.

The other is the **correlated-agreement error** — the chance a random combination of two far-from-the-code words happens to land near it. That one depends on the codeword length and the size of the field challenges come from. **Opening more rows does nothing to it.** It is a ceiling.

Over `B128` at rate 1/2 that ceiling is a flat 124.5 bits. So a 128-bit target is out of reach on the algebra alone, at every witness size — short by about 3.5 bits, and the gap does not grow.

That is exactly the sort of gap proof of work closes. Both reference Ligerito implementations grind — `flock` 16 bits, `leanVM-b` 17. This repo grinds nowhere, and `soundness.rs` counted none of it, so `achieved_security_bits` could not describe any configuration above the ceiling.

### The idea

Before the prover is allowed to see a challenge, make it find a nonce whose hash comes out with `bits` leading zeros. That costs `2^bits` tries.

Now a prover that dislikes the challenge it got cannot simply try again — retrying means redoing the whole search. Every attempt to re-roll costs `2^bits` times what it did before, so every term that challenge feeds gains `bits` of soundness.

### Walk through it

Say the algebra gives you 124.5 bits and you want 128.

Without grinding, a cheating prover re-rolls the challenge until it gets a lucky one. It expects to succeed after about `2^124.5` attempts.

Grind 4 bits first. Each attempt now costs 16 hashes instead of 1, so the same attack costs about `2^128.5`. The deficit is closed — for 16 hashes per honest proof.

That is the whole trick, and it is why the *fixed* 3.5-bit gap matters so much more than a sliding one. A ceiling that falls a bit per doubling would need grinding that grows with the witness; a flat one needs the same four bits forever.

### Two grinds, not one

They are not interchangeable, and conflating them would be a real soundness bug.

**Challenge grinding** happens before the challenge the algebraic terms depend on. It lifts the ceiling.

**Query grinding** happens after the commitment and before query positions are drawn. It pays for rows — 17 ground bits are 17 the rows no longer have to cover — but it leaves the ceiling exactly where it was.

So query grinding can never make an out-of-reach target reachable. `Grinding` keeps them as separate fields, and a test pins that the largest expressible query grind still cannot reach 128 bits.

### Why the search is safe

The prover trials nonces on a **cloned challenger**, not a cloned transcript. Cloning the transcript would copy the whole proof tape on every attempt — `O(tape)` per trial, times `2^bits` trials. Cloning the challenger is `O(1)`.

That is only sound if the bytes a trial observes are exactly the bytes the real write feeds through. They are, and the chain is short enough to check by hand:

- `SerializeBytes for u64` is `put_u64_le` — eight little-endian bytes;
- `FiatShamirBuf::advance_mut` hands the challenger precisely the slice just written;
- the verifier's `read::<u64>()` goes through `Buf::advance`, which observes that same slice off the tape.

Prover trial, prover write and verifier read therefore reach identical challenger states. A test asserts it directly: both sides sample a challenge after the grind and the values match.

Both sides also consume the same challenger state whether or not the check passes, so a caller may keep going after an error without the two drifting apart.

### The one place this could have gone quietly wrong

`sample_bits_reader` masks what it returns to 32 bits:

```rust
let bits = bits.min(u32::BITS as usize);
```

So a caller asking for 40 bits of difficulty would silently get 32 — a security parameter weaker than requested, with nothing to indicate it. `MAX_GRINDING_BITS = 32` and an assert on both sides make that a panic instead.

`Grinding::new` carries the same bound. Otherwise a budget could claim 40 bits of credit that the transcript is structurally unable to deliver, and report a security level nothing produces.

### The change

```rust
// binius-transcript
pub const MAX_GRINDING_BITS: usize = 32;
ProverTranscript::grind(bits) -> u64                        // where Challenger: Clone
VerifierTranscript::verify_grind(bits) -> Result<u64, Error>
Error::InsufficientWork { bits, sampled }

// binius-iop::soundness
pub struct Grinding { challenge_bits, query_bits }          // Grinding::NONE
SoundnessRegime::achieved_security_bits(.., grinding)       // widened
SoundnessRegime::plan_queries(.., grinding)                 // widened
SoundnessRegime::required_challenge_grinding(..) -> usize
```

The two existing signatures were widened rather than given grinding-aware twins. A parallel API invites quoting the grinding-free number by accident; `Grinding::NONE` at the call site is visible. The only caller outside the module computes its own terms, so the ripple was zero.

`required_challenge_grinding` returns only the challenge side, because query grinding is a proof-size-for-prover-time choice rather than a deficit — returning it would imply an obligation that does not exist.

### Deliberately not here

**Wiring grinding into the FRI or BaseFold flow.** That changes the proof format, and it needs a design pass on where each grind sits relative to commitment and query sampling. `LIGERITO_PLAN.md` does not pin that down, so guessing it here would be the wrong kind of decision to make silently.

**A parallel nonce search.** It needs care to stay deterministic — lowest nonce wins — and 17 bits is 131k hashes, which is not yet worth the complexity.

**Out-of-domain binding** remains the one uncounted term in the budget. It only matters for the Johnson regime, which `B128` cannot afford anyway.

### Scope

- **changed:** `crates/transcript/src/{transcript.rs,error.rs}`, `crates/iop/src/soundness.rs`
- no protocol code, no proof-format change, no caller migrated

### Verification

- `cargo test -p binius-transcript -p binius-iop` — 10 and 49 passed, doctests clean
- `cargo clippy -p binius-transcript -p binius-iop --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean
- `typos` and the copyright hook — clean

Neither crate has a `rayon` feature, so that gate is inapplicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
