### PR TITLE
BINIUS-536: Build the Ligerito induced weight through the encoder's adjoint

### DIFF
--- a/crates/iop-prover/src/ligerito/induced_weight.rs
+++ b/crates/iop-prover/src/ligerito/induced_weight.rs
@@ -1,0 +1,302 @@
+// Copyright 2026 The Binius Developers
+
+//! The weight a level's opened rows induce, and the two routes that build it.
+
+use std::iter::zip;
+
+use binius_compute::Allocator;
+use binius_core::word::Word;
+use binius_field::{BinaryField, PackedField};
+use binius_iop::ligerito::{InducedBasis, LigeritoLevel};
+use binius_math::{
+	FieldBuffer, FieldVec, ReedSolomonCode,
+	ntt::{AdditiveNTT, domain_context::GaoMateerOnTheFly},
+};
+
+/// The weight one level's opened rows induce on the message that level folded to.
+///
+/// The rows make `t` linear claims, batched by the powers of one coefficient:
+///
+/// ```text
+///     <w, m> = sum_i alpha^i * encode(m)[q_i]
+/// ```
+///
+/// Two routes produce the same `w`, and which is cheaper turns on the level's shape alone.
+/// Holding the inputs together is what lets the choice be a method rather than a parameter.
+pub(super) struct InducedWeight<'a, F, NTT> {
+	/// The level whose rows were opened, whose shape picks the route.
+	level: &'a LigeritoLevel,
+	/// The transform the adjoint route runs its layers over.
+	ntt: &'a NTT,
+	/// The codeword positions the queries landed on, in the order they were drawn.
+	indices: Vec<usize>,
+	/// The row-batching coefficient whose powers scale the rows.
+	alpha: F,
+}
+
+impl<'a, F, NTT> InducedWeight<'a, F, NTT>
+where
+	F: BinaryField,
+	NTT: AdditiveNTT<Field = F> + Sync,
+{
+	/// Collects what a level's query round produced into one weight to be built.
+	///
+	/// ## Preconditions
+	///
+	/// * `ntt`'s domain covers the level's codeword domain.
+	pub(super) fn new(level: &'a LigeritoLevel, ntt: &'a NTT, indices: &[Word], alpha: F) -> Self {
+		Self {
+			level,
+			ntt,
+			indices: indices
+				.iter()
+				.map(|index| index.as_u64() as usize)
+				.collect(),
+			alpha,
+		}
+	}
+
+	/// Whether the adjoint route beats the row-by-row one at this shape.
+	///
+	/// Both routes produce `2^cols` entries, so dividing their costs by `2^cols` leaves
+	///
+	/// ```text
+	///     row by row   t row entries
+	///     adjoint      cols * 2^rate layer entries
+	/// ```
+	///
+	/// where `t` is the number of opened rows.
+	/// Neither cost depends on the level's lane count, which is why that field is not read.
+	///
+	/// A row entry and a layer entry are not the same price, so the comparison needs a constant.
+	/// Timing both routes over 128-bit binary field elements puts a row entry at 2.9 ns.
+	/// It puts a layer entry at 1.6 ns, steady to a few percent from `2^9` up to `2^24` entries.
+	/// The ratio of the two, 1.9, is what the integers below encode.
+	pub(super) const fn adjoint_is_cheaper(&self) -> bool {
+		// The two costs above, each scaled by 10 so the measured 1.9 is an integer ratio.
+		let row_cost = 19 * self.indices.len();
+		let adjoint_cost = 10 * (self.level.log_msg_cols << self.level.log_inv_rate);
+		adjoint_cost < row_cost
+	}
+
+	/// Builds the weight by whichever route is cheaper at this shape.
+	pub(super) fn build<P, A>(&self, alloc: &A) -> FieldVec<P, A>
+	where
+		P: PackedField<Scalar = F>,
+		A: Allocator,
+	{
+		if self.adjoint_is_cheaper() {
+			self.by_adjoint(alloc)
+		} else {
+			self.by_rows(alloc)
+		}
+	}
+
+	/// Builds the weight by expanding one opened row at a time.
+	///
+	/// A row is a tensor of `log_msg_cols` factors, so expanding it costs `2^log_msg_cols`
+	/// products. Accumulating it into the running vector costs as many multiplications again.
+	/// For `t` opened rows the whole build is therefore `2 * t * 2^log_msg_cols` multiplications.
+	///
+	/// This is the reference the adjoint route is tested against.
+	pub(super) fn by_rows<P, A>(&self, alloc: &A) -> FieldVec<P, A>
+	where
+		P: PackedField<Scalar = F>,
+		A: Allocator,
+	{
+		let domain_context = GaoMateerOnTheFly::generate(self.level.log_codeword_len());
+		let dense =
+			InducedBasis::new(&domain_context, self.level.log_msg_cols, &self.indices, self.alpha)
+				.to_dense();
+		FieldBuffer::from_values_in(alloc, &dense)
+	}
+
+	/// Builds the weight as one pass of the encoder's adjoint.
+	///
+	/// The weight is defined by what it does to a message:
+	///
+	/// ```text
+	///     <w, m> = sum_i alpha^i * encode(m)[q_i] = <a, encode(m)>,   a[q_i] = alpha^i
+	/// ```
+	///
+	/// The right-hand side is the encoder's adjoint identity read backwards.
+	/// So `w` is that adjoint applied to the sparse weight `a`.
+	///
+	/// The cost is `log_msg_cols` butterfly layers over `2^(log_msg_cols + log_inv_rate)` entries.
+	/// Nothing in it grows with the number of rows opened.
+	pub(super) fn by_adjoint<P, A>(&self, alloc: &A) -> FieldVec<P, A>
+	where
+		P: PackedField<Scalar = F>,
+		A: Allocator,
+	{
+		// A position can be drawn twice, so the powers landing on it accumulate rather than
+		// overwrite.
+		let mut weights = FieldBuffer::zeros_in(alloc, self.level.log_codeword_len());
+		for (&index, power) in zip(&self.indices, self.alpha.powers()) {
+			weights.set(index, weights.get(index) + power);
+		}
+
+		let code = ReedSolomonCode::<F>::new(self.level.log_msg_cols, self.level.log_inv_rate);
+		code.encode_batch_transpose(self.ntt, weights.as_mut_view(), 0, alloc)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_compute::GlobalAllocator;
+	use binius_field::{Field, Ghash128b as B128, Random};
+	use binius_math::{
+		FieldBuffer,
+		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
+	};
+	use proptest::prelude::*;
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	/// Both routes of the induced weight, over one level shape and one set of query indices.
+	fn both_builds(
+		log_msg_cols: usize,
+		log_inv_rate: usize,
+		indices: &[usize],
+		alpha: B128,
+	) -> (FieldBuffer<B128>, FieldBuffer<B128>) {
+		// The lane count does not enter either build, so any value serves here.
+		let level = LigeritoLevel {
+			log_msg_cols,
+			log_lanes: 1,
+			log_inv_rate,
+			n_queries: indices.len(),
+		};
+		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::<B128>::generate(
+			level.log_codeword_len(),
+		));
+		let words = indices
+			.iter()
+			.map(|&index| Word::from_u64(index as u64))
+			.collect::<Vec<_>>();
+		let weight = InducedWeight::new(&level, &ntt, &words, alpha);
+		(weight.by_rows(&GlobalAllocator), weight.by_adjoint(&GlobalAllocator))
+	}
+
+	/// The two builds must agree entry for entry, not merely at one evaluation point.
+	///
+	/// The transposed build reaches the weight through the encoder's adjoint.
+	/// The row build reaches it through the tensor expansion of each generator row.
+	/// Nothing but a test connects the two derivations.
+	#[test]
+	fn the_transposed_build_matches_the_row_build_at_the_boundaries() {
+		let alpha = B128::new(0x9e3779b97f4a7c15);
+
+		// A message of one column, which leaves the transform no layer to run at all.
+		let (rows, transposed) = both_builds(0, 3, &[0, 5, 5], alpha);
+		assert_eq!(rows, transposed);
+
+		// No rows opened, which induces the all-zero weight rather than an empty one.
+		let (rows, transposed) = both_builds(4, 2, &[], alpha);
+		assert_eq!(rows, transposed, "no rows");
+		assert_eq!(rows, FieldBuffer::zeros(4));
+
+		// Every rate the ladder search may pick, at one row and at a row drawn three times.
+		// Sampling is with replacement.
+		// So a repeated index must add its powers rather than overwrite them.
+		for log_inv_rate in 1..=8 {
+			let (rows, transposed) = both_builds(3, log_inv_rate, &[6], alpha);
+			assert_eq!(rows, transposed, "one row at rate {log_inv_rate}");
+
+			let (rows, transposed) = both_builds(3, log_inv_rate, &[2, 2, 2], alpha);
+			assert_eq!(rows, transposed, "a repeated row at rate {log_inv_rate}");
+		}
+	}
+
+	/// The selection rule, at every level shape the ladder search picks at 96-bit security.
+	///
+	/// The last column is the row build's measured time over the transposed build's.
+	/// A value above one is therefore a shape where the transposed build won.
+	/// The rule must agree with that comparison at every shape.
+	#[test]
+	fn the_selection_rule_follows_the_measured_crossover() {
+		// (log_msg_cols, log_inv_rate, n_queries, measured speedup of the transposed build)
+		let measured: &[(usize, usize, usize, f64)] = &[
+			(9, 1, 232, 26.43),
+			(9, 3, 116, 3.86),
+			(9, 5, 101, 0.88),
+			(9, 6, 99, 0.41),
+			(10, 3, 116, 3.06),
+			(10, 4, 106, 1.39),
+			(10, 5, 101, 0.66),
+			(10, 6, 99, 0.32),
+			(10, 8, 97, 0.08),
+			(11, 4, 106, 1.17),
+			(11, 6, 99, 0.26),
+			(12, 4, 106, 1.12),
+			(12, 5, 101, 0.52),
+			(13, 2, 142, 5.15),
+			(13, 4, 106, 0.94),
+			(13, 5, 101, 0.43),
+			(13, 6, 99, 0.20),
+			(14, 1, 232, 15.21),
+			(14, 7, 98, 0.09),
+			(15, 4, 106, 0.78),
+			(15, 5, 101, 0.37),
+			(16, 2, 142, 4.12),
+			(16, 4, 106, 0.74),
+			(17, 1, 232, 11.75),
+			(17, 4, 106, 0.74),
+			(17, 5, 101, 0.34),
+			(18, 6, 99, 0.16),
+			(19, 4, 106, 0.75),
+			(19, 5, 101, 0.34),
+			(20, 2, 142, 3.46),
+			(21, 1, 232, 10.95),
+			(21, 4, 106, 0.62),
+			(22, 1, 232, 10.36),
+			(23, 3, 116, 1.26),
+			(24, 1, 232, 9.60),
+			(24, 2, 142, 2.96),
+		];
+		for &(log_msg_cols, log_inv_rate, n_queries, speedup) in measured {
+			let level = LigeritoLevel {
+				log_msg_cols,
+				log_lanes: 1,
+				log_inv_rate,
+				n_queries,
+			};
+			// The rule reads the level's shape and the row count, so any index and coefficient
+			// serve; only how many there are matters.
+			let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::<B128>::generate(
+				level.log_codeword_len(),
+			));
+			let words = vec![Word::ZERO; n_queries];
+			assert_eq!(
+				InducedWeight::new(&level, &ntt, &words, B128::ONE).adjoint_is_cheaper(),
+				speedup > 1.0,
+				"cols={log_msg_cols} rate={log_inv_rate} t={n_queries} speedup={speedup}"
+			);
+		}
+	}
+
+	proptest! {
+		/// The two builds must agree over the whole shape space, not the shapes a fixed test picks.
+		///
+		/// Indices are drawn with replacement, exactly as the channel draws them.
+		/// A run can therefore land on the same row twice.
+		#[test]
+		fn the_transposed_build_matches_the_row_build(
+			seed: u64,
+			log_msg_cols in 0usize..7,
+			log_inv_rate in 1usize..5,
+			n_queries in 0usize..24,
+		) {
+			let mut rng = StdRng::seed_from_u64(seed);
+			let log_codeword_len = log_msg_cols + log_inv_rate;
+			let indices = (0..n_queries)
+				.map(|_| rng.random_range(0..1usize << log_codeword_len))
+				.collect::<Vec<_>>();
+			let alpha = B128::random(&mut rng);
+
+			let (rows, transposed) = both_builds(log_msg_cols, log_inv_rate, &indices, alpha);
+			prop_assert_eq!(rows, transposed);
+		}
+	}
+}

