### PR TITLE
BINIUS-533: Open a single Ligerito level, prover and verifier

### DIFF
--- a/crates/iop-prover/src/lib.rs
+++ b/crates/iop-prover/src/lib.rs
@@ -15,6 +15,7 @@
 //!
 //! - [`basefold`] - BaseFold polynomial commitment scheme proving
 //! - [`fri`] - FRI (Fast Reed-Solomon Interactive Oracle Proof) proving
+//! - [`ligerito`] - Ligerito polynomial commitment scheme proving
 //! - [`merkle_tree`] - Merkle tree commitment construction
 //! - [`channel`] - IOP prover channel traits for abstracting oracle interactions
 //!
@@ -29,6 +30,7 @@ pub mod basefold;
 pub mod channel;
 pub mod commit_pipeline;
 pub mod fri;
+pub mod ligerito;
 pub mod logup_star;
 pub mod merkle_channel;
 pub mod merkle_tree;

--- a/crates/iop-prover/src/ligerito/mod.rs
+++ b/crates/iop-prover/src/ligerito/mod.rs
@@ -1,0 +1,10 @@
+// Copyright 2026 The Binius Developers
+
+//! Proving one committed Ligerito level.
+//!
+//! The verifier side lives in [`binius_iop::ligerito`], where the protocol is described.
+//! This module holds [`LevelProver`], which commits a level's message and then opens it.
+
+mod opening;
+
+pub use opening::LevelProver;

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -1,0 +1,301 @@
+// Copyright 2026 The Binius Developers
+
+//! One committed Ligerito level, on the prover side.
+//!
+//! The counterpart of [`binius_iop::ligerito::LevelVerifier`], which describes the protocol.
+//! Two facts recorded there drive everything here.
+//! The MLE-check challenges are the lane fold.
+//! And the residual is bound before the queries are drawn.
+
+use binius_compute::{Allocator, GlobalAllocator};
+use binius_field::{BinaryField, PackedField};
+use binius_iop::ligerito::LigeritoLevel;
+use binius_ip::mlecheck;
+use binius_ip_prover::sumcheck::{
+	common::MleCheckProver, multilinear_eval::multilinear_eval_prover,
+};
+use binius_math::{
+	FieldBuffer, FieldSlice, multilinear::MultilinearMut, ntt::AdditiveNTT,
+	reed_solomon::ReedSolomonCode,
+};
+
+use crate::{
+	fri::{BrakedownOracleProver, ProxTestOracleProver},
+	merkle_channel::MerkleIPProverChannel,
+};
+
+/// Proves one committed Ligerito level whose residual is sent in the clear.
+///
+/// Holds the level's shape alongside the oracle that answers queries against its codeword.
+pub struct LevelProver<P: PackedField, C> {
+	/// The level's shape: lane count, column count, rate, and query count.
+	level: LigeritoLevel,
+	/// The committed interleaved codeword, and the handle that opens it.
+	oracle: BrakedownOracleProver<P, C>,
+}
+
+impl<F, P, C> LevelProver<P, C>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+{
+	/// Binds a prover to a level shape and the oracle over its committed codeword.
+	///
+	/// [`Self::commit`] is the way to build both consistently.
+	pub const fn new(level: LigeritoLevel, oracle: BrakedownOracleProver<P, C>) -> Self {
+		Self { level, oracle }
+	}
+
+	/// Encodes `message` lane by lane, Merkle-commits the result, and sends the commitment.
+	///
+	/// `message` is the level's multilinear in variable order, so its high `log_lanes` variables
+	/// carry the lane index and its low `log_msg_cols` variables carry the column.
+	/// That is already the layout [`ReedSolomonCode::encode_batch`] reads, which takes lane
+	/// `lane`'s columns from
+	///
+	/// ```text
+	///     message[(reverse_bits(lane, log_lanes) << log_msg_cols) | j]
+	/// ```
+	///
+	/// as [`binius_math::ntt::subspace_polys`] pins.
+	/// The bit reversal is what makes an opened coset fold by the MLE-check challenges in sampling
+	/// order, which [`binius_iop::ligerito::LevelVerifier`] spells out.
+	/// So no reshaping happens here, and a caller must not do any either.
+	///
+	/// One leaf is one codeword position across every lane, so a leaf is `2^log_lanes` scalars.
+	///
+	/// The codeword is allocated globally rather than from an arena.
+	/// A level's codeword outlives the call that builds it, and nothing here is on a hot path yet.
+	///
+	/// ## Preconditions
+	///
+	/// * `message` has `level.log_msg_len()` variables.
+	/// * `ntt` is defined over the level's codeword domain.
+	pub fn commit<NTT, Channel>(
+		level: LigeritoLevel,
+		ntt: &NTT,
+		message: FieldSlice<P>,
+		channel: &mut Channel,
+	) -> Self
+	where
+		NTT: AdditiveNTT<Field = F> + Sync,
+		Channel: MerkleIPProverChannel<F, Commitment = C>,
+	{
+		assert_eq!(
+			message.log_len(),
+			level.log_msg_len(),
+			"precondition: message must have one variable per message variable of the level"
+		);
+
+		let code = ReedSolomonCode::<F>::new(level.log_msg_cols, level.log_inv_rate);
+		let codeword = code.encode_batch(ntt, message, level.log_lanes, &GlobalAllocator);
+		let commitment = channel.send_merkle_commitment(codeword.as_view(), 1 << level.log_lanes);
+
+		Self::new(level, BrakedownOracleProver::new(codeword, commitment, 0))
+	}
+
+	/// Proves the opening of `<message, eq(eval_point)> = eval_claim`.
+	///
+	/// Runs `log_lanes` MLE-check rounds, folds the message by their challenges into the residual,
+	/// commits and sends the residual, and only then answers the queries the channel draws.
+	///
+	/// The trailing sample matches the challenge the verifier batches the opened rows with.
+	/// The prover has nothing to do with that value beyond keeping the two transcripts in step.
+	///
+	/// ## Preconditions
+	///
+	/// * `message` is the multilinear [`Self::commit`] committed.
+	/// * `eval_point` has `level.log_msg_len()` coordinates, in low-to-high variable order.
+	pub fn prove<A, Channel>(
+		&self,
+		message: FieldSlice<P>,
+		eval_point: &[F],
+		eval_claim: F,
+		alloc: &A,
+		channel: &mut Channel,
+	) where
+		A: Allocator,
+		Channel: MerkleIPProverChannel<F, Commitment = C>,
+	{
+		let n_vars = self.level.log_msg_len();
+		assert_eq!(
+			message.log_len(),
+			n_vars,
+			"precondition: message must have one variable per message variable of the level"
+		);
+		assert_eq!(
+			eval_point.len(),
+			n_vars,
+			"precondition: eval_point must have one coordinate per message variable"
+		);
+
+		let mut sumcheck = multilinear_eval_prover(
+			alloc,
+			FieldBuffer::from_view_in(alloc, message),
+			eval_point,
+			eval_claim,
+		);
+
+		// Each round binds the message's highest remaining variable, so once the lane variables
+		// are gone what is left of the message is the residual.
+		let mut residual = FieldBuffer::from_view_in(alloc, message);
+		for _ in 0..self.level.log_lanes {
+			let round_coeffs = sumcheck
+				.execute()
+				.pop()
+				.expect("the multilinear-evaluation prover proves exactly one claim");
+			channel.send_many(mlecheck::RoundProof::truncate(round_coeffs).coeffs());
+
+			let challenge = channel.sample();
+			sumcheck.fold(challenge);
+			residual.fold_highest_var(challenge);
+		}
+
+		// The residual is bound here, before a single query position exists.
+		let residual_commitment = channel.send_merkle_commitment(residual.as_view(), 1);
+		channel.send_committed_vector(&residual_commitment, residual.as_view());
+
+		let indices = (0..self.level.n_queries)
+			.map(|_| channel.sample_bits(self.level.log_codeword_len()))
+			.collect::<Vec<_>>();
+		self.oracle.open_queries(&indices, channel);
+
+		// The verifier's row-batching challenge, drawn only to keep the two transcripts in step.
+		let _batching_challenge: F = channel.sample();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{Field, Ghash128b as B128, Random};
+	use binius_hash::{StdDigest, StdHashSuite};
+	use binius_iop::{
+		ligerito::{Error, LevelVerifier},
+		merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
+	};
+	use binius_math::{
+		multilinear::Multilinear,
+		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
+		test_utils::random_field_buffer,
+	};
+	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::merkle_channel::ProverMerkleTranscriptChannel;
+
+	type StdChallenger = HasherChallenger<StdDigest>;
+
+	/// Commits `committed`, then proves and verifies `<opened, eq(z)> = opened(z) + claim_offset`.
+	///
+	/// Splitting the committed message from the opened one is how a dishonest prover is expressed
+	/// here: every value it sends in the clear is consistent with `opened`, while the codeword the
+	/// queries land in encodes `committed`.
+	/// An honest run passes the same buffer twice and a zero offset.
+	fn run(
+		level: LigeritoLevel,
+		committed: &FieldBuffer<B128>,
+		opened: &FieldBuffer<B128>,
+		claim_offset: B128,
+	) -> Result<(), Error> {
+		let mut rng = StdRng::seed_from_u64(level.log_msg_len() as u64);
+		let eval_point = (0..level.log_msg_len())
+			.map(|_| B128::random(&mut rng))
+			.collect::<Vec<_>>();
+		let eval_claim = opened.evaluate(&eval_point) + claim_offset;
+
+		let ntt =
+			NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(level.log_codeword_len()));
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let mut prover_channel =
+			ProverMerkleTranscriptChannel::<_, StdChallenger, B128, StdHashSuite>::new(
+				&mut prover_transcript,
+			);
+		let prover = LevelProver::commit(level, &ntt, committed.as_view(), &mut prover_channel);
+		prover.prove(
+			opened.as_view(),
+			&eval_point,
+			eval_claim,
+			&GlobalAllocator,
+			&mut prover_channel,
+		);
+		prover_channel.into_transcript();
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel =
+			VerifierMerkleTranscriptChannel::<_, StdChallenger, B128, StdHashSuite>::new(
+				&mut verifier_transcript,
+			);
+		let commitment = verifier_channel
+			.recv_merkle_commitment(1 << level.log_lanes, level.log_codeword_len())?;
+		LevelVerifier::new(level, commitment).verify(&eval_point, eval_claim, &mut verifier_channel)
+	}
+
+	/// A random message of the level's shape.
+	fn message(level: LigeritoLevel, seed: u64) -> FieldBuffer<B128> {
+		random_field_buffer(&mut StdRng::seed_from_u64(seed), level.log_msg_len())
+	}
+
+	/// Every shape of level an honest prover can produce must verify.
+	///
+	/// The shapes vary all three dimensions independently, including `log_lanes = 0`, where the
+	/// MLE-check runs no rounds at all and the residual is the whole message.
+	#[test]
+	fn an_honest_opening_verifies() {
+		for log_msg_cols in 1..5 {
+			for log_lanes in 0..4 {
+				for log_inv_rate in 1..3 {
+					let level = LigeritoLevel {
+						log_msg_cols,
+						log_lanes,
+						log_inv_rate,
+						n_queries: 5,
+					};
+					let msg = message(level, 0);
+					run(level, &msg, &msg, B128::ZERO)
+						.unwrap_or_else(|err| panic!("{level:?}: {err}"));
+				}
+			}
+		}
+	}
+
+	/// A residual that does not fold out of the committed codeword must be caught.
+	///
+	/// This is the check the query round exists for.
+	/// The prover's MLE-check, its residual, and its claim are all consistent with each other; only
+	/// the codeword the queries open disagrees.
+	#[test]
+	fn a_residual_unrelated_to_the_codeword_is_rejected() {
+		let level = LigeritoLevel {
+			log_msg_cols: 3,
+			log_lanes: 2,
+			log_inv_rate: 2,
+			n_queries: 5,
+		};
+		// Everything sent in the clear is consistent with the proved message, so the sumcheck half
+		// passes. Only the codeword the queries land in disagrees, which is the query half alone.
+		let err = run(level, &message(level, 0), &message(level, 1), B128::ZERO)
+			.expect_err("the opened rows encode a different message than the residual");
+		assert!(matches!(err, Error::IPChannel(binius_ip::channel::Error::InvalidAssert)));
+	}
+
+	/// A claim the message does not satisfy must be caught.
+	///
+	/// This is the check the MLE-check exists for: the reduced sum no longer matches the residual's
+	/// own evaluation, even though every value the prover sent is internally consistent.
+	#[test]
+	fn a_claim_the_message_does_not_satisfy_is_rejected() {
+		let level = LigeritoLevel {
+			log_msg_cols: 3,
+			log_lanes: 2,
+			log_inv_rate: 2,
+			n_queries: 5,
+		};
+		// The round proofs still fix the same challenges, so the fold and the query half agree.
+		// Only the reduced sum is wrong, which is the sumcheck half alone.
+		let msg = message(level, 0);
+		let err =
+			run(level, &msg, &msg, B128::ONE).expect_err("the evaluation claim is off by one");
+		assert!(matches!(err, Error::IPChannel(binius_ip::channel::Error::InvalidAssert)));
+	}
+}

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -1,5 +1,10 @@
 // Copyright 2026 The Binius Developers
 
