### PR TITLE
BINIUS-539: Make the Ligerito ladder pay the proof of work it is credited for

### DIFF
--- a/crates/iop-prover/src/channel/grinding.rs
+++ b/crates/iop-prover/src/channel/grinding.rs
@@ -2,19 +2,20 @@
 
 //! Proof-of-work grinding, as a capability a prover channel may carry.
 //!
-//! The counterpart of `binius_iop::channel::grinding::GrindingVerifierChannel`.
-//! That trait states the contract both sides obey.
+//! The counterpart of
+//! [`GrindingVerifierChannel`](binius_iop::channel::grinding::GrindingVerifierChannel). That trait
+//! states the contract both sides obey, and why it is a capability not a method.
 
 /// A prover channel that can pay a proof of work into the transcript.
 ///
-/// The mirror of `binius_iop::channel::grinding::GrindingVerifierChannel`.
-/// It is a trait of its own for the same reason that one is.
-/// Grinding is a property of the Fiat-Shamir state rather than of what is committed.
+/// The mirror of
+/// [`GrindingVerifierChannel`](binius_iop::channel::grinding::GrindingVerifierChannel).
+/// It is a trait of its own for the same reason: grinding acts on the Fiat-Shamir state alone.
 ///
 /// # Contract
 ///
 /// A difficulty of zero is not a grind, and must leave tape and challenger untouched.