--- a/crates/iop-prover/src/ligerito/mod.rs
+++ b/crates/iop-prover/src/ligerito/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod channel;
 pub mod compiler;
+mod induced_weight;
 mod opening;
 
 pub use opening::LigeritoProver;

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -85,22 +85,125 @@ where
 
 /// The weight vector `level`'s opened rows induce, built over that level's codeword domain.
 ///
-/// The prover needs every entry of it, unlike the verifier, which reaches the same weight through
-/// [`InducedBasis::evaluate`] alone.
-/// So this is the one place the ladder holds a query position as a number rather than a word, and
-/// the only reason [`LigeritoProver::prove`] pins the channel's word type.
+/// The prover needs every entry of it.
+/// A verifier reaches the same weight through the induced basis's closed form instead.
+/// So this is the one place the ladder holds a query position as a number rather than a word.
+/// It is also the only reason the proving loop pins the channel's word type.
 ///
-/// [`InducedBasis::to_dense`] expands one row at a time, costing `O(t * 2^log_msg_cols)`.
-/// `AdditiveNTT::transpose_transform` computes the same vector as one encode, independent of `t`.
-/// Which wins turns on the row count, so substituting it needs a selection rule rather than an
-/// edit, and that is left to the pass that benchmarks the ladder.
-fn induced_weight<F: BinaryField>(level: &LigeritoLevel, indices: &[Word], alpha: F) -> Vec<F> {
-	let domain_context = GaoMateerOnTheFly::generate(level.log_codeword_len());
+/// Two builds reach the same vector, and which is cheaper turns on the level's shape.
+///
+/// ## Preconditions
+///
+/// * `ntt`'s domain covers the level's codeword domain.
+fn induced_weight<F, P, NTT, A>(
+	level: &LigeritoLevel,
+	ntt: &NTT,
+	indices: &[Word],
+	alpha: F,
+	alloc: &A,
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	A: Allocator,
+{
 	let indices = indices
 		.iter()
 		.map(|index| index.as_u64() as usize)
 		.collect::<Vec<_>>();
-	InducedBasis::new(&domain_context, level.log_msg_cols, &indices, alpha).to_dense()
+
+	if transposed_build_is_cheaper(level) {
+		induced_weight_by_transpose(level, ntt, &indices, alpha, alloc)
+	} else {
+		induced_weight_by_rows(level, &indices, alpha, alloc)
+	}
+}
+
+/// Builds the induced weight by expanding one opened row at a time.
+///
+/// A row is a tensor of `log_msg_cols` factors, so expanding it costs `2^log_msg_cols` products.
+/// Accumulating it into the running vector costs as many multiplications again.
+/// For `t` opened rows the whole build is therefore `2 * t * 2^log_msg_cols` multiplications.
+///
+/// This is the reference the transposed build is tested against.
+fn induced_weight_by_rows<F, P, A>(
+	level: &LigeritoLevel,
+	indices: &[usize],
+	alpha: F,
+	alloc: &A,
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	A: Allocator,
+{
+	let domain_context = GaoMateerOnTheFly::generate(level.log_codeword_len());
+	let dense = InducedBasis::new(&domain_context, level.log_msg_cols, indices, alpha).to_dense();
+	FieldBuffer::from_values_in(alloc, &dense)
+}
+
+/// Builds the induced weight as one pass of the encoder's adjoint.
+///
+/// The weight is defined by what it does to a message:
+///
+/// ```text
+///     <w, m> = sum_i alpha^i * encode(m)[q_i] = <a, encode(m)>,   a[q_i] = alpha^i
+/// ```
+///
+/// The right-hand side is the encoder's adjoint identity read backwards.
+/// So `w` is that adjoint applied to the sparse weight `a`.
+///
+/// The cost is `log_msg_cols` butterfly layers over `2^(log_msg_cols + log_inv_rate)` entries.
+/// Nothing in it grows with the number of rows opened.
+///
+/// ## Preconditions
+///
+/// * `ntt`'s domain covers the level's codeword domain.
+fn induced_weight_by_transpose<F, P, NTT, A>(
+	level: &LigeritoLevel,
+	ntt: &NTT,
+	indices: &[usize],
+	alpha: F,
+	alloc: &A,
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	A: Allocator,
+{
+	// A position can be drawn twice, so the powers landing on it accumulate rather than overwrite.
+	let mut weights = FieldBuffer::zeros_in(alloc, level.log_codeword_len());
+	for (&index, power) in zip(indices, alpha.powers()) {
+		weights.set(index, weights.get(index) + power);
+	}
+
+	let code = ReedSolomonCode::<F>::new(level.log_msg_cols, level.log_inv_rate);
+	code.encode_batch_transpose(ntt, weights.as_mut_view(), 0, alloc)
+}
+
+/// Whether the transposed build beats the row-by-row one at this level's shape.
+///
+/// Both builds produce `2^cols` entries, so dividing their costs by `2^cols` leaves
+///
+/// ```text
+///     row by row   t row entries
+///     transposed   cols * 2^rate layer entries
+/// ```
+///
+/// where `t` is the number of opened rows.
+/// Neither cost depends on the level's lane count, which is why that field is not read here.
+///
+/// A row entry and a layer entry are not the same price, so the comparison needs a constant.
+/// Timing both builds over 128-bit binary field elements puts a row entry at 2.9 ns.
+/// It puts a layer entry at 1.6 ns, steady to a few percent from `2^9` up to `2^24` entries.
+/// The ratio of the two, 1.9, is what the integers below encode.
+const fn transposed_build_is_cheaper(level: &LigeritoLevel) -> bool {
+	// The two costs above, each scaled by 10 so the measured 1.9 is an integer ratio.
+	let row_cost = 19 * level.n_queries;
+	let transposed_cost = 10 * (level.log_msg_cols << level.log_inv_rate);
+	transposed_cost < row_cost
 }
 
 /// Proves a Ligerito opening against a committed ladder of Reed-Solomon codewords.
@@ -262,8 +365,7 @@ where
 
 			if next.is_some() {
 				let beta: F = channel.sample();
-				let mut glued =
-					FieldBuffer::from_values_in(alloc, &induced_weight(level, &indices, alpha));
+				let mut glued = induced_weight(level, self.ntt, &indices, alpha, alloc);
 
 				// The claim the opened rows make is the induced weight paired with the message
 				// they folded to, which is what the verifier reads off as `enforced_sum`.
@@ -308,7 +410,8 @@ mod tests {
 		test_utils::random_field_buffer,
 	};
 	use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
-	use rand::{SeedableRng, rngs::StdRng};
+	use proptest::prelude::*;
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::merkle_channel::ProverMerkleTranscriptChannel;
@@ -536,6 +639,144 @@ mod tests {
 
 				assert_eq!(params.proof_size(&scheme), written, "{lanes:?} n_queries={n_queries}");
 			}
+		}
+	}
+
+	/// Both builds of the induced weight, over one level shape and one set of query indices.
+	fn both_builds(
+		log_msg_cols: usize,
+		log_inv_rate: usize,
+		indices: &[usize],
+		alpha: B128,
+	) -> (FieldBuffer<B128>, FieldBuffer<B128>) {
+		// The lane count does not enter either build, so any value serves here.
+		let level = LigeritoLevel {
+			log_msg_cols,
+			log_lanes: 1,
+			log_inv_rate,
+			n_queries: indices.len(),
+		};
+		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::<B128>::generate(
+			level.log_codeword_len(),
+		));
+		(
+			induced_weight_by_rows(&level, indices, alpha, &GlobalAllocator),
+			induced_weight_by_transpose(&level, &ntt, indices, alpha, &GlobalAllocator),
+		)
+	}
+
+	/// The two builds must agree entry for entry, not merely at one evaluation point.
+	///
+	/// The transposed build reaches the weight through the encoder's adjoint.
+	/// The row build reaches it through the tensor expansion of each generator row.
+	/// Nothing but a test connects the two derivations.
+	#[test]
+	fn the_transposed_build_matches_the_row_build_at_the_boundaries() {
+		let alpha = B128::new(0x9e3779b97f4a7c15);
+
+		// A message of one column, which leaves the transform no layer to run at all.
+		let (rows, transposed) = both_builds(0, 3, &[0, 5, 5], alpha);
+		assert_eq!(rows, transposed);
+
+		// No rows opened, which induces the all-zero weight rather than an empty one.
+		let (rows, transposed) = both_builds(4, 2, &[], alpha);
+		assert_eq!(rows, transposed, "no rows");
+		assert_eq!(rows, FieldBuffer::zeros(4));
+
+		// Every rate the ladder search may pick, at one row and at a row drawn three times.
+		// Sampling is with replacement.
+		// So a repeated index must add its powers rather than overwrite them.
+		for log_inv_rate in 1..=8 {
+			let (rows, transposed) = both_builds(3, log_inv_rate, &[6], alpha);
+			assert_eq!(rows, transposed, "one row at rate {log_inv_rate}");
+
+			let (rows, transposed) = both_builds(3, log_inv_rate, &[2, 2, 2], alpha);
+			assert_eq!(rows, transposed, "a repeated row at rate {log_inv_rate}");
+		}
+	}
+
+	/// The selection rule, at every level shape the ladder search picks at 96-bit security.
+	///
+	/// The last column is the row build's measured time over the transposed build's.
+	/// A value above one is therefore a shape where the transposed build won.
+	/// The rule must agree with that comparison at every shape.
+	#[test]
+	fn the_selection_rule_follows_the_measured_crossover() {
+		// (log_msg_cols, log_inv_rate, n_queries, measured speedup of the transposed build)
+		let measured: &[(usize, usize, usize, f64)] = &[
+			(9, 1, 232, 26.43),
+			(9, 3, 116, 3.86),
+			(9, 5, 101, 0.88),
+			(9, 6, 99, 0.41),
+			(10, 3, 116, 3.06),
+			(10, 4, 106, 1.39),
+			(10, 5, 101, 0.66),
+			(10, 6, 99, 0.32),
+			(10, 8, 97, 0.08),
+			(11, 4, 106, 1.17),
+			(11, 6, 99, 0.26),
+			(12, 4, 106, 1.12),
+			(12, 5, 101, 0.52),
+			(13, 2, 142, 5.15),
+			(13, 4, 106, 0.94),
+			(13, 5, 101, 0.43),
+			(13, 6, 99, 0.20),
+			(14, 1, 232, 15.21),
+			(14, 7, 98, 0.09),
+			(15, 4, 106, 0.78),
+			(15, 5, 101, 0.37),
+			(16, 2, 142, 4.12),
+			(16, 4, 106, 0.74),
+			(17, 1, 232, 11.75),
+			(17, 4, 106, 0.74),
+			(17, 5, 101, 0.34),
+			(18, 6, 99, 0.16),
+			(19, 4, 106, 0.75),
+			(19, 5, 101, 0.34),
+			(20, 2, 142, 3.46),
+			(21, 1, 232, 10.95),
+			(21, 4, 106, 0.62),
+			(22, 1, 232, 10.36),
+			(23, 3, 116, 1.26),
+			(24, 1, 232, 9.60),
+			(24, 2, 142, 2.96),
+		];
+		for &(log_msg_cols, log_inv_rate, n_queries, speedup) in measured {
+			let level = LigeritoLevel {
+				log_msg_cols,
+				log_lanes: 1,
+				log_inv_rate,
+				n_queries,
+			};
+			assert_eq!(
+				transposed_build_is_cheaper(&level),
+				speedup > 1.0,
+				"cols={log_msg_cols} rate={log_inv_rate} t={n_queries} speedup={speedup}"
+			);
+		}
+	}
+
+	proptest! {
+		/// The two builds must agree over the whole shape space, not the shapes a fixed test picks.
+		///
+		/// Indices are drawn with replacement, exactly as the channel draws them.
+		/// A run can therefore land on the same row twice.
+		#[test]
+		fn the_transposed_build_matches_the_row_build(
+			seed: u64,
+			log_msg_cols in 0usize..7,
+			log_inv_rate in 1usize..5,
+			n_queries in 0usize..24,
+		) {
+			let mut rng = StdRng::seed_from_u64(seed);
+			let log_codeword_len = log_msg_cols + log_inv_rate;
+			let indices = (0..n_queries)
+				.map(|_| rng.random_range(0..1usize << log_codeword_len))
+				.collect::<Vec<_>>();
+			let alpha = B128::random(&mut rng);
+
+			let (rows, transposed) = both_builds(log_msg_cols, log_inv_rate, &indices, alpha);
+			prop_assert_eq!(rows, transposed);
 		}
 	}
 }

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -13,7 +13,7 @@ use std::iter::zip;
 use binius_compute::{Allocator, GlobalAllocator};
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
-use binius_iop::ligerito::{InducedBasis, LigeritoLevel, LigeritoParams};
+use binius_iop::ligerito::{LigeritoLevel, LigeritoParams};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
 	bivariate_product_evaluator::bivariate_product_prover,
@@ -24,10 +24,11 @@ use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec,
 	inner_product::inner_product_packed,
 	multilinear::{MultilinearMut, hypercube::Hypercube},
-	ntt::{AdditiveNTT, domain_context::GaoMateerOnTheFly},
+	ntt::AdditiveNTT,
 	reed_solomon::ReedSolomonCode,
 };
 
