### PR TITLE
BINIUS-540: Batch several committed oracles into one Ligerito ladder

### DIFF
--- a/crates/iop-prover/src/ligerito/channel/combined_message.rs
+++ b/crates/iop-prover/src/ligerito/channel/combined_message.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 The Binius Developers
+
+//! The single message a batched ladder folds, assembled from the committed ones.
+
+use binius_compute::Allocator;
+use binius_field::{Field, PackedField};
+use binius_math::{FieldBuffer, FieldSlice, FieldVec};
+use binius_utils::rayon::{
+	prelude::*,
+	task_size::{IndexedParallelIteratorExt, WorkPerItem},
+};
+
+/// The single level-0 message a batched Ligerito opening folds.
+///
+/// Each committed message enters scaled by its batching coefficient.
+/// A message shorter than the longest one is zero-extended over the coordinates it lacks.
+///
+/// ```text
+///     PI = sum_i e_i * pi_i,   pi_i zero-extended to the longest message's variables
+/// ```
+///
+/// This is the message the ladder's level 0 folds.
+/// Its encoding is the same combination of the committed codewords.
+/// That is what lets one query position serve every one of them.
+pub(super) struct CombinedMessage<P: PackedField, A: Allocator> {
+	/// The running sum, one entry per variable assignment of the longest message.
+	buffer: FieldVec<P, A>,
+}
+
+impl<P: PackedField, A: Allocator> CombinedMessage<P, A> {
+	/// An empty combination over `log_len` variables, which every message is added into.
+	pub(super) fn zeros_in(alloc: &A, log_len: usize) -> Self {
+		Self {
+			buffer: FieldBuffer::zeros_in(alloc, log_len),
+		}
+	}
+
+	/// Adds one committed message, scaled by its batching coefficient.
+	///
+	/// The message lands on the low entries and the rest keep whatever they already hold.
+	/// That is what zero-extending a shorter multilinear means.
+	///
+	/// ## Preconditions
+	///
+	/// * `message` is no longer than the combination.
+	pub(super) fn add_scaled(&mut self, message: FieldSlice<'_, P>, coefficient: P::Scalar) {
+		assert!(
+			message.log_len() <= self.buffer.log_len(),
+			"precondition: a message of 2^{} entries exceeds the combination's 2^{}",
+			message.log_len(),
+			self.buffer.log_len()
+		);
+
+		let scale = P::broadcast(coefficient);
+		if message.log_len() >= P::LOG_WIDTH {
+			// Whole packed elements line up, so the scaled add is a prefix of the destination.
+			let n_packed = 1usize << (message.log_len() - P::LOG_WIDTH);
+			self.buffer.as_mut()[..n_packed]
+				.par_iter_mut()
+				.zip(message.as_ref())
+				.with_min_task(WorkPerItem::FieldMuls)
+				.for_each(|(entry, addend)| *entry += scale * *addend);
+		} else {
+			// The message is narrower than one packed element, so only its low lanes are live and
+			// the rest of that element must contribute nothing.
+			let live = 1usize << message.log_len();
+			let lanes = P::WIDTH.min(1usize << self.buffer.log_len());
+			let padded = P::from_scalars((0..lanes).map(|lane| {
+				if lane < live {
+					message.get(lane)
+				} else {
+					P::Scalar::ZERO
+				}
+			}));
+			self.buffer.as_mut()[0] += scale * padded;
+		}
+	}
+
+	/// The assembled message, ready for the ladder to fold.
+	pub(super) fn into_buffer(self) -> FieldVec<P, A> {
+		self.buffer
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_compute::GlobalAllocator;
+	use binius_field::{
+		Field, Ghash128b as B128, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
+		PackedBinaryGhash4x128b, Random,
+	};
+	use binius_math::test_utils::random_field_buffer;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	/// The definition the packed path is checked against, one scalar at a time.
+	fn add_scaled_by_scalars<P: PackedField>(
+		dst: &mut FieldBuffer<P>,
+		src: &FieldBuffer<P>,
+		coefficient: P::Scalar,
+	) {
+		for index in 0..1usize << src.log_len() {
+			dst.set(index, dst.get(index) + coefficient * src.get(index));
+		}
+	}
+
+	/// Every message shape must land exactly where the scalar definition puts it.
+	fn check_all_shapes<P: PackedField<Scalar = B128>>() {
+		let mut rng = StdRng::seed_from_u64(0);
+		for log_len in 0..=4 {
+			for log_msg in 0..=log_len {
+				// Fixture state: one combination over 2^log_len entries, two messages added in.
+				let first = random_field_buffer::<P>(&mut rng, log_msg);
+				let second = random_field_buffer::<P>(&mut rng, log_len);
+				let coefficients = [B128::random(&mut rng), B128::random(&mut rng)];
+
+				let mut expected = FieldBuffer::<P>::zeros(log_len);
+				add_scaled_by_scalars(&mut expected, &first, coefficients[0]);
+				add_scaled_by_scalars(&mut expected, &second, coefficients[1]);
+
+				let mut combined = CombinedMessage::zeros_in(&GlobalAllocator, log_len);
+				combined.add_scaled(first.as_view(), coefficients[0]);
+				combined.add_scaled(second.as_view(), coefficients[1]);
+				let actual = combined.into_buffer();
+
+				for index in 0..1usize << log_len {
+					assert_eq!(
+						actual.get(index),
+						expected.get(index),
+						"P::LOG_WIDTH={}, log_msg={log_msg}, log_len={log_len}, index={index}",
+						P::LOG_WIDTH,
+					);
+				}
+			}
+		}
+	}
+
+	// Packed widths from one scalar per element up to four, so the sub-element path is exercised
+	// against a reference that never packs.
+	#[test]
+	fn a_combination_matches_the_scalar_definition_at_every_width() {
+		check_all_shapes::<PackedBinaryGhash1x128b>();
+		check_all_shapes::<PackedBinaryGhash2x128b>();
+		check_all_shapes::<PackedBinaryGhash4x128b>();
+	}
+
+	#[test]
+	#[should_panic(expected = "exceeds the combination's")]
+	fn a_message_longer_than_the_combination_is_refused() {
+		// The combination spans 2^3 entries and the message claims 2^4, so it has nowhere to land.
+		let message = random_field_buffer::<B128>(&mut StdRng::seed_from_u64(0), 4);
+		let mut combined = CombinedMessage::zeros_in(&GlobalAllocator, 3);
+		combined.add_scaled(message.as_view(), B128::ONE);
+	}
+}

--- a/crates/iop-prover/src/ligerito/channel/mod.rs
+++ b/crates/iop-prover/src/ligerito/channel/mod.rs
@@ -2,17 +2,21 @@
 
 //! Ligerito implementation of the IOP prover channel.
 //!
-//! One file per concern: the oracle handle here, the queued relation beside it, and the channel
-//! that turns a queue of relations into one ladder opening.
+//! One file per concern.
+//! The oracle handle is here, and the pieces the channel assembles sit beside it.
 
+mod combined_message;
 mod prover;
 mod relation;
 
 pub use prover::LigeritoProverChannel;
 
-/// A handle to the oracle a Ligerito channel opens.
+/// A handle to one of the oracles a Ligerito channel opens.
 ///
 /// The inner field is private, so the only way to hold one is to have sent the commitment.
-/// A ladder opens exactly one committed message, so the handle carries nothing else.
+/// It names the position the commitment was sent in, which is the position its relations queue at.
 #[derive(Debug, Clone, Copy)]
-pub struct LigeritoOracle(());
+pub struct LigeritoOracle {
+	/// The order this oracle's commitment was sent in.
+	index: usize,
+}

--- a/crates/iop-prover/src/ligerito/channel/prover.rs
+++ b/crates/iop-prover/src/ligerito/channel/prover.rs
@@ -8,20 +8,29 @@ use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, ligerito::LigeritoParams};
 use binius_ip_prover::{
 	channel::{IPProverChannel, WordIPProverChannel},
-	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
+	sumcheck::{
+		self, PaddedSumcheckDecorator, batch::BatchSumcheckOutput,
+		bivariate_product_evaluator::BivariateProductEvaluator, mle_store::MleStore,
+		round_evaluator::SharedSumcheckProver,
+	},
 };
-use binius_math::{FieldBuffer, FieldSlice, FieldVec, ntt::AdditiveNTT};
+use binius_math::{
+	FieldBuffer, FieldSlice, FieldVec, multilinear::hypercube::Hypercube, ntt::AdditiveNTT,
+};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
+use itertools::izip;
 
-use super::{LigeritoOracle, relation::QueuedRelation};
+use super::{LigeritoOracle, combined_message::CombinedMessage, relation::QueuedRelation};
 use crate::{
 	channel::{IOPProverChannel, grinding::GrindingProverChannel},
-	ligerito::LigeritoProver,
+	fri::{BatchBrakedownOracleProver, BrakedownOracleProver},
+	ligerito::{LigeritoProver, opening::commit_level},
 	merkle_channel::MerkleIPProverChannel,
 };
 
-/// A prover channel that opens its one committed oracle with a Ligerito ladder.
+/// A prover channel that opens every committed oracle with one Ligerito ladder.
 ///
-/// The counterpart of the Ligerito verifier channel, where the two reductions are described.
+/// The counterpart of the Ligerito verifier channel, where the three reductions are described.
 ///
 /// The channel is transparent rather than zero-knowledge.
 /// No mask is drawn, so it needs no randomness of its own.
@@ -49,14 +58,16 @@ where
 	ntt: &'a NTT,
 	/// The ladder the opening runs down.
 	params: &'a LigeritoParams,
-	/// The one oracle this channel expects, held as a vector so the trait can hand it back.
+	/// The oracles this channel expects, in the order it will commit them.
 	oracle_specs: Vec<OracleSpec>,
-	/// Level 0's committed codeword and the handle that opens it, absent until the oracle is sent.
-	prover: Option<LigeritoProver<'a, P, Channel::Commitment, NTT>>,
-	/// The committed message, handed over when the caller finalizes the oracle.
-	message: Option<FieldVec<P, A>>,
-	/// Relations queued against the oracle, all opened together once the caller finishes.
-	queue: Vec<QueuedRelation<P, A>>,
+	/// The committed level-0 codewords, in the order their commitments were sent.
+	oracles: Vec<BrakedownOracleProver<P, Channel::Commitment>>,
+	/// The committed messages, each handed over when the caller finalizes its oracle.
+	/// One entry per committed oracle, absent until that oracle is finalized.
+	messages: Vec<Option<FieldVec<P, A>>>,
+	/// Relations queued against each oracle, all opened together once the caller finishes.
+	/// One entry per committed oracle, so its length is also the number committed so far.
+	queue: Vec<Vec<QueuedRelation<P, A>>>,
 	/// The allocator the opening's working buffers are drawn from.
 	alloc: A,
 }