-/// The verifier's trait documentation says why that rule lives in the channel.
+/// The verifier's trait documents why that rule belongs to the channel rather than the call sites.
 pub trait GrindingProverChannel {
 	/// Searches for a nonce meeting `bits` of difficulty and writes it, returning the nonce.
 	///
@@ -22,6 +23,6 @@ pub trait GrindingProverChannel {
 	///
 	/// ## Preconditions
 	///
-	/// * `bits` is at most [`binius_transcript::MAX_GRINDING_BITS`].
+	/// * `bits` is at most [`MAX_GRINDING_BITS`](binius_transcript::MAX_GRINDING_BITS).
 	fn grind(&mut self, bits: usize) -> u64;
 }

--- a/crates/iop-prover/src/channel/grinding.rs
+++ b/crates/iop-prover/src/channel/grinding.rs
@@ -1,0 +1,27 @@
+// Copyright 2026 The Binius Developers
+
+//! Proof-of-work grinding, as a capability a prover channel may carry.
+//!
+//! The counterpart of `binius_iop::channel::grinding::GrindingVerifierChannel`.
+//! That trait states the contract both sides obey.
+
+/// A prover channel that can pay a proof of work into the transcript.
+///
+/// The mirror of `binius_iop::channel::grinding::GrindingVerifierChannel`.
+/// It is a trait of its own for the same reason that one is.
+/// Grinding is a property of the Fiat-Shamir state rather than of what is committed.
+///
+/// # Contract
+///
+/// A difficulty of zero is not a grind, and must leave tape and challenger untouched.
+/// The verifier's trait documentation says why that rule lives in the channel.
+pub trait GrindingProverChannel {
+	/// Searches for a nonce meeting `bits` of difficulty and writes it, returning the nonce.
+	///
+	/// The expected cost is `2^bits` challenger trials, paid in wall clock.
+	///
+	/// ## Preconditions
+	///
+	/// * `bits` is at most [`binius_transcript::MAX_GRINDING_BITS`].
+	fn grind(&mut self, bits: usize) -> u64;
+}

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -2,6 +2,7 @@
 
 //! Channel abstraction for interactive oracle protocol (IOP) provers.
 
+pub mod grinding;
 pub mod naive;
 
 use binius_compute::Allocator;

--- a/crates/iop-prover/src/ligerito/channel/prover.rs
+++ b/crates/iop-prover/src/ligerito/channel/prover.rs
@@ -14,7 +14,9 @@ use binius_math::{FieldBuffer, FieldSlice, FieldVec, ntt::AdditiveNTT};
 
 use super::{LigeritoOracle, relation::QueuedRelation};
 use crate::{
-	channel::IOPProverChannel, ligerito::LigeritoProver, merkle_channel::MerkleIPProverChannel,
+	channel::{IOPProverChannel, grinding::GrindingProverChannel},
+	ligerito::LigeritoProver,
+	merkle_channel::MerkleIPProverChannel,
 };
 
 /// A prover channel that opens its one committed oracle with a Ligerito ladder.
@@ -114,7 +116,13 @@ where
 	///
 	/// Mirrors the verifier's own finishing step, message for message.
 	/// Nothing happens when no relation was queued, since the commitment alone asserts nothing.
-	pub fn finish(self) {
+	///
+	/// The channel has to be able to pay a proof of work, because the ladder may ask for one.
+	/// A configuration that grinds nothing still asks for the capability, and never uses it.
+	pub fn finish(self)
+	where
+		Channel: GrindingProverChannel,
+	{
 		let Self {
 			mut channel,
 			ntt: _,
@@ -158,7 +166,9 @@ where
 		message: FieldSlice<'_, P>,
 		queue: Vec<QueuedRelation<P, A>>,
 		alloc: &A,
-	) {
+	) where
+		Channel: GrindingProverChannel,
+	{
 		// Every claim in the queue is already bound to the transcript, so a coefficient drawn
 		// here cannot be anticipated by any of them.
 		let lambda = channel.sample();
@@ -316,7 +326,7 @@ mod tests {
 	use binius_iop::{
 		channel::{Error, IOPVerifierChannel},
 		ligerito::{LigeritoLevel, compiler::LigeritoVerifierCompiler},
-		soundness::SoundnessRegime,
+		soundness::{Grinding, SoundnessRegime},
 	};
 	use binius_math::{
 		multilinear::Multilinear,
@@ -452,12 +462,16 @@ mod tests {
 			(4, &[2, 0, 1]),
 		];
 		for &(log_msg_cols, lanes) in shapes {
-			let params = ladder(log_msg_cols, lanes);
-			let msg = message(&params, 0);
-			let mut rng = StdRng::seed_from_u64(1);
-			let relations = [relation(&mut rng, &msg)];
-			run(&params, &msg, &msg, &relations)
-				.unwrap_or_else(|err| panic!("{log_msg_cols} {lanes:?}: {err}"));
+			// Both grinding profiles run the whole channel, so the compiler carries the ladder's
+			// proof of work to both sides and the two stay in step through it.
+			for grinding in [Grinding::NONE, Grinding::new(3, 4)] {
+				let params = ladder(log_msg_cols, lanes).with_grinding(grinding);
+				let msg = message(&params, 0);
+				let mut rng = StdRng::seed_from_u64(1);
+				let relations = [relation(&mut rng, &msg)];
+				run(&params, &msg, &msg, &relations)
+					.unwrap_or_else(|err| panic!("{log_msg_cols} {lanes:?} {grinding:?}: {err}"));
+			}
 		}
 	}
 

--- a/crates/iop-prover/src/ligerito/compiler.rs
+++ b/crates/iop-prover/src/ligerito/compiler.rs
@@ -12,7 +12,7 @@ use binius_iop::{
 	channel::OracleSpec,
 	ligerito::{LigeritoParams, compiler::LigeritoVerifierCompiler},
 	merkle_tree::MerkleTreeScheme,
-	soundness::SoundnessRegime,
+	soundness::{Grinding, SoundnessRegime},
 };
 use binius_math::ntt::AdditiveNTT;
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
@@ -74,6 +74,8 @@ where
 	///
 	/// `None` means no ladder over this message reaches the security target.
 	///
+	/// `grinding` is what the ladder will pay per level; pass [`Grinding::NONE`] for none.
+	///
 	/// ## Preconditions
 	///
 	/// * `oracle_specs` holds exactly one spec, and that spec is not zero-knowledge.
@@ -86,6 +88,7 @@ where
 		l0_log_inv_rate: usize,
 		regime: SoundnessRegime,
 		security_bits: usize,
+		grinding: Grinding,
 	) -> Option<Self>
 	where
 		MerkleScheme: MerkleTreeScheme<F>,
@@ -96,6 +99,7 @@ where
 			l0_log_inv_rate,
 			regime,
 			security_bits,
+			grinding,
 		)?;
 		Some(Self::from_verifier_compiler(&verifier, ntt))
 	}

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -7,6 +7,10 @@
 //! The sumcheck challenges of a level are its lane fold.
 //! Whatever a level folds to is committed before that level's queries are drawn.
 //! And only level 0 may use the MLE-check shortcut.
+//!
+//! A fourth fact is this side's alone.
+//! The proof of work is paid at exactly the two points the verifier checks it.
+//! That module's `Where the proof of work stands` section draws them.
 
 use std::iter::zip;
 
@@ -30,6 +34,7 @@ use binius_math::{
 
 use super::induced_weight::InducedWeight;
 use crate::{
+	channel::grinding::GrindingProverChannel,
 	fri::{BrakedownOracleProver, ProxTestOracleProver},
 	merkle_channel::MerkleIPProverChannel,
 };
@@ -139,6 +144,10 @@ where
 	/// An intermediate level's query claim is glued into the running sumcheck at a fresh challenge;
 	/// the last level's is left for the verifier to check against the cleartext residual.
 	///
+	/// The proof of work the parameters fix is ground before every fold challenge.
+	/// One more grind stands before each level's queries.
+	/// The verifier checks each of them at the point it was paid.
+	///
 	/// ## Preconditions
 	///
 	/// * `message` is the multilinear [`Self::commit`] committed.
@@ -152,9 +161,10 @@ where
 		channel: &mut Channel,
 	) where
 		A: Allocator,
-		Channel: MerkleIPProverChannel<F, Commitment = C, Word = Word>,
+		Channel: MerkleIPProverChannel<F, Commitment = C, Word = Word> + GrindingProverChannel,
 	{
 		let levels = self.params.levels();
+		let grinding = self.params.grinding();
 		assert_eq!(
 			message.log_len(),
 			self.params.log_msg_len(),
@@ -187,6 +197,7 @@ where
 					for _ in 0..level.log_lanes {
 						let coeffs = prover.execute().pop().expect("the prover has one claim");
 						channel.send_many(mlecheck::RoundProof::truncate(coeffs.clone()).coeffs());
+						channel.grind(grinding.challenge_bits());
 						let challenge = channel.sample();
 						prover.fold(challenge);
 						// The full round polynomial at the challenge is the reduced claim, which
@@ -206,6 +217,7 @@ where
 					for _ in 0..level.log_lanes {
 						let coeffs = prover.execute().pop().expect("the prover has one claim");
 						channel.send_many(coeffs.clone().truncate().coeffs());
+						channel.grind(grinding.challenge_bits());
 						let challenge = channel.sample();
 						prover.fold(challenge);
 						sum = coeffs.evaluate(&challenge);
@@ -227,6 +239,10 @@ where
 					None
 				}
 			};
+
+			// The commitment above is fixed, and no position exists yet, which is where the
+			// verifier checks this grind too.
+			channel.grind(grinding.query_bits());
 
 			let indices = (0..level.n_queries)
 				.map(|_| channel.sample_bits(level.log_codeword_len()))
@@ -290,10 +306,11 @@ mod tests {
 		binary_merkle_tree::HashSuite,
 	};
 	use binius_iop::{
+		channel::grinding::GrindingVerifierChannel,
 		ligerito::{Error, LigeritoVerifier, VerifierCost},
-		merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
-		merkle_tree::BinaryMerkleTreeScheme,
-		soundness::SoundnessRegime,
+		merkle_channel::{self, MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
+		merkle_tree::{self, BinaryMerkleTreeScheme},
+		soundness::{Grinding, SoundnessRegime},
 	};
 	use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 	use binius_math::{
@@ -301,7 +318,10 @@ mod tests {
 		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 		test_utils::random_field_buffer,
 	};
-	use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
+	use binius_transcript::{
+		Error as TranscriptError, ProverTranscript, VerifierTranscript,
+		fiat_shamir::HasherChallenger,
+	};
 	use digest::Output;
 	use rand::{SeedableRng, rngs::StdRng};
 
@@ -375,16 +395,16 @@ mod tests {
 		(transcript.finalize(), eval_point, eval_claim)
 	}
 
-	/// Proves and verifies one opening, returning the finished proof's length in bytes.
+	/// Verifies a written proof against `params`, returning its length in bytes.
 	///
-	/// The byte count is only ever taken from a transcript that convinced the verifier.
-	fn run(
+	/// The ladder is taken from `params` rather than from the transcript, so a verifier can be
+	/// pointed at a proof written under different parameters.
+	fn verify_proof(
 		params: &LigeritoParams,
-		committed: &FieldBuffer<B128>,
-		opened: &FieldBuffer<B128>,
-		claim_offset: B128,
+		proof: Vec<u8>,
+		eval_point: &[B128],
+		eval_claim: B128,
 	) -> Result<usize, Error> {
-		let (proof, eval_point, eval_claim) = write_proof(params, committed, opened, claim_offset);
 		let proof_size = proof.len();
 
 		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
@@ -396,12 +416,38 @@ mod tests {
 		let commitment = verifier_channel
 			.recv_merkle_commitment(1 << level.log_lanes, level.log_codeword_len())?;
 		LigeritoVerifier::new(params, commitment).verify(
-			&eval_point,
+			eval_point,
 			eval_claim,
 			&mut verifier_channel,
 		)?;
 
 		Ok(proof_size)
+	}
+
+	/// Proves and verifies one opening, returning the finished proof's length in bytes.
+	///
+	/// The byte count is only ever taken from a transcript that convinced the verifier.
+	fn run(
+		params: &LigeritoParams,
+		committed: &FieldBuffer<B128>,
+		opened: &FieldBuffer<B128>,
+		claim_offset: B128,
+	) -> Result<usize, Error> {
+		let (proof, eval_point, eval_claim) = write_proof(params, committed, opened, claim_offset);
+		verify_proof(params, proof, &eval_point, eval_claim)
+	}
+
+	/// Proves an honest opening under one ladder and verifies it under another.
+	///
+	/// The two ladders are the same shape and differ only in the proof of work they pay, which is
+	/// how a grind checked in the wrong place is expressed here.
+	fn run_across(
+		prover_params: &LigeritoParams,
+		verifier_params: &LigeritoParams,
+	) -> Result<usize, Error> {
+		let msg = message(prover_params, 0);
+		let (proof, eval_point, eval_claim) = write_proof(prover_params, &msg, &msg, B128::ZERO);
+		verify_proof(verifier_params, proof, &eval_point, eval_claim)
 	}
 
 	/// A random message of the ladder's shape.
@@ -476,6 +522,176 @@ mod tests {
 				.expect_err("the evaluation claim is off by one");
 			assert!(matches!(err, Error::IPChannel(binius_ip::channel::Error::InvalidAssert)));
 		}
+	}
+
+	// Proof of work
+
+	/// A ladder that grinds must still verify, at every depth and on either side of the split.
+	#[test]
+	fn an_honest_opening_with_a_proof_of_work_verifies() {
+		// Fixture state: the two grinds are exercised alone and together, and zero is included so
+		// the grinding path and the ungrinding one are held to the same ladder.
+		let grinds = [
+			Grinding::NONE,
+			Grinding::new(0, 4),
+			Grinding::new(4, 0),
+			Grinding::new(3, 5),
+		];
+		for grinding in grinds {
+			for lanes in [&[2usize] as &[usize], &[2, 2], &[1, 2, 1]] {
+				let params = ladder(6, lanes, 5).with_grinding(grinding);
+				let msg = message(&params, 0);
+				run(&params, &msg, &msg, B128::ZERO)
+					.unwrap_or_else(|err| panic!("{lanes:?} {grinding:?}: {err}"));
+			}
+		}
+	}
+
+	/// Grinding lengthens the proof by one nonce per grind, and by nothing else.
+	#[test]
+	fn a_grind_costs_one_nonce_and_the_estimate_counts_it() {
+		// Invariant: the two call sites are the only thing grinding adds to a transcript. One
+		// nonce stands before each fold challenge, one more before each level's queries, and a
+		// difficulty of zero writes nothing at all.
+		//
+		// Fixture state: ladders of three shapes, priced bare and then at each of the three
+		// grinding profiles.
+		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+		for lanes in [&[2usize] as &[usize], &[2, 2], &[1, 2, 1]] {
+			let bare = ladder(6, lanes, 5);
+			let msg = message(&bare, 0);
+			let bare_size = run(&bare, &msg, &msg, B128::ZERO).expect("honest proof rejected");
+			assert_eq!(bare.proof_size(&scheme), bare_size);
+
+			for grinding in [
+				Grinding::new(0, 4),
+				Grinding::new(4, 0),
+				Grinding::new(3, 5),
+			] {
+				let ground = bare.clone().with_grinding(grinding);
+				let ground_size =
+					run(&ground, &msg, &msg, B128::ZERO).expect("honest proof rejected");
+
+				// One `u64` per nonce, and the ladder says how many nonces it writes.
+				let nonces = ground
+					.levels()
+					.iter()
+					.map(|level| level.n_grind_nonces(grinding))
+					.sum::<usize>();
+				assert_eq!(
+					ground_size - bare_size,
+					nonces * size_of::<u64>(),
+					"{lanes:?} {grinding:?}"
+				);
+				// Which is also what the estimate says, so the ladder search prices a real proof.
+				assert_eq!(ground.proof_size(&scheme), ground_size, "{lanes:?} {grinding:?}");
+			}
+
+			// A query grind writes one nonce per level; a challenge grind writes one per fold
+			// round. So the two profiles differ in length whenever a level folds more than one
+			// lane, which is what keeps them from being confused for one another by size alone.
+			let query_only = bare
+				.levels()
+				.iter()
+				.map(|level| level.n_grind_nonces(Grinding::new(0, 4)))
+				.sum::<usize>();
+			let challenge_only = bare
+				.levels()
+				.iter()
+				.map(|level| level.n_grind_nonces(Grinding::new(4, 0)))
+				.sum::<usize>();
+			assert_eq!(query_only, bare.n_levels());
+			assert_eq!(challenge_only, bare.n_fold_rounds());
+		}
+	}
+
+	/// A verifier expecting a different amount of work must reject the proof.
+	#[test]
+	fn a_proof_ground_at_one_difficulty_is_rejected_at_another() {
+		// Invariant: the difficulty is part of the statement, not advice the prover carries. The
+		// sampler reads four bytes whatever the difficulty, so a mismatch of nonzero difficulties
+		// leaves both transcripts in step and shows up only as unmet work.
+		//
+		// Fixture state: four bits are ground and twenty-four are demanded. The gap is what makes
+		// the rejection certain rather than a coin flip: a nonce that happens to satisfy twenty
+		// more bits than it was searched for turns up once in a million.
+		let base = ladder(6, &[2, 2], 5);
+		let ground = base.clone().with_grinding(Grinding::new(4, 0));
+		let demanded = base.clone().with_grinding(Grinding::new(24, 0));
+		let err = run_across(&ground, &demanded)
+			.expect_err("four bits of work cannot satisfy a twenty-four bit demand");
+		let Error::ProofOfWork(TranscriptError::InsufficientWork { bits, sampled }) = err else {
+			panic!("expected unmet proof of work, got {err}")
+		};
+		assert_eq!(bits, 24);
+		assert_ne!(sampled, 0);
+
+		// The same on the query side, where the nonce stands after the commitment instead.
+		let ground = base.clone().with_grinding(Grinding::new(0, 4));
+		let demanded = base.clone().with_grinding(Grinding::new(0, 24));
+		let err = run_across(&ground, &demanded)
+			.expect_err("four bits of work cannot satisfy a twenty-four bit demand");
+		let Error::ProofOfWork(TranscriptError::InsufficientWork { bits, sampled }) = err else {
+			panic!("expected unmet proof of work, got {err}")
+		};
+		assert_eq!(bits, 24);
+		assert_ne!(sampled, 0);
+
+		// And the other way round: work the verifier never asks for is eight stray bytes on the
+		// tape. The two sides then read different things at every offset below, and the residual
+		// is the first value checked against a commitment, so that is where it breaks.
+		let bare = base.clone();
+		let ground = base.with_grinding(Grinding::new(4, 4));
+		let err = run_across(&ground, &bare)
+			.expect_err("a nonce the verifier never reads desynchronizes the transcript");
+		let Error::Channel(merkle_channel::Error::MerkleTree(merkle_tree::Error::Verification(
+			merkle_tree::VerificationError::InvalidProof,
+		))) = err
+		else {
+			panic!("expected a Merkle verification failure, got {err}")
+		};
+	}
+
+	/// Work paid at one call site must not settle the debt at the other.
+	#[test]
+	fn a_challenge_grind_is_not_accepted_as_a_query_grind() {
+		// Invariant: the two grinds buy different terms of the security budget, so the transcript
+		// has to tell them apart by *where* the nonce stands rather than by how the tape looks.
+		//
+		// The two ladders below swap the difficulties between the sites. Both write one nonce
+		// before the fold challenge and one before the queries, both of the same width, so the
+		// two transcripts are laid out byte for byte alike and stay in step to the very end.
+		// Nothing but the position separates them. A grind checked at the wrong site would
+		// therefore be checked against the *other* site's work and pass.
+		//
+		// Fixture state: one level folding one lane, so each site carries exactly one nonce. The
+		// difficulties differ by sixteen bits, which is what makes the rejection certain rather
+		// than a coin flip.
+		let base = ladder(6, &[1], 5);
+		let heavy_fold = base.clone().with_grinding(Grinding::new(18, 2));
+		let heavy_query = base.with_grinding(Grinding::new(2, 18));
+		assert_eq!(
+			heavy_fold.levels()[0].n_grind_nonces(heavy_fold.grinding()),
+			heavy_query.levels()[0].n_grind_nonces(heavy_query.grinding()),
+		);
+
+		// Eighteen bits before the fold challenge do not pay for the query positions.
+		let err = run_across(&heavy_fold, &heavy_query)
+			.expect_err("work before the fold challenge does not pay for the query positions");
+		let Error::ProofOfWork(TranscriptError::InsufficientWork { bits, sampled }) = err else {
+			panic!("expected unmet proof of work, got {err}")
+		};
+		assert_eq!(bits, 18);
+		assert_ne!(sampled, 0);
+
+		// And eighteen bits before the query positions do not pay for the fold challenge.
+		let err = run_across(&heavy_query, &heavy_fold)
+			.expect_err("work before the query positions does not pay for the fold challenge");
+		let Error::ProofOfWork(TranscriptError::InsufficientWork { bits, sampled }) = err else {
+			panic!("expected unmet proof of work, got {err}")
+		};
+		assert_eq!(bits, 18);
+		assert_ne!(sampled, 0);
 	}
 
 	/// The proof-size estimate must equal the transcript, not merely approximate it.
@@ -856,6 +1072,12 @@ mod tests {
 				.into_iter()
 				.map(Counted)
 				.collect()
+		}
+	}
+
+	impl<C: GrindingVerifierChannel> GrindingVerifierChannel for CountingChannel<C> {
+		fn verify_grind(&mut self, bits: usize) -> Result<(), binius_transcript::Error> {
+			self.inner.verify_grind(bits)
 		}
 	}
 

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -24,7 +24,10 @@ use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2};
 use digest::Output;
 
-use crate::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use crate::{
+	channel::grinding::GrindingProverChannel,
+	merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver},
+};
 
 /// An extension of [`WordIPProverChannel`] that can send and open Merkle commitments.
 ///
@@ -181,6 +184,21 @@ where
 	}
 }
 
+impl<T, Challenger_, F, H: HashSuite, A: Allocator> GrindingProverChannel
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>
+where
+	T: BorrowMut<ProverTranscript<Challenger_>>,
+	Challenger_: Challenger + Clone,
+{
+	fn grind(&mut self, bits: usize) -> u64 {
+		// Zero difficulty is not a grind, so no nonce goes out and the challenger does not move.
+		if bits == 0 {
+			return 0;
+		}
+		self.transcript.borrow_mut().grind(bits)
+	}
+}
+
 impl<F, T, Challenger_, H, A> MerkleIPProverChannel<F>
 	for ProverMerkleTranscriptChannel<T, Challenger_, F, H, A>
 where
@@ -264,13 +282,21 @@ mod tests {
 	use binius_core::word::Word;
 	use binius_field::{Ghash128b as B128, PackedBinaryGhash2x128b};
 	use binius_hash::{StdDigest, StdHashSuite};
-	use binius_iop::merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel};
-	use binius_ip::channel::WordIPVerifierChannel;
+	use binius_iop::{
+		channel::grinding::GrindingVerifierChannel,
+		merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
+	};
+	use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 	use binius_math::{FieldBuffer, test_utils::random_scalars};
-	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use binius_transcript::{
+		Error as TranscriptError, ProverTranscript, fiat_shamir::HasherChallenger,
+	};
 	use rand::prelude::*;
 
-	use super::{MerkleIPProverChannel, ProverMerkleTranscriptChannel};
+	use super::{
+		GrindingProverChannel, IPProverChannel, MerkleIPProverChannel,
+		ProverMerkleTranscriptChannel,
+	};
 
 	type StdChallenger = HasherChallenger<StdDigest>;
 	type P = PackedBinaryGhash2x128b;
@@ -328,6 +354,66 @@ mod tests {
 		assert_eq!(vector, scalars);
 
 		verifier_channel.into_transcript().finalize().unwrap();
+	}
+
+	#[test]
+	fn a_grind_round_trips_and_zero_bits_is_not_a_grind() {
+		// Invariant: the two sides read the same difficulty out of the same parameters, so a grind
+		// has to leave the channels in step. And a difficulty of zero must be indistinguishable
+		// from never having grinding in the protocol at all, since that is what keeps
+		// `Grinding::NONE` free.
+		//
+		// Fixture state: four bits, which costs sixteen challenger trials on average.
+		const BITS: usize = 4;
+
+		let mut prover_channel =
+			ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
+		prover_channel.grind(BITS);
+		let challenge = IPProverChannel::<B128>::sample(&mut prover_channel);
+
+		let mut transcript = ProverChannel::into_transcript(prover_channel).into_verifier();
+		{
+			let mut verifier_channel = VerifierChannel::new(&mut transcript);
+			verifier_channel.verify_grind(BITS).unwrap();
+			// The challenger absorbed the same nonce on both sides, so the next draw agrees.
+			assert_eq!(IPVerifierChannel::<B128>::sample(&mut verifier_channel), challenge);
+		}
+		transcript.finalize().unwrap();
+
+		// A zero-bit grind writes no nonce and moves no challenger, so the two transcripts below
+		// are byte for byte the same and both sample the same challenge.
+		let write = |bits: Option<usize>| {
+			let mut channel = ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
+			if let Some(bits) = bits {
+				channel.grind(bits);
+			}
+			let challenge = IPProverChannel::<B128>::sample(&mut channel);
+			(ProverChannel::into_transcript(channel).finalize(), challenge)
+		};
+		assert_eq!(write(Some(0)), write(None));
+	}
+
+	#[test]
+	fn a_grind_checked_at_the_wrong_difficulty_is_rejected() {
+		// Invariant: the sampler reads four bytes whatever the difficulty, so a mismatch leaves
+		// both challengers in step and shows up only as work the prover never did.
+		//
+		// Fixture state: four bits are ground and twenty-four demanded, a gap wide enough that a
+		// nonce satisfying the larger demand by accident turns up once in a million.
+		let mut prover_channel =
+			ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
+		prover_channel.grind(4);
+
+		let mut transcript = ProverChannel::into_transcript(prover_channel).into_verifier();
+		let mut verifier_channel = VerifierChannel::new(&mut transcript);
+		let err = verifier_channel
+			.verify_grind(24)
+			.expect_err("four bits of work cannot satisfy a twenty-four bit demand");
+		let TranscriptError::InsufficientWork { bits, sampled } = err else {
+			panic!("expected unmet proof of work, got {err}")
+		};
+		assert_eq!(bits, 24);
+		assert_ne!(sampled, 0);
 	}
 
 	#[test]

--- a/crates/iop/src/channel/grinding.rs
+++ b/crates/iop/src/channel/grinding.rs
@@ -2,27 +2,25 @@
 
 //! Proof-of-work grinding, as a capability a verifier channel may carry.
 //!
-//! A grind is a nonce the prover searched for and the verifier checks.
-//! It taxes re-rolling whatever challenge comes next.
-//! That is the one lever that moves a proximity bound no query count can reach.
-//! [`crate::soundness::Grinding`] is where the bits it buys enter a security budget.
+//! A grind is a nonce the prover had to search for and the verifier re-checks cheaply.
+//! It taxes re-rolling the challenge that follows it, and that tax is the whole point.
+//! Grinding is the one lever that moves a proximity bound no number of queries can reach.
+//! [`Grinding`](crate::soundness::Grinding) turns it into bits a security budget can count.
 
 use binius_transcript::Error;
 
 /// A verifier channel that can check a proof of work its prover paid into the transcript.
 ///
-/// This sits apart from the traits a protocol reads messages through.
-/// Grinding is a property of the Fiat-Shamir state rather than of what is committed.
-/// So a protocol that grinds asks for this alongside its ordinary channel bound.
-/// A channel that cannot express a proof of work then cannot be handed to it at all.
+/// Grinding acts on the Fiat-Shamir state rather than on anything committed.
+/// So it is a trait of its own, asked for alongside the channel bound a protocol already needs.
+/// A channel with no way to express a proof of work is then rejected at the type level.
 ///
 /// # Contract
 ///
-/// A difficulty of zero is not a grind.
-/// It must leave both the proof tape and the challenger untouched.
-/// A protocol configured to grind nothing therefore writes the transcript an ungrinding one does.
-/// That rule lives here rather than at the call sites.
-/// Prover and verifier have to apply it in the same places, and neither can do so alone.
+/// A difficulty of zero is not a grind: it leaves the proof tape and the challenger untouched.
+/// So a protocol configured to grind nothing writes exactly the transcript it wrote before.
+/// That rule lives here rather than at the call sites, where the two sides could drift apart.
+/// A grind is sound only when prover and verifier apply it at the same point in the transcript.
 pub trait GrindingVerifierChannel {
 	/// Checks the proof of work of `bits` difficulty standing at this point in the transcript.
 	///
@@ -33,6 +31,6 @@ pub trait GrindingVerifierChannel {
 	///
 	/// ## Preconditions
 	///
-	/// * `bits` is at most [`binius_transcript::MAX_GRINDING_BITS`].
+	/// * `bits` is at most [`MAX_GRINDING_BITS`](binius_transcript::MAX_GRINDING_BITS).
 	fn verify_grind(&mut self, bits: usize) -> Result<(), Error>;
 }

--- a/crates/iop/src/channel/grinding.rs
+++ b/crates/iop/src/channel/grinding.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 The Binius Developers
+
+//! Proof-of-work grinding, as a capability a verifier channel may carry.
+//!
+//! A grind is a nonce the prover searched for and the verifier checks.
+//! It taxes re-rolling whatever challenge comes next.
+//! That is the one lever that moves a proximity bound no query count can reach.
+//! [`crate::soundness::Grinding`] is where the bits it buys enter a security budget.
+
+use binius_transcript::Error;
+
+/// A verifier channel that can check a proof of work its prover paid into the transcript.
+///
+/// This sits apart from the traits a protocol reads messages through.
+/// Grinding is a property of the Fiat-Shamir state rather than of what is committed.
+/// So a protocol that grinds asks for this alongside its ordinary channel bound.
+/// A channel that cannot express a proof of work then cannot be handed to it at all.
+///
+/// # Contract
+///
+/// A difficulty of zero is not a grind.
+/// It must leave both the proof tape and the challenger untouched.
+/// A protocol configured to grind nothing therefore writes the transcript an ungrinding one does.
+/// That rule lives here rather than at the call sites.
+/// Prover and verifier have to apply it in the same places, and neither can do so alone.
+pub trait GrindingVerifierChannel {
+	/// Checks the proof of work of `bits` difficulty standing at this point in the transcript.
+	///
+	/// ## Errors
+	///
+	/// Returns [`Error::InsufficientWork`] when the nonce the prover sent does not meet `bits`.
+	/// Returns a deserialization error when the proof carries no nonce here.
+	///
+	/// ## Preconditions
+	///
+	/// * `bits` is at most [`binius_transcript::MAX_GRINDING_BITS`].
+	fn verify_grind(&mut self, bits: usize) -> Result<(), Error>;
+}

--- a/crates/iop/src/channel/mod.rs
+++ b/crates/iop/src/channel/mod.rs
@@ -2,6 +2,7 @@
 
 //! Channel abstraction for interactive oracle protocol (IOP) verifiers.
 
+pub mod grinding;
 pub mod naive;
 pub mod oracle_setup;
 pub mod size_tracking;

--- a/crates/iop/src/channel/size_tracking.rs
+++ b/crates/iop/src/channel/size_tracking.rs
@@ -12,6 +12,7 @@ use binius_ip::channel::{
 use binius_utils::serialization::FixedSizeSerializeBytes;
 
 use crate::{
+	channel::grinding::GrindingVerifierChannel,
 	merkle_channel::{Error, MerkleIPVerifierChannel},
 	merkle_tree::MerkleTreeScheme,
 };
@@ -132,6 +133,18 @@ where
 	}
 }
 
+impl<F, MerkleScheme_> GrindingVerifierChannel for SizeTrackingChannel<'_, F, MerkleScheme_> {
+	fn verify_grind(&mut self, bits: usize) -> Result<(), binius_transcript::Error> {
+		// Zero difficulty is not a grind, so nothing reaches the tape and nothing is charged.
+		if bits == 0 {
+			return Ok(());
+		}
+		// A grind puts one `u64` nonce on the tape, whatever its difficulty.
+		self.proof_size += size_of::<u64>();
+		Ok(())
+	}
+}
+
 impl<F, MerkleScheme_> MerkleIPVerifierChannel<F> for SizeTrackingChannel<'_, F, MerkleScheme_>
 where
 	F: BinaryField + FixedSizeSerializeBytes,
@@ -174,5 +187,36 @@ where
 		let len = commitment.leaf_size << commitment.depth;
 		self.proof_size += len * F::BYTE_SIZE;
 		Ok(vec![F::ZERO; len])
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::Ghash128b as B128;
+	use binius_hash::StdHashSuite;
+
+	use super::*;
+	use crate::merkle_tree::BinaryMerkleTreeScheme;
+
+	#[test]
+	fn a_grind_is_charged_one_nonce_and_a_zero_bit_one_is_charged_nothing() {
+		// Invariant: this channel prices a protocol by running it, so what it charges for a grind
+		// has to be what the prover really writes. That is one `u64` nonce, whatever the
+		// difficulty, and nothing at all when the difficulty is zero.
+		//
+		// Fixture state: a channel over the shipped Merkle scheme, with nothing else received.
+		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+		let mut channel = SizeTrackingChannel::<B128, _>::new(&scheme);
+		assert_eq!(channel.proof_size(), 0);
+
+		channel
+			.verify_grind(0)
+			.expect("a zero-bit grind cannot fail");
+		assert_eq!(channel.proof_size(), 0);
+
+		for bits in [1, 8, 32] {
+			channel.verify_grind(bits).expect("nothing here can fail");
+		}
+		assert_eq!(channel.proof_size(), 3 * size_of::<u64>());
 	}
 }