+use super::induced_weight::InducedWeight;
 use crate::{
 	fri::{BrakedownOracleProver, ProxTestOracleProver},
 	merkle_channel::MerkleIPProverChannel,
@@ -81,129 +82,6 @@ where
 	let commitment = channel.send_merkle_commitment(codeword.as_view(), 1 << level.log_lanes);
 
 	BrakedownOracleProver::new(codeword, commitment, 0)
-}
-
-/// The weight vector `level`'s opened rows induce, built over that level's codeword domain.
-///
-/// The prover needs every entry of it.
-/// A verifier reaches the same weight through the induced basis's closed form instead.
-/// So this is the one place the ladder holds a query position as a number rather than a word.
-/// It is also the only reason the proving loop pins the channel's word type.
-///
-/// Two builds reach the same vector, and which is cheaper turns on the level's shape.
-///
-/// ## Preconditions
-///
-/// * `ntt`'s domain covers the level's codeword domain.
-fn induced_weight<F, P, NTT, A>(
-	level: &LigeritoLevel,
-	ntt: &NTT,
-	indices: &[Word],
-	alpha: F,
-	alloc: &A,
-) -> FieldVec<P, A>
-where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-	NTT: AdditiveNTT<Field = F> + Sync,
-	A: Allocator,
-{
-	let indices = indices
-		.iter()
-		.map(|index| index.as_u64() as usize)
-		.collect::<Vec<_>>();
-
-	if transposed_build_is_cheaper(level) {
-		induced_weight_by_transpose(level, ntt, &indices, alpha, alloc)
-	} else {
-		induced_weight_by_rows(level, &indices, alpha, alloc)
-	}
-}
-
-/// Builds the induced weight by expanding one opened row at a time.
-///
-/// A row is a tensor of `log_msg_cols` factors, so expanding it costs `2^log_msg_cols` products.
-/// Accumulating it into the running vector costs as many multiplications again.
-/// For `t` opened rows the whole build is therefore `2 * t * 2^log_msg_cols` multiplications.
-///
-/// This is the reference the transposed build is tested against.
-fn induced_weight_by_rows<F, P, A>(
-	level: &LigeritoLevel,
-	indices: &[usize],
-	alpha: F,
-	alloc: &A,
-) -> FieldVec<P, A>
-where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-	A: Allocator,
-{
-	let domain_context = GaoMateerOnTheFly::generate(level.log_codeword_len());
-	let dense = InducedBasis::new(&domain_context, level.log_msg_cols, indices, alpha).to_dense();
-	FieldBuffer::from_values_in(alloc, &dense)
-}
-
-/// Builds the induced weight as one pass of the encoder's adjoint.
-///
-/// The weight is defined by what it does to a message:
-///
-/// ```text
-///     <w, m> = sum_i alpha^i * encode(m)[q_i] = <a, encode(m)>,   a[q_i] = alpha^i
-/// ```
-///
-/// The right-hand side is the encoder's adjoint identity read backwards.
-/// So `w` is that adjoint applied to the sparse weight `a`.
-///
-/// The cost is `log_msg_cols` butterfly layers over `2^(log_msg_cols + log_inv_rate)` entries.
-/// Nothing in it grows with the number of rows opened.
-///
-/// ## Preconditions
-///
-/// * `ntt`'s domain covers the level's codeword domain.
-fn induced_weight_by_transpose<F, P, NTT, A>(
-	level: &LigeritoLevel,
-	ntt: &NTT,
-	indices: &[usize],
-	alpha: F,
-	alloc: &A,
-) -> FieldVec<P, A>
-where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-	NTT: AdditiveNTT<Field = F> + Sync,
-	A: Allocator,
-{
-	// A position can be drawn twice, so the powers landing on it accumulate rather than overwrite.
-	let mut weights = FieldBuffer::zeros_in(alloc, level.log_codeword_len());
-	for (&index, power) in zip(indices, alpha.powers()) {
-		weights.set(index, weights.get(index) + power);
-	}
-
-	let code = ReedSolomonCode::<F>::new(level.log_msg_cols, level.log_inv_rate);
-	code.encode_batch_transpose(ntt, weights.as_mut_view(), 0, alloc)
-}
-
-/// Whether the transposed build beats the row-by-row one at this level's shape.
-///
-/// Both builds produce `2^cols` entries, so dividing their costs by `2^cols` leaves
-///
-/// ```text
-///     row by row   t row entries
-///     transposed   cols * 2^rate layer entries
-/// ```
-///
-/// where `t` is the number of opened rows.
-/// Neither cost depends on the level's lane count, which is why that field is not read here.
-///
-/// A row entry and a layer entry are not the same price, so the comparison needs a constant.
-/// Timing both builds over 128-bit binary field elements puts a row entry at 2.9 ns.
-/// It puts a layer entry at 1.6 ns, steady to a few percent from `2^9` up to `2^24` entries.
-/// The ratio of the two, 1.9, is what the integers below encode.
-const fn transposed_build_is_cheaper(level: &LigeritoLevel) -> bool {
-	// The two costs above, each scaled by 10 so the measured 1.9 is an integer ratio.
-	let row_cost = 19 * level.n_queries;
-	let transposed_cost = 10 * (level.log_msg_cols << level.log_inv_rate);
-	transposed_cost < row_cost
 }
 
 /// Proves a Ligerito opening against a committed ladder of Reed-Solomon codewords.