@@ -69,13 +80,13 @@ where
 	Channel: MerkleIPProverChannel<F, Word = Word>,
 	A: Allocator,
 {
-	/// Creates a channel that opens one oracle with the given ladder.
+	/// Creates a channel that opens the given oracles with the given ladder.
 	///
 	/// ## Preconditions
 	///
-	/// * `oracle_specs` holds exactly one spec.
-	/// * That spec is not zero-knowledge.
-	/// * Its message length is the ladder's message length.
+	/// * `oracle_specs` is non-empty.
+	/// * No spec is zero-knowledge.
+	/// * The longest message is the ladder's message length.
 	/// * `ntt`'s domain covers every level's codeword domain.
 	pub fn new(
 		channel: Channel,
@@ -84,20 +95,22 @@ where
 		params: &'a LigeritoParams,
 		alloc: A,
 	) -> Self {
-		assert_eq!(
-			oracle_specs.len(),
-			1,
-			"precondition: a Ligerito channel opens exactly one oracle, got {}",
-			oracle_specs.len()
+		assert!(
+			!oracle_specs.is_empty(),
+			"precondition: a Ligerito channel opens at least one oracle"
 		);
 		assert!(
-			!oracle_specs[0].is_zk,
+			oracle_specs.iter().all(|spec| !spec.is_zk),
 			"precondition: Ligerito commits no mask, so a zero-knowledge oracle cannot be opened"
 		);
 		assert_eq!(
-			oracle_specs[0].log_msg_len,
+			oracle_specs
+				.iter()
+				.map(|spec| spec.log_msg_len)
+				.max()
+				.expect("oracle_specs is non-empty"),
 			params.log_msg_len(),
-			"precondition: the oracle's message length must be the ladder's message length"
+			"precondition: the longest oracle's message length must be the ladder's message length"
 		);
 
 		Self {
@@ -105,8 +118,8 @@ where
 			ntt,
 			params,
 			oracle_specs,
-			prover: None,
-			message: None,
+			oracles: Vec::new(),
+			messages: Vec::new(),
 			queue: Vec::new(),
 			alloc,
 		}
@@ -115,104 +128,139 @@ where
 	/// Consumes the channel and proves every queued relation in one opening.
 	///
 	/// Mirrors the verifier's own finishing step, message for message.
-	/// Nothing happens when no relation was queued, since the commitment alone asserts nothing.
+	/// Nothing happens when no relation was queued, since commitments alone assert nothing.
 	///
 	/// The channel has to be able to pay a proof of work, because the ladder may ask for one.
 	/// A configuration that grinds nothing still asks for the capability, and never uses it.
+	///
+	/// ## Preconditions
+	///
+	/// * Either every oracle carries a relation, or none of them does.
+	/// * Every oracle carrying a relation was finalized.
 	pub fn finish(self)
 	where
 		Channel: GrindingProverChannel,
 	{
 		let Self {
 			mut channel,
-			ntt: _,
-			params: _,
+			ntt,
+			params,
 			oracle_specs,
-			prover,
-			message,
+			oracles,
+			messages,
 			queue,
 			alloc,
 		} = self;
 
-		// The oracle is committed at most once, so what remains is one spec or none.
-		let n_remaining = oracle_specs.len() - usize::from(prover.is_some());
+		// Every oracle is committed at most once, so what remains is whatever was not.
+		let n_remaining = oracle_specs.len() - oracles.len();
 		assert!(n_remaining == 0, "finish called but {n_remaining} oracle specs remaining");
 
-		if queue.is_empty() {
+		if queue.iter().all(Vec::is_empty) {
 			return;
 		}
+		assert!(
+			queue.iter().all(|relations| !relations.is_empty()),
+			"precondition: every committed oracle must carry at least one relation"
+		);
 
-		let prover = prover.expect("a relation can only be queued against a committed oracle");
-		let message = message.expect("the oracle was committed but never finalized");
-		Self::prove(&mut channel, &prover, message.as_view(), queue, &alloc);
+		let messages = messages
+			.into_iter()
+			.map(|message| message.expect("the oracle was committed but never finalized"))
+			.collect::<Vec<_>>();
+		let prover = LigeritoProver::new(params, ntt, BatchBrakedownOracleProver::new(oracles));
+
+		Self::prove(&mut channel, &prover, &oracle_specs, &messages, queue, &alloc);
 	}
 
 	/// Proves the queued relations against the committed ladder.
 	///
-	/// The two reductions the verifier runs, in the same order.
+	/// The three reductions the verifier runs, in the same order.
 	///
 	/// ```text
-	///     <pi, t> = s          the relations, batched into one
-	///       -> sumcheck        binds every variable at a sampled point r
-	///     pi(r) = alpha        the evaluation claim the ladder takes
+	///     <pi_i, t_ij> = s_ij      the relations, batched per oracle into <pi_i, T_i> = S_i
+	///       -> sumcheck            binds every variable at a sampled point r
+	///     pi_i(r) = alpha_i        one evaluation claim per oracle
+	///       -> eq-combine          at coefficients e_i drawn once every alpha is on the wire
+	///     PI(r) = sum_i e_i alpha_i
 	///       -> ladder
 	/// ```
 	///
-	/// The sumcheck leaves both multilinears evaluated at `r`.
-	/// Only the committed one has to be sent, since the verifier builds the transparent itself.
+	/// The sumcheck leaves both multilinears of every oracle evaluated at `r`.
+	/// Only the committed ones have to be sent, since the verifier builds the transparents itself.
 	fn prove(
 		channel: &mut Channel,
 		prover: &LigeritoProver<'_, P, Channel::Commitment, NTT>,
-		message: FieldSlice<'_, P>,
-		queue: Vec<QueuedRelation<P, A>>,
+		oracle_specs: &[OracleSpec],
+		messages: &[FieldVec<P, A>],
+		queue: Vec<Vec<QueuedRelation<P, A>>>,
 		alloc: &A,
 	) where
 		Channel: GrindingProverChannel,
 	{
+		let n_oracles = messages.len();
+		let max_n_vars = prover.params().log_msg_len();
+
 		// Every claim in the queue is already bound to the transcript, so a coefficient drawn
 		// here cannot be anticipated by any of them.
 		let lambda = channel.sample();
-		let QueuedRelation { transparent, claim } = QueuedRelation::batch(queue, lambda);
 
-		// The sumcheck consumes both of its multilinears, and the ladder still needs the message.
-		// So it runs over a copy.
-		let sumcheck_prover = bivariate_product_prover(
-			alloc,
-			[
-				FieldBuffer::from_view_in(alloc, message.as_view()),
-				transparent,
-			],
-			claim,
-		);
-		let ProveSingleOutput {
-			multilinear_evals,
+		// One padded sumcheck prover per oracle, in the order the oracles were committed. A
+		// message shorter than the longest one rides the same rounds, its claim carried through
+		// the extra ones by the equality indicator at zero.
+		let provers = izip!(queue, messages, oracle_specs)
+			.map(|(relations, message, spec)| {
+				let QueuedRelation { transparent, claim } =
+					QueuedRelation::batch(relations, lambda);
+				let n_vars = spec.log_msg_len;
+
+				let mut store = MleStore::new(n_vars, alloc);
+				let message_col = store.push(message.as_view());
+				let transparent_col = store.push_owned(transparent);
+				let inner = SharedSumcheckProver::new(
+					store,
+					[(claim, BivariateProductEvaluator::new([message_col, transparent_col]))],
+				);
+				PaddedSumcheckDecorator::new(inner, max_n_vars - n_vars, vec![claim])
+			})
+			.collect::<Vec<_>>();
+
+		let BatchSumcheckOutput {
 			mut challenges,
-		} = prove_single(sumcheck_prover, channel);
+			multilinear_evals,
+		} = sumcheck::batch_prove(provers, channel);
 
-		// The store holds the message first, so its evaluation is the one the ladder opens.
-		let alpha = multilinear_evals[0];
-		channel.send_one(alpha);
+		// The store holds each message first, so its evaluation is the one the ladder opens.
+		let alphas = multilinear_evals
+			.iter()
+			.map(|evals| evals[0])
+			.collect::<Vec<_>>();
+		channel.send_many(&alphas);
 
 		// Sumcheck rounds bind the highest variable first, so reversing gives variable order.
 		challenges.reverse();
+		let point = challenges;
 
-		prover.prove(message, &challenges, alpha, alloc, channel);
+		// Every stated evaluation is now bound to the transcript, so the coefficients that combine
+		// the messages into one cannot be anticipated either.
+		let outer_challenges = channel.sample_many(log2_ceil_usize(n_oracles));
+		let coefficients = Hypercube::One.expand(&outer_challenges).build_scalars();
+
+		let mut combined = CombinedMessage::zeros_in(alloc, max_n_vars);
+		let mut combined_claim = F::ZERO;
+		for (message, spec, coefficient, alpha) in
+			izip!(messages, oracle_specs, &coefficients, &alphas)
+		{
+			combined.add_scaled(message.as_view(), *coefficient);
+			combined_claim +=
+				*coefficient * *alpha * Hypercube::One.eq_ind_zero(&point[spec.log_msg_len..]);
+		}
+
+		let combined = combined.into_buffer();
+		prover.prove(combined.as_view(), &point, combined_claim, alloc, channel);
 	}
 }
 
-/// Proves the queued relations against the committed ladder.
-///
-/// The two reductions the verifier runs, in the same order.
-///
-/// ```text
-///     <pi, t> = s          the relations, batched into one
-///       -> sumcheck        binds every variable at a sampled point r
-///     pi(r) = alpha        the evaluation claim the ladder takes
-///       -> ladder
-/// ```
-///
-/// The sumcheck leaves both multilinears evaluated at `r`.
-/// Only the committed one has to be sent, since the verifier builds the transparent itself.
 impl<F, P, NTT, Channel, A> IPProverChannel<F> for LigeritoProverChannel<'_, F, P, NTT, Channel, A>
 where
 	F: BinaryField,
@@ -278,7 +326,7 @@ where
 	type Oracle = LigeritoOracle;
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
-		&self.oracle_specs[usize::from(self.prover.is_some())..]
+		&self.oracle_specs[self.oracles.len()..]
 	}
 
 	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
@@ -292,29 +340,52 @@ where
 			buffer.log_len()
 		);
 
+		// Every oracle shares level 0's column count, so only the lane count follows the message
+		// length. A message below one column block commits a single zero-padded lane.
+		let level = self.params.level_zero_shape(buffer.log_len());
+		// Only a message below one column block needs padding, so a longer one is never copied.
+		let padded = (buffer.log_len() < level.log_msg_len()).then(|| {
+			FieldBuffer::from_view_in(&self.alloc, buffer)
+				.zero_extend_in(&self.alloc, level.log_msg_len())
+		});
+		let message = padded
+			.as_ref()
+			.map_or_else(|| buffer.as_view(), FieldBuffer::as_view);
+
 		// Encoding and committing level 0 is the whole of the commit phase.
 		// The deeper levels only exist once the folds above them have run.
-		self.prover =
-			Some(LigeritoProver::commit(self.params, self.ntt, buffer, &mut self.channel));
+		let index = self.oracles.len();
+		self.oracles
+			.push(commit_level(&level, self.ntt, message, &mut self.channel));
+		self.messages.push(None);
+		self.queue.push(Vec::new());
 
-		LigeritoOracle(())
+		LigeritoOracle { index }
 	}
 
 	fn prove_oracle_relation(
 		&mut self,
-		_oracle: Self::Oracle,
+		oracle: Self::Oracle,
 		transparent: FieldVec<P, A>,
 		claim: P::Scalar,
 	) {
-		// A handle can only exist once the oracle was committed, and there is one oracle.
-		// So the handle names no index to look up.
-		self.queue.push(QueuedRelation { transparent, claim });
+		// A handle can only exist once its oracle was committed, so the slot is already there.
+		let n_committed = self.queue.len();
+		self.queue
+			.get_mut(oracle.index)
+			.unwrap_or_else(|| {
+				panic!("oracle index {} out of bounds, expected < {n_committed}", oracle.index)
+			})
+			.push(QueuedRelation { transparent, claim });
 	}
 
-	fn finalize_oracle(&mut self, _oracle: Self::Oracle, buffer: FieldVec<P, A>) {
+	fn finalize_oracle(&mut self, oracle: Self::Oracle, buffer: FieldVec<P, A>) {
 		// The ladder folds the message down to the residual.
 		// So it needs the buffer itself and not just the codeword it was encoded into.
-		assert!(self.message.replace(buffer).is_none(), "the oracle was finalized twice");
+		assert!(
+			self.messages[oracle.index].replace(buffer).is_none(),
+			"the oracle was finalized twice"
+		);
 	}
 }
 