--- a/crates/iop/src/ligerito/channel/verifier.rs
+++ b/crates/iop/src/ligerito/channel/verifier.rs
@@ -11,7 +11,9 @@ use binius_ip::{
 
 use super::{LigeritoOracle, relation::QueuedRelation};
 use crate::{
-	channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn},
+	channel::{
+		Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn, grinding::GrindingVerifierChannel,
+	},
 	ligerito::{LigeritoParams, LigeritoVerifier},
 	merkle_channel::MerkleIPVerifierChannel,
 };
@@ -101,7 +103,13 @@ where
 	/// Nothing happens when no relation was queued, since a commitment alone asserts nothing.
 	///
 	/// Returns the Merkle channel, so a caller can still reach what it accumulated.
-	pub fn finish(self) -> Result<Channel, Error> {
+	///
+	/// The channel has to be able to check a proof of work, because the ladder may pay one.
+	/// A configuration that grinds nothing still asks for the capability, and never uses it.
+	pub fn finish(self) -> Result<Channel, Error>
+	where
+		Channel: GrindingVerifierChannel,
+	{
 		let Self {
 			mut channel,
 			oracle_specs,
@@ -145,7 +153,10 @@ where
 		params: &LigeritoParams,
 		commitment: Channel::Commitment,
 		queue: Vec<QueuedRelation<Channel::Elem>>,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		Channel: GrindingVerifierChannel,
+	{
 		// Every claim in the queue is already bound to the transcript, so a coefficient drawn
 		// here cannot be anticipated by any of them.
 		let lambda = channel.sample();

--- a/crates/iop/src/ligerito/common.rs
+++ b/crates/iop/src/ligerito/common.rs
@@ -4,7 +4,10 @@ use binius_field::BinaryField;
 use getset::CopyGetters;
 
 use super::{size_estimation, verifier_cost, verifier_cost::VerifierCost};
-use crate::{merkle_tree::MerkleTreeScheme, soundness::SoundnessRegime};
+use crate::{
+	merkle_tree::MerkleTreeScheme,
+	soundness::{Grinding, SoundnessRegime},
+};
 
 /// One committed level of the Ligerito recursion.
 ///
@@ -31,6 +34,10 @@ pub struct LigeritoLevel {
 impl LigeritoLevel {
 	/// A level whose query count is derived from `regime` at this level's own rate.
 	///
+	/// Query grinding closes part of the target before a single row is opened.
+	/// So the rows only have to cover what is left of `security_bits`.
+	/// Challenge grinding buys nothing here, because it moves the term the query count cannot.
+	///
 	/// ## Preconditions
 	///
 	/// * Those of [`SoundnessRegime::n_queries`].
@@ -40,12 +47,14 @@ impl LigeritoLevel {
 		log_inv_rate: usize,
 		regime: SoundnessRegime,
 		security_bits: usize,
+		grinding: Grinding,
 	) -> Self {
+		let from_queries = security_bits.saturating_sub(grinding.query_bits());
 		Self {
 			log_msg_cols,
 			log_lanes,
 			log_inv_rate,
-			n_queries: regime.n_queries(security_bits, log_inv_rate),
+			n_queries: regime.n_queries(from_queries, log_inv_rate),
 		}
 	}
 
@@ -69,6 +78,24 @@ impl LigeritoLevel {
 	/// The ladder search declines to price such a shape.
 	pub const fn is_feasible(&self) -> bool {
 		self.n_queries <= pow2_saturating(self.log_codeword_len())
+	}
+
+	/// Proof-of-work nonces this level writes, at the given grinding depth.
+	///
+	/// One stands before each of the `log_lanes` fold challenges.
+	/// One more stands after the level's commitment goes out and before its queries are drawn.
+	/// A depth of zero is not a grind and writes nothing.
+	/// So an ungrinding ladder writes no nonces at all.
+	pub const fn n_grind_nonces(&self, grinding: Grinding) -> usize {
+		let challenge = match grinding.challenge_bits() {
+			0 => 0,
+			_ => self.log_lanes,
+		};
+		let query = match grinding.query_bits() {
+			0 => 0,
+			_ => 1,
+		};
+		challenge + query
 	}
 }
 
@@ -105,6 +132,9 @@ pub struct LigeritoParams {
 	/// The target query-phase soundness, in bits.
 	#[getset(get_copy = "pub")]
 	security_bits: usize,
+	/// The proof of work each level pays, split by the term each half buys back.
+	#[getset(get_copy = "pub")]
+	grinding: Grinding,
 }
 
 impl LigeritoParams {
@@ -161,7 +191,21 @@ impl LigeritoParams {
 			log_residual_dim,
 			regime,
 			security_bits,
+			grinding: Grinding::NONE,
 		}
+	}
+
+	/// The same ladder, with a proof of work paid at every level.
+	///
+	/// [`Self::new`] leaves this at [`Grinding::NONE`].
+	/// So a caller that says nothing writes the transcript an ungrinding protocol writes.
+	///
+	/// The query counts are not re-derived here.
+	/// Setting a query grind therefore leaves the rows opening more than the target needs.
+	/// [`Self::optimal_ladder`] is the one that sizes them against the grind.
+	pub const fn with_grinding(mut self, grinding: Grinding) -> Self {
+		self.grinding = grinding;
+		self
 	}
 
 	/// The committed levels, outermost first. Non-empty.
@@ -207,6 +251,9 @@ impl LigeritoParams {
 	/// No number of queries raises this.
 	/// See [`crate::soundness`] for why, and `PROXIMITY_GAPS.md` for where it falls in practice.
 	///
+	/// Proof of work is the one thing that does raise it, and it is not counted here.
+	/// [`Self::achieved_security_bits`] adds it, on the side it belongs to.
+	///
 	/// A level folding `2^log_lanes` interleaved lanes applies the underlying bound once per
 	/// lane-fold round, so it pays a row union that the single-step bound does not carry.
 	/// The two reference implementations disagree on the size of that union, charging a factor
@@ -230,14 +277,25 @@ impl LigeritoParams {
 	/// The security this ladder reaches over a field of that size, counting both terms.
 	///
 	/// This is the worse of [`Self::correlated_agreement_bits`] and the query-phase soundness.
+	/// Each of the two is credited with the half of [`Self::grinding`] that buys it.
 	/// It can fall below [`Self::security_bits`], which is the *target* the queries were sized to.
+	///
+	/// A level grinds before every fold challenge.
+	/// So every level's algebraic term gains the same [`Grinding::challenge_bits`].
+	/// A level grinds once more before its queries are drawn.
+	/// That is where [`Grinding::query_bits`] lands.
 	pub fn achieved_security_bits(&self, log_field_size: usize) -> f64 {
+		let algebra =
+			self.correlated_agreement_bits(log_field_size) + self.grinding.challenge_bits() as f64;
+		// The same grind stands before every level's queries, so crediting it to the worst level
+		// is crediting it to all of them.
 		let queries = self
 			.levels
 			.iter()
 			.map(|level| level.n_queries as f64 * self.regime.bits_per_query(level.log_inv_rate))
-			.fold(f64::INFINITY, f64::min);
-		self.correlated_agreement_bits(log_field_size).min(queries)
+			.fold(f64::INFINITY, f64::min)
+			+ self.grinding.query_bits() as f64;
+		algebra.min(queries)
 	}
 
 	/// The exact byte-size of a Ligerito proof at these parameters, without running the prover.
@@ -289,9 +347,14 @@ impl LigeritoParams {
 	/// `None` means no ladder reaches `security_bits`, for either of two reasons.
 	/// A level must have at least as many codeword positions as it opens queries, which rules out
 	/// small `log_n`.
-	/// And a level's correlated-agreement term must itself clear the target, which rules out large
-	/// `log_n` over a field this size.
+	/// And a level's algebraic term must itself clear the target, `grinding` included.
+	/// That rules out large `log_n` over a field this size.
 	/// See [`crate::soundness`] for why the second one cannot be bought back with more queries.
+	///
+	/// `grinding` is paid by the search rather than assumed away.
+	/// Its challenge half raises the ceiling a level has to clear to be priced at all.
+	/// Its query half shrinks the row count every level opens.
+	/// Both halves cost nonce bytes, which the returned size counts.
 	///
 	/// ## Panics
 	///
@@ -302,6 +365,7 @@ impl LigeritoParams {
 		l0_log_inv_rate: usize,
 		regime: SoundnessRegime,
 		security_bits: usize,
+		grinding: Grinding,
 	) -> Option<(Self, usize)>
 	where
 		F: BinaryField,
@@ -313,6 +377,7 @@ impl LigeritoParams {
 			l0_log_inv_rate,
 			regime,
 			security_bits,
+			grinding,
 		)
 	}
 }
@@ -328,15 +393,17 @@ const fn pow2_saturating(log: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+	use binius_transcript::MAX_GRINDING_BITS;
+
 	use super::*;
 
 	// A three-level ladder that satisfies every invariant, used as the base for the rejection
 	// tests below. Message 2^12, lanes 3/2/1, rates 1/2 -> 1/4 -> 1/8, residual 2^6.
 	fn valid_levels() -> Vec<LigeritoLevel> {
 		vec![
-			LigeritoLevel::new(9, 3, 1, SoundnessRegime::UniqueDecoding, 100),
-			LigeritoLevel::new(7, 2, 2, SoundnessRegime::UniqueDecoding, 100),
-			LigeritoLevel::new(6, 1, 3, SoundnessRegime::UniqueDecoding, 100),
+			LigeritoLevel::new(9, 3, 1, SoundnessRegime::UniqueDecoding, 100, Grinding::NONE),
+			LigeritoLevel::new(7, 2, 2, SoundnessRegime::UniqueDecoding, 100, Grinding::NONE),
+			LigeritoLevel::new(6, 1, 3, SoundnessRegime::UniqueDecoding, 100, Grinding::NONE),
 		]
 	}
 
@@ -399,11 +466,106 @@ mod tests {
 		//     level 0: 2^4 columns at rate 1/2  -> 2^5 positions
 		//     level 1: 2^4 columns at rate 1/4  -> 2^6 positions
 		let flat = vec![
-			LigeritoLevel::new(4, 0, 1, SoundnessRegime::UniqueDecoding, 8),
-			LigeritoLevel::new(4, 0, 2, SoundnessRegime::UniqueDecoding, 8),
+			LigeritoLevel::new(4, 0, 1, SoundnessRegime::UniqueDecoding, 8, Grinding::NONE),
+			LigeritoLevel::new(4, 0, 2, SoundnessRegime::UniqueDecoding, 8, Grinding::NONE),
 		];
 		let params = LigeritoParams::new(flat, SoundnessRegime::UniqueDecoding, 8);
 		assert_eq!(params.max_log_codeword_len(), 6);
+	}
+
+	#[test]
+	fn a_ladder_grinds_nothing_unless_it_is_asked_to() {
+		// Invariant: the default has to be no proof of work at all, since a grinding transcript
+		// and an ungrinding one are different protocols and only the caller knows which it wants.
+		//
+		// Fixture state: the three-level ladder above, built the ordinary way.
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100);
+		assert_eq!(params.grinding(), Grinding::NONE);
+		for level in params.levels() {
+			assert_eq!(level.n_grind_nonces(Grinding::NONE), 0);
+		}
+	}
+
+	#[test]
+	fn the_nonce_count_follows_the_two_call_sites() {
+		// Invariant: a level grinds once before each of its fold challenges and once more before
+		// its queries are drawn. So the two halves of a grind are told apart by count as well as
+		// by position, everywhere but a level folding a single lane.
+		//
+		// Fixture state: level 0 of the ladder above, which folds three lanes.
+		let level = valid_levels()[0];
+		assert_eq!(level.log_lanes, 3);
+		assert_eq!(level.n_grind_nonces(Grinding::new(4, 0)), 3);
+		assert_eq!(level.n_grind_nonces(Grinding::new(0, 4)), 1);
+		assert_eq!(level.n_grind_nonces(Grinding::new(4, 4)), 4);
+
+		// A level that folds nothing has no fold challenge to stand before, so a challenge grind
+		// writes nothing there while a query grind still writes its one nonce.
+		let flat = LigeritoLevel {
+			log_lanes: 0,
+			..level
+		};
+		assert_eq!(flat.n_grind_nonces(Grinding::new(4, 0)), 0);
+		assert_eq!(flat.n_grind_nonces(Grinding::new(0, 4)), 1);
+	}
+
+	#[test]
+	fn the_two_grinds_are_credited_to_the_terms_they_buy() {
+		// Invariant: charging one grind where the other belongs would report security nothing
+		// produces. So the ladder credits the challenge half to the algebraic term and the query
+		// half to the row term, and never the other way round.
+		//
+		// Fixture state: the ladder above at 100 bits over B128. Its message is small, so the
+		// ceiling sits well above the target and the row term is the binding one. A query grind
+		// therefore shows in the total and a challenge grind does not.
+		let levels = valid_levels();
+		let bare = LigeritoParams::new(levels, SoundnessRegime::UniqueDecoding, 100);
+		let ceiling = bare.correlated_agreement_bits(128);
+		let base = bare.achieved_security_bits(128);
+		assert!(base < ceiling, "base={base} ceiling={ceiling}");
+
+		// The ceiling itself never moves: it describes the code and the field, not the transcript.
+		let query_ground = bare.clone().with_grinding(Grinding::new(0, 7));
+		assert!((query_ground.correlated_agreement_bits(128) - ceiling).abs() < 1e-9);
+
+		// What moves is the total, by exactly the bits ground, since the row term binds.
+		let ground_bits = query_ground.achieved_security_bits(128);
+		assert!((ground_bits - base - 7.0).abs() < 1e-9, "{ground_bits} {base}");
+		assert!(ground_bits < ceiling, "the row term still binds after the grind");
+
+		// The same depth on the other side buys nothing here, because it lands on the term that
+		// was already the slacker of the two.
+		let challenge_ground = bare.with_grinding(Grinding::new(7, 0));
+		assert!((challenge_ground.achieved_security_bits(128) - base).abs() < 1e-9);
+	}
+
+	#[test]
+	fn the_largest_grind_the_transcript_can_express_is_a_usable_ladder() {
+		// Invariant: `Grinding::new` refuses a difficulty past what the transcript can sample, so
+		// nothing downstream has to re-check the bound. What is left to pin is that the largest
+		// one it does accept still describes a coherent ladder.
+		//
+		// Fixture state: the ladder above, ground as hard as the transcript allows.
+		let grinding = Grinding::new(MAX_GRINDING_BITS, MAX_GRINDING_BITS);
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100)
+			.with_grinding(grinding);
+		assert_eq!(params.grinding().challenge_bits(), MAX_GRINDING_BITS);
+		assert_eq!(params.grinding().query_bits(), MAX_GRINDING_BITS);
+		for level in params.levels() {
+			assert_eq!(level.n_grind_nonces(grinding), level.log_lanes + 1);
+		}
+
+		// A query grind deeper than the target leaves the rows nothing to cover. That is a
+		// misconfigured budget rather than a protocol, and it saturates rather than wrapping.
+		let level = LigeritoLevel::new(
+			9,
+			3,
+			1,
+			SoundnessRegime::UniqueDecoding,
+			MAX_GRINDING_BITS - 1,
+			grinding,
+		);
+		assert_eq!(level.n_queries, 0);
 	}
 
 	#[test]

--- a/crates/iop/src/ligerito/compiler.rs
+++ b/crates/iop/src/ligerito/compiler.rs
@@ -15,7 +15,7 @@ use crate::{
 	channel::OracleSpec,
 	merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
 	merkle_tree::MerkleTreeScheme,
-	soundness::SoundnessRegime,
+	soundness::{Grinding, SoundnessRegime},
 };
 
 /// A compiler that creates Ligerito verifier channels from a precomputed ladder.
@@ -77,6 +77,10 @@ where
 	///
 	/// `None` means no ladder over this message reaches the security target.
 	///
+	/// `grinding` is what the ladder will pay per level.
+	/// The search prices it rather than assuming it away.
+	/// Pass [`Grinding::NONE`] for a transcript with no proof of work in it.
+	///
 	/// ## Preconditions
 	///
 	/// * `oracle_specs` holds exactly one spec.
@@ -88,6 +92,7 @@ where
 		l0_log_inv_rate: usize,
 		regime: SoundnessRegime,
 		security_bits: usize,
+		grinding: Grinding,
 	) -> Option<Self>
 	where
 		MerkleScheme: MerkleTreeScheme<F>,
@@ -106,6 +111,7 @@ where
 			l0_log_inv_rate,
 			regime,
 			security_bits,
+			grinding,
 		)?;
 
 		Some(Self::new(oracle_specs, params))
@@ -218,6 +224,7 @@ mod tests {
 			1,
 			SoundnessRegime::UniqueDecoding,
 			96,
+			Grinding::NONE,
 		)
 		.expect("a 2^20 message at rate 1/2 admits a ladder at 96 bits");
 
@@ -239,6 +246,7 @@ mod tests {
 			1,
 			SoundnessRegime::UniqueDecoding,
 			96,
+			Grinding::NONE,
 		);
 		assert!(compiler.is_none());
 	}

--- a/crates/iop/src/ligerito/error.rs
+++ b/crates/iop/src/ligerito/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
 	/// A committed value did not match what the transcript bound it to.
 	#[error("verification: {0}")]
 	Verification(#[from] VerificationError),
+	/// The prover did not pay the proof of work the parameters fix, or sent no nonce at all.
+	#[error("proof of work: {0}")]
+	ProofOfWork(#[from] binius_transcript::Error),
 }
 
 /// A prover message that was well-formed but wrong.

--- a/crates/iop/src/ligerito/opening.rs
+++ b/crates/iop/src/ligerito/opening.rs
@@ -44,25 +44,25 @@
 //!
 //! # Where the proof of work stands
 //!
-//! [`super::LigeritoParams::grinding`] fixes two difficulties, and each has one place it belongs.
+//! [`LigeritoParams::grinding`](super::LigeritoParams::grinding) fixes two difficulties.
+//! Each of them has exactly one place in the transcript where it belongs.
 //!
 //! ```text
 //!     level i:  round message -> GRIND challenge_bits -> fold challenge     (log_lanes times)
 //!               next commitment -> GRIND query_bits -> query positions
 //! ```
 //!
-//! The fold challenge is the one the correlated-agreement term is about.
-//! Everything a prover could vary to re-roll it is this round's coefficients, already sent.
-//! So a grind standing here is the whole cost of asking for another challenge.
+//! The fold challenge is the one the correlated-agreement term bounds.
+//! By the time it is drawn, the only thing a prover could still vary is this round's coefficients.
+//! Those are already sent, so a grind there is the entire cost of asking for a second challenge.
 //!
 //! The query positions are drawn once the level's commitment is fixed.
-//! A grind standing there taxes re-rolling the positions.
-//! That is what lets a target be reached with fewer rows opened.
+//! A grind before them taxes re-rolling the positions rather than the challenge.
+//! That is what lets a security target be reached with fewer rows opened.
 //!
-//! The two are not interchangeable.
-//! The first raises a ceiling no query count touches.
+//! The two are not interchangeable, and [`Grinding`](crate::soundness::Grinding) keeps them apart.
+//! The first raises a ceiling that no number of queries can touch.
 //! The second only shortens the query phase.
-//! [`crate::soundness::Grinding`] charges them separately for that reason.
 //!
 //! # Why only level 0 gets the MLE-check shortcut
 //!

--- a/crates/iop/src/ligerito/opening.rs
+++ b/crates/iop/src/ligerito/opening.rs
@@ -42,6 +42,28 @@
 //! A prover therefore has to fix what it folded to without knowing which rows will be checked
 //! against it, which is the entire soundness argument for a cleartext residual.
 //!
+//! # Where the proof of work stands
+//!
+//! [`super::LigeritoParams::grinding`] fixes two difficulties, and each has one place it belongs.
+//!
+//! ```text
+//!     level i:  round message -> GRIND challenge_bits -> fold challenge     (log_lanes times)
+//!               next commitment -> GRIND query_bits -> query positions
+//! ```
+//!
+//! The fold challenge is the one the correlated-agreement term is about.
+//! Everything a prover could vary to re-roll it is this round's coefficients, already sent.
+//! So a grind standing here is the whole cost of asking for another challenge.
+//!
+//! The query positions are drawn once the level's commitment is fixed.
+//! A grind standing there taxes re-rolling the positions.
+//! That is what lets a target be reached with fewer rows opened.
+//!
+//! The two are not interchangeable.
+//! The first raises a ceiling no query count touches.
+//! The second only shortens the query phase.
+//! [`crate::soundness::Grinding`] charges them separately for that reason.
+//!
 //! # Why only level 0 gets the MLE-check shortcut
 //!
 //! An MLE-check is a sumcheck whose weight is known to be an equality indicator, which lets the
@@ -69,6 +91,7 @@ use binius_math::{
 
 use super::{InducedBasis, LigeritoParams, error::Error};
 use crate::{
+	channel::grinding::GrindingVerifierChannel,
 	fri::batch::{BrakedownOracle, ProxTestOracle},
 	merkle_channel::MerkleIPVerifierChannel,
 };
@@ -114,6 +137,9 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 	/// Both are asserted through the channel rather than compared, so a channel that builds a
 	/// circuit records them as constraints.
 	///
+	/// The proof of work the parameters fix is checked at the two points named above.
+	/// A difficulty of zero costs the transcript nothing.
+	///
 	/// ## Preconditions
 	///
 	/// * `eval_point` has `params.log_msg_len()` coordinates, in low-to-high variable order.
@@ -125,10 +151,11 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 	) -> Result<(), Error>
 	where
 		F: BinaryField,
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C> + GrindingVerifierChannel,
 		Channel::Elem: From<F>,
 	{
 		let levels = self.params.levels();
+		let grinding = self.params.grinding();
 		assert_eq!(
 			eval_point.len(),
 			self.params.log_msg_len(),
@@ -160,6 +187,9 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 					sumcheck::RoundProof(RoundCoeffs(channel.recv_many(PRODUCT_DEGREE)?))
 						.recover(sum)
 				};
+				// The round message is out, so this is the last moment before the challenge it
+				// decides. A prover asking for another one redoes the search from here.
+				channel.verify_grind(grinding.challenge_bits())?;
 				let challenge = channel.sample();
 				sum = coeffs.evaluate(&challenge);
 				// The MLE-check divides its round's equality factor out; a plain round does not.
@@ -185,6 +215,10 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 			for (_, basis) in &mut glued {
 				*basis = basis.fold_high(&challenges);
 			}
+
+			// The commitment above is fixed, and no position exists yet. A prover that dislikes
+			// the positions it is about to see pays for the next draw here.
+			channel.verify_grind(grinding.query_bits())?;
 
 			let indices = (0..level.n_queries)
 				.map(|_| channel.sample_bits(level.log_codeword_len()))

--- a/crates/iop/src/ligerito/size_estimation.rs
+++ b/crates/iop/src/ligerito/size_estimation.rs
@@ -8,7 +8,10 @@ use super::{
 	common::{LigeritoLevel, LigeritoParams},
 	opening,
 };
-use crate::{merkle_tree::MerkleTreeScheme, soundness::SoundnessRegime};
+use crate::{
+	merkle_tree::MerkleTreeScheme,
+	soundness::{Grinding, SoundnessRegime},
+};
 
 /// The largest `log_lanes` the ladder search considers.
 ///
@@ -81,6 +84,7 @@ const fn round_degree(level_index: usize) -> usize {
 ///     rows        n_queries * 2^log_lanes field elements
 ///     branches    one Merkle multi-proof over 2^(log_msg_cols + log_inv_rate) leaves
 ///     sumcheck    round_degree(level_index) field elements per fold round, log_lanes of them
+///     nonces      one u64 per proof of work, which `LigeritoLevel::n_grind_nonces` counts
 /// ```
 ///
 /// The index is carried only for that last line; see [`round_degree`] for why it matters.
@@ -96,6 +100,7 @@ fn level_size<F, VCS>(
 	level_index: usize,
 	vcs: &VCS,
 	sizes: &ByteSizes,
+	grinding: Grinding,
 ) -> usize
 where
 	F: BinaryField,
@@ -107,8 +112,9 @@ where
 
 	let rows_size = level.n_queries * (1 << level.log_lanes) * sizes.value;
 	let sumcheck_size = round_degree(level_index) * level.log_lanes * sizes.value;
+	let grinding_size = level.n_grind_nonces(grinding) * size_of::<u64>();
 
-	sizes.digest + rows_size + merkle_size + sumcheck_size
+	sizes.digest + rows_size + merkle_size + sumcheck_size + grinding_size
 }
 
 /// Computes the exact byte-size of a Ligerito proof without running the prover.
@@ -119,6 +125,7 @@ where
 /// - **Decommitment channel**: per level, the opened rows and one Merkle multi-proof.
 /// - **Sumcheck transcript**: [`round_degree`] elements per fold round, which level 0 discounts.
 /// - **Residual**: its commitment, then `2^log_residual_dim` elements in the clear.
+/// - **Proof of work**: one `u64` nonce per grind, at the depths the parameters fix.
 ///
 /// Exact is meant literally.
 /// `the_estimate_equals_the_proof_the_prover_writes` proves real openings and compares this.
@@ -133,7 +140,7 @@ where
 		.levels()
 		.iter()
 		.enumerate()
-		.map(|(level_index, level)| level_size(level, level_index, vcs, &sizes))
+		.map(|(level_index, level)| level_size(level, level_index, vcs, &sizes, params.grinding()))
 		.sum::<usize>();
 	levels_size + residual_size(params.log_residual_dim(), &sizes)
 }
@@ -172,6 +179,8 @@ struct Search<'a, F, MerkleScheme> {
 	regime: SoundnessRegime,
 	/// The target every level must reach, in bits.
 	security_bits: usize,
+	/// The proof of work every level pays, which both terms of the target are credited with.
+	grinding: Grinding,
 	/// Ties `F` to the Merkle scheme without storing a value of it.
 	_field: PhantomData<F>,
 }
@@ -186,6 +195,7 @@ where
 	/// Two independent ways to fail, and neither is fixable by opening more rows.
 	/// A level cannot sample more distinct positions than its codeword has.
 	/// And its correlated-agreement term is a ceiling set by the codeword length and the field.
+	/// Proof of work raises that ceiling, which is why the challenge grind is credited here.
 	fn reaches_target(&self, level: &LigeritoLevel) -> bool {
 		let base = self.regime.correlated_agreement_bits(
 			level.log_msg_len(),
@@ -194,7 +204,11 @@ where
 		);
 		// Same row union `LigeritoParams::correlated_agreement_bits` charges, so the search and
 		// the reported ceiling cannot disagree about which levels clear the target.
-		let algebra = base - (level.log_lanes.saturating_sub(1)) as f64;
+		//
+		// The challenge grind is added on the same side `LigeritoParams::achieved_security_bits`
+		// adds it, so a level priced here is a level that really reaches the target.
+		let algebra = base - (level.log_lanes.saturating_sub(1)) as f64
+			+ self.grinding.challenge_bits() as f64;
 		level.is_feasible() && algebra >= self.security_bits as f64
 	}
 
@@ -237,7 +251,8 @@ where
 				if !self.reaches_target(&level) {
 					continue;
 				}
-				let here = level_size(&level, level_index, self.merkle_scheme, &self.sizes);
+				let here =
+					level_size(&level, level_index, self.merkle_scheme, &self.sizes, self.grinding);
 
 				// Terminate: fold this level and send the remaining columns in the clear.
 				consider(Decision {
@@ -272,6 +287,11 @@ where
 ///
 /// Returns the parameters together with the estimated proof size in bytes.
 /// That size is exactly [`LigeritoParams::proof_size`] of the returned parameters.
+///
+/// `grinding` enters on both sides.
+/// Its challenge half raises the ceiling a level must clear.
+/// Its query half shrinks every level's row count.
+/// Both halves add nonce bytes.
 ///
 /// ## The search
 ///
@@ -320,6 +340,7 @@ pub(super) fn optimal_ladder<F, MerkleScheme>(
 	l0_log_inv_rate: usize,
 	regime: SoundnessRegime,
 	security_bits: usize,
+	grinding: Grinding,
 ) -> Option<(LigeritoParams, usize)>
 where
 	F: BinaryField,
@@ -333,17 +354,22 @@ where
 
 	// Query counts depend only on the rate, so derive them once. Index 0 is unused: rate 1 is
 	// not a proximity test at all.
+	//
+	// The query grind closes part of the target before a row is opened, so the rows cover only
+	// what is left of it.
+	let from_queries = security_bits.saturating_sub(grinding.query_bits());
 	let search = Search::<F, MerkleScheme> {
 		merkle_scheme,
 		sizes: ByteSizes::new::<F, MerkleScheme>(),
 		n_queries: (0..=MAX_LOG_INV_RATE)
 			.map(|log_inv_rate| match log_inv_rate {
 				0 => 0,
-				_ => regime.n_queries(security_bits, log_inv_rate),
+				_ => regime.n_queries(from_queries, log_inv_rate),
 			})
 			.collect(),
 		regime,
 		security_bits,
+		grinding,
 		_field: PhantomData,
 	};
 
@@ -383,7 +409,8 @@ where
 			.expect("a recursing decision was scored against a solved subproblem");
 	}
 
-	Some((LigeritoParams::new(levels, regime, security_bits), estimated_size))
+	let params = LigeritoParams::new(levels, regime, security_bits).with_grinding(grinding);
+	Some((params, estimated_size))
 }
 
 #[cfg(test)]
@@ -425,37 +452,155 @@ mod tests {
 			assert!(level.log_lanes >= 1);
 			assert!(level.log_lanes <= MAX_LOG_LANES);
 			assert!(level.log_inv_rate <= MAX_LOG_INV_RATE);
+			// Query grinding closes part of the target before a row is opened, so the rows only
+			// cover what is left of it.
+			let from_queries = params
+				.security_bits()
+				.saturating_sub(params.grinding().query_bits());
 			assert_eq!(
 				level.n_queries,
-				params
-					.regime()
-					.n_queries(params.security_bits(), level.log_inv_rate)
+				params.regime().n_queries(from_queries, level.log_inv_rate)
 			);
 		}
 		assert_eq!(params.log_residual_dim(), levels.last().expect("non-empty").log_msg_cols);
 	}
 
+	/// The lossy regime both reference Ligerito implementations ship a conjecture-free profile in.
+	/// Priced here over this repo's own field.
+	fn lossy_regime(log_n: usize) -> SoundnessRegime {
+		let (regime, _) = SoundnessRegime::optimal_unique_decoding(120, log_n, 1, 128)
+			.expect("120 bits is reachable with a constant loss");
+		regime
+	}
+
+	#[test]
+	fn a_ladder_that_grinds_reaches_a_target_the_algebra_alone_cannot() {
+		// Invariant: the correlated-agreement term is a ceiling no query count raises, and over
+		// B128 it falls short of 128 bits. Proof of work is the only lever that moves it, so a
+		// 128-bit ladder exists exactly when enough of it is paid.
+		//
+		// Fixture state: a 2^24 message at L0 rate 1/2, in the lossy unique-decoding regime whose
+		// ceiling is a flat 124.5 bits at every size.
+		let merkle_scheme = test_merkle_scheme();
+		let regime = lossy_regime(24);
+		let ladder = |grinding| {
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, regime, 128, grinding)
+		};
+
+		// A level also pays the fold row union, so the ceiling a real ladder has to clear sits
+		// below the flat 124.5 and the first grind that buys anything is larger than the 3.5 bits
+		// the bare ceiling is short by.
+		for challenge_bits in 0..8 {
+			assert!(ladder(Grinding::new(challenge_bits, 0)).is_none(), "{challenge_bits}");
+		}
+
+		let grinding = Grinding::new(11, 0);
+		let (params, size) = ladder(grinding).expect("eleven bits of work reach 128");
+		assert_invariants(&params);
+		assert_eq!(params.grinding(), grinding);
+		// The bits the ladder reports are the bits its transcript pays for, and they clear the
+		// target rather than merely approaching it.
+		assert!(params.achieved_security_bits(128) >= 128.0);
+		assert_eq!(size, params.proof_size(&merkle_scheme));
+	}
+
+	#[test]
+	fn the_two_halves_of_the_grind_buy_different_parts_of_the_proof() {
+		// Invariant: the two grinds are not interchangeable, and the search shows why. Challenge
+		// bits raise the ceiling, which lets a level fold more lanes before the row union eats its
+		// headroom. Query bits close part of the target outright, which lets every level open
+		// fewer rows. Neither does the other's work.
+		//
+		// Fixture state: the same 2^24 message at 128 bits in the lossy regime.
+		let merkle_scheme = test_merkle_scheme();
+		let regime = lossy_regime(24);
+		let ladder = |grinding| {
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, regime, 128, grinding)
+				.expect("the profiles below all reach 128 bits")
+				.0
+		};
+
+		// More challenge bits, wider lanes, and a smaller proof at every step.
+		let widening = (8..=11)
+			.map(|challenge_bits| ladder(Grinding::new(challenge_bits, 0)))
+			.collect::<Vec<_>>();
+		for pair in widening.windows(2) {
+			assert!(pair[1].levels()[0].log_lanes >= pair[0].levels()[0].log_lanes);
+			assert!(pair[1].proof_size(&merkle_scheme) < pair[0].proof_size(&merkle_scheme));
+		}
+		// And the row count never moves, because the query phase was never the binding term.
+		let rows = widening[0].levels()[0].n_queries;
+		for params in &widening {
+			assert_eq!(params.levels()[0].n_queries, rows);
+		}
+
+		// Query bits do the opposite: the same shape, fewer rows, a smaller proof.
+		let bare = ladder(Grinding::new(11, 0));
+		// Seventeen bits is what one reference implementation grinds before drawing positions.
+		let ground = ladder(Grinding::new(11, 17));
+		assert_eq!(ground.n_levels(), bare.n_levels());
+		assert_eq!(ground.levels()[0].log_lanes, bare.levels()[0].log_lanes);
+		assert_eq!(bare.levels()[0].n_queries, 312);
+		assert_eq!(ground.levels()[0].n_queries, 270);
+		assert!(ground.proof_size(&merkle_scheme) < bare.proof_size(&merkle_scheme));
+		assert!(ground.achieved_security_bits(128) >= 128.0);
+	}
+
+	#[test]
+	fn grinding_a_term_that_does_not_bind_costs_bytes_and_buys_nothing() {
+		// Invariant: proof of work is not free, and it only pays on the term that binds. At the
+		// shipped target over B128 the query phase is the binding one, so challenge grinding buys
+		// no bits at all and still writes a nonce per fold round. That is why `Grinding::NONE` is
+		// the default rather than a small positive number.
+		//
+		// Fixture state: the shipped 96-bit target, unique decoding, a 2^24 message at rate 1/2.
+		let merkle_scheme = test_merkle_scheme();
+		let ladder = |grinding| {
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, UDR, 96, grinding)
+				.expect("96 bits is reachable over a 2^24 message")
+				.0
+		};
+
+		let (bare, ground) = (ladder(Grinding::NONE), ladder(Grinding::new(4, 0)));
+		assert_eq!(bare.levels(), ground.levels());
+		// One nonce per fold round, and nothing else changed.
+		let nonces = ground.n_fold_rounds() * size_of::<u64>();
+		assert_eq!(ground.proof_size(&merkle_scheme), bare.proof_size(&merkle_scheme) + nonces);
+		// And the reported security does not move, because the algebraic term was already the
+		// slacker of the two.
+		let (bare_bits, ground_bits) =
+			(bare.achieved_security_bits(128), ground.achieved_security_bits(128));
+		assert!((bare_bits - ground_bits).abs() < 1e-9, "{bare_bits} {ground_bits}");
+		assert!(bare_bits >= 96.0);
+	}
+
 	#[test]
 	fn ladder_is_valid_and_its_estimate_is_exact() {
 		let merkle_scheme = test_merkle_scheme();
-		for regime in [SoundnessRegime::UniqueDecoding, JOHNSON] {
-			for log_n in [12, 17, 20, 24, 28, 30] {
-				for l0_log_inv_rate in [1, 2, 4] {
-					let Some((params, estimate)) = LigeritoParams::optimal_ladder::<B128, _>(
-						&merkle_scheme,
-						log_n,
-						l0_log_inv_rate,
-						regime,
-						SECURITY_BITS,
-					) else {
-						continue;
-					};
-					assert_invariants(&params);
-					// Level 0's rate is the caller's to pin, and the message is fully covered.
-					assert_eq!(params.levels()[0].log_inv_rate, l0_log_inv_rate);
-					assert_eq!(params.log_msg_len(), log_n);
-					// The search's own objective is the byte count, not an approximation of it.
-					assert_eq!(estimate, params.proof_size(&merkle_scheme));
+		// The grinding profiles are swept alongside the shapes, since a ladder that grinds writes
+		// nonces the estimate has to count.
+		for grinding in [Grinding::NONE, Grinding::new(0, 17), Grinding::new(4, 0)] {
+			for regime in [SoundnessRegime::UniqueDecoding, JOHNSON] {
+				for log_n in [12, 17, 20, 24, 28, 30] {
+					for l0_log_inv_rate in [1, 2, 4] {
+						let Some((params, estimate)) = LigeritoParams::optimal_ladder::<B128, _>(
+							&merkle_scheme,
+							log_n,
+							l0_log_inv_rate,
+							regime,
+							SECURITY_BITS,
+							grinding,
+						) else {
+							continue;
+						};
+						assert_invariants(&params);
+						// Level 0's rate is the caller's, and the message is fully covered.
+						assert_eq!(params.levels()[0].log_inv_rate, l0_log_inv_rate);
+						assert_eq!(params.log_msg_len(), log_n);
+						assert_eq!(params.grinding(), grinding);
+						// The search's own objective is the byte count, not an approximation.
+						assert_eq!(estimate, params.proof_size(&merkle_scheme));
+					}
 				}
 			}
 		}
@@ -483,6 +628,7 @@ mod tests {
 				1,
 				UDR,
 				SECURITY_BITS,
+				Grinding::NONE,
 			)
 			.expect("pinned shapes are feasible");
 			assert_eq!(size, bytes, "log_n={log_n}");
@@ -502,6 +648,7 @@ mod tests {
 				1,
 				JOHNSON,
 				SECURITY_BITS,
+				Grinding::NONE,
 			);
 			assert!(ladder.is_none(), "log_n={log_n}");
 		}
@@ -532,6 +679,7 @@ mod tests {
 							l0_log_inv_rate,
 							regime,
 							SECURITY_BITS,
+							Grinding::NONE,
 						)
 						.expect("feasible")
 						.1
@@ -557,6 +705,7 @@ mod tests {
 					MAX_LOG_INV_RATE,
 					regime,
 					SECURITY_BITS,
+					Grinding::NONE,
 				) else {
 					continue;
 				};
@@ -570,7 +719,7 @@ mod tests {
 	fn single_level_ladder_prices_the_residual_in_the_clear() {
 		let merkle_scheme = test_merkle_scheme();
 		// One level, 2^9 columns by 2^3 lanes, rate 1/2, residual 2^9 elements in the clear.
-		let level = LigeritoLevel::new(9, 3, 1, UDR, SECURITY_BITS);
+		let level = LigeritoLevel::new(9, 3, 1, UDR, SECURITY_BITS, Grinding::NONE);
 		let params = LigeritoParams::new(vec![level], UDR, SECURITY_BITS);
 		assert_eq!(params.log_residual_dim(), 9);
 
@@ -598,10 +747,13 @@ mod tests {
 		let value_size = size_of::<B128>();
 
 		// The same shape, once as the only level and once as the second of two.
-		let deep = LigeritoLevel::new(10, 3, 2, UDR, SECURITY_BITS);
+		let deep = LigeritoLevel::new(10, 3, 2, UDR, SECURITY_BITS, Grinding::NONE);
 		let alone = LigeritoParams::new(vec![deep], UDR, SECURITY_BITS);
 		let below = LigeritoParams::new(
-			vec![LigeritoLevel::new(13, 3, 1, UDR, SECURITY_BITS), deep],
+			vec![
+				LigeritoLevel::new(13, 3, 1, UDR, SECURITY_BITS, Grinding::NONE),
+				deep,
+			],
 			UDR,
 			SECURITY_BITS,
 		);
@@ -609,7 +761,14 @@ mod tests {
 		// Level 0 of the two-level ladder, priced on its own, plus the extra element per fold
 		// round the deeper copy pays.
 		let level_zero = LigeritoParams::new(
-			vec![LigeritoLevel::new(13, 3, 1, UDR, SECURITY_BITS)],
+			vec![LigeritoLevel::new(
+				13,
+				3,
+				1,
+				UDR,
+				SECURITY_BITS,
+				Grinding::NONE,
+			)],
 			UDR,
 			SECURITY_BITS,
 		);
@@ -629,9 +788,15 @@ mod tests {
 		let merkle_scheme = test_merkle_scheme();
 		// At 96 bits and rate 1/2 the unique-decoding regime opens 232 queries, so a level needs
 		// 2^8 codeword positions. With one lane folded away that puts the floor at log_n = 8.
-		let (params, size) =
-			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 8, 1, UDR, SECURITY_BITS)
-				.expect("log_n = 8 is the smallest feasible shape");
+		let (params, size) = LigeritoParams::optimal_ladder::<B128, _>(
+			&merkle_scheme,
+			8,
+			1,
+			UDR,
+			SECURITY_BITS,
+			Grinding::NONE,
+		)
+		.expect("log_n = 8 is the smallest feasible shape");
 		assert_invariants(&params);
 		// The search stops at one level, not because a second is infeasible but because it costs
 		// more: the 2^7-element residual is cheaper than another root, rows, and multi-proof.
@@ -650,6 +815,7 @@ mod tests {
 			1,
 			UDR,
 			SECURITY_BITS,
+			Grinding::NONE,
 		);
 		assert!(ladder.is_none());
 	}
@@ -661,8 +827,15 @@ mod tests {
 		// Over B128 the ceiling falls one bit per doubling, so a target picks out a largest shape.
 		// At 96 bits and L0 rate 1/2 nothing past log_n = 32 has a ladder at all.
 		let ladder = |log_n, target| {
-			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, log_n, 1, UDR, target)
-				.is_some()
+			LigeritoParams::optimal_ladder::<B128, _>(
+				&merkle_scheme,
+				log_n,
+				1,
+				UDR,
+				target,
+				Grinding::NONE,
+			)
+			.is_some()
 		};
 		assert!(ladder(32, 96));
 		assert!(!ladder(33, 96));
@@ -671,12 +844,24 @@ mod tests {
 		// only levels that still clear the target fold one lane at a time, so the search is forced
 		// into a huge cleartext residual rather than a ladder. Pinning that keeps a caller from
 		// reading the returned size as a usable configuration.
-		let (_, degenerate) =
-			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 32, 1, UDR, SECURITY_BITS)
-				.expect("log_n = 32 still has a ladder, of a sort");
-		let (_, sane) =
-			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 30, 1, UDR, SECURITY_BITS)
-				.expect("log_n = 30 has a real ladder");
+		let (_, degenerate) = LigeritoParams::optimal_ladder::<B128, _>(
+			&merkle_scheme,
+			32,
+			1,
+			UDR,
+			SECURITY_BITS,
+			Grinding::NONE,
+		)
+		.expect("log_n = 32 still has a ladder, of a sort");
+		let (_, sane) = LigeritoParams::optimal_ladder::<B128, _>(
+			&merkle_scheme,
+			30,
+			1,
+			UDR,
+			SECURITY_BITS,
+			Grinding::NONE,
+		)
+		.expect("log_n = 30 has a real ladder");
 		assert!(degenerate > 100 * sane, "degenerate={degenerate} sane={sane}");
 
 		// Raising the target lowers that boundary, which is the whole point of tracking the term.
@@ -733,7 +918,8 @@ mod tests {
 		// Checking it here keeps an infeasible cell a printed row rather than a panic.
 		let ladder_feasible = |log_n: usize, l0: usize, regime: SoundnessRegime| {
 			(1..=MAX_LOG_LANES.min(log_n)).any(|lanes| {
-				LigeritoLevel::new(log_n - lanes, lanes, l0, regime, 100).is_feasible()
+				LigeritoLevel::new(log_n - lanes, lanes, l0, regime, 100, Grinding::NONE)
+					.is_feasible()
 			})
 		};
 
@@ -755,6 +941,7 @@ mod tests {
 							1,
 							regime,
 							SECURITY_BITS,
+							Grinding::NONE,
 						)
 					})
 					.flatten()
@@ -818,7 +1005,7 @@ mod tests {
 				l0_log_inv_rate,
 				regime,
 				security_bits,
-			) else {
+				Grinding::NONE,) else {
 				// Infeasible shapes are a documented outcome, not a failure to search.
 				return Ok(());
 			};

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -22,7 +22,10 @@ use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
 
-use crate::merkle_tree::{BinaryMerkleTreeScheme, Commitment, MerkleTreeScheme};
+use crate::{
+	channel::grinding::GrindingVerifierChannel,
+	merkle_tree::{BinaryMerkleTreeScheme, Commitment, MerkleTreeScheme},
+};
 
 /// An extension of [`WordIPVerifierChannel`] that can receive and open Merkle commitments.
 ///
@@ -172,6 +175,22 @@ where
 
 	fn pack_words(&mut self, words: &[Word]) -> Vec<F> {
 		WordIPVerifierChannel::<F>::pack_words(self.transcript.borrow_mut(), words)
+	}
+}
+
+impl<T, Challenger_, F, H: HashSuite> GrindingVerifierChannel
+	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	T: BorrowMut<VerifierTranscript<Challenger_>>,
+	Challenger_: Challenger,
+{
+	fn verify_grind(&mut self, bits: usize) -> Result<(), binius_transcript::Error> {
+		// Zero difficulty is not a grind, so the tape holds no nonce to read here.
+		if bits == 0 {
+			return Ok(());
+		}
+		self.transcript.borrow_mut().verify_grind(bits)?;
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
Linear: [BINIUS-539](https://linear.app/jimpo/issue/BINIUS-539/make-the-ligerito-ladder-pay-the-proof-of-work-it-is-credited-for)

## The problem

#2301 landed a proof of work and the accounting that prices it. Nothing called either.

`ProverTranscript::grind` and `VerifierTranscript::verify_grind` exist. `soundness::Grinding` splits the work into `challenge_bits` and `query_bits` and adds each to the term it buys. But no protocol ground anything, so the credit was theoretical: you could hand a `Grinding` to `achieved_security_bits` and get back a number no transcript pays for.

That matters most for Ligerito. Over `B128` at rate 1/2 the correlated-agreement ceiling is a flat 124.5 bits at every witness size, so 128 bits is out of reach on the algebra alone. Proof of work is the only cheap lever that moves it, and both reference implementations pull it — `flock` grinds 16 bits, `leanVM-b` 17.

## Where the grinds go

```text
level i:  round message   -> GRIND challenge_bits -> fold challenge     (log_lanes times)
          next commitment -> GRIND query_bits     -> query positions
```

**Before each fold challenge.** The fold challenge is the one the correlated-agreement term is about. Everything a prover could vary to re-roll it — this round's coefficients — has already gone out, so a grind standing here is the whole cost of asking for another challenge. Without it, a prover that dislikes level `i + 1`'s challenge re-rolls it for free by adjusting the round polynomial it just sent.

**After the commitment, before the queries.** The commitment is fixed and no position exists yet. Grinding here taxes re-rolling the positions, which is what lets a target be reached with fewer rows opened.

The two are not interchangeable. The first raises a ceiling no query count touches; the second only shortens the query phase. A grind checked at the wrong site would be checked against the other site's work and pass, which is what the adversarial tests below are for.

The batching challenges `alpha` and `beta` are deliberately left alone. Both are drawn after the query positions, and nothing the prover can vary sits between the position draw and them — the opened rows go out as unobserved decommitment advice. So the query grind already prices any attempt to re-roll them.

## The change

**A capability trait per side.** `GrindingVerifierChannel::verify_grind` in `binius-iop`, `GrindingProverChannel::grind` in `binius-iop-prover`. Grinding is a property of the Fiat-Shamir state rather than of what is committed, so it sits apart from the Merkle channel traits and a protocol asks for it as an extra bound on `verify` / `prove` / `finish`. That also keeps the prover impl's `Challenger: Clone` requirement — `grind` trials on a cloned challenger — from widening the existing traits.

The traits carry one contract: **a difficulty of zero is not a grind.** It touches neither tape nor challenger, so a ladder at `Grinding::NONE` writes byte for byte the transcript it wrote before this PR. `ProverTranscript::grind(0)` does write an eight-byte nonce, so the rule has to live somewhere — it lives in the channel rather than at the call sites, because prover and verifier have to apply it in the same places and neither can do so alone.

**Grinding reaches the protocol through the parameters.** `LigeritoParams` carries a `Grinding` alongside its `SoundnessRegime` and security target, defaulting to `Grinding::NONE` and set with `with_grinding`.

**The reported security and the transcript are made to agree.** `achieved_security_bits` credits `challenge_bits` to the algebraic term and `query_bits` to the row term. `optimal_ladder` now reads the grind rather than assuming it away: the challenge half raises the ceiling a level must clear to be priced at all, the query half shrinks every level's row count, and both halves add the nonce bytes `proof_size` counts.

## What a realistic configuration buys

By `soundness.rs`'s own accounting, on a 2^24 message at L0 rate 1/2 over `B128` in the lossy unique-decoding regime — the conjecture-free profile both reference implementations ship:

| target | grind | ladder | L0 queries | proof | achieved |
|---|---|---|---|---|---|
| 120 | none | 8 levels, 1 lane each | 292 | 1.79 MB | 120.02 |
| 120 | 3 challenge bits | 4 levels, 3 lanes | 292 | 427 KB | 120.03 |
| 128 | none | — | — | unreachable | — |
| 128 | 11 challenge bits | 4 levels, 3 lanes | 312 | 452 KB | 128.03 |
| 128 | 11 challenge + 17 query | 4 levels, 3 lanes | 270 | 398 KB | 128.02 |

Two things to read off. First, 128 bits is not reachable at any grind below 8 bits and needs 11 for a usable shape, rather than the 3.5 the bare ceiling is short by — a level also pays the fold row union, `log_lanes - 1` bits, so grinding buys *lanes* as well as headroom. That is why 3 bits cuts the 120-bit proof by 4.2x: it lets the ladder fold 3 lanes at a level instead of 1. Second, query grinding is a straight trade of prover time for rows: 17 bits (leanVM-b's number) is 42 fewer L0 queries and an 11.8% smaller proof at the same 128 bits.

At the shipped 96-bit target grinding buys nothing at all — the query phase is the binding term there — and still costs a nonce per fold round. `Grinding::NONE` is the default for that reason.

## Tests

Honest-path, in `iop-prover/src/ligerito/opening.rs` and `channel/prover.rs`:
- an honest opening verifies at `NONE`, `(0, 4)`, `(4, 0)` and `(3, 5)`, over three ladder shapes, both through `LigeritoProver` directly and through the compiler-built channel;
- a ground proof is longer than a bare one by exactly one `u64` per grind, and `proof_size` predicts it — the existing byte-exactness tests then run over three grinding profiles;
- through the channel, a zero-bit grind produces a byte-identical transcript to no grinding at all.

Adversarial:
- **`a_proof_ground_at_one_difficulty_is_rejected_at_another`** — 4 bits ground, 24 demanded. The sampler reads four bytes whatever the difficulty, so both challengers stay in step and the failure is exactly `InsufficientWork { bits: 24 }`. The reverse (work the verifier never reads) desynchronizes the tape and breaks at the residual's commitment.
- **`a_challenge_grind_is_not_accepted_as_a_query_grind`** — this is the one that catches a misplaced call site. Two ladders, `(18, 2)` and `(2, 18)`, over a one-level one-lane shape: both write one nonce before the fold challenge and one before the queries, same width, so the transcripts are laid out byte for byte alike and stay in step to the end. Nothing but the *position* separates them. A grind checked at the wrong site would be checked against the other site's work and pass; instead both directions fail with `InsufficientWork { bits: 18 }`.

Accounting, in `ligerito/common.rs` and `ligerito/size_estimation.rs`: the nonce count follows the two call sites; each grind is credited to the term it buys and to no other; no ladder reaches 128 bits below 8 challenge bits; challenge bits buy lanes while query bits buy rows, and neither does the other's work; the largest difficulty the transcript can express is still a coherent ladder.

## Not here

FRI and BaseFold. They have the same two call sites available and the same accounting to draw on, but each needs its own pass over where the grinds sit relative to commitment and query sampling.

Circuit-side grinding. `binius-recursion`'s channels do not implement the new traits, because nothing there opens a Ligerito ladder yet. A recursive Ligerito verifier will need `verify_grind` as a subcircuit: read the nonce as a wire, absorb it, assert the sampled bits are zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