@@ -365,7 +243,7 @@ where
 
 			if next.is_some() {
 				let beta: F = channel.sample();
-				let mut glued = induced_weight(level, self.ntt, &indices, alpha, alloc);
+				let mut glued = InducedWeight::new(level, self.ntt, &indices, alpha).build(alloc);
 
 				// The claim the opened rows make is the induced weight paired with the message
 				// they folded to, which is what the verifier reads off as `enforced_sum`.
@@ -410,8 +288,7 @@ mod tests {
 		test_utils::random_field_buffer,
 	};
 	use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
-	use proptest::prelude::*;
-	use rand::{RngExt, SeedableRng, rngs::StdRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::merkle_channel::ProverMerkleTranscriptChannel;
@@ -639,144 +516,6 @@ mod tests {
 
 				assert_eq!(params.proof_size(&scheme), written, "{lanes:?} n_queries={n_queries}");
 			}
-		}
-	}
-
-	/// Both builds of the induced weight, over one level shape and one set of query indices.
-	fn both_builds(
-		log_msg_cols: usize,
-		log_inv_rate: usize,
-		indices: &[usize],
-		alpha: B128,
-	) -> (FieldBuffer<B128>, FieldBuffer<B128>) {
-		// The lane count does not enter either build, so any value serves here.
-		let level = LigeritoLevel {
-			log_msg_cols,
-			log_lanes: 1,
-			log_inv_rate,
-			n_queries: indices.len(),
-		};
-		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::<B128>::generate(
-			level.log_codeword_len(),
-		));
-		(
-			induced_weight_by_rows(&level, indices, alpha, &GlobalAllocator),
-			induced_weight_by_transpose(&level, &ntt, indices, alpha, &GlobalAllocator),
-		)
-	}
-
-	/// The two builds must agree entry for entry, not merely at one evaluation point.
-	///
-	/// The transposed build reaches the weight through the encoder's adjoint.
-	/// The row build reaches it through the tensor expansion of each generator row.
-	/// Nothing but a test connects the two derivations.
-	#[test]
-	fn the_transposed_build_matches_the_row_build_at_the_boundaries() {
-		let alpha = B128::new(0x9e3779b97f4a7c15);
-
-		// A message of one column, which leaves the transform no layer to run at all.
-		let (rows, transposed) = both_builds(0, 3, &[0, 5, 5], alpha);
-		assert_eq!(rows, transposed);
-
-		// No rows opened, which induces the all-zero weight rather than an empty one.
-		let (rows, transposed) = both_builds(4, 2, &[], alpha);
-		assert_eq!(rows, transposed, "no rows");
-		assert_eq!(rows, FieldBuffer::zeros(4));
-
-		// Every rate the ladder search may pick, at one row and at a row drawn three times.
-		// Sampling is with replacement.
-		// So a repeated index must add its powers rather than overwrite them.
-		for log_inv_rate in 1..=8 {
-			let (rows, transposed) = both_builds(3, log_inv_rate, &[6], alpha);
-			assert_eq!(rows, transposed, "one row at rate {log_inv_rate}");
-
-			let (rows, transposed) = both_builds(3, log_inv_rate, &[2, 2, 2], alpha);
-			assert_eq!(rows, transposed, "a repeated row at rate {log_inv_rate}");
-		}
-	}
-
-	/// The selection rule, at every level shape the ladder search picks at 96-bit security.
-	///
-	/// The last column is the row build's measured time over the transposed build's.
-	/// A value above one is therefore a shape where the transposed build won.
-	/// The rule must agree with that comparison at every shape.
-	#[test]
-	fn the_selection_rule_follows_the_measured_crossover() {
-		// (log_msg_cols, log_inv_rate, n_queries, measured speedup of the transposed build)
-		let measured: &[(usize, usize, usize, f64)] = &[
-			(9, 1, 232, 26.43),
-			(9, 3, 116, 3.86),
-			(9, 5, 101, 0.88),
-			(9, 6, 99, 0.41),
-			(10, 3, 116, 3.06),
-			(10, 4, 106, 1.39),
-			(10, 5, 101, 0.66),
-			(10, 6, 99, 0.32),
-			(10, 8, 97, 0.08),
-			(11, 4, 106, 1.17),
-			(11, 6, 99, 0.26),
-			(12, 4, 106, 1.12),
-			(12, 5, 101, 0.52),
-			(13, 2, 142, 5.15),
-			(13, 4, 106, 0.94),
-			(13, 5, 101, 0.43),
-			(13, 6, 99, 0.20),
-			(14, 1, 232, 15.21),
-			(14, 7, 98, 0.09),
-			(15, 4, 106, 0.78),
-			(15, 5, 101, 0.37),
-			(16, 2, 142, 4.12),
-			(16, 4, 106, 0.74),
-			(17, 1, 232, 11.75),
-			(17, 4, 106, 0.74),
-			(17, 5, 101, 0.34),
-			(18, 6, 99, 0.16),
-			(19, 4, 106, 0.75),
-			(19, 5, 101, 0.34),
-			(20, 2, 142, 3.46),
-			(21, 1, 232, 10.95),
-			(21, 4, 106, 0.62),
-			(22, 1, 232, 10.36),
-			(23, 3, 116, 1.26),
-			(24, 1, 232, 9.60),
-			(24, 2, 142, 2.96),
-		];
-		for &(log_msg_cols, log_inv_rate, n_queries, speedup) in measured {
-			let level = LigeritoLevel {
-				log_msg_cols,
-				log_lanes: 1,
-				log_inv_rate,
-				n_queries,
-			};
-			assert_eq!(
-				transposed_build_is_cheaper(&level),
-				speedup > 1.0,
-				"cols={log_msg_cols} rate={log_inv_rate} t={n_queries} speedup={speedup}"
-			);
-		}
-	}
-
-	proptest! {
-		/// The two builds must agree over the whole shape space, not the shapes a fixed test picks.
-		///
-		/// Indices are drawn with replacement, exactly as the channel draws them.
-		/// A run can therefore land on the same row twice.
-		#[test]
-		fn the_transposed_build_matches_the_row_build(
-			seed: u64,
-			log_msg_cols in 0usize..7,
-			log_inv_rate in 1usize..5,
-			n_queries in 0usize..24,
-		) {
-			let mut rng = StdRng::seed_from_u64(seed);
-			let log_codeword_len = log_msg_cols + log_inv_rate;
-			let indices = (0..n_queries)
-				.map(|_| rng.random_range(0..1usize << log_codeword_len))
-				.collect::<Vec<_>>();
-			let alpha = B128::random(&mut rng);
-
-			let (rows, transposed) = both_builds(log_msg_cols, log_inv_rate, &indices, alpha);
-			prop_assert_eq!(rows, transposed);
 		}
 	}
 }

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -5,7 +5,7 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
-use std::{marker::PhantomData, ptr};
+use std::{iter, marker::PhantomData, ptr};
 
 use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
