### PR TITLE
BINIUS-534: Recurse the Ligerito ladder with introduce and glue

### DIFF
--- a/crates/iop-prover/src/ligerito/mod.rs
+++ b/crates/iop-prover/src/ligerito/mod.rs
@@ -3,8 +3,8 @@
 //! Proving one committed Ligerito level.
 //!
 //! The verifier side lives in [`binius_iop::ligerito`], where the protocol is described.
-//! This module holds [`LevelProver`], which commits a level's message and then opens it.
+//! This module holds [`LigeritoProver`], which commits a level's message and then opens it.
 
 mod opening;
 
-pub use opening::LevelProver;
+pub use opening::LigeritoProver;

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -1,21 +1,30 @@
 // Copyright 2026 The Binius Developers
 
-//! One committed Ligerito level, on the prover side.
+//! The Ligerito opening protocol on the prover side.
 //!
-//! The counterpart of [`binius_iop::ligerito::LevelVerifier`], which describes the protocol.
-//! Two facts recorded there drive everything here.
-//! The MLE-check challenges are the lane fold.
-//! And the residual is bound before the queries are drawn.
+//! The counterpart of [`binius_iop::ligerito::LigeritoVerifier`], which describes the protocol.
+//! Three facts recorded there drive everything here.
+//! The sumcheck challenges of a level are its lane fold.
+//! Whatever a level folds to is committed before that level's queries are drawn.
+//! And only level 0 may use the MLE-check shortcut.
+
+use std::iter::zip;
 
 use binius_compute::{Allocator, GlobalAllocator};
+use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
-use binius_iop::ligerito::LigeritoLevel;
+use binius_iop::ligerito::{InducedBasis, LigeritoLevel, LigeritoParams};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
-	common::MleCheckProver, multilinear_eval::multilinear_eval_prover,
+	bivariate_product_evaluator::bivariate_product_prover,
+	common::{MleCheckProver, SumcheckProver},
+	multilinear_eval::multilinear_eval_prover,
 };
 use binius_math::{
-	FieldBuffer, FieldSlice, multilinear::MultilinearMut, ntt::AdditiveNTT,
+	FieldBuffer, FieldSlice, FieldVec,
+	inner_product::inner_product_packed,
+	multilinear::{MultilinearMut, hypercube::Hypercube},
+	ntt::{AdditiveNTT, domain_context::GaoMateerOnTheFly},
 	reed_solomon::ReedSolomonCode,
 };
 
@@ -24,88 +33,135 @@ use crate::{
 	merkle_channel::MerkleIPProverChannel,
 };
 
-/// Proves one committed Ligerito level whose residual is sent in the clear.
+/// Encodes `message` lane by lane, Merkle-commits the result, and sends the commitment.
 ///
