### PR TITLE
BINIUS-542: count the breadth-first NTT's packed pairs from the buffer

### DIFF
--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -217,8 +217,9 @@ fn forward_breadth_first<P: PackedField>(
 			}
 		}
 
-		// log2 the number of packed element pairs to process in this layer
-		let log_packed_pairs = packed_cutoff - base_layer - 1;
+		// log2 the number of packed element pairs to process in this layer.
+		// This call's data is `2^(log_d - P::LOG_WIDTH)` packed elements, hence half that in pairs.
+		let log_packed_pairs = log_d - P::LOG_WIDTH - 1;
 		let layer_twiddles = domain_context
 			.iter_twiddles(layer, log_half_blocks_per_packed)
 			.skip(base_block << log_packed_pairs)


### PR DESCRIPTION
Closes [BINIUS-542](https://linear.app/jimpo/issue/BINIUS-542).

Fixes a latent wrong-answer bug in the breadth-first additive NTT. One line.

### The problem

`forward_breadth_first` splits its work at `packed_cutoff`, the layer where butterflies start moving *inside* a packed element rather than between packed elements:

```
let packed_cutoff = (log_n - P::LOG_WIDTH).clamp(layer_range.start, layer_range.end);
```

The clamp keeps the two loop bounds inside the requested layer range, which is what it is for.

The same clamped value was then reused for a second, unrelated job: counting how many packed-element *pairs* the buffer holds.
That count is a property of the buffer alone — it has nothing to do with which layers were requested.

When `layer_range.start` sits above the unclamped cutoff, the clamp raises `packed_cutoff` and the pair count comes out too large.

The count also strides the twiddle iterator:

```
.skip(base_block << log_packed_pairs)
```

An inflated stride skips past every twiddle for the later chunks, so `zip` yields nothing and their butterflies never run.
The output keeps a silently untransformed suffix — a wrong codeword, in release, with no panic.

### The idea

The buffer holds `2^(log_d - P::LOG_WIDTH)` packed elements, hence half that many pairs. Take the count from there, and the clamp never enters into it.

The function already asserted exactly this, so the intended value was never in doubt:

```
debug_assert_eq!(data_pairs.len(), 1 << log_packed_pairs);
```

Since `log_n == log_d + base_layer`, the old and new expressions agree precisely when the clamp is a no-op.

### The change

```diff
-// log2 the number of packed element pairs to process in this layer
-let log_packed_pairs = packed_cutoff - base_layer - 1;
+// log2 the number of packed element pairs to process in this layer.
+// This call's data is `2^(log_d - P::LOG_WIDTH)` packed elements, hence half that in pairs.
+let log_packed_pairs = log_d - P::LOG_WIDTH - 1;
```

### Reachability — latent, not live

Triggering it needs `layer_range.start > log_d - P::LOG_WIDTH`.

- With `P::LOG_WIDTH == 0` it is unreachable, so the aarch64 default `PackedBinaryGhash1x128b` can never hit it.
- With `P::LOG_WIDTH == 2` it needs `skip_early > log_d - 2`.

Pushing that second case through `ReedSolomonCode::encode_batch`, where `skip_early` is `log_inv_rate` and `log_d` is `log_dim + log_batch_size + log_inv_rate`, the condition collapses to `log_dim + log_batch_size < 2` — a message of at most two scalars.

So no parameter set in the tree reaches it today.
It is still a broken invariant in a primitive whose output gets committed to, and the fix is one line.

A concrete failing shape, for anyone who wants to see it: `log_d = 4`, `skip_early = 3`, over `PackedBinaryGhash4x128b` leaves half its output untransformed, in release as well as debug.

### Scope

- **changed:** `crates/math/src/ntt/neighbors_last.rs`, one expression
- no public API change, no behaviour change at any parameter set currently exercised

### Verification

- `cargo test -p binius-math --features rayon` — 167 passed
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt -p binius-math -- --check` — clean

### Context

Found while building [BINIUS-543](https://linear.app/jimpo/issue/BINIUS-543), whose equivalence proptest could not cover its natural parameter range until this was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)