@@ -245,6 +245,87 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		);
 		output
 	}
+
+	/// The adjoint of the interleaved encoder, taking a codeword weight back to a message weight.
+	///
+	/// The encoder is a linear map, so it has a transpose.
+	/// Writing `E` for the encoder, this applies `E^T`, which is defined by
+	///
+	/// ```text
+	///     <E^T a, m> = <a, E m>
+	/// ```
+	///
+	/// for every weight `a` over codeword positions and every message `m`.
+	///
+	/// A caller reaches for this holding a sparse weight over codeword positions.
+	/// What it wants back is the message weight that sparse weight induces.
+	/// Expanding one generator row per nonzero costs `2^log_dim` per row.
+	/// This costs one encode however many nonzeros there are.
+	///
+	/// # Algorithm
+	///
+	/// The encoder is three steps, so its transpose is those three steps reversed:
+	///
+	/// ```text
+	///     encode   =  transform  after  repeat  after  bit-reverse
+	///     adjoint  =  bit-reverse  after  sum-of-repeats  after  transposed transform
+	/// ```
+	///
+	/// Bit reversal is a permutation that is its own inverse, so it transposes to itself.
+	/// Repeating a message `2^log_inv_rate` times transposes to summing those repeats back down.
+	///
+	/// ## Preconditions
+	///
+	/// * `weights.log_len()` must equal `log_len() + log_batch_size`.
+	/// * The NTT subspace must match the code's subspace.
+	pub fn encode_batch_transpose<P, NTT, A>(
+		&self,
+		ntt: &NTT,
+		mut weights: FieldSliceMut<'_, P>,
+		log_batch_size: usize,
+		alloc: &A,
+	) -> FieldBuffer<P, A::Vec<P>>
+	where
+		P: PackedField<Scalar = F>,
+		NTT: AdditiveNTT<Field = F> + Sync,
+		A: Allocator,
+	{
+		assert_eq!(
+			ntt.subspace(self.log_len()),
+			self.subspace(),
+			"precondition: NTT subspace must match code subspace"
+		);
+		assert_eq!(
+			weights.log_len(),
+			self.log_len() + log_batch_size,
+			"precondition: weights.log_len() must equal log_len() + log_batch_size"
+		);
+
+		let _scope = tracing::trace_span!(
+			"Reed-Solomon encode transpose",
+			log_len = self.log_len(),
+			log_batch_size = log_batch_size,
+			symbol_bits = F::N_BITS,
+		)
+		.entered();
+
+		// The transform runs at the same skips the encoder uses, with its layers reversed.
+		ntt.transpose_transform(weights.as_mut_view(), self.log_inv_rate, log_batch_size);
+
+		// The encoder repeated the message to fill the codeword, so the adjoint sums the repeats.
+		let log_msg_len = self.log_dim() + log_batch_size;
+		let mut folded = FieldBuffer::zeros_in(alloc, log_msg_len);
+		for repeat in weights.chunks(log_msg_len) {
+			for (accumulator, &word) in iter::zip(folded.as_mut(), repeat.as_ref()) {
+				*accumulator += word;
+			}
+		}
+
+		// The encoder permuted the message before repeating it.
+		// A bit reversal is its own transpose, so the same permutation undoes it here.
+		folded.as_mut_view().bit_reverse();
+		folded
+	}
 }
 
 /// Builds a buffer of `total` words holding the bit-reversed message, repeated.