@@ -341,6 +412,48 @@ mod tests {
 
 	type StdChallenger = HasherChallenger<StdDigest>;
 
+	/// One oracle a run commits, opens, and states relations about.
+	///
+	/// Splitting the committed message from the opened one is how a dishonest prover is expressed.
+	/// Every value it sends in the clear is consistent with the opened buffer.
+	/// The codeword level 0's queries land in encodes the committed one.
+	/// An honest oracle holds the same buffer twice.
+	struct Oracle {
+		/// The buffer level 0's codeword encodes.
+		committed: FieldBuffer<B128>,
+		/// The buffer every value sent in the clear is consistent with.
+		opened: FieldBuffer<B128>,
+		/// The transparent multilinears, each with the inner product claimed against it.
+		relations: Vec<(FieldBuffer<B128>, B128)>,
+	}
+
+	impl Oracle {
+		/// An honest oracle over `log_msg_len` variables, carrying `n_relations` true claims.
+		///
+		/// A dense random weight rather than an equality indicator.
+		/// So each relation is a general inner product, not the evaluation claim the ladder takes.
+		fn honest(rng: &mut StdRng, log_msg_len: usize, n_relations: usize) -> Self {
+			let message = random_field_buffer::<B128>(&mut *rng, log_msg_len);
+			let relations = (0..n_relations)
+				.map(|_| {
+					let transparent = random_field_buffer::<B128>(&mut *rng, log_msg_len);
+					let claim = message.inner_product(&transparent);
+					(transparent, claim)
+				})
+				.collect();
+			Self {
+				committed: message.clone(),
+				opened: message,
+				relations,
+			}
+		}
+
+		/// The oracle's shape, as the channel is told about it up front.
+		fn spec(&self) -> OracleSpec {
+			OracleSpec::new(self.opened.log_len())
+		}
+	}
+
 	/// A ladder whose level `i` commits at inverse rate `2^(i + 1)` and opens `n_queries` rows.
 	///
 	/// `lanes[i]` is level `i`'s fold amount, and `log_msg_cols` is level 0's column count.
@@ -366,39 +479,19 @@ mod tests {
 		LigeritoParams::new(levels, SoundnessRegime::default(), 32)
 	}
 
-	/// A random multilinear of the ladder's message shape.
-	fn message(params: &LigeritoParams, seed: u64) -> FieldBuffer<B128> {
-		random_field_buffer(&mut StdRng::seed_from_u64(seed), params.log_msg_len())
+	/// One honest oracle filling the ladder, carrying one relation.
+	fn one_oracle(params: &LigeritoParams, seed: u64) -> Vec<Oracle> {
+		let mut rng = StdRng::seed_from_u64(seed);
+		vec![Oracle::honest(&mut rng, params.log_msg_len(), 1)]
 	}
 
-	/// A random dense transparent over the message, paired with the claim it truthfully makes.
-	///
-	/// A dense random weight rather than an equality indicator.
-	/// So the relation is a general inner product, not the evaluation claim the ladder takes.
-	fn relation(rng: &mut StdRng, message: &FieldBuffer<B128>) -> (FieldBuffer<B128>, B128) {
-		let transparent = random_field_buffer::<B128>(rng, message.log_len());
-		let claim = message.inner_product(&transparent);
-		(transparent, claim)
-	}
-
-	/// Commits `committed`, proves `relations` about `opened`, and verifies the result.
-	///
-	/// Splitting the committed message from the opened one is how a dishonest prover is expressed.
-	/// Every value it sends in the clear is consistent with the opened buffer.
-	/// The codeword level 0's queries land in encodes the committed one.
-	/// An honest run passes the same buffer twice.
+	/// Commits every oracle, proves its relations, and verifies the whole batch in one opening.
 	///
 	/// Returns the finished proof's length in bytes.
 	/// So a byte count is only ever taken from a transcript that convinced the verifier.
-	fn run(
-		params: &LigeritoParams,
-		committed: &FieldBuffer<B128>,
-		opened: &FieldBuffer<B128>,
-		relations: &[(FieldBuffer<B128>, B128)],
-	) -> Result<usize, Error> {
-		let n_vars = params.log_msg_len();
-		let verifier_compiler =
-			LigeritoVerifierCompiler::<B128>::new(vec![OracleSpec::new(n_vars)], params.clone());
+	fn run(params: &LigeritoParams, oracles: &[Oracle]) -> Result<usize, Error> {
+		let specs = oracles.iter().map(Oracle::spec).collect::<Vec<_>>();
+		let verifier_compiler = LigeritoVerifierCompiler::<B128>::new(specs, params.clone());
 
 		// One transform for the whole ladder, sized by the compiler rather than by hand.
 		let domain = GaoMateerOnTheFly::generate(verifier_compiler.max_log_domain_size());
@@ -414,13 +507,19 @@ mod tests {
 				GlobalAllocator,
 			);
 
-		// The commit phase: level 0's codeword, and nothing else.
-		let oracle = prover_channel.send_oracle(committed.as_view());
-		for (transparent, claim) in relations {
-			prover_channel.prove_oracle_relation(oracle, transparent.clone(), *claim);
+		// The commit phase: one level-0 codeword per oracle, and nothing else.
+		let handles = oracles
+			.iter()
+			.map(|oracle| prover_channel.send_oracle(oracle.committed.as_view()))
+			.collect::<Vec<_>>();
+		for (handle, oracle) in std::iter::zip(&handles, oracles) {
+			for (transparent, claim) in &oracle.relations {
+				prover_channel.prove_oracle_relation(*handle, transparent.clone(), *claim);
+			}
+			// The ladder folds the message itself, so it needs the buffer and not just its
+			// codeword.
+			prover_channel.finalize_oracle(*handle, oracle.opened.clone());
 		}
-		// The ladder folds the message itself, so it needs the buffer and not just its codeword.
-		prover_channel.finalize_oracle(oracle, opened.clone());
 		prover_channel.finish();
 
 		let proof = prover_transcript.finalize();
@@ -432,14 +531,19 @@ mod tests {
 				&mut verifier_transcript,
 			);
 
-		let oracle = verifier_channel.recv_oracle(n_vars, true)?;
-		for (transparent, claim) in relations {
-			let transparent = transparent.clone();
-			verifier_channel.verify_oracle_relation(
-				oracle,
-				Box::new(move |point: &[B128]| transparent.evaluate(point)),
-				*claim,
-			)?;
+		let handles = oracles
+			.iter()
+			.map(|oracle| verifier_channel.recv_oracle(oracle.opened.log_len(), true))
+			.collect::<Result<Vec<_>, _>>()?;
+		for (handle, oracle) in std::iter::zip(&handles, oracles) {
+			for (transparent, claim) in &oracle.relations {
+				let transparent = transparent.clone();
+				verifier_channel.verify_oracle_relation(
+					*handle,
+					Box::new(move |point: &[B128]| transparent.evaluate(point)),
+					*claim,
+				)?;
+			}
 		}
 		verifier_channel.finish()?;
 
@@ -466,10 +570,8 @@ mod tests {
 			// proof of work to both sides and the two stay in step through it.
 			for grinding in [Grinding::NONE, Grinding::new(3, 4)] {
 				let params = ladder(log_msg_cols, lanes).with_grinding(grinding);
-				let msg = message(&params, 0);
-				let mut rng = StdRng::seed_from_u64(1);
-				let relations = [relation(&mut rng, &msg)];
-				run(&params, &msg, &msg, &relations)
+				let oracles = one_oracle(&params, 0);
+				run(&params, &oracles)
 					.unwrap_or_else(|err| panic!("{log_msg_cols} {lanes:?} {grinding:?}: {err}"));
 			}
 		}
@@ -487,42 +589,93 @@ mod tests {
 	#[test]
 	fn several_relations_on_one_oracle_share_a_single_opening() {
 		let params = ladder(5, &[2, 1]);
-		let msg = message(&params, 0);
 		let mut rng = StdRng::seed_from_u64(1);
+		let one = [Oracle::honest(&mut rng, params.log_msg_len(), 1)];
+		let three = [Oracle::honest(&mut rng, params.log_msg_len(), 3)];
 
-		let one = [relation(&mut rng, &msg)];
-		let three = [
-			relation(&mut rng, &msg),
-			relation(&mut rng, &msg),
-			relation(&mut rng, &msg),
-		];
-
-		let one_size = run(&params, &msg, &msg, &one).expect("one honest relation");
-		let three_size = run(&params, &msg, &msg, &three).expect("three honest relations");
+		let one_size = run(&params, &one).expect("one honest relation");
+		let three_size = run(&params, &three).expect("three honest relations");
 
 		// The extra relations are folded before anything is committed or opened.
 		// So they add nothing to the transcript.
 		assert_eq!(one_size, three_size);
 	}
 
+	/// Several oracles of the same length collapse into a single ladder.
+	///
+	/// Their level-0 codewords have one length over one domain, so one query set serves all three.
+	/// Their folded rows are combined at the batching coefficients into one claim per position.
+	/// That is a claim about the single message level 1 commits.
+	///
+	///     level 0: three Merkle trees, one query set, three openings per query
+	///     level 1: one Merkle tree over `sum_i e_i * X_1^(i)`
+	///
+	/// So a batch pays three level-0 openings but only one of everything below.
+	#[test]
+	fn several_oracles_of_one_length_share_a_single_ladder() {
+		let params = ladder(5, &[2, 1]);
+		let mut rng = StdRng::seed_from_u64(2);
+		let batch = [
+			Oracle::honest(&mut rng, params.log_msg_len(), 1),
+			Oracle::honest(&mut rng, params.log_msg_len(), 1),
+			Oracle::honest(&mut rng, params.log_msg_len(), 1),
+		];
+
+		let batch_size = run(&params, &batch).expect("three honest oracles");
+		let alone = batch
+			.iter()
+			.map(|oracle| run(&params, std::slice::from_ref(oracle)).expect("one honest oracle"))
+			.sum::<usize>();
+
+		assert!(
+			batch_size < alone,
+			"one ladder over three oracles wrote {batch_size} bytes, three ladders {alone}"
+		);
+	}
+
+	/// Oracles of different lengths share the ladder of the longest.
+	///
+	/// Level 0's column count is shared, so a shorter message carries fewer interleaved lanes.
+	/// One shorter than a single column block carries one lane, zero-padded out to the count.
+	///
+	/// Fixture state: 2^5 columns and 2^2 lanes at level 0, so the ladder commits 2^7 elements.
+	///
+	///     2^7 elements -> 2^2 lanes
+	///     2^6 elements -> 2^1 lanes
+	///     2^5 elements -> 2^0 lanes, exactly one column block
+	///     2^3 elements -> 2^0 lanes, zero-padded out to 2^5 columns
+	#[test]
+	fn oracles_of_different_lengths_share_a_single_ladder() {
+		let params = ladder(5, &[2, 1]);
+		let mut rng = StdRng::seed_from_u64(3);
+		let batch = [7, 6, 5, 3]
+			.map(|log_msg_len| Oracle::honest(&mut rng, log_msg_len, 1))
+			.into_iter()
+			.collect::<Vec<_>>();
+
+		run(&params, &batch).expect("four honest oracles of four lengths");
+	}
+
 	/// A claim the message does not satisfy must be caught by the relation sumcheck.
 	///
 	/// The ladder itself is honest here.
-	/// The commitment encodes the message that was opened.
+	/// Every commitment encodes the message that was opened.
 	/// Every value sent in the clear is internally consistent.
-	/// Only the claim is wrong.
-	/// So the reduced sumcheck value no longer matches the two stated evaluations multiplied.
+	/// Only one claim, on one oracle of several, is wrong.
+	/// So the reduced sumcheck value no longer matches the stated evaluations multiplied.
 	#[test]
 	fn a_claim_the_message_does_not_satisfy_is_rejected() {
 		let params = ladder(5, &[2, 1]);
-		let msg = message(&params, 0);
-		let mut rng = StdRng::seed_from_u64(1);
-		let (transparent, claim) = relation(&mut rng, &msg);
+		let mut rng = StdRng::seed_from_u64(4);
+		let mut batch = [
+			Oracle::honest(&mut rng, params.log_msg_len(), 1),
+			Oracle::honest(&mut rng, 6, 1),
+		];
 
-		// Mutation: the claim is off by one, and nothing else changes.
-		let relations = [(transparent, claim + B128::ONE)];
-		let err = run(&params, &msg, &msg, &relations)
-			.expect_err("the inner-product claim is off by one");
+		// Mutation: the second oracle's claim is off by one, and nothing else changes.
+		batch[1].relations[0].1 += B128::ONE;
+
+		let err = run(&params, &batch).expect_err("the inner-product claim is off by one");
 
 		match err {
 			Error::IPChannel(binius_ip::channel::Error::InvalidAssert) => {}
@@ -533,7 +686,7 @@ mod tests {
 	/// A commitment that does not encode the opened message must be caught by the ladder.
 	///
 	/// The relation is honest about the message the prover reduced.
-	/// So the sumcheck passes and the stated evaluation matches.
+	/// So the sumcheck passes and every stated evaluation matches.
 	/// The rows the query phase opens come from a different codeword, and only the ladder sees it.
 	///
 	///     relation sumcheck: about `opened`      -> consistent
@@ -541,13 +694,17 @@ mod tests {
 	#[test]
 	fn a_commitment_that_does_not_encode_the_opened_message_is_rejected() {
 		let params = ladder(5, &[2, 1]);
-		let committed = message(&params, 0);
-		let opened = message(&params, 1);
-		let mut rng = StdRng::seed_from_u64(1);
-		let relations = [relation(&mut rng, &opened)];
+		let mut rng = StdRng::seed_from_u64(5);
+		let mut batch = [
+			Oracle::honest(&mut rng, params.log_msg_len(), 1),
+			Oracle::honest(&mut rng, 6, 1),
+		];
 
-		let err = run(&params, &committed, &opened, &relations)
-			.expect_err("the committed codeword encodes a different message");
+		// Mutation: the second oracle commits a different buffer from the one it opens.
+		batch[1].committed = random_field_buffer::<B128>(&mut rng, 6);
+
+		let err =
+			run(&params, &batch).expect_err("the committed codeword encodes a different message");
 
 		// The ladder's own assertion, so the error arrives wrapped rather than raised here.
 		match err {
@@ -558,20 +715,19 @@ mod tests {
 		}
 	}
 
-	/// A commitment carrying no relation opens nothing.
+	/// Commitments carrying no relation open nothing.
 	///
-	/// The commitment on its own asserts nothing about the message.
+	/// A commitment on its own asserts nothing about the message.
 	/// So neither side runs a sumcheck, a query round, or a residual.
-	/// The transcript then holds the Merkle root and nothing more.
+	/// The transcript then holds the Merkle roots and nothing more.
 	#[test]
-	fn a_commitment_with_no_relation_opens_nothing() {
+	fn commitments_with_no_relation_open_nothing() {
 		let params = ladder(5, &[2, 1]);
-		let msg = message(&params, 0);
-		let mut rng = StdRng::seed_from_u64(1);
-		let relations = [relation(&mut rng, &msg)];
+		let mut oracles = one_oracle(&params, 6);
+		let opened_size = run(&params, &oracles).expect("one honest relation");
 
-		let empty_size = run(&params, &msg, &msg, &[]).expect("a commitment alone always verifies");
-		let opened_size = run(&params, &msg, &msg, &relations).expect("one honest relation");
+		oracles[0].relations.clear();
+		let empty_size = run(&params, &oracles).expect("a commitment alone always verifies");
 
 		assert!(
 			empty_size < opened_size,
@@ -579,7 +735,26 @@ mod tests {
 		);
 	}
 
-	/// The buffer handed to the commit phase must have the ladder's message length.
+	/// Opening some oracles but not others is refused rather than silently skipped.
+	///
+	/// One ladder opens every committed message together, so leaving one out has no meaning.
+	/// The prover would have to commit a codeword whose rows nothing ever checks.
+	#[test]
+	#[should_panic(expected = "every committed oracle must carry at least one relation")]
+	fn an_oracle_left_unopened_beside_an_opened_one_is_refused() {
+		let params = ladder(5, &[2, 1]);
+		let mut rng = StdRng::seed_from_u64(7);
+		let mut batch = [
+			Oracle::honest(&mut rng, params.log_msg_len(), 1),
+			Oracle::honest(&mut rng, 6, 1),
+		];
+
+		// Mutation: the second oracle is committed and finalized, but never opened.
+		batch[1].relations.clear();
+		let _ = run(&params, &batch);
+	}
+
+	/// The buffer handed to the commit phase must have the length its spec announced.
 	///
 	/// A shorter one would encode into a codeword of the wrong shape.
 	/// The verifier would then read its Merkle tree at a depth the prover never committed.
@@ -587,9 +762,13 @@ mod tests {
 	#[should_panic(expected = "oracle buffer log_len mismatch")]
 	fn a_message_of_the_wrong_length_is_refused() {
 		let params = ladder(5, &[2, 1]);
+		let mut oracles = one_oracle(&params, 8);
+
+		// Mutation: the buffer loses a variable while its spec keeps the ladder's length.
 		let short =
-			random_field_buffer::<B128>(&mut StdRng::seed_from_u64(0), params.log_msg_len() - 1);
-		run(&params, &short, &short, &[]).expect("the commit phase panics before this");
+			random_field_buffer::<B128>(&mut StdRng::seed_from_u64(9), params.log_msg_len() - 1);
+		oracles[0].committed = short;
+		let _ = run(&params, &oracles);
 	}
 
 	/// The committed buffer must be handed back before the opening runs.
@@ -599,14 +778,11 @@ mod tests {
 	#[should_panic(expected = "the oracle was committed but never finalized")]
 	fn an_unfinalized_oracle_cannot_be_opened() {
 		let params = ladder(5, &[2, 1]);
-		let msg = message(&params, 0);
-		let mut rng = StdRng::seed_from_u64(1);
-		let (transparent, claim) = relation(&mut rng, &msg);
+		let oracles = one_oracle(&params, 10);
+		let (transparent, claim) = oracles[0].relations[0].clone();
 
-		let verifier_compiler = LigeritoVerifierCompiler::<B128>::new(
-			vec![OracleSpec::new(params.log_msg_len())],
-			params,
-		);
+		let verifier_compiler =
+			LigeritoVerifierCompiler::<B128>::new(vec![oracles[0].spec()], params);
 		let domain = GaoMateerOnTheFly::generate(verifier_compiler.max_log_domain_size());
 		let prover_compiler = LigeritoProverCompiler::<B128, _>::from_verifier_compiler(
 			&verifier_compiler,
@@ -621,8 +797,8 @@ mod tests {
 			);
 
 		// Mutation: the relation is queued, but the message is never handed over.
-		let oracle = channel.send_oracle(msg.as_view());
-		channel.prove_oracle_relation(oracle, transparent, claim);
+		let handle = channel.send_oracle(oracles[0].committed.as_view());
+		channel.prove_oracle_relation(handle, transparent, claim);
 		channel.finish();
 	}
 }

--- a/crates/iop-prover/src/ligerito/compiler.rs
+++ b/crates/iop-prover/src/ligerito/compiler.rs
@@ -43,7 +43,7 @@ where
 {
 	/// The transform every level encodes over, sized for the ladder's longest codeword.
 	ntt: NTT,
-	/// The one oracle every channel this compiler makes will commit.
+	/// The oracles every channel this compiler makes will commit, in the order they are sent.
 	oracle_specs: Vec<OracleSpec>,
 	/// The ladder each of those openings runs down.
 	params: LigeritoParams,
@@ -61,8 +61,8 @@ where
 	///
 	/// ## Preconditions
 	///
-	/// * `oracle_specs` holds exactly one spec, and that spec is not zero-knowledge.
-	/// * Its message length is the ladder's message length.
+	/// * `oracle_specs` is non-empty and no spec is zero-knowledge.
+	/// * The longest message is the ladder's message length.
 	/// * `ntt`'s domain covers every level's codeword domain.
 	pub fn new(ntt: NTT, oracle_specs: Vec<OracleSpec>, params: LigeritoParams) -> Self {
 		// The two sides must agree on the ladder, so the checks are the verifier's, run here too.
@@ -70,15 +70,15 @@ where
 		Self::from_verifier_compiler(&verifier, ntt)
 	}
 
-	/// Creates a compiler whose ladder is the proof-size-minimizing one for the oracle.
+	/// Creates a compiler whose ladder is the proof-size-minimizing one for the longest oracle.
 	///
-	/// `None` means no ladder over this message reaches the security target.
+	/// `None` means no ladder over that message reaches the security target.
 	///
 	/// `grinding` is what the ladder will pay per level; pass [`Grinding::NONE`] for none.
 	///
 	/// ## Preconditions
 	///
-	/// * `oracle_specs` holds exactly one spec, and that spec is not zero-knowledge.
+	/// * `oracle_specs` is non-empty and no spec is zero-knowledge.
 	/// * `l0_log_inv_rate` is a usable inverse rate and `security_bits` is positive.
 	/// * `ntt`'s domain covers every level's codeword domain.
 	pub fn optimal<MerkleScheme>(

--- a/crates/iop-prover/src/ligerito/mod.rs
+++ b/crates/iop-prover/src/ligerito/mod.rs
@@ -9,6 +9,6 @@
 pub mod channel;
 pub mod compiler;
 mod induced_weight;
-mod opening;
+pub(crate) mod opening;
 
 pub use opening::LigeritoProver;

--- a/crates/iop-prover/src/ligerito/opening.rs
+++ b/crates/iop-prover/src/ligerito/opening.rs
@@ -35,7 +35,7 @@ use binius_math::{
 use super::induced_weight::InducedWeight;
 use crate::{
 	channel::grinding::GrindingProverChannel,
-	fri::{BrakedownOracleProver, ProxTestOracleProver},
+	fri::{BatchBrakedownOracleProver, BrakedownOracleProver, ProxTestOracleProver},
 	merkle_channel::MerkleIPProverChannel,
 };
 
@@ -64,7 +64,7 @@ use crate::{
 ///
 /// * `message` has `level.log_msg_len()` variables.
 /// * `ntt`'s domain covers the level's codeword domain.
-fn commit_level<F, P, NTT, Channel>(
+pub(crate) fn commit_level<F, P, NTT, Channel>(
 	level: &LigeritoLevel,
 	ntt: &NTT,
 	message: FieldSlice<'_, P>,
@@ -91,16 +91,15 @@ where
 
 /// Proves a Ligerito opening against a committed ladder of Reed-Solomon codewords.
 ///
-/// Holds the ladder's shape, the transform its levels encode over, and the oracle that answers
-/// queries against level 0's codeword.
+/// Holds the ladder's shape, the transform its levels encode over, and level 0's oracles.
 /// Deeper levels only exist once the folds above them have run, so [`Self::prove`] commits those.
 pub struct LigeritoProver<'a, P: PackedField, C, NTT> {
 	/// The ladder's shape, one [`LigeritoLevel`] per committed level.
 	params: &'a LigeritoParams,
 	/// The transform every level encodes over, sized for the largest of them.
 	ntt: &'a NTT,
-	/// Level 0's committed interleaved codeword, and the handle that opens it.
-	oracle: BrakedownOracleProver<P, C>,
+	/// Level 0's committed interleaved codewords, in the order their openings are written.
+	oracles: BatchBrakedownOracleProver<P, C>,
 }
 
 impl<'a, F, P, C, NTT> LigeritoProver<'a, P, C, NTT>
@@ -130,11 +129,33 @@ where
 		Channel: MerkleIPProverChannel<F, Commitment = C>,
 	{
 		let level = &params.levels()[0];
+		let oracle = commit_level(level, ntt, message, channel);
+		Self::new(params, ntt, BatchBrakedownOracleProver::new(vec![oracle]))
+	}
+
+	/// Binds a prover to a ladder and the level-0 codewords its opening answers queries against.
+	///
+	/// The codewords must be listed in the order their commitments were sent.
+	/// That is the order the verifier reads their openings in.
+	///
+	/// ## Preconditions
+	///
+	/// * Every codeword spans level 0's codeword length, so one query position addresses all.
+	pub const fn new(
+		params: &'a LigeritoParams,
+		ntt: &'a NTT,
+		oracles: BatchBrakedownOracleProver<P, C>,
+	) -> Self {
 		Self {
 			params,
 			ntt,
-			oracle: commit_level(level, ntt, message, channel),
+			oracles,
 		}
+	}
+
+	/// The ladder's shape, one level per committed level.
+	pub const fn params(&self) -> &LigeritoParams {
+		self.params
 	}
 
 	/// Proves the opening of `<message, eq(eval_point)> = eval_claim`.
@@ -247,10 +268,12 @@ where
 			let indices = (0..level.n_queries)
 				.map(|_| channel.sample_bits(level.log_codeword_len()))
 				.collect::<Vec<_>>();
-			deeper
-				.as_ref()
-				.unwrap_or(&self.oracle)
-				.open_queries(&indices, channel);
+			match deeper.as_ref() {
+				// Level 0 writes every committed codeword's openings, one after another.
+				None => self.oracles.open_queries(&indices, channel),
+				// A deeper level has one codeword, committed by the level above it.
+				Some(oracle) => oracle.open_queries(&indices, channel),
+			}
 
 			// The row-batching challenge.
 			// The last level's is drawn only to keep the two transcripts in step, since its rows

--- a/crates/iop/src/ligerito/channel/mod.rs
+++ b/crates/iop/src/ligerito/channel/mod.rs
@@ -2,17 +2,20 @@
 
 //! Ligerito implementation of the IOP verifier channel.
 //!
-//! One file per concern: the oracle handle here, the queued relation beside it, and the channel
-//! that turns a queue of relations into one ladder opening.
+//! One file per concern.
+//! The oracle handle is here, and the pieces the channel assembles sit beside it.
 
 mod relation;
 mod verifier;
 
 pub use verifier::LigeritoVerifierChannel;
 
-/// A handle to the oracle a Ligerito channel opens.
+/// A handle to one of the oracles a Ligerito channel opens.
 ///
 /// The inner field is private, so the only way to hold one is to have received the commitment.
-/// A ladder opens exactly one committed message, so the handle carries nothing else.
+/// It names the position the commitment arrived in, which is the position its relations queue at.
 #[derive(Debug, Clone, Copy)]
-pub struct LigeritoOracle(());
+pub struct LigeritoOracle {
+	/// The order this oracle's commitment was received in.
+	index: usize,
+}

--- a/crates/iop/src/ligerito/channel/verifier.rs
+++ b/crates/iop/src/ligerito/channel/verifier.rs
@@ -182,6 +182,19 @@ where
 	/// Its row union therefore grows from `2^log_lanes` rows to `2^log_lanes * k` of them.
 	/// The ladder prices exactly that.
 	/// Nothing below level 0 is affected, since the batch is one combined message from level 1 on.
+	///
+	/// Two limits on where that third charge comes from, since neither is obvious from the code.
+	///
+	/// The coefficients `e_i` are a tensor rather than a power curve.
+	/// So the step they batch is covered by [DP24], and only in the unique-decoding regime.
+	/// Read a Johnson-regime figure as a bound on the fold, never on the batch.
+	///
+	/// [NA25] section 6.5 sketches this very construction, level 0 per proof and combined after.
+	/// It states no error bound for it, and suspects only that communication is reduced.
+	/// So the row-union charge is this repository's conservative reading, not a citation.
+	///
+	/// [DP24]: <https://eprint.iacr.org/2024/504>
+	/// [NA25]: <https://eprint.iacr.org/2025/1187>
 	fn verify(
 		channel: &mut Channel,
 		oracle_specs: &[OracleSpec],

--- a/crates/iop/src/ligerito/channel/verifier.rs
+++ b/crates/iop/src/ligerito/channel/verifier.rs
@@ -6,15 +6,18 @@ use binius_core::word::Word;
 use binius_field::BinaryField;
 use binius_ip::{
 	channel::{IPVerifierChannel, WordIPVerifierChannel},
-	sumcheck::{self, SumcheckOutput},
+	sumcheck::{self, BatchSumcheckOutput},
 };
+use binius_math::{multilinear::hypercube::Hypercube, univariate::evaluate_univariate};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
+use itertools::izip;
 
 use super::{LigeritoOracle, relation::QueuedRelation};
 use crate::{
 	channel::{
 		Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn, grinding::GrindingVerifierChannel,
 	},
-	ligerito::{LigeritoParams, LigeritoVerifier},
+	ligerito::{CommittedOracle, LigeritoParams, LigeritoVerifier},
 	merkle_channel::MerkleIPVerifierChannel,
 };
 
@@ -25,10 +28,10 @@ use crate::{
 /// The constant one is recovered from the running claim, leaving two on the wire.
 const RELATION_DEGREE: usize = 2;
 
-/// A verifier channel that opens its one committed oracle with a Ligerito ladder.
+/// A verifier channel that opens every committed oracle with one Ligerito ladder.
 ///
 /// The channel is transparent rather than zero-knowledge.
-/// The committed message is never masked.
+/// No committed message is ever masked.
 /// The ladder's residual reaches the verifier in the clear.
 ///
 /// # Type Parameters
@@ -44,14 +47,15 @@ where
 	/// The Merkle channel carrying all prover interaction.
 	/// Field elements, challenges, commitments and openings all pass through it.
 	channel: Channel,
-	/// The one oracle this channel expects, held as a slice so the trait can hand it back.
+	/// The oracles this channel expects, in the order it will receive them.
 	oracle_specs: &'a [OracleSpec],
 	/// The ladder the opening runs down.
 	params: &'a LigeritoParams,
-	/// The commitment to level 0's interleaved codeword, absent until the oracle is received.
-	commitment: Option<Channel::Commitment>,
-	/// Relations queued against the oracle, all opened together once the caller finishes.
-	queue: Vec<QueuedRelation<Channel::Elem>>,
+	/// The commitments to the level-0 codewords, in the order they were received.
+	commitments: Vec<Channel::Commitment>,
+	/// Relations queued against each oracle, all opened together once the caller finishes.
+	/// One entry per received oracle, so its length is also the number received so far.
+	queue: Vec<Vec<QueuedRelation<Channel::Elem>>>,
 }
 
 impl<'a, F, Channel> LigeritoVerifierChannel<'a, F, Channel>
@@ -59,53 +63,60 @@ where
 	F: BinaryField,
 	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
-	/// Creates a channel that opens one oracle with the given ladder.
+	/// Creates a channel that opens the given oracles with the given ladder.
 	///
 	/// ## Preconditions
 	///
-	/// * `oracle_specs` holds exactly one spec.
-	/// * That spec is not zero-knowledge.
-	/// * Its message length is the ladder's message length.
+	/// * `oracle_specs` is non-empty.
+	/// * No spec is zero-knowledge.
+	/// * The longest message is the ladder's message length.
 	pub fn new(
 		channel: Channel,
 		oracle_specs: &'a [OracleSpec],
 		params: &'a LigeritoParams,
 	) -> Self {
-		assert_eq!(
-			oracle_specs.len(),
-			1,
-			"precondition: a Ligerito channel opens exactly one oracle, got {}",
-			oracle_specs.len()
+		assert!(
+			!oracle_specs.is_empty(),
+			"precondition: a Ligerito channel opens at least one oracle"
 		);
 		assert!(
-			!oracle_specs[0].is_zk,
+			oracle_specs.iter().all(|spec| !spec.is_zk),
 			"precondition: Ligerito commits no mask, so a zero-knowledge oracle cannot be opened"
 		);
+		// Every oracle shares level 0's column count, so the ladder must fit the longest message.
 		assert_eq!(
-			oracle_specs[0].log_msg_len,
+			oracle_specs
+				.iter()
+				.map(|spec| spec.log_msg_len)
+				.max()
+				.expect("oracle_specs is non-empty"),
 			params.log_msg_len(),
-			"precondition: the oracle's message length must be the ladder's message length"
+			"precondition: the longest oracle's message length must be the ladder's message length"
 		);
 
 		Self {
 			channel,
 			oracle_specs,
 			params,
-			commitment: None,
+			commitments: Vec::new(),
 			queue: Vec::new(),
 		}
 	}
 
 	/// Consumes the channel and verifies every queued relation in one opening.
 	///
-	/// The relations are folded into one, then reduced to a single evaluation claim.
-	/// That claim is what the ladder opens.
-	/// Nothing happens when no relation was queued, since a commitment alone asserts nothing.
+	/// The relations on each oracle are folded into one, then reduced to one evaluation claim.
+	/// Those claims are then combined into the single claim the ladder opens.
+	/// Nothing happens when no relation was queued, since commitments alone assert nothing.
 	///
 	/// Returns the Merkle channel, so a caller can still reach what it accumulated.
 	///
 	/// The channel has to be able to check a proof of work, because the ladder may pay one.
 	/// A configuration that grinds nothing still asks for the capability, and never uses it.
+	///
+	/// ## Preconditions
+	///
+	/// * Either every oracle carries a relation, or none of them does.
 	pub fn finish(self) -> Result<Channel, Error>
 	where
 		Channel: GrindingVerifierChannel,
@@ -114,91 +125,143 @@ where
 			mut channel,
 			oracle_specs,
 			params,
-			commitment,
+			commitments,
 			queue,
 		} = self;
 
-		// The oracle is received at most once, so what remains is one spec or none.
-		let n_remaining = oracle_specs.len() - usize::from(commitment.is_some());
+		// Every oracle is received at most once, so what remains is whatever was not.
+		let n_remaining = oracle_specs.len() - commitments.len();
 		assert!(n_remaining == 0, "finish called but {n_remaining} oracle specs remaining");
 
-		if queue.is_empty() {
+		if queue.iter().all(Vec::is_empty) {
 			return Ok(channel);
 		}
+		assert!(
+			queue.iter().all(|relations| !relations.is_empty()),
+			"precondition: every committed oracle must carry at least one relation"
+		);
 
-		let commitment = commitment.expect("a relation can only be queued against a commitment");
-		Self::verify(&mut channel, params, commitment, queue)?;
+		Self::verify(&mut channel, oracle_specs, params, commitments, queue)?;
 
 		Ok(channel)
 	}
 
 	/// Verifies the queued relations against the committed ladder.
 	///
-	/// Two reductions run back to back.
-	/// A sumcheck turns the relation into an evaluation claim at a point neither party chose.
-	/// That is the only shape the ladder opens.
+	/// Three reductions run back to back.
+	/// Each oracle's relations fold into one at a shared coefficient.
+	/// A batched sumcheck turns those into one evaluation claim per oracle, at a shared point.
+	/// Those claims are combined into a claim about the one message the ladder folds.
 	///
 	/// ```text
-	///     <pi, t> = s          the relations, batched into one
-	///       -> sumcheck        binds every variable at a sampled point r
-	///     pi(r) = alpha        the evaluation claim the ladder takes
+	///     <pi_i, t_ij> = s_ij      the relations, batched per oracle into <pi_i, T_i> = S_i
+	///       -> sumcheck            binds every variable at a sampled point r
+	///     pi_i(r) = alpha_i        one evaluation claim per oracle
+	///       -> eq-combine          at coefficients e_i drawn once every alpha is on the wire
+	///     PI(r) = sum_i e_i alpha_i
 	///       -> ladder
 	/// ```
 	///
-	/// The sumcheck's reduced value is the product of both multilinears at `r`.
-	/// The prover states `pi(r)` and the verifier computes `t(r)` itself.
-	/// So the product pins the stated evaluation.
+	/// A message shorter than the longest one is that multilinear zero-extended.
+	/// Its claim then carries the factor the extra coordinates contribute at zero.
+	///
+	/// # Soundness
+	///
+	/// Every coefficient is drawn only after the claims it combines are bound to the transcript.
+	/// The three batching steps then cost, in order:
+	///
+	/// - `sum_i (k_i - 1) / |F|`, for folding oracle `i`'s `k_i` relations by powers of one
+	///   coefficient rather than by `k_i` independent ones;
+	/// - `(k - 1) / |F|`, for folding the `k` oracle claims into one sumcheck the same way;
+	/// - a wider row union at level 0, for combining the `k` messages into the one the ladder
+	///   folds.
+	///
+	/// The third is a proximity-gap statement rather than a linear-independence one.
+	/// So no number of queries buys it back.
+	/// Level 0 folds a tensor over its own lane index *and* the message index.
+	/// Its row union therefore grows from `2^log_lanes` rows to `2^log_lanes * k` of them.
+	/// The ladder prices exactly that.
+	/// Nothing below level 0 is affected, since the batch is one combined message from level 1 on.
 	fn verify(
 		channel: &mut Channel,
+		oracle_specs: &[OracleSpec],
 		params: &LigeritoParams,
-		commitment: Channel::Commitment,
-		queue: Vec<QueuedRelation<Channel::Elem>>,
+		commitments: Vec<Channel::Commitment>,
+		queue: Vec<Vec<QueuedRelation<Channel::Elem>>>,
 	) -> Result<(), Error>
 	where
 		Channel: GrindingVerifierChannel,
 	{
+		let n_oracles = commitments.len();
+		let max_n_vars = params.log_msg_len();
+
 		// Every claim in the queue is already bound to the transcript, so a coefficient drawn
 		// here cannot be anticipated by any of them.
 		let lambda = channel.sample();
-		let QueuedRelation { transparent, claim } = QueuedRelation::batch(queue, lambda);
+		let relations = queue
+			.into_iter()
+			.map(|relations| QueuedRelation::batch(relations, lambda.clone()))
+			.collect::<Vec<_>>();
+		let claims = relations
+			.iter()
+			.map(|relation| relation.claim.clone())
+			.collect::<Vec<_>>();
 
-		// Bind every variable of the committed multilinear at a point the prover cannot predict.
-		let SumcheckOutput { eval, challenges } =
-			sumcheck::verify::<F, _>(params.log_msg_len(), RELATION_DEGREE, claim, channel)?;
+		// Bind every variable of every committed multilinear at a point the prover cannot predict.
+		// A shorter message rides the same rounds, zero-extended over the coordinates it lacks.
+		let BatchSumcheckOutput {
+			batch_coeff,
+			eval,
+			challenges,
+		} = sumcheck::batch_verify::<F, _>(max_n_vars, RELATION_DEGREE, &claims, channel)?;
 
-		// The evaluation of the committed multilinear at that point, which the prover has to state.
-		let alpha = channel.recv_one()?;
+		// The evaluation of each committed multilinear at that point, which the prover has to
+		// state, in the order the oracles were received.
+		let alphas = channel.recv_many(n_oracles)?;
 
 		// Sumcheck rounds bind the highest variable first, so reversing gives variable order.
 		let mut point = challenges;
 		point.reverse();
 
-		// The reduced value is the product of the two multilinears, and only one factor is
-		// committed.
-		channel.assert_zero(eval - alpha.clone() * transparent(&point))?;
+		// The reduced value is the batched product of each message with its transparent, and only
+		// the messages are committed.
+		let contributions = izip!(relations, oracle_specs, &alphas)
+			.map(|(relation, spec, alpha)| {
+				let (eval_point, padding) = point.split_at(spec.log_msg_len);
+				alpha.clone()
+					* (relation.transparent)(eval_point)
+					* Hypercube::One.eq_ind_zero(padding)
+			})
+			.collect::<Vec<_>>();
+		channel.assert_zero(eval - evaluate_univariate(&contributions, &batch_coeff))?;
 
-		LigeritoVerifier::new(params, commitment).verify(&point, alpha, channel)?;
+		// Every stated evaluation is now bound to the transcript, so the coefficients that combine
+		// them into one message cannot be anticipated either.
+		let outer_challenges = channel.sample_many(log2_ceil_usize(n_oracles));
+		let coefficients = Hypercube::One.expand(&outer_challenges).build_scalars();
+
+		// The combined message is the zero-extended messages summed at those coefficients, so its
+		// evaluation is the same combination of the stated ones.
+		let combined_claim = izip!(oracle_specs, &coefficients, &alphas)
+			.map(|(spec, coefficient, alpha)| {
+				coefficient.clone()
+					* alpha.clone() * Hypercube::One.eq_ind_zero(&point[spec.log_msg_len..])
+			})
+			.sum::<Channel::Elem>();
+
+		let oracles = izip!(commitments, oracle_specs, coefficients)
+			.map(|(commitment, spec, coefficient)| {
+				let log_lanes = params.level_zero_shape(spec.log_msg_len).log_lanes;
+				CommittedOracle::new(commitment, log_lanes, coefficient)
+			})
+			.collect();
+
+		LigeritoVerifier::batched(params, oracles).verify(&point, combined_claim, channel)?;
 
 		Ok(())
 	}
 }
 
-/// Verifies the queued relations against the committed ladder.
-///
-/// Two reductions run back to back.
-/// A sumcheck turns the relation into an evaluation claim at a point neither party chose.
-/// That is the only shape the ladder opens.
-///
-/// ```text
-///     <pi, t> = s          the relations, batched into one
-///       -> sumcheck        binds every variable at a sampled point r
-///     pi(r) = alpha        the evaluation claim the ladder takes
-///       -> ladder
-/// ```
-///
-/// The sumcheck's reduced value is the product of both multilinears at `r`.
-/// The prover states `pi(r)` and the verifier computes `t(r)` itself.
-/// So the product pins the stated evaluation.
 impl<F, Channel> IPVerifierChannel<F> for LigeritoVerifierChannel<'_, F, Channel>
 where
 	F: BinaryField,
@@ -275,7 +338,7 @@ where
 	type Oracle = LigeritoOracle;
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
-		&self.oracle_specs[usize::from(self.commitment.is_some())..]
+		&self.oracle_specs[self.commitments.len()..]
 	}
 
 	fn recv_oracle(
@@ -290,26 +353,36 @@ where
 			"recv_oracle called but no remaining oracle specs"
 		);
 
-		// Level 0 holds one codeword position per leaf, across every interleaved lane.
-		let level = &self.params.levels()[0];
+		// Level 0 holds one codeword position per leaf, across every interleaved lane. Every
+		// oracle shares the column count, so only the lane count follows the message length.
+		let index = self.commitments.len();
+		let level = self
+			.params
+			.level_zero_shape(self.oracle_specs[index].log_msg_len);
 		let commitment = self
 			.channel
 			.recv_merkle_commitment(1 << level.log_lanes, level.log_codeword_len())?;
 
-		self.commitment = Some(commitment);
+		self.commitments.push(commitment);
+		self.queue.push(Vec::new());
 
-		Ok(LigeritoOracle(()))
+		Ok(LigeritoOracle { index })
 	}
 
 	fn verify_oracle_relation(
 		&mut self,
-		_oracle: Self::Oracle,
+		oracle: Self::Oracle,
 		transparent: TransparentEvalFn<Self::Elem>,
 		claim: Self::Elem,
 	) -> Result<(), Error> {
-		// A handle can only exist once the commitment arrived, and there is one oracle.
-		// So the handle names no index to look up.
-		self.queue.push(QueuedRelation { transparent, claim });
+		// A handle can only exist once its commitment arrived, so the slot is already there.
+		let n_received = self.queue.len();
+		self.queue
+			.get_mut(oracle.index)
+			.unwrap_or_else(|| {
+				panic!("oracle index {} out of bounds, expected < {n_received}", oracle.index)
+			})
+			.push(QueuedRelation { transparent, claim });
 		Ok(())
 	}
 }

--- a/crates/iop/src/ligerito/committed_oracle.rs
+++ b/crates/iop/src/ligerito/committed_oracle.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 The Binius Developers
+
+//! One committed message, as level 0 of a ladder sees it.
+
+use binius_field::{BinaryField, field::FieldOps};
+use binius_math::multilinear::hypercube::Hypercube;
+
+use crate::{
+	fri::batch::{BrakedownOracle, Error, ProxTestOracle},
+	merkle_channel::MerkleIPVerifierChannel,
+};
+
+/// One committed message a ladder opens, as its level 0 sees it.
+///
+/// A ladder can open several messages together.
+/// They share level 0's column count, so their codewords all have one length.
+/// One set of query positions then addresses every one of them.
+/// What differs between them is the lane count, and the coefficient the batch weighs each by.
+///
+/// # Soundness
+///
+/// The coefficient must be drawn only once every claim it combines is bound to the transcript.
+/// It is taken rather than sampled here so that the ordering is visible where the batch is built.
+#[derive(Debug, Clone)]
+pub struct CommittedOracle<E, C> {
+	/// The Merkle commitment to this message's level-0 interleaved codeword.
+	commitment: C,
+	/// log2 the number of interleaved lanes that codeword carries.
+	log_lanes: usize,
+	/// The coefficient this message's level-0 row claims enter the batch with.
+	coefficient: E,
+}
+
+impl<E: FieldOps, C: Clone> CommittedOracle<E, C> {
+	/// Names one committed message, its lane count, and the coefficient it is batched with.
+	pub const fn new(commitment: C, log_lanes: usize, coefficient: E) -> Self {
+		Self {
+			commitment,
+			log_lanes,
+			coefficient,
+		}
+	}
+
+	/// log2 the number of interleaved lanes this message's level-0 codeword carries.
+	pub const fn log_lanes(&self) -> usize {
+		self.log_lanes
+	}
+
+	/// Opens this message's rows at the shared positions, folded and scaled into the batch.
+	///
+	/// The batch folds as many variables as its longest message has lanes.
+	/// A message with fewer lanes is that multilinear zero-extended over the missing ones.
+	/// So the first rounds bind variables it is zero over.
+	/// Sumcheck binds the highest variable first, so those are the *first* challenges.
+	/// Binding a variable the multilinear vanishes above scales it rather than folding it.
+	///
+	/// ```text
+	///     challenges = [ padding .. | this message's lanes .. ]
+	///     scale      = coefficient * eq(0, padding)
+	/// ```
+	///
+	/// ## Preconditions
+	///
+	/// * `challenges` holds at least [`Self::log_lanes`] entries.
+	pub(super) fn open_scaled_rows<F, Channel>(
+		&self,
+		challenges: &[E],
+		indices: &[Channel::Word],
+		channel: &mut Channel,
+	) -> Result<Vec<E>, Error>
+	where
+		F: BinaryField,
+		E: FieldOps<Scalar = F>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
+	{
+		assert!(
+			self.log_lanes <= challenges.len(),
+			"precondition: {} lanes cannot be folded by {} challenges",
+			self.log_lanes,
+			challenges.len()
+		);
+
+		// The lane challenges are the trailing ones, and everything before them is padding.
+		let (padding, lanes) = challenges.split_at(challenges.len() - self.log_lanes);
+		let scale = self.coefficient.clone() * Hypercube::One.eq_ind_zero(padding);
+
+		// Every message's codeword has the same length, so the shared positions address this one
+		// directly and no lift is needed.
+		let rows = BrakedownOracle::new(lanes.to_vec(), self.commitment.clone(), 0)
+			.open_queries(indices, channel)?;
+
+		Ok(rows.into_iter().map(|row| row * scale.clone()).collect())
+	}
+}

--- a/crates/iop/src/ligerito/common.rs
+++ b/crates/iop/src/ligerito/common.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::BinaryField;
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 use getset::CopyGetters;
 
 use super::{size_estimation, verifier_cost, verifier_cost::VerifierCost};
@@ -223,6 +224,33 @@ impl LigeritoParams {
 		self.levels[0].log_msg_len()
 	}
 
+	/// The level-0 shape a message of `log_msg_len` elements is committed at.
+	///
+	/// A ladder can open several messages at once, and they all share level 0's column count.
+	/// So every level-0 codeword has one length over one domain, and one query set serves them all.
+	/// The lane count is then the only thing a shorter message changes.
+	///
+	/// A message with fewer elements than one column block folds nothing at level 0.
+	/// It commits a single lane, zero-padded out to the shared column count.
+	/// That costs a full-width encoding for a message that does not need one.
+	/// It is the price of sharing the query set.
+	///
+	/// ## Preconditions
+	///
+	/// * `log_msg_len` is at most the ladder's own message length.
+	pub fn level_zero_shape(&self, log_msg_len: usize) -> LigeritoLevel {
+		assert!(
+			log_msg_len <= self.log_msg_len(),
+			"precondition: a message of 2^{log_msg_len} elements exceeds the ladder's 2^{}",
+			self.log_msg_len()
+		);
+
+		LigeritoLevel {
+			log_lanes: log_msg_len.saturating_sub(self.levels[0].log_msg_cols),
+			..self.levels[0]
+		}
+	}
+
 	/// The total number of sumcheck fold rounds, `sum_i log_lanes_i`.
 	pub fn n_fold_rounds(&self) -> usize {
 		self.levels.iter().map(|level| level.log_lanes).sum()
@@ -260,16 +288,44 @@ impl LigeritoParams {
 	/// `log_lanes` and `2^(log_lanes - 1)` respectively.
 	/// This charges the second, which is the pessimistic one.
 	pub fn correlated_agreement_bits(&self, log_field_size: usize) -> f64 {
+		self.batched_correlated_agreement_bits(log_field_size, 1)
+	}
+
+	/// The same ceiling when level 0 opens `n_oracles` separately committed messages at once.
+	///
+	/// The messages are combined by a tensor of `ceil(log2 n_oracles)` challenges.
+	/// That sits on top of the `log_lanes` challenges level 0 already folds its own lanes by.
+	/// So level 0's proximity test runs against a fold of `2^log_lanes * n_oracles` rows.
+	/// Its row union grows by exactly that factor.
+	///
+	/// The deeper levels are untouched.
+	/// The batch is one combined message from level 1 onwards.
+	/// So nothing below level 0 knows how many messages went into it.
+	///
+	/// ## Preconditions
+	///
+	/// * `n_oracles` is positive.
+	pub fn batched_correlated_agreement_bits(
+		&self,
+		log_field_size: usize,
+		n_oracles: usize,
+	) -> f64 {
+		assert!(n_oracles > 0, "precondition: a ladder opens at least one message");
+
+		let log_n_oracles = log2_ceil_usize(n_oracles);
 		self.levels
 			.iter()
-			.map(|level| {
+			.enumerate()
+			.map(|(i, level)| {
 				let base = self.regime.correlated_agreement_bits(
 					level.log_msg_len(),
 					level.log_inv_rate,
 					log_field_size,
 				);
-				// The worst of the `log_lanes` fold rounds pays `2^(log_lanes - 1)`.
-				base - (level.log_lanes.saturating_sub(1)) as f64
+				// Level 0 folds the lane index and the message index together.
+				let log_rows = level.log_lanes + if i == 0 { log_n_oracles } else { 0 };
+				// The worst of those fold rounds pays `2^(log_rows - 1)`.
+				base - (log_rows.saturating_sub(1)) as f64
 			})
 			.fold(f64::INFINITY, f64::min)
 	}
@@ -285,8 +341,21 @@ impl LigeritoParams {
 	/// A level grinds once more before its queries are drawn.
 	/// That is where [`Grinding::query_bits`] lands.
 	pub fn achieved_security_bits(&self, log_field_size: usize) -> f64 {
-		let algebra =
-			self.correlated_agreement_bits(log_field_size) + self.grinding.challenge_bits() as f64;
+		self.batched_achieved_security_bits(log_field_size, 1)
+	}
+
+	/// The same figure when level 0 opens `n_oracles` separately committed messages at once.
+	///
+	/// Only the correlated-agreement half moves.
+	/// The query counts are per level, and one query position serves every message.
+	/// So opening more messages changes nothing about how many rows are checked.
+	///
+	/// ## Preconditions
+	///
+	/// * `n_oracles` is positive.
+	pub fn batched_achieved_security_bits(&self, log_field_size: usize, n_oracles: usize) -> f64 {
+		let algebra = self.batched_correlated_agreement_bits(log_field_size, n_oracles)
+			+ self.grinding.challenge_bits() as f64;
 		// The same grind stands before every level's queries, so crediting it to the worst level
 		// is crediting it to all of them.
 		let queries = self
@@ -298,7 +367,9 @@ impl LigeritoParams {
 		algebra.min(queries)
 	}
 
-	/// The exact byte-size of a Ligerito proof at these parameters, without running the prover.
+	/// The exact byte-size of a Ligerito proof over one committed message, without running it.
+	///
+	/// A ladder opening several messages pays extra per-message level-0 openings on top of this.
 	///
 	/// Counted on the message channel:
 	/// - one Merkle root per committed level.
@@ -317,7 +388,9 @@ impl LigeritoParams {
 		size_estimation::proof_size(self, vcs)
 	}
 
-	/// What checking a proof at these parameters costs the verifier, one row per level.
+	/// What checking a proof over one committed message costs the verifier, one row per level.
+	///
+	/// A ladder opening several messages pays extra per-message level-0 openings on top of this.
 	///
 	/// The rows are the committed levels in ladder order.
 	/// One final row follows them, for the cleartext residual.
@@ -487,6 +560,25 @@ mod tests {
 	}
 
 	#[test]
+	fn a_shorter_message_commits_fewer_lanes_at_level_zero() {
+		// Fixture state: level 0 is 2^9 columns by 2^3 lanes, so the ladder commits 2^12 elements.
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100);
+
+		//     2^12 elements -> 2^9 columns * 2^3 lanes   the ladder's own message
+		//     2^11 elements -> 2^9 columns * 2^2 lanes   one lane fewer, same codeword
+		//     2^9  elements -> 2^9 columns * 2^0 lanes   a single lane, nothing to fold
+		//     2^6  elements -> 2^9 columns * 2^0 lanes   zero-padded out to the column count
+		for (log_msg_len, log_lanes) in [(12, 3), (11, 2), (9, 0), (6, 0)] {
+			let shape = params.level_zero_shape(log_msg_len);
+			assert_eq!(shape.log_lanes, log_lanes);
+			// The column count, the rate and the query count are shared by every oracle.
+			assert_eq!(shape.log_msg_cols, 9);
+			assert_eq!(shape.log_inv_rate, 1);
+			assert_eq!(shape.log_codeword_len(), 10);
+		}
+	}
+
+	#[test]
 	fn the_nonce_count_follows_the_two_call_sites() {
 		// Invariant: a level grinds once before each of its fold challenges and once more before
 		// its queries are drawn. So the two halves of a grind are told apart by count as well as
@@ -569,6 +661,41 @@ mod tests {
 	}
 
 	#[test]
+	#[should_panic(expected = "exceeds the ladder's")]
+	fn a_message_longer_than_the_ladder_has_no_level_zero_shape() {
+		// The ladder commits 2^12 elements, so 2^13 has no lane count that fits its level 0.
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100);
+		params.level_zero_shape(13);
+	}
+
+	#[test]
+	fn batching_messages_costs_level_zero_a_wider_row_union() {
+		// Fixture state: level 0 folds 2^3 lanes, so alone it already pays a union of 2^2 rows.
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100);
+		let alone = params.correlated_agreement_bits(128);
+
+		// One message is the unbatched figure, so the two routes must not drift.
+		assert_eq!(params.batched_correlated_agreement_bits(128, 1), alone);
+
+		//     1 message  -> 2^3 rows folded -> union 2^2
+		//     4 messages -> 2^5 rows folded -> union 2^4, two bits worse
+		//     5 messages -> 2^6 rows folded -> union 2^5, three bits worse
+		assert_eq!(params.batched_correlated_agreement_bits(128, 4), alone - 2.0);
+		assert_eq!(params.batched_correlated_agreement_bits(128, 5), alone - 3.0);
+
+		// The queries are unchanged, since one position serves every message.
+		let queries = params.achieved_security_bits(128);
+		assert_eq!(params.batched_achieved_security_bits(128, 4), queries.min(alone - 2.0));
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: a ladder opens at least one message")]
+	fn a_batch_of_no_messages_has_no_ceiling() {
+		let params = LigeritoParams::new(valid_levels(), SoundnessRegime::UniqueDecoding, 100);
+		params.batched_correlated_agreement_bits(128, 0);
+	}
+
+	#[test]
 	fn feasibility_is_exact_at_the_boundary() {
 		let mut level = LigeritoLevel {
 			log_msg_cols: 6,
@@ -579,5 +706,64 @@ mod tests {
 		assert!(level.is_feasible());
 		level.n_queries = 513;
 		assert!(!level.is_feasible());
+	}
+	#[test]
+	fn scratch_grind_offsets_batching() {
+		use binius_field::Ghash128b as B128;
+
+		use crate::merkle_tree::BinaryMerkleTreeScheme;
+		let scheme = BinaryMerkleTreeScheme::<B128, binius_hash::StdHashSuite>::new();
+		let (regime, _) =
+			SoundnessRegime::optimal_unique_decoding(120, 24, 1, 128).expect("reachable");
+		let (params, _) =
+			LigeritoParams::optimal_ladder::<B128, _>(&scheme, 24, 1, regime, 120, Grinding::NONE)
+				.expect("feasible");
+		for bits in [0usize, 1, 2, 3] {
+			let g = params.clone().with_grinding(Grinding::new(bits, 0));
+			println!(
+				"INT grind={bits} k=1 {:.2} k=2 {:.2} k=4 {:.2} k=8 {:.2}",
+				g.batched_achieved_security_bits(128, 1),
+				g.batched_achieved_security_bits(128, 2),
+				g.batched_achieved_security_bits(128, 4),
+				g.batched_achieved_security_bits(128, 8),
+			);
+		}
+	}
+
+	/// Challenge grinding buys back exactly what batching costs.
+	///
+	/// Both act on the algebraic term and neither touches the query one.
+	/// Batching `k` messages widens level 0's row union by `k`, costing `log2(k)` bits.
+	/// A challenge grind raises the same ceiling, one bit per bit ground.
+	/// So a caller who wants both can price them against each other.
+	#[test]
+	fn a_challenge_grind_buys_back_what_batching_costs() {
+		use binius_field::Ghash128b as B128;
+		use binius_hash::StdHashSuite;
+
+		use crate::merkle_tree::BinaryMerkleTreeScheme;
+
+		// Fixture state: a 2^24 message at 120 bits over B128, where the ceiling binds. At the
+		// shipped 96-bit target the query term binds instead and neither lever shows at all.
+		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+		let (regime, _) = SoundnessRegime::optimal_unique_decoding(120, 24, 1, 128)
+			.expect("120 bits is reachable with a constant loss");
+		let (params, _) =
+			LigeritoParams::optimal_ladder::<B128, _>(&scheme, 24, 1, regime, 120, Grinding::NONE)
+				.expect("a 120-bit ladder exists for one message");
+
+		for log_k in 0..4 {
+			let k = 1usize << log_k;
+			// Unground, each doubling of the oracle count takes one bit off the target.
+			let unground = params.batched_achieved_security_bits(128, k);
+			assert!(unground < 120.0 || k == 1, "k={k} kept {unground:.2}");
+
+			// Ground by that many bits, the batch reaches the target again.
+			let ground = params
+				.clone()
+				.with_grinding(Grinding::new(log_k, 0))
+				.batched_achieved_security_bits(128, k);
+			assert!(ground >= 120.0, "k={k} ground to {ground:.2}");
+		}
 	}
 }

--- a/crates/iop/src/ligerito/compiler.rs
+++ b/crates/iop/src/ligerito/compiler.rs
@@ -64,6 +64,19 @@ where
 			params.log_msg_len(),
 			"precondition: the longest oracle's message length must be the ladder's message length"
 		);
+		// Batching widens level 0's row union, which lowers a ceiling no query count can raise.
+		// A ladder sized for one message can therefore miss a target it otherwise clears, and the
+		// miss is silent: the unbatched figure keeps reporting the number the batch does not pay.
+		// Whether the ladder clears its target on its own is `LigeritoParams`'s business, so this
+		// refuses only the batches that cause the shortfall.
+		let target = params.security_bits() as f64;
+		let batched = params.batched_achieved_security_bits(F::N_BITS, oracle_specs.len());
+		assert!(
+			batched >= target || params.achieved_security_bits(F::N_BITS) < target,
+			"precondition: {} oracles reach {batched:.2} bits against a target of {}",
+			oracle_specs.len(),
+			params.security_bits()
+		);
 
 		Self {
 			oracle_specs,
@@ -309,5 +322,28 @@ mod tests {
 			vec![OracleSpec::new(7), OracleSpec::new(6)],
 			params(),
 		);
+	}
+
+	/// A batch that would miss the target the ladder was sized for must be refused.
+	///
+	/// At 96 bits the query term binds, so batching costs nothing there.
+	/// Above roughly 117 bits over `B128` the algebraic ceiling binds instead.
+	/// Each doubling of the oracle count then takes one bit off it.
+	/// A ladder sized for one message misses its target once several share it.
+	#[test]
+	#[should_panic(expected = "oracles reach")]
+	fn a_batch_that_would_miss_the_target_is_refused() {
+		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+		let (regime, _) = SoundnessRegime::optimal_unique_decoding(120, 24, 1, 128)
+			.expect("120 bits is reachable with a constant loss");
+		let (params, _) =
+			LigeritoParams::optimal_ladder::<B128, _>(&scheme, 24, 1, regime, 120, Grinding::NONE)
+				.expect("a 120-bit ladder exists for one message");
+
+		// One oracle clears 120, so the shortfall below is caused by the batch and nothing else.
+		assert!(params.achieved_security_bits(128) >= 120.0);
+
+		let spec = OracleSpec::new(params.log_msg_len());
+		LigeritoVerifierCompiler::<B128>::new(vec![spec, spec], params);
 	}
 }

--- a/crates/iop/src/ligerito/compiler.rs
+++ b/crates/iop/src/ligerito/compiler.rs
@@ -20,13 +20,13 @@ use crate::{
 
 /// A compiler that creates Ligerito verifier channels from a precomputed ladder.
 ///
-/// The ladder is chosen once, for the one oracle the channel opens.
-/// Every channel the compiler creates reuses it.
+/// The ladder is chosen once, for the longest oracle the channel opens.
+/// Every channel the compiler creates reuses it, and every oracle shares its column count.
 ///
-/// Ligerito commits no mask, so the oracle it opens is never zero-knowledge.
+/// Ligerito commits no mask, so the oracles it opens are never zero-knowledge.
 #[derive(Debug, Clone)]
 pub struct LigeritoVerifierCompiler<F> {
-	/// The one oracle every channel this compiler makes will open.
+	/// The oracles every channel this compiler makes will open, in the order they arrive.
 	oracle_specs: Vec<OracleSpec>,
 	/// The ladder each of those openings runs down.
 	params: LigeritoParams,
@@ -43,24 +43,26 @@ where
 	///
 	/// ## Preconditions
 	///
-	/// * `oracle_specs` holds exactly one spec.
-	/// * That spec is not zero-knowledge.
-	/// * Its message length is the ladder's message length.
+	/// * `oracle_specs` is non-empty.
+	/// * No spec is zero-knowledge.
+	/// * The longest message is the ladder's message length.
 	pub fn new(oracle_specs: Vec<OracleSpec>, params: LigeritoParams) -> Self {
-		assert_eq!(
-			oracle_specs.len(),
-			1,
-			"precondition: a Ligerito compiler serves exactly one oracle, got {}",
-			oracle_specs.len()
+		assert!(
+			!oracle_specs.is_empty(),
+			"precondition: a Ligerito compiler serves at least one oracle"
 		);
 		assert!(
-			!oracle_specs[0].is_zk,
+			oracle_specs.iter().all(|spec| !spec.is_zk),
 			"precondition: Ligerito commits no mask, so a zero-knowledge oracle cannot be opened"
 		);
 		assert_eq!(
-			oracle_specs[0].log_msg_len,
+			oracle_specs
+				.iter()
+				.map(|spec| spec.log_msg_len)
+				.max()
+				.expect("oracle_specs is non-empty"),
 			params.log_msg_len(),
-			"precondition: the oracle's message length must be the ladder's message length"
+			"precondition: the longest oracle's message length must be the ladder's message length"
 		);
 
 		Self {
@@ -70,12 +72,15 @@ where
 		}
 	}
 
-	/// Creates a compiler whose ladder is the proof-size-minimizing one for the oracle.
+	/// Creates a compiler whose ladder is the proof-size-minimizing one for the longest oracle.
 	///
 	/// Level 0's rate is pinned by the caller, because level 0's encoding dominates prover time.
 	/// The deeper levels are small, so the search is free to drop their rate as far as it likes.
 	///
-	/// `None` means no ladder over this message reaches the security target.
+	/// The search input is the longest message, since every oracle shares level 0's column count.
+	/// A shorter one then simply carries fewer interleaved lanes.
+	///
+	/// `None` means no ladder over that message reaches the security target.
 	///
 	/// `grinding` is what the ladder will pay per level.
 	/// The search prices it rather than assuming it away.
@@ -83,8 +88,8 @@ where
 	///
 	/// ## Preconditions
 	///
-	/// * `oracle_specs` holds exactly one spec.
-	/// * That spec is not zero-knowledge.
+	/// * `oracle_specs` is non-empty.
+	/// * No spec is zero-knowledge.
 	/// * `l0_log_inv_rate` is a usable inverse rate and `security_bits` is positive.
 	pub fn optimal<MerkleScheme>(
 		merkle_scheme: &MerkleScheme,
@@ -97,17 +102,19 @@ where
 	where
 		MerkleScheme: MerkleTreeScheme<F>,
 	{
-		assert_eq!(
-			oracle_specs.len(),
-			1,
-			"precondition: a Ligerito compiler serves exactly one oracle, got {}",
-			oracle_specs.len()
+		assert!(
+			!oracle_specs.is_empty(),
+			"precondition: a Ligerito compiler serves at least one oracle"
 		);
 
-		// The ladder is searched over the one message it commits, so its size is the search input.
+		// Level 0's shape is shared, so the longest message is what the ladder is searched over.
 		let (params, _proof_size) = LigeritoParams::optimal_ladder::<F, _>(
 			merkle_scheme,
-			oracle_specs[0].log_msg_len,
+			oracle_specs
+				.iter()
+				.map(|spec| spec.log_msg_len)
+				.max()
+				.expect("oracle_specs is non-empty"),
 			l0_log_inv_rate,
 			regime,
 			security_bits,
@@ -252,14 +259,29 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "precondition: a Ligerito compiler serves exactly one oracle")]
-	fn two_oracles_are_refused() {
-		// Batching several committed oracles into one ladder is not implemented.
-		// So the compiler refuses the shape rather than silently opening only the first.
-		LigeritoVerifierCompiler::<B128>::new(
-			vec![OracleSpec::new(8), OracleSpec::new(8)],
-			params(),
-		);
+	fn several_oracles_share_the_ladder_of_the_longest() {
+		// Fixture state: level 0 is 2^6 columns by 2^2 lanes, so the ladder commits 2^8 elements.
+		//
+		//     2^8 elements -> 2^2 lanes   the oracle the ladder was sized for
+		//     2^7 elements -> 2^1 lanes   one lane fewer over the same codeword
+		//     2^5 elements -> 2^0 lanes   a single lane, zero-padded out to 2^6 columns
+		let specs = vec![OracleSpec::new(8), OracleSpec::new(7), OracleSpec::new(5)];
+		let compiler = LigeritoVerifierCompiler::<B128>::new(specs.clone(), params());
+
+		assert_eq!(compiler.oracle_specs(), &specs);
+		for (spec, log_lanes) in std::iter::zip(&specs, [2, 1, 0]) {
+			let shape = compiler.params().level_zero_shape(spec.log_msg_len);
+			assert_eq!(shape.log_lanes, log_lanes);
+			// One codeword length, so one set of query positions serves every oracle.
+			assert_eq!(shape.log_codeword_len(), 7);
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: a Ligerito compiler serves at least one oracle")]
+	fn no_oracle_at_all_is_refused() {
+		// A ladder with nothing to open is a mis-specified channel rather than a trivial one.
+		LigeritoVerifierCompiler::<B128>::new(Vec::new(), params());
 	}
 
 	#[test]
@@ -271,10 +293,21 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "precondition: the oracle's message length must be the ladder's")]
+	#[should_panic(expected = "precondition: the longest oracle's message length must be the")]
 	fn a_ladder_over_a_different_message_length_is_refused() {
-		// The ladder commits 2^8 elements and the oracle claims 2^9.
+		// The ladder commits 2^8 elements and the longest oracle claims 2^9.
 		// So level 0's codeword would not encode the buffer the channel is handed.
 		LigeritoVerifierCompiler::<B128>::new(vec![OracleSpec::new(9)], params());
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: the longest oracle's message length must be the")]
+	fn a_ladder_wider_than_every_oracle_is_refused() {
+		// The ladder commits 2^8 elements and no oracle reaches that.
+		// Level 0 would then fold lanes that none of them has, wasting a round on nothing.
+		LigeritoVerifierCompiler::<B128>::new(
+			vec![OracleSpec::new(7), OracleSpec::new(6)],
+			params(),
+		);
 	}
 }

--- a/crates/iop/src/ligerito/mod.rs
+++ b/crates/iop/src/ligerito/mod.rs
@@ -18,6 +18,7 @@
 //!
 //! - [`LigeritoParams`] and its invariants;
 //! - [`InducedBasis`], the weight vector a level's opened rows put on its message;
+//! - [`CommittedOracle`], one committed message as level 0 sees it;
 //! - [`LigeritoVerifier`], the ladder of committed levels down to a cleartext residual;
 //! - [`channel::LigeritoVerifierChannel`], the ladder behind the IOP verifier channel trait;
 //! - [`LigeritoParams::proof_size`], the byte-exact estimate;
@@ -31,6 +32,7 @@
 //! [NA25]: <https://eprint.iacr.org/2025/1187>
 
 pub mod channel;
+mod committed_oracle;
 mod common;
 pub mod compiler;
 mod error;
@@ -39,6 +41,7 @@ mod opening;
 mod size_estimation;
 mod verifier_cost;
 
+pub use committed_oracle::CommittedOracle;
 pub use common::*;
 pub use error::{Error, VerificationError};
 pub use induced_basis::InducedBasis;

--- a/crates/iop/src/ligerito/opening.rs
+++ b/crates/iop/src/ligerito/opening.rs
@@ -42,6 +42,29 @@
 //! A prover therefore has to fix what it folded to without knowing which rows will be checked
 //! against it, which is the entire soundness argument for a cleartext residual.
 //!
+//! # Why several messages can share one ladder
+//!
+//! Every message a ladder opens together is committed with the *same* number of columns.
+//! The lane count is then the only thing that varies between them.
+//! Their level-0 codewords all have one length over one domain.
+//! So one set of query positions addresses every one of them, and they fold to one column count.
+//! Weighing message `i`'s folded rows by a coefficient `e_i` gives
+//!
+//! ```text
+//!     sum_i e_i * <G_q, X_1^(i)>  =  <G_q, sum_i e_i * X_1^(i)>
+//! ```
+//!
+//! which is a claim about a *single* level-1 message.
+//! Level 1 commits exactly that combined message.
+//! So every level below level 0 is the one-message ladder unchanged.
+//!
+//! This is not how the FRI-based scheme in this repository batches, and the reason is structural.
+//! FRI folds one codeword, so every oracle is reconciled in the codeword domain before that fold.
+//! A short one is stretched by duplication to reach the common length.
+//! A Ligerito level never folds a codeword: it folds the message and re-encodes it.
+//! So level `i + 1` is a fresh commitment rather than a fold of level `i`'s.
+//! Equalizing the *column* count is therefore enough, and no duplication is needed.
+//!
 //! # Where the proof of work stands
 //!
 //! [`LigeritoParams::grinding`](super::LigeritoParams::grinding) fixes two difficulties.
@@ -79,6 +102,8 @@
 //! Those levels run a plain degree-2 sumcheck over the product of the message and the weight, and
 //! the equality factor each round strips has to be carried by hand.
 
+use std::iter::zip;
+
 use binius_field::{BinaryField, FieldOps};
 use binius_ip::{
 	mlecheck,
@@ -89,7 +114,7 @@ use binius_math::{
 	ntt::domain_context::GaoMateerOnTheFly,
 };
 
-use super::{InducedBasis, LigeritoParams, error::Error};
+use super::{CommittedOracle, InducedBasis, LigeritoParams, error::Error};
 use crate::{
 	channel::grinding::GrindingVerifierChannel,
 	fri::batch::{BrakedownOracle, ProxTestOracle},
@@ -110,21 +135,88 @@ pub(super) const PRODUCT_DEGREE: usize = 2;
 
 /// Verifies a Ligerito opening against a committed ladder of Reed-Solomon codewords.
 ///
-/// Holds the parameters and the commitment to level 0's codeword.
-/// The caller receives that commitment, so it stays in charge of when the first oracle arrives.
+/// Holds the parameters and the commitments level 0 opens.
+/// The caller receives those commitments, so it stays in charge of when the first oracles arrive.
 /// Every deeper commitment arrives at a point the protocol fixes, so this reads those itself.
 #[derive(Debug, Clone)]
-pub struct LigeritoVerifier<'a, C> {
+pub struct LigeritoVerifier<'a, E, C> {
 	/// The ladder's shape, one [`super::LigeritoLevel`] per committed level.
 	params: &'a LigeritoParams,
-	/// The commitment to level 0's interleaved codeword.
-	commitment: C,
+	/// The messages level 0 opens together, in the order their openings are read.
+	oracles: Vec<CommittedOracle<E, C>>,
 }
 
-impl<'a, C: Clone> LigeritoVerifier<'a, C> {
-	/// Binds a verifier to a ladder and the commitment to its outermost codeword.
-	pub const fn new(params: &'a LigeritoParams, commitment: C) -> Self {
-		Self { params, commitment }
+impl<'a, E: FieldOps, C: Clone> LigeritoVerifier<'a, E, C> {
+	/// Binds a verifier to a ladder and the commitment to its one outermost codeword.
+	///
+	/// The message fills level 0, so it carries every lane the ladder folds there.
+	/// A batch of one weighs its only member by one.
+	pub fn new(params: &'a LigeritoParams, commitment: C) -> Self {
+		let log_lanes = params.levels()[0].log_lanes;
+		Self::batched(params, vec![CommittedOracle::new(commitment, log_lanes, E::one())])
+	}
+
+	/// Binds a verifier to a ladder and the several messages its level 0 opens together.
+	///
+	/// The messages fold to one column count, so level 1 commits a single combined message.
+	/// Every level below it is then the one-message ladder unchanged.
+	///
+	/// ## Preconditions
+	///
+	/// * `oracles` is non-empty.
+	/// * No message carries more lanes than level 0 folds.
+	/// * At least one message carries exactly that many, so no fold round is wasted.
+	pub fn batched(params: &'a LigeritoParams, oracles: Vec<CommittedOracle<E, C>>) -> Self {
+		assert!(!oracles.is_empty(), "precondition: a ladder opens at least one message");
+
+		let log_lanes = params.levels()[0].log_lanes;
+		let max_log_lanes = oracles
+			.iter()
+			.map(CommittedOracle::log_lanes)
+			.max()
+			.expect("oracles is non-empty");
+		assert_eq!(
+			max_log_lanes, log_lanes,
+			"precondition: level 0 folds 2^{log_lanes} lanes, and the longest message has \
+			 2^{max_log_lanes}"
+		);
+
+		Self { params, oracles }
+	}
+
+	/// Opens every committed message at the shared positions, combined into one claim per position.
+	///
+	/// Level 0's codewords all have one length over one domain, so a single position addresses
+	/// every one of them.
+	/// The openings are read in commit order.
+	/// Each message's rows are folded by its own share of the challenges and scaled by its own
+	/// coefficient.
+	/// That turns the batch into a claim about the single message level 1 commits:
+	///
+	/// ```text
+	///     sum_i e_i * <G_q, X_1^(i)>  =  <G_q, sum_i e_i * X_1^(i)>
+	/// ```
+	///
+	/// Encoding and folding are both linear, so the two sides are the same value read two ways.
+	fn open_level_zero<F, Channel>(
+		&self,
+		challenges: &[E],
+		indices: &[Channel::Word],
+		channel: &mut Channel,
+	) -> Result<Vec<E>, Error>
+	where
+		F: BinaryField,
+		E: FieldOps<Scalar = F>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
+	{
+		let mut combined = vec![E::zero(); indices.len()];
+		for oracle in &self.oracles {
+			let rows = oracle.open_scaled_rows(challenges, indices, channel)?;
+			for (entry, row) in zip(&mut combined, rows) {
+				*entry += row;
+			}
+		}
+		Ok(combined)
 	}
 
 	/// Verifies the opening of `<X_0, eq(eval_point)> = eval_claim`.
@@ -145,14 +237,14 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 	/// * `eval_point` has `params.log_msg_len()` coordinates, in low-to-high variable order.
 	pub fn verify<F, Channel>(
 		&self,
-		eval_point: &[Channel::Elem],
-		eval_claim: Channel::Elem,
+		eval_point: &[E],
+		eval_claim: E,
 		channel: &mut Channel,
 	) -> Result<(), Error>
 	where
 		F: BinaryField,
-		Channel: MerkleIPVerifierChannel<F, Commitment = C> + GrindingVerifierChannel,
-		Channel::Elem: From<F>,
+		E: FieldOps<Scalar = F> + From<F>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E> + GrindingVerifierChannel,
 	{
 		let levels = self.params.levels();
 		let grinding = self.params.grinding();
@@ -165,10 +257,11 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 		let mut sum = eval_claim;
 		// The equality factor the plain rounds strip, which the MLE-check level would have divided
 		// out for itself.
-		let mut eq_scale = Channel::Elem::one();
+		let mut eq_scale = E::one();
 		// The query claims glued in so far, each still weighing the message it was induced on.
-		let mut glued = Vec::<(Channel::Elem, InducedBasis<Channel::Elem>)>::new();
-		let mut commitment = self.commitment.clone();
+		let mut glued = Vec::<(E, InducedBasis<E>)>::new();
+		// Absent while level 0 is running, since level 0 opens the batch rather than one codeword.
+		let mut commitment: Option<C> = None;
 		let mut residual = None;
 
 		for (i, level) in levels.iter().enumerate() {
@@ -224,10 +317,15 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 				.map(|_| channel.sample_bits(level.log_codeword_len()))
 				.collect::<Vec<_>>();
 
-			// `open_queries` returns each opened coset already folded by the challenges, which is
-			// the value the module documentation identifies with `<G_q, X_{i+1}>`.
-			let oracle = BrakedownOracle::new(challenges, commitment.clone(), 0);
-			let folded_rows = oracle.open_queries(&indices, channel)?;
+			// Opening a coset returns it already folded by the challenges, which is the value the
+			// module documentation identifies with `<G_q, X_{i+1}>`.
+			let folded_rows = match &commitment {
+				// Level 0 opens every committed message and combines them into one claim.
+				None => self.open_level_zero(&challenges, &indices, channel)?,
+				// A deeper level has one codeword, committed by the level above it.
+				Some(commitment) => BrakedownOracle::new(challenges, commitment.clone(), 0)
+					.open_queries(&indices, channel)?,
+			};
 
 			let alpha = channel.sample();
 			let domain_context = GaoMateerOnTheFly::generate(level.log_codeword_len());
@@ -246,7 +344,7 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 					let beta = channel.sample();
 					sum += beta.clone() * basis.enforced_sum(&folded_rows);
 					glued.push((beta, basis));
-					commitment = next;
+					commitment = Some(next);
 				}
 				None => {
 					// The residual is in the clear, so the row claim is checked directly against
@@ -261,7 +359,7 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 
 		// The sumcheck half: the reduced claim against the residual paired with the weight the
 		// ladder accumulated, which is the equality indicator plus every glued basis.
-		let mut paired = Channel::Elem::zero();
+		let mut paired = E::zero();
 		for (beta, basis) in &glued {
 			paired += beta.clone() * basis.pair(&residual);
 		}
@@ -270,5 +368,98 @@ impl<'a, C: Clone> LigeritoVerifier<'a, C> {
 		channel.assert_zero(paired + eq_scale * residual_eval - sum)?;
 
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{Field, Ghash128b as B128};
+
+	use super::*;
+	use crate::{ligerito::LigeritoLevel, soundness::SoundnessRegime};
+
+	/// A two-level ladder over a 2^8 message: 2^6 columns and 4 lanes, then 2^5 columns and 2.
+	fn params() -> LigeritoParams {
+		LigeritoParams::new(
+			vec![
+				LigeritoLevel {
+					log_msg_cols: 6,
+					log_lanes: 2,
+					log_inv_rate: 1,
+					n_queries: 5,
+				},
+				LigeritoLevel {
+					log_msg_cols: 5,
+					log_lanes: 1,
+					log_inv_rate: 2,
+					n_queries: 5,
+				},
+			],
+			SoundnessRegime::UniqueDecoding,
+			32,
+		)
+	}
+
+	/// One message, weighed by one, carrying the lanes the ladder names for a message that long.
+	fn oracle(log_msg_len: usize) -> CommittedOracle<B128, ()> {
+		let log_lanes = params().level_zero_shape(log_msg_len).log_lanes;
+		CommittedOracle::new((), log_lanes, B128::ONE)
+	}
+
+	#[test]
+	fn one_message_fills_level_zero_by_itself() {
+		// Fixture state: level 0 folds 2^2 lanes, and the ladder's own message has exactly that.
+		let params = params();
+		let verifier = LigeritoVerifier::<B128, ()>::new(&params, ());
+		assert_eq!(verifier.oracles.len(), 1);
+		assert_eq!(verifier.oracles[0].log_lanes(), 2);
+	}
+
+	#[test]
+	fn shorter_messages_ride_alongside_the_longest() {
+		// Fixture state: 2^6 columns at level 0, so the lane count is what a shorter message loses.
+		//
+		//     2^8 elements -> 2^2 lanes
+		//     2^7 elements -> 2^1 lanes
+		//     2^4 elements -> 2^0 lanes, zero-padded out to 2^6 columns
+		let params = params();
+		let oracles = vec![oracle(8), oracle(7), oracle(4)];
+		let verifier = LigeritoVerifier::<B128, ()>::batched(&params, oracles);
+
+		let lanes = verifier
+			.oracles
+			.iter()
+			.map(CommittedOracle::log_lanes)
+			.collect::<Vec<_>>();
+		assert_eq!(lanes, vec![2, 1, 0]);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: a ladder opens at least one message")]
+	fn a_ladder_with_nothing_to_open_is_refused() {
+		// A ladder whose level 0 has no codeword has no rows to fold and no claim to reduce.
+		let params = params();
+		LigeritoVerifier::<B128, ()>::batched(&params, Vec::new());
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: level 0 folds")]
+	fn a_batch_that_underfills_level_zero_is_refused() {
+		// Level 0 folds 2^2 lanes and the longest message here carries 2^1.
+		// The extra round would bind a variable no message has, so the ladder is mis-sized.
+		let params = params();
+		LigeritoVerifier::<B128, ()>::batched(&params, vec![oracle(7), oracle(6)]);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: level 0 folds")]
+	fn a_message_with_more_lanes_than_level_zero_is_refused() {
+		// Level 0 folds 2^2 lanes and this message claims 2^3.
+		// One of its lanes would never be folded, so its rows would go unchecked.
+		let params = params();
+		LigeritoVerifier::<B128, ()>::batched(
+			&params,
+			vec![CommittedOracle::new((), 3, B128::ONE)],
+		);
 	}
 }


### PR DESCRIPTION
Linear:
[BINIUS-540](https://linear.app/jimpo/issue/BINIUS-540/batch-several-committed-oracles-into-one-ligerito-ladder)

Follows #2308, which put the Ligerito ladder behind the IOP channel traits for
exactly one oracle and deferred batching. The channel asserted it was handed one
spec and refused anything else, so a caller that commits more than one
polynomial — Iron Spartan commits three — could not use it at all.

## Why this is not FRI's batching

FRI folds one codeword. `BatchBrakedownFolder::fold` materializes a single
combined codeword the remaining rounds consume, so every oracle has to be
reconciled *in the codeword domain, before the first fold*. A short oracle is
stretched to fit by duplication — `combined[j] += folded[j >> log_lift]` — and
that is what `log_lift` is for.

Ligerito never folds a codeword. Its prover folds the *message* and re-encodes
it (`current.fold_highest_var(challenge)` then `commit_level(...)`), so level
`i + 1` is a fresh Merkle tree rather than a fold of level `i`'s codeword. The
differing-length problem therefore leaves the codeword side entirely.

Give every oracle the same level-0 column count, so the lane count is the only
thing a shorter message changes:

```
    lanes_i = max(n_i - cols_0, 0)
```

Every level-0 codeword then has identical length over an identical domain, one
set of query positions serves all of them, and they all fold to the same column
count. Weighing oracle `i`'s folded rows by a coefficient `e_i` gives

```
    sum_i e_i <G_q, X_1^(i)>  =  <G_q, sum_i e_i X_1^(i)>
```

a claim about a *single* level-1 message. Level 1 commits exactly that message,
so **every level below level 0 is the one-oracle ladder unchanged**.

## Two amendments the code forced

**A message shorter than one column block.** `lanes_i = n_i - cols_0` has no
answer when `n_i < cols_0`. Refusing such an oracle would make the channel
unusable for a caller with one small polynomial, so instead it commits a single
lane, zero-padded out to the shared column count. Everything downstream is then
uniform: `lanes_i = 0`, the coset it opens is one element, and the fold is the
identity. The cost is a full-width encoding for a message that does not need
one, which is the price of sharing the query set. `LigeritoParams::level_zero_shape`
is where that rule lives, and its doc says so.

**`BatchBrakedownOracle` does not fit.** It combines its oracles by an outer
tensor it expands itself, with no per-oracle scale. A shorter message needs one
here: it rides the same fold rounds as the longest, and the rounds that bind
variables it is zero over contribute a known scalar rather than a fold. Working
the bit-reversal through, oracle `i`'s share of the level-0 challenges is the
trailing `lanes_i` of them, and the leading ones contribute `eq(0, .)`:

```
    challenges = [ padding .. | this message's lanes .. ]
    scale      = coefficient * eq(0, padding)
```

So level 0 gets `CommittedOracle`, which carries a commitment, a lane count and
a coefficient, and derives its own share.

## The shape of the opening

Three reductions, mirroring what BaseFold's channel already does:

```
    <pi_i, t_ij> = s_ij      relations, batched per oracle at one lambda
      -> sumcheck            padded to the longest oracle, binds a shared point r
    pi_i(r) = alpha_i        one evaluation claim per oracle
      -> eq-combine          at coefficients drawn once every alpha is on the wire
    PI(r) = sum_i e_i alpha_i
      -> ladder
```

The padded sumcheck is `SharedSumcheckProver` + `MleStore` +
`PaddedSumcheckDecorator` from BINIUS-282, which is exactly the tool for
differing round counts. A shorter oracle is its own multilinear zero-extended,
so its claim carries the factor the extra coordinates contribute at zero.

The one-oracle path is the same code with `k = 1`: `CommittedOracle` with
coefficient one, no outer challenges (`log2_ceil(1) = 0`), and no padding. It is
not byte-identical to #2308 only because `sumcheck::batch_verify` samples its
batching coefficient unconditionally, which changes challenges but not bytes.

## Soundness

Every coefficient is drawn only after the claims it combines are bound to the
transcript. The three batching steps cost, in order:

- `sum_i (k_i - 1) / |F|`, for folding oracle `i`'s `k_i` relations by powers of
  one coefficient rather than `k_i` independent ones;
- `(k - 1) / |F|`, for folding the `k` oracle claims into one sumcheck the same
  way;
- a wider row union at level 0, for combining the `k` messages into the one the
  ladder folds.

The third is a proximity-gap statement, so no number of queries buys it back,
and it is now priced rather than asserted. Level 0 folds a tensor over its own
lane index *and* the message index, so its row union grows from `2^log_lanes`
rows to `2^log_lanes * k`. `LigeritoParams::batched_correlated_agreement_bits`
charges exactly that, on the same pessimistic `2^(rows - 1)` convention the
ladder already uses for its lane folds. Nothing below level 0 moves, because the
batch is one combined message from level 1 on.

The residual ordering is untouched: it is still committed and sent before any
query position is sampled, at every level. Everything added here runs before the
ladder is entered. The verifier still reaches nothing outside
`MerkleIPVerifierChannel` and `WordIPVerifierChannel`, and takes no field
inverse of a witness-dependent value. A zero-knowledge oracle is still refused
at the boundary.

## Tests

- several oracles of one length verify through one ladder, and cost strictly
  less than one ladder each;
- oracles of lengths `2^7, 2^6, 2^5, 2^3` against a ladder with `2^5` columns and
  `2^2` lanes, so the lane counts are `2, 1, 0, 0` and the last is zero-padded;
- a wrong claim on the *second* of two oracles is caught by the relation
  sumcheck;
- a commitment that does not encode its opened message is caught by the ladder,
  again on the second oracle;
- opening some oracles but not others is refused;
- the combined message's packed assembly is pinned against a scalar reference at
  three packing widths and every shape up to `2^4`;
- the batched soundness accounting is pinned at 1, 4 and 5 oracles.

## Deliberately not here

`LigeritoParams::proof_size` and `verifier_cost` still price one committed
message. A batch pays extra per-message level-0 openings on top of what they
report, and their docs now say so. Extending them wants the level-0 shape search
to take the whole oracle set, which is its own change.