-/// Holds the level's shape alongside the oracle that answers queries against its codeword.
-pub struct LevelProver<P: PackedField, C> {
-	/// The level's shape: lane count, column count, rate, and query count.
-	level: LigeritoLevel,
-	/// The committed interleaved codeword, and the handle that opens it.
-	oracle: BrakedownOracleProver<P, C>,
-}
-
-impl<F, P, C> LevelProver<P, C>
+/// `message` is the level's multilinear in variable order, so its high `log_lanes` variables carry
+/// the lane index and its low `log_msg_cols` variables carry the column.
+/// That is already the layout [`ReedSolomonCode::encode_batch`] reads, which takes lane `lane`'s
+/// columns from
+///
+/// ```text
+///     message[(reverse_bits(lane, log_lanes) << log_msg_cols) | j]
+/// ```
+///
+/// as [`binius_math::ntt::subspace_polys`] pins.
+/// The bit reversal is what makes an opened coset fold by the sumcheck challenges in sampling
+/// order, which [`binius_iop::ligerito::LigeritoVerifier`] spells out.
+/// So no reshaping happens here, and a caller must not do any either.
+///
+/// One leaf is one codeword position across every lane, so a leaf is `2^log_lanes` scalars.
+///
+/// The codeword is allocated globally rather than from an arena.
+/// A level's codeword outlives the call that builds it, and nothing here is on a hot path yet.
+///
+/// ## Preconditions
+///
+/// * `message` has `level.log_msg_len()` variables.
+/// * `ntt`'s domain covers the level's codeword domain.
+fn commit_level<F, P, NTT, Channel>(
+	level: &LigeritoLevel,
+	ntt: &NTT,
+	message: FieldSlice<'_, P>,
+	channel: &mut Channel,
+) -> BrakedownOracleProver<P, Channel::Commitment>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	Channel: MerkleIPProverChannel<F>,
 {
-	/// Binds a prover to a level shape and the oracle over its committed codeword.
-	///
-	/// [`Self::commit`] is the way to build both consistently.
-	pub const fn new(level: LigeritoLevel, oracle: BrakedownOracleProver<P, C>) -> Self {
-		Self { level, oracle }
-	}
+	assert_eq!(
+		message.log_len(),
+		level.log_msg_len(),
+		"precondition: message must have one variable per message variable of the level"
+	);
 
-	/// Encodes `message` lane by lane, Merkle-commits the result, and sends the commitment.
+	let code = ReedSolomonCode::<F>::new(level.log_msg_cols, level.log_inv_rate);
+	let codeword = code.encode_batch(ntt, message, level.log_lanes, &GlobalAllocator);
+	let commitment = channel.send_merkle_commitment(codeword.as_view(), 1 << level.log_lanes);
+
+	BrakedownOracleProver::new(codeword, commitment, 0)
+}
+
+/// The weight vector `level`'s opened rows induce, built over that level's codeword domain.
+///
+/// The prover needs every entry of it, unlike the verifier, which reaches the same weight through
+/// [`InducedBasis::evaluate`] alone.
+/// So this is the one place the ladder holds a query position as a number rather than a word, and
+/// the only reason [`LigeritoProver::prove`] pins the channel's word type.
+///
+/// [`InducedBasis::to_dense`] expands one row at a time, costing `O(t * 2^log_msg_cols)`.
+/// `AdditiveNTT::transpose_transform` computes the same vector as one encode, independent of `t`.
+/// Which wins turns on the row count, so substituting it needs a selection rule rather than an
+/// edit, and that is left to the pass that benchmarks the ladder.
+fn induced_weight<F: BinaryField>(level: &LigeritoLevel, indices: &[Word], alpha: F) -> Vec<F> {
+	let domain_context = GaoMateerOnTheFly::generate(level.log_codeword_len());
+	let indices = indices
+		.iter()
+		.map(|index| index.as_u64() as usize)
+		.collect::<Vec<_>>();
+	InducedBasis::new(&domain_context, level.log_msg_cols, &indices, alpha).to_dense()
+}
+
+/// Proves a Ligerito opening against a committed ladder of Reed-Solomon codewords.
+///
+/// Holds the ladder's shape, the transform its levels encode over, and the oracle that answers
+/// queries against level 0's codeword.
+/// Deeper levels only exist once the folds above them have run, so [`Self::prove`] commits those.
+pub struct LigeritoProver<'a, P: PackedField, C, NTT> {
+	/// The ladder's shape, one [`LigeritoLevel`] per committed level.
+	params: &'a LigeritoParams,
+	/// The transform every level encodes over, sized for the largest of them.
+	ntt: &'a NTT,
+	/// Level 0's committed interleaved codeword, and the handle that opens it.
+	oracle: BrakedownOracleProver<P, C>,
+}
+
+impl<'a, F, P, C, NTT> LigeritoProver<'a, P, C, NTT>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+{
+	/// Encodes and commits level 0, sending its Merkle root.
 	///
-	/// `message` is the level's multilinear in variable order, so its high `log_lanes` variables
-	/// carry the lane index and its low `log_msg_cols` variables carry the column.
-	/// That is already the layout [`ReedSolomonCode::encode_batch`] reads, which takes lane
-	/// `lane`'s columns from
-	///
-	/// ```text
-	///     message[(reverse_bits(lane, log_lanes) << log_msg_cols) | j]
-	/// ```
-	///
-	/// as [`binius_math::ntt::subspace_polys`] pins.
-	/// The bit reversal is what makes an opened coset fold by the MLE-check challenges in sampling
-	/// order, which [`binius_iop::ligerito::LevelVerifier`] spells out.
-	/// So no reshaping happens here, and a caller must not do any either.
-	///
-	/// One leaf is one codeword position across every lane, so a leaf is `2^log_lanes` scalars.
-	///
-	/// The codeword is allocated globally rather than from an arena.
-	/// A level's codeword outlives the call that builds it, and nothing here is on a hot path yet.
+	/// A single `ntt` serves the whole ladder.
+	/// The levels encode over nested Gao-Mateer domains, so the largest of them covers them all.
+	/// That is normally level 0, whose codeword is the longest, but a level that drops the rate
+	/// without folding any lanes has a longer one still.
 	///
 	/// ## Preconditions
 	///
-	/// * `message` has `level.log_msg_len()` variables.
-	/// * `ntt` is defined over the level's codeword domain.
-	pub fn commit<NTT, Channel>(
-		level: LigeritoLevel,
-		ntt: &NTT,
+	/// * `message` has `params.log_msg_len()` variables.
+	/// * `ntt`'s domain covers every level's codeword domain.
+	pub fn commit<Channel>(
+		params: &'a LigeritoParams,
+		ntt: &'a NTT,
 		message: FieldSlice<'_, P>,
 		channel: &mut Channel,
 	) -> Self
 	where
-		NTT: AdditiveNTT<Field = F> + Sync,
 		Channel: MerkleIPProverChannel<F, Commitment = C>,
 	{
-		assert_eq!(
-			message.log_len(),
-			level.log_msg_len(),
-			"precondition: message must have one variable per message variable of the level"
-		);
-
-		let code = ReedSolomonCode::<F>::new(level.log_msg_cols, level.log_inv_rate);
-		let codeword = code.encode_batch(ntt, message, level.log_lanes, &GlobalAllocator);
-		let commitment = channel.send_merkle_commitment(codeword.as_view(), 1 << level.log_lanes);
-
-		Self::new(level, BrakedownOracleProver::new(codeword, commitment, 0))
+		let level = &params.levels()[0];
+		Self {
+			params,
+			ntt,
+			oracle: commit_level(level, ntt, message, channel),
+		}
 	}
 
 	/// Proves the opening of `<message, eq(eval_point)> = eval_claim`.
 	///
-	/// Runs `log_lanes` MLE-check rounds, folds the message by their challenges into the residual,
-	/// commits and sends the residual, and only then answers the queries the channel draws.
-	///
-	/// The trailing sample matches the challenge the verifier batches the opened rows with.
-	/// The prover has nothing to do with that value beyond keeping the two transcripts in step.
+	/// Per level: runs the fold rounds, commits what they folded to, and only then answers the
+	/// queries the channel draws against that level's codeword.
+	/// An intermediate level's query claim is glued into the running sumcheck at a fresh challenge;
+	/// the last level's is left for the verifier to check against the cleartext residual.
 	///
 	/// ## Preconditions
 	///
 	/// * `message` is the multilinear [`Self::commit`] committed.
-	/// * `eval_point` has `level.log_msg_len()` coordinates, in low-to-high variable order.
+	/// * `eval_point` has `params.log_msg_len()` coordinates, in low-to-high variable order.
 	pub fn prove<A, Channel>(
 		&self,
 		message: FieldSlice<'_, P>,
@@ -115,53 +171,124 @@ where
 		channel: &mut Channel,
 	) where
 		A: Allocator,
-		Channel: MerkleIPProverChannel<F, Commitment = C>,
+		Channel: MerkleIPProverChannel<F, Commitment = C, Word = Word>,
 	{
-		let n_vars = self.level.log_msg_len();
+		let levels = self.params.levels();
 		assert_eq!(
 			message.log_len(),
-			n_vars,
-			"precondition: message must have one variable per message variable of the level"
+			self.params.log_msg_len(),
+			"precondition: message must have one variable per message variable of the ladder"
 		);
 		assert_eq!(
 			eval_point.len(),
-			n_vars,
+			self.params.log_msg_len(),
 			"precondition: eval_point must have one coordinate per message variable"
 		);
 
-		let mut sumcheck = multilinear_eval_prover(
-			alloc,
-			FieldBuffer::from_view_in(alloc, message),
-			eval_point,
-			eval_claim,
-		);
+		// The message the current level commits, folded down the ladder into the residual.
+		let mut current = FieldBuffer::from_view_in(alloc, message);
+		// The running sumcheck weight, absent while the MLE-check carries it implicitly.
+		let mut weight: Option<FieldVec<P, A>> = None;
+		let mut sum = eval_claim;
+		// Level 0's oracle lives in `self`; every deeper level's is built in this loop.
+		let mut deeper: Option<BrakedownOracleProver<P, C>> = None;
 
-		// Each round binds the message's highest remaining variable, so once the lane variables
-		// are gone what is left of the message is the residual.
-		let mut residual = FieldBuffer::from_view_in(alloc, message);
-		for _ in 0..self.level.log_lanes {
-			let round_coeffs = sumcheck
-				.execute()
-				.pop()
-				.expect("the multilinear-evaluation prover proves exactly one claim");
-			channel.send_many(mlecheck::RoundProof::truncate(round_coeffs).coeffs());
+		for (i, level) in levels.iter().enumerate() {
+			let n_vars = level.log_msg_len();
+			let witness = FieldBuffer::from_view_in(alloc, current.as_view());
 
-			let challenge = channel.sample();
-			sumcheck.fold(challenge);
-			residual.fold_highest_var(challenge);
+			match weight.take() {
+				None => {
+					// Level 0's weight is the equality indicator, which the MLE-check factors out.
+					// So it interpolates a degree-1 polynomial and truncates its constant term.
+					let mut prover =
+						multilinear_eval_prover(alloc, witness, &eval_point[..n_vars], sum);
+					for _ in 0..level.log_lanes {
+						let coeffs = prover.execute().pop().expect("the prover has one claim");
+						channel.send_many(mlecheck::RoundProof::truncate(coeffs.clone()).coeffs());
+						let challenge = channel.sample();
+						prover.fold(challenge);
+						// The full round polynomial at the challenge is the reduced claim, which
+						// is what the verifier recovers from the truncated one.
+						sum = coeffs.evaluate(&challenge);
+						current.fold_highest_var(challenge);
+					}
+				}
+				Some(mut running) => {
+					// A glued weight is not an equality indicator, so the round polynomial is the
+					// full degree-2 product and the truncated coefficient is the leading one.
+					let mut prover = bivariate_product_prover(
+						alloc,
+						[witness, FieldBuffer::from_view_in(alloc, running.as_view())],
+						sum,
+					);
+					for _ in 0..level.log_lanes {
+						let coeffs = prover.execute().pop().expect("the prover has one claim");
+						channel.send_many(coeffs.clone().truncate().coeffs());
+						let challenge = channel.sample();
+						prover.fold(challenge);
+						sum = coeffs.evaluate(&challenge);
+						current.fold_highest_var(challenge);
+						running.fold_highest_var(challenge);
+					}
+					weight = Some(running);
+				}
+			}
+
+			// Whatever this level folded to is bound here, before a query position exists.
+			let next = match levels.get(i + 1) {
+				Some(next_level) => {
+					Some(commit_level(next_level, self.ntt, current.as_view(), channel))
+				}
+				None => {
+					let commitment = channel.send_merkle_commitment(current.as_view(), 1);
+					channel.send_committed_vector(&commitment, current.as_view());
+					None
+				}
+			};
+
+			let indices = (0..level.n_queries)
+				.map(|_| channel.sample_bits(level.log_codeword_len()))
+				.collect::<Vec<_>>();
+			deeper
+				.as_ref()
+				.unwrap_or(&self.oracle)
+				.open_queries(&indices, channel);
+
+			// The row-batching challenge.
+			// The last level's is drawn only to keep the two transcripts in step, since its rows
+			// meet the residual in the clear rather than a weight this prover has to build.
+			let alpha: F = channel.sample();
+
+			if next.is_some() {
+				let beta: F = channel.sample();
+				let mut glued =
+					FieldBuffer::from_values_in(alloc, &induced_weight(level, &indices, alpha));
+
+				// The claim the opened rows make is the induced weight paired with the message
+				// they folded to, which is what the verifier reads off as `enforced_sum`.
+				sum += beta
+					* inner_product_packed::<F, P>(
+						level.log_msg_cols,
+						glued.as_ref().iter().copied(),
+						current.as_ref().iter().copied(),
+					);
+
+				// Level 0 leaves no running weight, having carried its equality indicator inside
+				// the MLE-check, so it is materialized here at the unbound coordinates.
+				let running = weight.take().unwrap_or_else(|| {
+					Hypercube::One
+						.expand(&eval_point[..level.log_msg_cols])
+						.build_in(alloc)
+				});
+				let beta = P::broadcast(beta);
+				for (entry, &carried) in zip(glued.as_mut(), running.as_ref()) {
+					*entry = carried + beta * *entry;
+				}
+				weight = Some(glued);
+			}
+			deeper = next;
 		}
-
-		// The residual is bound here, before a single query position exists.
-		let residual_commitment = channel.send_merkle_commitment(residual.as_view(), 1);
-		channel.send_committed_vector(&residual_commitment, residual.as_view());
-
-		let indices = (0..self.level.n_queries)
-			.map(|_| channel.sample_bits(self.level.log_codeword_len()))
-			.collect::<Vec<_>>();
-		self.oracle.open_queries(&indices, channel);
-
-		// The verifier's row-batching challenge, drawn only to keep the two transcripts in step.
-		let _batching_challenge: F = channel.sample();
 	}
 }
 
@@ -170,7 +297,7 @@ mod tests {
 	use binius_field::{Field, Ghash128b as B128, Random};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
-		ligerito::{Error, LevelVerifier, LigeritoParams},
+		ligerito::{Error, LigeritoVerifier},
 		merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
 		merkle_tree::BinaryMerkleTreeScheme,
 		soundness::SoundnessRegime,
@@ -188,35 +315,68 @@ mod tests {
 
 	type StdChallenger = HasherChallenger<StdDigest>;
 
+	/// A ladder whose level `i` commits at inverse rate `2^(i + 1)` and opens `n_queries` rows.
+	///
+	/// `lanes[i]` is level `i`'s fold amount, and `log_msg_cols` is level 0's column count.
+	/// Level `i + 1` takes what level `i` folds to, so its columns are `cols_i - lanes_{i+1}`.
+	fn ladder(log_msg_cols: usize, lanes: &[usize], n_queries: usize) -> LigeritoParams {
+		let mut log_msg_cols = log_msg_cols;
+		let levels = lanes
+			.iter()
+			.enumerate()
+			.map(|(i, &log_lanes)| {
+				// Level 0 keeps the column count it was given; every deeper one loses its lanes.
+				if i > 0 {
+					log_msg_cols -= log_lanes;
+				}
+				LigeritoLevel {
+					log_msg_cols,
+					log_lanes,
+					log_inv_rate: i + 1,
+					n_queries,
+				}
+			})
+			.collect();
+		LigeritoParams::new(levels, SoundnessRegime::default(), 32)
+	}
+
 	/// Commits `committed`, then proves and verifies `<opened, eq(z)> = opened(z) + claim_offset`.
 	///
 	/// Splitting the committed message from the opened one is how a dishonest prover is expressed
-	/// here: every value it sends in the clear is consistent with `opened`, while the codeword the
-	/// queries land in encodes `committed`.
+	/// here: every value it sends in the clear is consistent with `opened`, while the codeword
+	/// level 0's queries land in encodes `committed`.
 	/// An honest run passes the same buffer twice and a zero offset.
 	///
 	/// Returns the finished proof's length in bytes, so a byte count is only ever taken from a
 	/// transcript that convinced the verifier.
 	fn run(
-		level: LigeritoLevel,
+		params: &LigeritoParams,
 		committed: &FieldBuffer<B128>,
 		opened: &FieldBuffer<B128>,
 		claim_offset: B128,
 	) -> Result<usize, Error> {
-		let mut rng = StdRng::seed_from_u64(level.log_msg_len() as u64);
-		let eval_point = (0..level.log_msg_len())
+		let n_vars = params.log_msg_len();
+		let mut rng = StdRng::seed_from_u64(n_vars as u64);
+		let eval_point = (0..n_vars)
 			.map(|_| B128::random(&mut rng))
 			.collect::<Vec<_>>();
 		let eval_claim = opened.evaluate(&eval_point) + claim_offset;
 
-		let ntt =
-			NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(level.log_codeword_len()));
+		// One transform for the whole ladder, sized for its longest codeword.
+		let log_domain = params
+			.levels()
+			.iter()
+			.map(LigeritoLevel::log_codeword_len)
+			.max()
+			.expect("levels is non-empty");
+		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(log_domain));
+
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover_channel =
 			ProverMerkleTranscriptChannel::<_, StdChallenger, B128, StdHashSuite>::new(
 				&mut prover_transcript,
 			);
-		let prover = LevelProver::commit(level, &ntt, committed.as_view(), &mut prover_channel);
+		let prover = LigeritoProver::commit(params, &ntt, committed.as_view(), &mut prover_channel);
 		prover.prove(
 			opened.as_view(),
 			&eval_point,
@@ -234,9 +394,10 @@ mod tests {
 			VerifierMerkleTranscriptChannel::<_, StdChallenger, B128, StdHashSuite>::new(
 				&mut verifier_transcript,
 			);
+		let level = &params.levels()[0];
 		let commitment = verifier_channel
 			.recv_merkle_commitment(1 << level.log_lanes, level.log_codeword_len())?;
-		LevelVerifier::new(level, commitment).verify(
+		LigeritoVerifier::new(params, commitment).verify(
 			&eval_point,
 			eval_claim,
 			&mut verifier_channel,
@@ -245,73 +406,80 @@ mod tests {
 		Ok(proof_size)
 	}
 
-	/// A random message of the level's shape.
-	fn message(level: LigeritoLevel, seed: u64) -> FieldBuffer<B128> {
-		random_field_buffer(&mut StdRng::seed_from_u64(seed), level.log_msg_len())
+	/// A random message of the ladder's shape.
+	fn message(params: &LigeritoParams, seed: u64) -> FieldBuffer<B128> {
+		random_field_buffer(&mut StdRng::seed_from_u64(seed), params.log_msg_len())
 	}
 
-	/// Every shape of level an honest prover can produce must verify.
+	/// Every ladder an honest prover can produce must verify.
 	///
-	/// The shapes vary all three dimensions independently, including `log_lanes = 0`, where the
-	/// MLE-check runs no rounds at all and the residual is the whole message.
+	/// The shapes vary the depth, the fold amounts and the column count independently.
+	/// One level is the terminal case, where no claim is ever glued and the whole protocol is the
+	/// MLE-check plus one query round.
+	/// A level folding no lanes is the degenerate case, where a level recommits at a lower rate
+	/// without reducing anything.
 	#[test]
 	fn an_honest_opening_verifies() {
-		for log_msg_cols in 1..5 {
-			for log_lanes in 0..4 {
-				for log_inv_rate in 1..3 {
-					let level = LigeritoLevel {
-						log_msg_cols,
-						log_lanes,
-						log_inv_rate,
-						n_queries: 5,
-					};
-					let msg = message(level, 0);
-					run(level, &msg, &msg, B128::ZERO)
-						.unwrap_or_else(|err| panic!("{level:?}: {err}"));
-				}
-			}
+		let shapes: &[(usize, &[usize])] = &[
+			(3, &[1]),
+			(4, &[2]),
+			(4, &[1, 1]),
+			(5, &[2, 1]),
+			(6, &[2, 2]),
+			(6, &[1, 1, 1]),
+			(6, &[2, 2, 2]),
+			(7, &[3, 1, 1, 1]),
+			(4, &[2, 0, 1]),
+		];
+		for &(log_msg_cols, lanes) in shapes {
+			let params = ladder(log_msg_cols, lanes, 5);
+			let msg = message(&params, 0);
+			run(&params, &msg, &msg, B128::ZERO)
+				.unwrap_or_else(|err| panic!("{log_msg_cols} {lanes:?}: {err}"));
 		}
 	}
 
-	/// A residual that does not fold out of the committed codeword must be caught.
+	/// A codeword that does not encode the message the prover reduced must be caught.
 	///
-	/// This is the check the query round exists for.
-	/// The prover's MLE-check, its residual, and its claim are all consistent with each other; only
-	/// the codeword the queries open disagrees.
+	/// This is the check the query round exists for, at one level.
+	/// The MLE-check, the residual and the claim are all consistent with each other; only the
+	/// codeword the queries open disagrees, and the terminal check pairs it against the residual.
 	#[test]
-	fn a_residual_unrelated_to_the_codeword_is_rejected() {
-		let level = LigeritoLevel {
-			log_msg_cols: 3,
-			log_lanes: 2,
-			log_inv_rate: 2,
-			n_queries: 5,
-		};
-		// Everything sent in the clear is consistent with the proved message, so the sumcheck half
-		// passes. Only the codeword the queries land in disagrees, which is the query half alone.
-		let err = run(level, &message(level, 0), &message(level, 1), B128::ZERO)
+	fn a_codeword_unrelated_to_the_residual_is_rejected() {
+		let params = ladder(3, &[2], 5);
+		let err = run(&params, &message(&params, 0), &message(&params, 1), B128::ZERO)
 			.expect_err("the opened rows encode a different message than the residual");
 		assert!(matches!(err, Error::IPChannel(binius_ip::channel::Error::InvalidAssert)));
 	}
 
-	/// A claim the message does not satisfy must be caught.
+	/// The same mismatch, deep enough that the glue is what has to catch it.
 	///
-	/// This is the check the MLE-check exists for: the reduced sum no longer matches the residual's
-	/// own evaluation, even though every value the prover sent is internally consistent.
+	/// Level 0's rows no longer meet a message in the clear.
+	/// Their claim is folded into the running sumcheck at a challenge the prover cannot predict,
+	/// and only the final pairing against the residual sees it.
 	#[test]
-	fn a_claim_the_message_does_not_satisfy_is_rejected() {
-		let level = LigeritoLevel {
-			log_msg_cols: 3,
-			log_lanes: 2,
-			log_inv_rate: 2,
-			n_queries: 5,
-		};
-		// The round proofs still fix the same challenges, so the fold and the query half agree.
-		// Only the reduced sum is wrong, which is the sumcheck half alone.
-		let msg = message(level, 0);
-		let err =
-			run(level, &msg, &msg, B128::ONE).expect_err("the evaluation claim is off by one");
+	fn a_glued_row_claim_that_does_not_hold_is_rejected() {
+		let params = ladder(6, &[2, 2, 2], 5);
+		let err = run(&params, &message(&params, 0), &message(&params, 1), B128::ZERO)
+			.expect_err("level 0's rows encode a different message than the ladder reduced");
 		assert!(matches!(err, Error::IPChannel(binius_ip::channel::Error::InvalidAssert)));
 	}
+	/// A claim the message does not satisfy must be caught, at every depth.
+	///
+	/// This is the check the sumcheck exists for: the reduced sum no longer matches the residual
+	/// paired with the accumulated weight, even though every value the prover sent is internally
+	/// consistent.
+	#[test]
+	fn a_claim_the_message_does_not_satisfy_is_rejected() {
+		for lanes in [&[2usize] as &[usize], &[2, 2], &[2, 2, 2]] {
+			let params = ladder(6, lanes, 5);
+			let msg = message(&params, 0);
+			let err = run(&params, &msg, &msg, B128::ONE)
+				.expect_err("the evaluation claim is off by one");
+			assert!(matches!(err, Error::IPChannel(binius_ip::channel::Error::InvalidAssert)));
+		}
+	}
+
 	/// The proof-size estimate must equal the transcript, not merely approximate it.
 	///
 	/// [`LigeritoParams::proof_size`] calls itself exact, and the ladder search minimizes it.
@@ -343,14 +511,34 @@ mod tests {
 						// to be one the constructor's feasibility check accepts.
 						let params =
 							LigeritoParams::new(vec![level], SoundnessRegime::UniqueDecoding, 8);
-						let msg = message(level, 0);
-						let written = run(level, &msg, &msg, B128::ZERO).unwrap_or_else(|err| {
+						let msg = message(&params, 0);
+						let written = run(&params, &msg, &msg, B128::ZERO).unwrap_or_else(|err| {
 							panic!("{level:?}: honest proof rejected: {err}")
 						});
 
 						assert_eq!(params.proof_size(&scheme), written, "{level:?}");
 					}
 				}
+			}
+		}
+	}
+	/// The estimate must stay exact once the ladder recurses.
+	///
+	/// Level 0 discounts its round message and no deeper level does.
+	/// A one-level sweep cannot tell those two prices apart, so this walks real ladders.
+	/// It is the only thing that measures [`PRODUCT_DEGREE`] rather than arguing for it.
+	#[test]
+	fn the_estimate_stays_exact_down_the_ladder() {
+		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+
+		for lanes in [&[2usize] as &[usize], &[2, 2], &[1, 2, 1], &[2, 2, 2]] {
+			for n_queries in [1, 5, 12] {
+				let params = ladder(6, lanes, n_queries);
+				let msg = message(&params, 0);
+				let written = run(&params, &msg, &msg, B128::ZERO)
+					.unwrap_or_else(|err| panic!("{lanes:?}: honest proof rejected: {err}"));
+
+				assert_eq!(params.proof_size(&scheme), written, "{lanes:?} n_queries={n_queries}");
 			}
 		}
 	}

--- a/crates/iop/src/ligerito/induced_basis.rs
+++ b/crates/iop/src/ligerito/induced_basis.rs
@@ -69,9 +69,11 @@ pub struct InducedBasis<F> {
 	/// Entry `j` of that row is the product of the factors its set bits select.
 	/// So the row is `2^n_vars` values described by `n_vars` of them.
 	factors: Vec<Vec<F>>,
-	/// `alpha^0, .., alpha^{t-1}`, the coefficients the rows are batched with.
+	/// The coefficient each row is batched with, `alpha^0, .., alpha^{t-1}` as built.
 	///
 	/// Held here so that no caller can batch the two halves of the claim with different values.
+	/// [`InducedBasis::fold_high`] scales each entry by what its row contributes to the fold, so a
+	/// folded basis carries the powers of `alpha` multiplied through.
 	batching: Vec<F>,
 	/// The code's `log_dim`, and the number of variables the weight vector spans.
 	///
@@ -233,6 +235,61 @@ impl<F: FieldOps> InducedBasis<F> {
 		inner_product_scalars(self.batching.iter().cloned(), terms)
 	}
 
+	/// Binds the top `challenges.len()` variables, giving the basis of the folded message.
+	///
+	/// A recursive level glues its induced basis into a running sumcheck, and every later level's
+	/// rounds bind more of that sumcheck's variables.
+	/// So a basis introduced at one level has to follow the message it weighs down the ladder.
+	///
+	/// Sumcheck binds the highest variable first, so `challenges[0]` binds variable `n_vars - 1`.
+	/// A row is a tensor, and binding variable `k` of a tensor at `c` scales the whole row:
+	///
+	/// ```text
+	///     (1 - c) * 1 + c * f[k]  =  1 + c * (1 + f[k])
+	/// ```
+	///
+	/// which is the same per-variable factor [`Self::evaluate`] uses.
+	/// The scale is therefore folded into the row's batching coefficient and the factor dropped,
+	/// which costs `O(n_rows * challenges.len())` and no allocation per row beyond the truncation.
+	///
+	/// [`Self::enforced_sum`] is not meaningful on the result.
+	/// The opened row values it batches belong to the level that introduced the basis, and this
+	/// basis no longer weighs that level's message.
+	///
+	/// ## Preconditions
+	///
+	/// * `challenges.len()` is at most [`Self::n_vars`].
+	pub fn fold_high(&self, challenges: &[F]) -> Self {
+		assert!(
+			challenges.len() <= self.n_vars,
+			"precondition: cannot bind more variables than the basis has"
+		);
+
+		let n_vars = self.n_vars - challenges.len();
+		let batching = std::iter::zip(&self.batching, &self.factors)
+			.map(|(coefficient, row)| {
+				// `challenges[0]` binds the highest variable, which is the last factor.
+				let scale = std::iter::zip(row[n_vars..].iter().rev(), challenges)
+					.map(|(factor, challenge)| {
+						F::one() + challenge.clone() * (F::one() + factor.clone())
+					})
+					.product::<F>();
+				coefficient.clone() * scale
+			})
+			.collect();
+		let factors = self
+			.factors
+			.iter()
+			.map(|row| row[..n_vars].to_vec())
+			.collect();
+
+		Self {
+			factors,
+			batching,
+			n_vars,
+		}
+	}
+
 	/// Pairs the basis with a message held in the clear, giving `<w, message>`.
 	///
 	/// This is the other side of the equation [`Self::enforced_sum`] gives, so a terminal level
@@ -322,7 +379,8 @@ mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{Field, Ghash128b as B128, Random};
 	use binius_math::{
-		multilinear::evaluate::evaluate_inplace_scalars,
+		FieldBuffer,
+		multilinear::{MultilinearMut, evaluate::evaluate_inplace_scalars},
 		ntt::{
 			NeighborsLastSingleThread,
 			domain_context::{GaoMateerOnTheFly, GaoMateerPreExpanded},
@@ -439,6 +497,27 @@ mod tests {
 		InducedBasis::new(&domain(3, 1), 3, &[0, 1], B128::ONE).enforced_sum(&[B128::ONE]);
 	}
 
+	#[test]
+	#[should_panic(expected = "cannot bind more variables than the basis has")]
+	fn folding_past_the_last_variable_is_rejected() {
+		InducedBasis::new(&domain(3, 1), 3, &[0], B128::ONE).fold_high(&[B128::ONE; 4]);
+	}
+
+	#[test]
+	fn the_two_ends_of_a_fold_are_the_identity_and_a_scalar() {
+		let basis = InducedBasis::new(&domain(4, 1), 4, &[0, 3, 9], B128::ONE);
+
+		// Binding nothing leaves the weight vector alone.
+		assert_eq!(basis.fold_high(&[]).to_dense(), basis.to_dense());
+
+		// Binding every variable leaves a zero-variate weight, whose one entry is the whole
+		// multilinear evaluated there.
+		let point = [B128::ONE, B128::ZERO, B128::ONE, B128::ONE];
+		let all = basis.fold_high(&[point[3], point[2], point[1], point[0]]);
+		assert_eq!(all.n_vars(), 0);
+		assert_eq!(all.to_dense(), vec![basis.evaluate(&point)]);
+	}
+
 	proptest! {
 		/// The closed form is the verifier's only route.
 		/// So it must agree with the dense vector everywhere, not at points a fixed test picks.
@@ -460,6 +539,36 @@ mod tests {
 			let point = (0..log_dim).map(|_| B128::random(&mut rng)).collect::<Vec<_>>();
 			let reference = evaluate_inplace_scalars(basis.to_dense(), &point);
 			prop_assert_eq!(basis.evaluate(&point), reference);
+		}
+
+		/// A glued basis follows its message down the ladder, so folding it must be folding it.
+		/// The reference is the dense weight vector put through the multilinear fold itself.
+		#[test]
+		fn folding_the_basis_folds_the_weight_vector(
+			seed: u64,
+			log_dim in 1usize..7,
+			log_inv_rate in 1usize..4,
+			n_rows in 0usize..6,
+			n_folded in 0usize..7,
+		) {
+			let n_folded = n_folded.min(log_dim);
+			let mut rng = StdRng::seed_from_u64(seed);
+			let log_len = log_dim + log_inv_rate;
+			let indices = (0..n_rows)
+				.map(|_| rng.random_range(0..1usize << log_len))
+				.collect::<Vec<_>>();
+			let alpha = B128::random(&mut rng);
+			let basis = InducedBasis::new(&domain(log_dim, log_inv_rate), log_dim, &indices, alpha);
+
+			let challenges = (0..n_folded).map(|_| B128::random(&mut rng)).collect::<Vec<_>>();
+			let mut reference = FieldBuffer::<B128>::from_values(&basis.to_dense());
+			for challenge in &challenges {
+				reference.fold_highest_var(*challenge);
+			}
+
+			let folded = basis.fold_high(&challenges);
+			prop_assert_eq!(folded.n_vars(), log_dim - n_folded);
+			prop_assert_eq!(folded.to_dense(), reference.as_ref().to_vec());
 		}
 	}
 	/// The recursion-safe route must agree with the native one at every index.

--- a/crates/iop/src/ligerito/mod.rs
+++ b/crates/iop/src/ligerito/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! - [`LigeritoParams`] and its invariants;
 //! - [`InducedBasis`], the weight vector a level's opened rows put on its message;
-//! - [`LevelVerifier`], one committed level whose residual is sent in the clear;
+//! - [`LigeritoVerifier`], the ladder of committed levels down to a cleartext residual;
 //! - [`LigeritoParams::proof_size`], the byte-exact estimate;
 //! - [`LigeritoParams::optimal_ladder`], the search that minimizes it subject to a security target.
 //!
@@ -37,5 +37,5 @@ mod size_estimation;
 pub use common::*;
 pub use error::{Error, VerificationError};
 pub use induced_basis::InducedBasis;
-pub use opening::LevelVerifier;
+pub use opening::LigeritoVerifier;
 pub use size_estimation::{MAX_LOG_INV_RATE, MAX_LOG_LANES};

--- a/crates/iop/src/ligerito/opening.rs
+++ b/crates/iop/src/ligerito/opening.rs
@@ -1,14 +1,16 @@
 // Copyright 2026 The Binius Developers
 
-//! One committed Ligerito level, on the verifier side.
+//! The Ligerito opening protocol on the verifier side.
 //!
-//! The level proves an evaluation claim `<X_0, eq(z)> = y` about the multilinear it committed.
-//! `X_0` is held as `2^log_lanes` interleaved lanes of `2^log_msg_cols` columns, and each lane is
-//! a Reed-Solomon codeword of the same code.
+//! The ladder proves an evaluation claim `<X_0, eq(z)> = y` about the multilinear level 0
+//! committed. `X_0` is held as `2^log_lanes` interleaved lanes of `2^log_msg_cols` columns, and
+//! each lane is a Reed-Solomon codeword of the same code.
+//! Level `i` folds its lanes away and the remainder becomes level `i + 1`'s message, committed at a
+//! strictly lower rate, until the last level's remainder is small enough to send in the clear.
 //!
 //! # Why the lane fold and the sumcheck are the same challenges
 //!
-//! An MLE-check binds one variable per round, highest first.
+//! A sumcheck binds one variable per round, highest first.
 //! Running it for `log_lanes` rounds binds exactly the variables the lane index occupies, so the
 //! claim it leaves behind is about the lane-folded matrix
 //!
@@ -19,7 +21,7 @@
 //! and `r` is the same tensor the queries have to be folded by.
 //! There is no separate folding phase because there is nothing left to fold.
 //!
-//! # Why an opened row is a claim about `X_1`
+//! # Why an opened row is a claim about the next message
 //!
 //! Every lane is an independent codeword of one code, which
 //! [`binius_math::ntt::subspace_polys`] pins against `ReedSolomonCode::encode_batch`.
@@ -32,64 +34,89 @@
 //! An opened row at position `q`, folded by `r`, is therefore exactly `<G_q, X_1>`.
 //! That is one linear claim about `X_1` per query, and [`InducedBasis`] batches them into one.
 //!
-//! # Why the residual goes out before the queries
+//! # Why the next commitment goes out before the queries
 //!
-//! The residual is the whole of `X_1`, sent in the clear because this level is terminal.
-//! Its commitment is observed before any query position is sampled.
-//! A prover therefore has to fix `X_1` without knowing which rows will be checked against it,
-//! which is the entire soundness argument for sending it in the clear.
+//! Whatever a level reduces to is bound before any of that level's query positions are sampled.
+//! For an intermediate level that is the next level's Merkle root.
+//! For the last level it is the residual, sent in the clear against its own commitment.
+//! A prover therefore has to fix what it folded to without knowing which rows will be checked
+//! against it, which is the entire soundness argument for a cleartext residual.
+//!
+//! # Why only level 0 gets the MLE-check shortcut
+//!
+//! An MLE-check is a sumcheck whose weight is known to be an equality indicator, which lets the
+//! verifier recover a round polynomial's missing coefficient from the evaluation point.
+//! Level 0's weight is `eq(., z)`, so it qualifies.
+//! Every level below it carries a glued query claim, making the weight
+//!
+//! ```text
+//!     W = eq_scale * eq(., z) + sum_i beta_i * w_i
+//! ```
+//!
+//! which is not an equality indicator.
+//! Those levels run a plain degree-2 sumcheck over the product of the message and the weight, and
+//! the equality factor each round strips has to be carried by hand.
 
-use binius_field::BinaryField;
-use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
+use binius_field::{BinaryField, FieldOps};
+use binius_ip::{
+	mlecheck,
+	sumcheck::{self, RoundCoeffs},
+};
 use binius_math::{
-	multilinear::evaluate::evaluate_inplace_scalars, ntt::domain_context::GaoMateerOnTheFly,
+	multilinear::{evaluate::evaluate_inplace_scalars, hypercube::Hypercube},
+	ntt::domain_context::GaoMateerOnTheFly,
 };
 
-use super::{InducedBasis, LigeritoLevel, error::Error};
+use super::{InducedBasis, LigeritoParams, error::Error};
 use crate::{
 	fri::batch::{BrakedownOracle, ProxTestOracle},
 	merkle_channel::MerkleIPVerifierChannel,
 };
 
-/// The MLE-check round polynomial is degree 1, since the composite is the multilinear itself.
+/// Level 0's round polynomial is degree 1, since the MLE-check factors the equality weight out.
 ///
 /// The proof-size estimate reads this rather than restating it, so the two cannot drift.
 /// Recovering the missing coefficient is what the equality indicator buys.
-/// A weight that is not an equality indicator would have to send it.
-pub(super) const DEGREE: usize = 1;
+pub(super) const MLECHECK_DEGREE: usize = 1;
 
-/// Verifies one committed Ligerito level whose residual is sent in the clear.
+/// Every later level's round polynomial is degree 2, the product of message and weight.
 ///
-/// Holds the level's shape and the commitment to its interleaved codeword.
-/// The caller receives that commitment, so it stays in charge of when the level's oracle arrives.
+/// A glued weight is not an equality indicator, so nothing recovers the missing coefficient.
+/// It has to be sent, and that is the extra element per fold round a deeper level pays.
+pub(super) const PRODUCT_DEGREE: usize = 2;
+
+/// Verifies a Ligerito opening against a committed ladder of Reed-Solomon codewords.
+///
+/// Holds the parameters and the commitment to level 0's codeword.
+/// The caller receives that commitment, so it stays in charge of when the first oracle arrives.
+/// Every deeper commitment arrives at a point the protocol fixes, so this reads those itself.
 #[derive(Debug, Clone)]
-pub struct LevelVerifier<C> {
-	/// The level's shape: lane count, column count, rate, and query count.
-	level: LigeritoLevel,
-	/// The commitment to the level's interleaved codeword.
+pub struct LigeritoVerifier<'a, C> {
+	/// The ladder's shape, one [`super::LigeritoLevel`] per committed level.
+	params: &'a LigeritoParams,
+	/// The commitment to level 0's interleaved codeword.
 	commitment: C,
 }
 
-impl<C: Clone> LevelVerifier<C> {
-	/// Binds a verifier to a level shape and the commitment to its codeword.
-	pub const fn new(level: LigeritoLevel, commitment: C) -> Self {
-		Self { level, commitment }
+impl<'a, C: Clone> LigeritoVerifier<'a, C> {
+	/// Binds a verifier to a ladder and the commitment to its outermost codeword.
+	pub const fn new(params: &'a LigeritoParams, commitment: C) -> Self {
+		Self { params, commitment }
 	}
 
 	/// Verifies the opening of `<X_0, eq(eval_point)> = eval_claim`.
 	///
-	/// The two checks it closes with are the two halves of the level.
-	/// The MLE-check's reduced sum must equal the residual's own evaluation at the coordinates the
-	/// fold left unbound.
-	/// And the opened rows, batched by [`InducedBasis`], must equal that basis paired with the
-	/// residual.
+	/// Walks the ladder, and closes with the two checks the residual makes possible.
+	/// The running sumcheck claim must equal the residual paired with the accumulated weight.
+	/// And the last level's opened rows, batched by [`InducedBasis`], must equal that level's
+	/// basis paired with the residual.
 	///
 	/// Both are asserted through the channel rather than compared, so a channel that builds a
 	/// circuit records them as constraints.
 	///
 	/// ## Preconditions
 	///
-	/// * `eval_point` has `level.log_msg_len()` coordinates, in low-to-high variable order.
+	/// * `eval_point` has `params.log_msg_len()` coordinates, in low-to-high variable order.
 	pub fn verify<F, Channel>(
 		&self,
 		eval_point: &[Channel::Elem],
@@ -101,61 +128,112 @@ impl<C: Clone> LevelVerifier<C> {
 		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
 		Channel::Elem: From<F>,
 	{
-		let n_vars = self.level.log_msg_len();
+		let levels = self.params.levels();
 		assert_eq!(
 			eval_point.len(),
-			n_vars,
+			self.params.log_msg_len(),
 			"precondition: eval_point must have one coordinate per message variable"
 		);
 
-		// MLE-check rounds. These bind the lane variables, highest first, and their challenges are
-		// what the opened rows get folded by.
 		let mut sum = eval_claim;
-		let mut challenges = Vec::with_capacity(self.level.log_lanes);
-		for round in 0..self.level.log_lanes {
-			let round_proof = mlecheck::RoundProof(RoundCoeffs(channel.recv_many(DEGREE)?));
-			let alpha = eval_point[n_vars - 1 - round].clone();
-			let round_coeffs = round_proof.recover(sum, alpha);
-			let challenge = channel.sample();
-			sum = round_coeffs.evaluate(&challenge);
-			challenges.push(challenge);
+		// The equality factor the plain rounds strip, which the MLE-check level would have divided
+		// out for itself.
+		let mut eq_scale = Channel::Elem::one();
+		// The query claims glued in so far, each still weighing the message it was induced on.
+		let mut glued = Vec::<(Channel::Elem, InducedBasis<Channel::Elem>)>::new();
+		let mut commitment = self.commitment.clone();
+		let mut residual = None;
+
+		for (i, level) in levels.iter().enumerate() {
+			// Only level 0 carries an equality indicator alone, so only it gets the shortcut.
+			let is_outermost = i == 0;
+			// The message this level commits spans its columns and its lanes.
+			let n_vars = level.log_msg_len();
+			let mut challenges = Vec::with_capacity(level.log_lanes);
+			for round in 0..level.log_lanes {
+				// Rounds bind the highest variable first.
+				let z = eval_point[n_vars - 1 - round].clone();
+				let coeffs = if is_outermost {
+					mlecheck::RoundProof(RoundCoeffs(channel.recv_many(MLECHECK_DEGREE)?))
+						.recover(sum, z.clone())
+				} else {
+					sumcheck::RoundProof(RoundCoeffs(channel.recv_many(PRODUCT_DEGREE)?))
+						.recover(sum)
+				};
+				let challenge = channel.sample();
+				sum = coeffs.evaluate(&challenge);
+				// The MLE-check divides its round's equality factor out; a plain round does not.
+				if !is_outermost {
+					eq_scale *= Hypercube::One.eq_one_var(challenge.clone(), z);
+				}
+				challenges.push(challenge);
+			}
+
+			// Whatever this level folded to is bound here, before a query position exists.
+			let next_commitment = match levels.get(i + 1) {
+				Some(next) => Some(
+					channel.recv_merkle_commitment(1 << next.log_lanes, next.log_codeword_len())?,
+				),
+				None => {
+					let handle = channel.recv_merkle_commitment(1, level.log_msg_cols)?;
+					residual = Some(channel.recv_committed_vector(&handle)?);
+					None
+				}
+			};
+
+			// A glued basis weighs the message this level just folded, so it follows the fold.
+			for (_, basis) in &mut glued {
+				*basis = basis.fold_high(&challenges);
+			}
+
+			let indices = (0..level.n_queries)
+				.map(|_| channel.sample_bits(level.log_codeword_len()))
+				.collect::<Vec<_>>();
+
+			// `open_queries` returns each opened coset already folded by the challenges, which is
+			// the value the module documentation identifies with `<G_q, X_{i+1}>`.
+			let oracle = BrakedownOracle::new(challenges, commitment.clone(), 0);
+			let folded_rows = oracle.open_queries(&indices, channel)?;
+
+			let alpha = channel.sample();
+			let domain_context = GaoMateerOnTheFly::generate(level.log_codeword_len());
+			let basis = InducedBasis::from_query_words(
+				&domain_context,
+				level.log_msg_cols,
+				&indices,
+				&alpha,
+				channel,
+			);
+
+			match next_commitment {
+				Some(next) => {
+					// No message in the clear to pair against, so the row claim joins the running
+					// sumcheck at a fresh challenge rather than being checked on its own.
+					let beta = channel.sample();
+					sum += beta.clone() * basis.enforced_sum(&folded_rows);
+					glued.push((beta, basis));
+					commitment = next;
+				}
+				None => {
+					// The residual is in the clear, so the row claim is checked directly against
+					// it and never enters the sumcheck.
+					let residual = residual.as_ref().expect("the last level sets the residual");
+					channel.assert_zero(basis.pair(residual) - basis.enforced_sum(&folded_rows))?;
+				}
+			}
 		}
 
-		// The residual is bound here, before a single query position exists.
-		let residual_commitment = channel.recv_merkle_commitment(1, self.level.log_msg_cols)?;
-		let residual = channel.recv_committed_vector(&residual_commitment)?;
+		let residual = residual.expect("levels is non-empty, so the last one sets the residual");
 
-		let indices = (0..self.level.n_queries)
-			.map(|_| channel.sample_bits(self.level.log_codeword_len()))
-			.collect::<Vec<_>>();
-
-		// `open_queries` returns each opened coset already folded by the challenges, which is the
-		// value the module documentation identifies with `<G_q, X_1>`.
-		let oracle = BrakedownOracle::new(challenges, self.commitment.clone(), 0);
-		let folded_rows = oracle.open_queries(&indices, channel)?;
-
-		let alpha = channel.sample();
-		let domain_context = GaoMateerOnTheFly::generate(self.level.log_codeword_len());
-		let basis = InducedBasis::from_query_words(
-			&domain_context,
-			self.level.log_msg_cols,
-			&indices,
-			&alpha,
-			channel,
-		);
-
-		// The query half: the batched rows against the basis paired with the residual.
-		//
-		// Pairing against a message in the clear is a terminal move. A recursive level never holds
-		// its residual, so it glues the induced claim into a sumcheck over the next level and
-		// reaches the basis through `InducedBasis::evaluate` alone.
-		channel.assert_zero(basis.pair(&residual) - basis.enforced_sum(&folded_rows))?;
-
-		// The sumcheck half: the reduced claim against the residual's own evaluation at the
-		// coordinates the lane fold left unbound.
+		// The sumcheck half: the reduced claim against the residual paired with the weight the
+		// ladder accumulated, which is the equality indicator plus every glued basis.
+		let mut paired = Channel::Elem::zero();
+		for (beta, basis) in &glued {
+			paired += beta.clone() * basis.pair(&residual);
+		}
 		let residual_eval =
-			evaluate_inplace_scalars(residual, &eval_point[..self.level.log_msg_cols]);
-		channel.assert_zero(residual_eval - sum)?;
+			evaluate_inplace_scalars(residual, &eval_point[..self.params.log_residual_dim()]);
+		channel.assert_zero(paired + eq_scale * residual_eval - sum)?;
 
 		Ok(())
 	}

--- a/crates/iop/src/ligerito/size_estimation.rs
+++ b/crates/iop/src/ligerito/size_estimation.rs
@@ -56,12 +56,6 @@ impl ByteSizes {
 /// Only level 0 versus not-level-0 changes a price, so every deeper level shares one index.
 const DEEPER_LEVEL: usize = 1;
 
-/// Round-polynomial degree of a fold round past level 0.
-///
-/// The weight there is `eq_remaining + alpha * w`, where `w` is a query-induced basis.
-/// A product of two general multilinears is degree 2 in the bound variable.
-const DEEP_ROUND_DEGREE: usize = 2;
-
 /// Field elements one fold round's message costs at `level_index`.
 ///
 /// A degree-`d` round message is `d` elements, whichever protocol sends it.
@@ -69,13 +63,12 @@ const DEEP_ROUND_DEGREE: usize = 2;
 /// An MLE-check truncates the low one and recovers it from the claimed evaluation.
 ///
 /// Level 0 folds under the equality indicator `eq(z)` alone, which is what makes it an MLE-check.
-/// Its composite is then the multilinear itself, of degree [`opening::DEGREE`].
 /// Gluing a query-induced basis into the weight destroys that structure at every deeper level.
-/// So those pay [`DEEP_ROUND_DEGREE`] instead, and the difference is one element per fold round.
+/// Both degrees are read from the protocol itself, so the price cannot drift from what is sent.
 const fn round_degree(level_index: usize) -> usize {
 	match level_index {
-		0 => opening::DEGREE,
-		_ => DEEP_ROUND_DEGREE,
+		0 => opening::MLECHECK_DEGREE,
+		_ => opening::PRODUCT_DEGREE,
 	}
 }
 


### PR DESCRIPTION
Closes [BINIUS-534](https://linear.app/jimpo/issue/BINIUS-534).

### In one line

One committed level becomes a ladder of them: each level's query claim is folded into a running sumcheck instead of being checked, until the last level's remainder is small enough to send in the clear.

### The problem

[BINIUS-533](https://linear.app/jimpo/issue/BINIUS-533) landed one Ligerito level. It works because the message that level folds to is sent in the clear, so the verifier can pair the opened rows against it directly.

That is the terminal case, not the protocol. Ligerito's whole point is that the remainder is *recommitted* at a lower rate and reduced again — a lower rate needs fewer queries, which is where the proof size goes. A level in the middle of the ladder has no message in the clear. Its opened rows still make `t` linear claims, and there is nowhere to check them.

### The idea

Carry them.

The rows induce one weight vector `w` on the message the level folded to, which [BINIUS-529](https://linear.app/jimpo/issue/BINIUS-529) already builds. There is already a sumcheck running over that same message. So add the claim to it:

```
    W'   =  W  +  beta * w
    sum' = sum +  beta * <w, X>
```

`beta` is fresh, drawn after the rows are opened. A prover who cheated on any one row now has to survive a random combination of a claim it made and a claim it did not choose. That is `introduce` and `glue`, and it is the only new protocol step in this PR.

### Two consequences that are easy to get wrong

**The MLE-check shortcut dies below level 0.**

An MLE-check is a sumcheck that recovers a round polynomial's missing coefficient from the fact that its weight is an equality indicator. Level 0's weight is `eq(., z)`, so it qualifies and a round costs one field element. After one glue the weight is

```
    W = eq_scale * eq(., z) + sum_i beta_i * w_i
```

which is not one. Every level below 0 runs a plain degree-2 sumcheck over the product of message and weight, at two elements a round, and the equality factor each round strips has to be carried by hand as `eq_scale`.

**A glued basis has to follow its message down the ladder.**

Every later level binds more of the sumcheck's variables, so a basis introduced above has to be folded by those challenges too. New: `InducedBasis::fold_high`, in `O(t * k)`.

A row is a tensor, and binding variable `k` of a tensor at `c` scales the whole row:

```
    (1 - c) * 1 + c * f[k]  =  1 + c * (1 + f[k])
```

which is the same per-variable factor `evaluate` already uses. So the scale folds into the row's batching coefficient and the factor is dropped. No row is ever materialized.

### What is preserved

**The soundness ordering, at every level.** Whatever a level reduces to is bound before that level's query positions are sampled. For an intermediate level that is the next level's Merkle root; for the last, the residual against its own commitment. A prover therefore fixes what it folded to without knowing which rows will be checked against it. Get this wrong and the protocol is worthless while every test still passes — which is exactly why it is stated in both module headers rather than left to the reader.

**A one-level ladder is the protocol [BINIUS-533](https://linear.app/jimpo/issue/BINIUS-533) shipped, byte for byte.** No glue challenge is drawn, `eq_scale` stays one, and the two terminal checks are the two it made. The last level never glues: its rows meet a message in the clear, so pairing them directly is both cheaper and stronger than folding them into a sumcheck.

### API

`LevelVerifier` / `LevelProver` become `LigeritoVerifier` / `LigeritoProver` over a `LigeritoParams` rather than a single `LigeritoLevel`. A single level is a one-entry ladder, so there is one protocol and one implementation of it.

The prover takes one `AdditiveNTT` for the whole ladder. The levels encode over nested Gao-Mateer domains, so the largest covers them all — pinned by the honest-opening sweep, which includes a level that drops the rate without folding any lanes and therefore has a *longer* codeword than level 0.

`LigeritoProver::prove` pins the channel's word type to `Word`. The prover materializes the induced weight vector, which needs query positions as numbers; §7's channel discipline constrains the verifier, which still reaches the same weight through `InducedBasis::evaluate` and `pair` alone.

### Tests

Honest openings verify across nine ladder shapes, one level to four, including a level that folds no lanes at all.

Three negatives:
- a codeword unrelated to the residual at one level, caught by the terminal pairing;
- the same mismatch at three levels, where level 0's rows no longer meet anything in the clear and only the glue can catch it;
- a claim the message does not satisfy, at one, two and three levels.

`fold_high` is pinned by proptest against the dense weight vector put through `fold_highest_var`, plus both ends of the range (binding nothing is the identity, binding everything leaves the multilinear's value).

Mutation-tested, four mutations, each caught: dropping `eq_scale`, skipping the glued-basis fold, gluing at the wrong challenge, and dropping the glued weight from the final check.

### Deliberately not here

**Wiring the transposed NTT.** `InducedBasis::to_dense` gains its first caller here, and it costs `O(t * 2^log_msg_cols)` — `t` times an encode. `AdditiveNTT::transpose_transform` from [BINIUS-532](https://linear.app/jimpo/issue/BINIUS-532) computes the same vector as *one* encode, independent of `t`. Which wins turns on the row count, so it needs a selection rule and a benchmark rather than a substitution.

### Rebased onto #2306

That PR landed first, so this one now carries the follow-up it flagged: `size_estimation` drops its local `DEEP_ROUND_DEGREE` and reads `MLECHECK_DEGREE` / `PRODUCT_DEGREE` from `opening`, so the price of a round message and the message itself come from one place.

Its proof-size sweep is ported to the ladder API and joined by `the_estimate_stays_exact_down_the_ladder`, which walks 1-to-3-level ladders. That closes the gap #2306 had to leave open: a one-level sweep cannot distinguish level 0's discounted round message from a deeper level's full one, so `PRODUCT_DEGREE` was argued rather than measured. It is measured now — setting it to 3 fails the new test.

Rebasing also surfaced two lints from #2299's stricter configuration: an elided lifetime, and a `challenges` vector in the prove loop that was collected and never read. The latter is dead rather than a missing fold — every challenge is consumed inline by `prover.fold`, `current.fold_highest_var`, `running.fold_highest_var` and the `sum` update, and the glue step rebuilds level 0's residual indicator from `eval_point[..log_msg_cols]`, which is correct because the MLE-check binds high-to-low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