@@ -330,14 +411,16 @@ fn repeated_message_buffer<P: PackedField, A: Allocator>(
 mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
-		BinaryField, PackedBinaryGhash1x128b, PackedBinaryGhash4x128b, PackedField,
+		BinaryField, Ghash128b, PackedBinaryGhash1x128b, PackedBinaryGhash4x128b, PackedField,
 	};
+	use proptest::prelude::*;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::{
 		FieldBuffer,
 		bit_reverse::reverse_bits,
+		inner_product::inner_product_scalars,
 		ntt::{NeighborsLastReference, domain_context::GaoMateerPreExpanded},
 		test_utils::random_field_buffer,
 	};
@@ -517,5 +600,81 @@ mod tests {
 				}
 			}
 		}
+	}
+
+	/// Checks the adjoint identity at one shape, over the packing `P`.
+	fn assert_encode_adjoint<P: PackedField>(
+		log_dim: usize,
+		log_inv_rate: usize,
+		log_batch_size: usize,
+		seed: u64,
+	) where
+		P::Scalar: BinaryField,
+	{
+		let code = ReedSolomonCode::<P::Scalar>::new(log_dim, log_inv_rate);
+		let domain_context = GaoMateerPreExpanded::<P::Scalar>::generate(code.log_len());
+		let ntt = NeighborsLastReference {
+			domain_context: &domain_context,
+		};
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		// `a` weighs codeword positions, `m` is a message the encoder could be handed.
+		let a = random_field_buffer::<P>(&mut rng, code.log_len() + log_batch_size);
+		let m = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
+
+		// Left side: pair the message with the weight the codeword weight induces on it.
+		// The adjoint runs in place, so it gets a copy and `a` stays readable below.
+		let mut scratch = a.clone();
+		let induced = code.encode_batch_transpose(
+			&ntt,
+			scratch.as_mut_view(),
+			log_batch_size,
+			&GlobalAllocator,
+		);
+		let left = inner_product_scalars(induced.iter_scalars(), m.iter_scalars());
+
+		// Right side: pair the codeword weight with the encoding itself.
+		let encoded = code.encode_batch(&ntt, m.as_view(), log_batch_size, &GlobalAllocator);
+		let right = inner_product_scalars(a.iter_scalars(), encoded.iter_scalars());
+
+		assert_eq!(left, right, "log_dim={log_dim} rate={log_inv_rate} batch={log_batch_size}");
+	}
+
+	proptest! {
+		/// The adjoint identity is the whole specification of the transposed encoder.
+		///
+		/// It is basis free, so one check covers an error in any of the three steps.
+		/// Those are the layer order, the direction the repeats are summed, and the permutation.
+		#[test]
+		fn transposed_encoding_is_the_adjoint_of_encoding(seed: u64) {
+			// A dimension of 0 is a one-element message, the smallest a code can carry.
+			// A batch of 0 is the single-lane case the induced basis uses.
+			for log_dim in 0..6 {
+				for log_inv_rate in 1..4 {
+					for log_batch_size in 0..3 {
+						// One lane per word and four lanes per word take different chunk paths.
+						assert_encode_adjoint::<PackedBinaryGhash1x128b>(
+							log_dim, log_inv_rate, log_batch_size, seed,
+						);
+						assert_encode_adjoint::<PackedBinaryGhash4x128b>(
+							log_dim, log_inv_rate, log_batch_size, seed,
+						);
+					}
+				}
+			}
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "weights.log_len() must equal log_len() + log_batch_size")]
+	fn transposed_encoding_rejects_a_weight_of_the_wrong_width() {
+		let code = ReedSolomonCode::<Ghash128b>::new(3, 1);
+		let domain_context = GaoMateerPreExpanded::generate(code.log_len());
+		let ntt = NeighborsLastReference {
+			domain_context: &domain_context,
+		};
+		// The codeword has 2^4 positions, so a weight of 2^3 cannot be one over them.
+		let mut weights = FieldBuffer::<PackedBinaryGhash1x128b>::zeros(3);
+		code.encode_batch_transpose(&ntt, weights.as_mut_view(), 0, &GlobalAllocator);
 	}
 }