+//! Proximity-test oracles, which recover a folded value by opening the cosets it folds.
+//!
+//! FRI drives them round by round.
+//! A Ligerito level drives one of them once, since its whole fold is a single round.
+
 use std::iter;
 
 use binius_field::{BinaryField, FieldOps, util::expand_subset_sums};

--- a/crates/iop/src/fri/mod.rs
+++ b/crates/iop/src/fri/mod.rs
@@ -23,7 +23,7 @@
 //! [BBHR17]: <https://eccc.weizmann.ac.il/report/2017/134/>
 //! [DP24]: <https://eprint.iacr.org/2024/504>
 
-mod batch;
+pub(crate) mod batch;
 mod common;
 mod error;
 pub mod fold;

--- a/crates/iop/src/ligerito/error.rs
+++ b/crates/iop/src/ligerito/error.rs
@@ -1,0 +1,36 @@
+// Copyright 2026 The Binius Developers
+
+use crate::{fri, merkle_channel};
+
+/// Anything that can go wrong verifying a Ligerito opening.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// The Merkle channel could not deliver a commitment or an opening.
+	#[error("Merkle channel: {0}")]
+	Channel(#[from] merkle_channel::Error),
+	/// The interactive-proof channel could not deliver a message.
+	#[error("IP channel: {0}")]
+	IPChannel(#[from] binius_ip::channel::Error),
+	/// A committed value did not match what the transcript bound it to.
+	#[error("verification: {0}")]
+	Verification(#[from] VerificationError),
+}
+
+/// A prover message that was well-formed but wrong.
+///
+/// Separated from [`Error`] so a caller can tell a malformed transcript from a rejected proof.
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+	/// A Merkle opening did not match its commitment.
+	#[error("Merkle tree: {0}")]
+	MerkleTree(#[from] crate::merkle_tree::VerificationError),
+}
+
+impl From<fri::batch::Error> for Error {
+	fn from(err: fri::batch::Error) -> Self {
+		match err {
+			fri::batch::Error::Channel(err) => err.into(),
+			fri::batch::Error::IPChannel(err) => Self::IPChannel(err),
+		}
+	}
+}

--- a/crates/iop/src/ligerito/induced_basis.rs
+++ b/crates/iop/src/ligerito/induced_basis.rs
@@ -48,6 +48,8 @@
 //!
 //! [`InducedBasis::to_dense`] materializes `w` anyway, as the reference the closed form is tested
 //! against, and for a prover that genuinely needs every entry.
+//! It needs a packed field, so a verifier written against a channel cannot reach it at all.
+//! [`InducedBasis::pair`] is how a terminal level pairs `w` with a message it holds in the clear.
 
 use binius_field::{BinaryField, PackedField, field::FieldOps, util::expand_subset_products};
 use binius_ip::channel::WordIPVerifierChannel;
@@ -231,6 +233,52 @@ impl<F: FieldOps> InducedBasis<F> {
 		inner_product_scalars(self.batching.iter().cloned(), terms)
 	}
 
+	/// Pairs the basis with a message held in the clear, giving `<w, message>`.
+	///
+	/// This is the other side of the equation [`Self::enforced_sum`] gives, so a terminal level
+	/// checks the two against each other.
+	///
+	/// Expanding the definition of `w`,
+	///
+	/// ```text
+	///     <w, message> = sum_i alpha^i * <G_{q_i}, message>
+	/// ```
+	///
+	/// and each row pairing folds `message` against that row's factors, one variable per step.
+	/// Entry `j` of a row selects `f[k]` exactly when bit `k` of `j` is set, so folding the pair
+	/// `(even, odd)` into `even + f[k] * odd` strips variable `k`.
+	///
+	/// Costs `O(n_rows * 2^n_vars)` and never materializes a row, so unlike [`Self::to_dense`] it
+	/// is available wherever the basis itself is.
+	/// A recursive level has no message in the clear to pair against and uses [`Self::evaluate`]
+	/// inside a sumcheck instead.
+	///
+	/// ## Preconditions
+	///
+	/// * `message` has `2^n_vars` entries.
+	pub fn pair(&self, message: &[F]) -> F {
+		assert_eq!(
+			message.len(),
+			1 << self.n_vars,
+			"precondition: message must have 2^n_vars entries"
+		);
+
+		let rows = self.factors.iter().map(|factors| {
+			let mut folded = message.to_vec();
+			for factor in factors {
+				let half = folded.len() / 2;
+				for j in 0..half {
+					folded[j] = folded[2 * j].clone() + factor.clone() * folded[2 * j + 1].clone();
+				}
+				folded.truncate(half);
+			}
+			folded
+				.pop()
+				.expect("folding n_vars times leaves exactly one element")
+		});
+		inner_product_scalars(self.batching.iter().cloned(), rows)
+	}
+
 	/// The dense weight vector, `2^n_vars` entries.
 	///
 	/// This is the reference [`Self::evaluate`] is tested against, and the vector a prover folds.
@@ -323,6 +371,14 @@ mod tests {
 				assert_eq!(
 					paired,
 					basis.enforced_sum(&opened),
+					"log_dim={log_dim} log_inv_rate={log_inv_rate}"
+				);
+
+				// `pair` is the route a verifier takes when it cannot build the dense vector, so it
+				// has to reach the same claim.
+				assert_eq!(
+					basis.pair(message.as_ref()),
+					paired,
 					"log_dim={log_dim} log_inv_rate={log_inv_rate}"
 				);
 			}

--- a/crates/iop/src/ligerito/mod.rs
+++ b/crates/iop/src/ligerito/mod.rs
@@ -14,11 +14,11 @@
 //! That is what makes the deep levels cheap, because a lower rate needs fewer queries.
 //! After the last level the residual matrix is sent in the clear.
 //!
-//! This module contains **no protocol code**.
-//! It holds only:
+//! This module holds:
 //!
 //! - [`LigeritoParams`] and its invariants;
 //! - [`InducedBasis`], the weight vector a level's opened rows put on its message;
+//! - [`LevelVerifier`], one committed level whose residual is sent in the clear;
 //! - [`LigeritoParams::proof_size`], the byte-exact estimate;
 //! - [`LigeritoParams::optimal_ladder`], the search that minimizes it subject to a security target.
 //!
@@ -29,9 +29,13 @@
 //! [NA25]: <https://eprint.iacr.org/2025/1187>
 
 mod common;
+mod error;
 mod induced_basis;
+mod opening;
 mod size_estimation;
 
 pub use common::*;
+pub use error::{Error, VerificationError};
 pub use induced_basis::InducedBasis;
+pub use opening::LevelVerifier;
 pub use size_estimation::{MAX_LOG_INV_RATE, MAX_LOG_LANES};

--- a/crates/iop/src/ligerito/opening.rs
+++ b/crates/iop/src/ligerito/opening.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 The Binius Developers
+
+//! One committed Ligerito level, on the verifier side.
+//!
+//! The level proves an evaluation claim `<X_0, eq(z)> = y` about the multilinear it committed.
+//! `X_0` is held as `2^log_lanes` interleaved lanes of `2^log_msg_cols` columns, and each lane is
+//! a Reed-Solomon codeword of the same code.
+//!
+//! # Why the lane fold and the sumcheck are the same challenges
+//!
+//! An MLE-check binds one variable per round, highest first.
+//! Running it for `log_lanes` rounds binds exactly the variables the lane index occupies, so the
+//! claim it leaves behind is about the lane-folded matrix
+//!
+//! ```text
+//!     X_1[j] = sum_lane X_0[lane][j] * eq(lane, r)
+//! ```
+//!
+//! and `r` is the same tensor the queries have to be folded by.
+//! There is no separate folding phase because there is nothing left to fold.
+//!
+//! # Why an opened row is a claim about `X_1`
+//!
+//! Every lane is an independent codeword of one code, which
+//! [`binius_math::ntt::subspace_polys`] pins against `ReedSolomonCode::encode_batch`.
+//! Encoding is linear, so folding across lanes and encoding commute:
+//!
+//! ```text
+//!     sum_lane cw_lane[x] * eq(lane, r)  =  (G . X_1)[x]
+//! ```
+//!
+//! An opened row at position `q`, folded by `r`, is therefore exactly `<G_q, X_1>`.
+//! That is one linear claim about `X_1` per query, and [`InducedBasis`] batches them into one.
+//!
+//! # Why the residual goes out before the queries
+//!
+//! The residual is the whole of `X_1`, sent in the clear because this level is terminal.
+//! Its commitment is observed before any query position is sampled.
+//! A prover therefore has to fix `X_1` without knowing which rows will be checked against it,
+//! which is the entire soundness argument for sending it in the clear.
+
+use binius_field::BinaryField;
+use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
+use binius_math::{
+	multilinear::evaluate::evaluate_inplace_scalars, ntt::domain_context::GaoMateerOnTheFly,
+};
+
+use super::{InducedBasis, LigeritoLevel, error::Error};
+use crate::{
+	fri::batch::{BrakedownOracle, ProxTestOracle},
+	merkle_channel::MerkleIPVerifierChannel,
+};
+
+/// The MLE-check round polynomial is degree 1, since the composite is the multilinear itself.
+const DEGREE: usize = 1;
+
+/// Verifies one committed Ligerito level whose residual is sent in the clear.
+///
+/// Holds the level's shape and the commitment to its interleaved codeword.
+/// The caller receives that commitment, so it stays in charge of when the level's oracle arrives.
+#[derive(Debug, Clone)]
+pub struct LevelVerifier<C> {
+	/// The level's shape: lane count, column count, rate, and query count.
+	level: LigeritoLevel,
+	/// The commitment to the level's interleaved codeword.
+	commitment: C,
+}
+
+impl<C: Clone> LevelVerifier<C> {
+	/// Binds a verifier to a level shape and the commitment to its codeword.
+	pub const fn new(level: LigeritoLevel, commitment: C) -> Self {
+		Self { level, commitment }
+	}
+
+	/// Verifies the opening of `<X_0, eq(eval_point)> = eval_claim`.
+	///
+	/// The two checks it closes with are the two halves of the level.
+	/// The MLE-check's reduced sum must equal the residual's own evaluation at the coordinates the
+	/// fold left unbound.
+	/// And the opened rows, batched by [`InducedBasis`], must equal that basis paired with the
+	/// residual.
+	///
+	/// Both are asserted through the channel rather than compared, so a channel that builds a
+	/// circuit records them as constraints.
+	///
+	/// ## Preconditions
+	///
+	/// * `eval_point` has `level.log_msg_len()` coordinates, in low-to-high variable order.
+	pub fn verify<F, Channel>(
+		&self,
+		eval_point: &[Channel::Elem],
+		eval_claim: Channel::Elem,
+		channel: &mut Channel,
+	) -> Result<(), Error>
+	where
+		F: BinaryField,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel::Elem: From<F>,
+	{
+		let n_vars = self.level.log_msg_len();
+		assert_eq!(
+			eval_point.len(),
+			n_vars,
+			"precondition: eval_point must have one coordinate per message variable"
+		);
+
+		// MLE-check rounds. These bind the lane variables, highest first, and their challenges are
+		// what the opened rows get folded by.
+		let mut sum = eval_claim;
+		let mut challenges = Vec::with_capacity(self.level.log_lanes);
+		for round in 0..self.level.log_lanes {
+			let round_proof = mlecheck::RoundProof(RoundCoeffs(channel.recv_many(DEGREE)?));
+			let alpha = eval_point[n_vars - 1 - round].clone();
+			let round_coeffs = round_proof.recover(sum, alpha);
+			let challenge = channel.sample();
+			sum = round_coeffs.evaluate(&challenge);
+			challenges.push(challenge);
+		}
+
+		// The residual is bound here, before a single query position exists.
+		let residual_commitment = channel.recv_merkle_commitment(1, self.level.log_msg_cols)?;
+		let residual = channel.recv_committed_vector(&residual_commitment)?;
+
+		let indices = (0..self.level.n_queries)
+			.map(|_| channel.sample_bits(self.level.log_codeword_len()))
+			.collect::<Vec<_>>();
+
+		// `open_queries` returns each opened coset already folded by the challenges, which is the
+		// value the module documentation identifies with `<G_q, X_1>`.
+		let oracle = BrakedownOracle::new(challenges, self.commitment.clone(), 0);
+		let folded_rows = oracle.open_queries(&indices, channel)?;
+
+		let alpha = channel.sample();
+		let domain_context = GaoMateerOnTheFly::generate(self.level.log_codeword_len());
+		let basis = InducedBasis::from_query_words(
+			&domain_context,
+			self.level.log_msg_cols,
+			&indices,
+			&alpha,
+			channel,
+		);
+
+		// The query half: the batched rows against the basis paired with the residual.
+		//
+		// Pairing against a message in the clear is a terminal move. A recursive level never holds
+		// its residual, so it glues the induced claim into a sumcheck over the next level and
+		// reaches the basis through `InducedBasis::evaluate` alone.
+		channel.assert_zero(basis.pair(&residual) - basis.enforced_sum(&folded_rows))?;
+
+		// The sumcheck half: the reduced claim against the residual's own evaluation at the
+		// coordinates the lane fold left unbound.
+		let residual_eval =
+			evaluate_inplace_scalars(residual, &eval_point[..self.level.log_msg_cols]);
+		channel.assert_zero(residual_eval - sum)?;
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-533](https://linear.app/jimpo/issue/BINIUS-533).

### In one line

The first Ligerito code that actually proves something: one committed level, a residual in the clear, and an evaluation claim closed end to end.

### Where this sits

Six merged PRs so far are all scaffolding — parameters, a cost model, a soundness budget, the induced basis, a transposed NTT. None of them prove anything. This is the unit the ladder recurses.

### The protocol

A level holds its message as `2^log_lanes` interleaved lanes of `2^log_msg_cols` columns, committed as one interleaved Reed–Solomon codeword: a Merkle leaf is one codeword position across all lanes.

```
    1.  log_lanes MLE-check rounds reduce  <X_0, eq(z)> = y
        their challenges ARE the lane fold — there is no separate folding phase

    2.  prover folds X_0 by those challenges into the residual X_1
        and sends it as a committed vector

    3.  ---- only now are query positions sampled ----

    4.  rows opened; each coset comes back already folded by the challenges

    5.  two terminal checks
```

**Step 3's position in that list is the entire soundness argument for a cleartext residual.** The residual is bound before the prover learns which rows will be checked, so it cannot be adapted to them. Get that ordering wrong and the protocol is worthless while every test still passes.

### The identity it rests on

Each lane is an independent codeword of the *same* code — pinned back in [BINIUS-514](https://linear.app/jimpo/issue/BINIUS-514). So folding an opened coset across lanes and encoding the folded message commute:

```
    sum_lane cw_lane[x] * tensor(r)[lane]  =  (G . X_1)[x]
```

An opened row at position `q` is therefore exactly `<G_q, X_1>`, which is what makes the terminal check possible at all.

### The two checks

- **Query half** — batch the opened rows by a challenge, and pair the induced basis against the residual.
- **Sumcheck half** — the reduced MLE-check claim against the residual's own evaluation at the coordinates the lane fold left unbound.

The query half is *equivalent* to checking each query directly against the residual's encoding, and the direct form would honestly be simpler here. It goes through the induced basis anyway, because that is the path a recursive level glues into a sumcheck rather than checking — better to exercise it end to end before recursing it than after.

### A correction to the plan, found by building it

`LIGERITO_PLAN.md` §7 says a verifier "must not" materialize the induced basis — stated as a discipline to follow.

It turns out to be stronger than that. `InducedBasis::to_dense` is bounded on `PackedField`, and a channel element never is. A channel-generic verifier therefore **cannot** call it, on any path. The rule is enforced by the type system, not by convention.

Which meant the terminal check needed a route that didn't exist, so this PR adds `InducedBasis::pair`. It computes `<w, msg>` by folding each row's factors against the message one variable at a time, so no row is ever built. It sits beside `enforced_sum` as the other side of the same equation.

### On the test count

Three tests: one happy path over 32 shapes (`log_msg_cols` 1..5 × `log_lanes` 0..4 × rate 1..3, so `log_lanes = 0` and the multi-lane cases both run), and two negatives.

Two negatives rather than four, because corrupting an opened row and corrupting the residual are the same disagreement seen from either end. The helper expresses it as one knob — commit message A, prove message B — so everything sent in the clear is consistent with B and only the codeword the queries land in encodes A.

I checked the reduction was safe by mutation rather than by argument. Removing each terminal check in turn:

| removed | which test fails |
|---|---|
| query-half assert | `a_residual_unrelated_to_the_codeword_is_rejected`, alone |
| sumcheck-half assert | `a_claim_the_message_does_not_satisfy_is_rejected`, alone |

Clean one-to-one: each negative test is load-bearing for exactly one check, and nothing else covers it.

### Two smaller notes

The prover samples a batching challenge it never uses. That is deliberate — the verifier draws one, and Fiat–Shamir requires both sides to consume identical challenger state, so the transcripts stay in step for anything that follows.

`fri::batch` moves from private to `pub(crate)`, not `pub`. `BrakedownOracle` is what a level opens its rows with, and `ligerito` is in the same crate, so the public API is unchanged.

### Deliberately not here

**Recursion.** A second level, the glue that turns an induced claim into a running sumcheck, and the rate ladder are the multi-level PR.

**Wiring `to_dense` to the transposed NTT** from [BINIUS-532](https://linear.app/jimpo/issue/BINIUS-532). That needs `InducedBasis` to retain its query indices and domain — a shape change to the type this PR builds on — and the two paths cross over around `t ≈ 2^rate · (cols + rate)`, so picking between them wants a real prover to measure.

### Scope

- **new:** `crates/iop/src/ligerito/{opening,error}.rs`, `crates/iop-prover/src/ligerito/`
- **changed:** `InducedBasis::pair`; `fri::batch` to `pub(crate)` with a module doc; module registrations

### Verification

- `cargo test -p binius-iop -p binius-iop-prover` — 58 and 49 passed, plus integration tests; `binius-iop-prover` also passes `--features rayon`
- `cargo clippy -p binius-iop -p binius-iop-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean
- `typos` and the copyright hook — clean

Rebased on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