### PR DESCRIPTION
Linear: [BINIUS-536](https://linear.app/jimpo/issue/BINIUS-536/build-the-ligerito-induced-weight-through-the-encoders-adjoint)

A Ligerito level opens `t` rows of its committed Reed-Solomon codeword and batches those `t` claims into one with the powers of a challenge `alpha`. The weight vector that batching induces on the level's message is

```
w[j] = sum_i alpha^i * G_{q_i}[j]
```

where `G_{q_i}` is the generator row at query position `q_i`. The prover glues `w` into its running sumcheck, so it needs every entry. Until now it built `w` one row at a time: a row is a tensor of `log_msg_cols` factors, expanding and accumulating one costs `2 * 2^log_msg_cols` multiplications, and the build costs `t` times that.

## The identity

Pair `w` with any message `m` and unfold the definition:

```
<w, m> = sum_i alpha^i * <G_{q_i}, m> = sum_i alpha^i * encode(m)[q_i] = <a, encode(m)>
```

where `a` is the sparse weight holding `alpha^i` at position `q_i` and zero elsewhere. That is the encoder's adjoint identity read backwards. So `w` is the encoder's transpose applied to `a`, and one pass of that transpose produces the whole vector however many rows were opened.

`AdditiveNTT::transpose_transform` (BINIUS-532, #2303) is only the butterfly half. The encoder is three steps, so its adjoint is those three reversed:

```
encode   =  transform  after  repeat  after  bit-reverse
adjoint  =  bit-reverse  after  sum-of-repeats  after  transposed transform
```

Bit reversal is a permutation that is its own inverse, so it transposes to itself. Repeating a message `2^log_inv_rate` times to fill the codeword transposes to summing those repeats back down. This is *not* the inverse transform — the forward butterfly has determinant 1, so its inverse is a different map.

## What lands

- `ReedSolomonCode::encode_batch_transpose` in `binius-math`. A proptest pins it to `<E^T a, m> == <a, E m>` against `encode_batch` itself, over both packings, at dimensions from `2^0`, rates 1 to 3, and batch sizes 0 to 2.
- Two builds of the induced weight in the Ligerito prover. The row-by-row one is unchanged and is the reference; a proptest asserts the two agree entry for entry over random shapes, plus a fixed test for the boundaries — no rows, one column, a row drawn three times, and every rate the ladder search can pick.
- A selection rule between them, measured rather than assumed.

## The crossover, measured

Both builds produce `2^cols` entries. Dividing their costs by `2^cols` leaves `t` row entries against `cols * 2^rate` layer entries, so only those three numbers matter — the lane count does not enter either.

Timing the two over `Ghash128b` puts a row entry at 2.9 ns and a layer entry at 1.6 ns, steady to a few percent from `2^9` to `2^24` entries. They therefore cross at `cols * 2^rate == 1.9 * t`, which is what `transposed_build_is_cheaper` encodes.

A sweep holding the shape and moving `t` confirms the shape of both costs — the transposed build is flat in `t`, the row build linear — and locates the crossover where the rule predicts:

| cols | rate | measured crossover `t` | rule's `t` |
| --- | --- | --- | --- |
| 18 | 1 | ~14 | 19 |
| 16 | 2 | ~35 | 34 |
| 12 | 4 | ~96 | 101 |
| 16 | 5 | ~295 | 269 |
| 14 | 6 | ~525 | 471 |
| 12 | 8 | ~1650 | 1617 |

The plan document's guess, `t ~ 2^rate * (cols + rate)`, is conservative by roughly a factor of two: at `cols = 18, rate = 1` it puts the crossover at 38 where the measurement puts it at 14.

At the shapes `optimal_ladder` actually picks (96-bit security), row build over transposed build:

| cols | rate | t | rows (ms) | transposed (ms) | speedup |
| --- | --- | --- | --- | --- | --- |
| 24 | 1 | 232 | 11229.5 | 1169.6 | **9.60** |
| 22 | 1 | 232 | 2797.0 | 269.9 | **10.36** |
| 21 | 1 | 232 | 1435.4 | 131.1 | **10.95** |
| 17 | 1 | 232 | 85.3 | 7.3 | **11.75** |
| 24 | 2 | 142 | 6845.9 | 2312.5 | **2.96** |
| 20 | 2 | 142 | 427.6 | 123.7 | **3.46** |
| 16 | 2 | 142 | 25.1 | 6.1 | **4.12** |
| 23 | 3 | 116 | 2821.2 | 2235.4 | **1.26** |
| 10 | 3 | 116 | 0.40 | 0.13 | **3.06** |
| 12 | 4 | 106 | 1.37 | 1.22 | **1.12** |
| 17 | 4 | 106 | 40.5 | 55.1 | 0.74 |
| 21 | 4 | 106 | 650.7 | 1046.5 | 0.62 |
| 15 | 5 | 101 | 8.9 | 24.4 | 0.37 |
| 18 | 6 | 99 | 73.4 | 471.3 | 0.16 |
| 10 | 8 | 97 | 0.36 | 4.71 | 0.08 |

The full 36-shape table is pinned in the test, and the rule agrees with the sign of the comparison at every one of them.

The pattern is that level 0 always lands on the transposed side, because its rate is the lowest on the ladder and it is also by far the most expensive level. At `log_n = 28` its induced weight drops from 11.2 s to 1.17 s. The deep, low-rate levels stay on the row side, where a transposed build would cost up to 12x more — and they are small enough that it barely matters either way.

## Not done here

`transpose_transform` still runs its default body, a scalar loop over `get`/`set` with no packing and no parallelism, while the row build accumulates through a packed buffer. That is why the measured layer entry is 1.6 ns against an arithmetic cost of roughly half a multiply. An override in `NeighborsLastSingleThread` mirroring `forward_depth_first` would roughly halve it and move the crossover out to `cols * 2^rate ~ 3.6 * t`, flipping the rate-4 levels. Those levels are a couple of percent of the ladder's build time, so it is not worth doing before something else needs a fast transposed transform.

The sparse input is also thrown away: `a` has at most `t` nonzeros out of `2^(cols + rate)`, and the layers nearest the input only touch blocks containing one. Exploiting that would cut the transposed build by roughly `cols / log2(t)` again.

## Verification

```
cargo +nightly-2026-07-01 fmt --all                                              exit 0
cargo clippy -p binius-math -p binius-iop -p binius-iop-prover \
  --all-features --all-targets -- -D warnings                                    exit 0
cargo test -p binius-math -p binius-iop -p binius-iop-prover                     exit 0  (62 + 55 + 2 + 167 + doctests)
cargo test -p binius-math -p binius-iop -p binius-iop-prover --features rayon    exit 0  (same counts)
RUSTDOCFLAGS="-D warnings" cargo doc -p binius-math -p binius-iop \
  -p binius-iop-prover --no-deps --all-features                                  exit 0
```
