### PR TITLE
BINIUS-543: fuse the multithreaded NTT's shared layers in pairs

### DIFF
--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -214,7 +214,9 @@ fn bench_fields(c: &mut Criterion) {
 			(PackedBinaryGhash4x128b, "4xGhash"),
 		],
 		log_d = [16, 20, 24],
-		skip_params = [(0, 0), (4, 0), (0, 4)],
+		// `skip_early = 1` is the shape a rate-1/2 Reed-Solomon encoder asks for.
+		// It is also the smallest skip that leaves the multithreaded shared phase non-empty.
+		skip_params = [(0, 0), (1, 0), (4, 0), (0, 4)],
 	}
 }
 

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -217,8 +217,9 @@ fn forward_breadth_first<P: PackedField>(
 			}
 		}
 
-		// log2 the number of packed element pairs to process in this layer
-		let log_packed_pairs = packed_cutoff - base_layer - 1;
+		// log2 the number of packed element pairs to process in this layer.
+		// This call's data is `2^(log_d - P::LOG_WIDTH)` packed elements, hence half that in pairs.
+		let log_packed_pairs = log_d - P::LOG_WIDTH - 1;
 		let layer_twiddles = domain_context
 			.iter_twiddles(layer, log_half_blocks_per_packed)
 			.skip(base_block << log_packed_pairs)

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -12,6 +12,7 @@ use binius_utils::rayon::{
 	iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator},
 	slice::ParallelSliceMut,
 };
+use itertools::izip;
 
 use super::{
 	AdditiveNTT, DomainContext,
@@ -326,6 +327,174 @@ fn forward_shared_layer<P: PackedField>(
 		});
 }
 
+/// Applies one butterfly of the network: `u += v * twiddle`, then `v += u`.
+#[inline(always)]
+fn butterfly<P: PackedField>(u: &mut P, v: &mut P, twiddle: P) {
+	*u += *v * twiddle;
+	*v += *u;
+}
+
+/// Applies two consecutive butterfly layers to four planes held in registers.
+///
+/// The four planes are the quarters of one super-block, in plane order.
+/// `twiddle_0` belongs to the first layer, which pairs planes `(0, 2)` and `(1, 3)`.
+/// `twiddle_1_even` and `twiddle_1_odd` belong to the second, which pairs `(0, 1)` and `(2, 3)`.
+///
+/// Each element is loaded once, takes part in both layers, and is stored once.
+fn fused_pair<P: PackedField>(
+	planes: [&mut [P]; 4],
+	twiddle_0: P,
+	twiddle_1_even: P,
+	twiddle_1_odd: P,
+) {
+	let [plane_0, plane_1, plane_2, plane_3] = planes;
+
+	for (x_0, x_1, x_2, x_3) in izip!(plane_0, plane_1, plane_2, plane_3) {
+		butterfly(x_0, x_2, twiddle_0);
+		butterfly(x_1, x_3, twiddle_0);
+		butterfly(x_0, x_1, twiddle_1_even);
+		butterfly(x_2, x_3, twiddle_1_odd);
+	}
+}
+
+/// Same as [`fused_pair`], for the super-block whose index is zero.
+///
+/// There `twiddle_0` and `twiddle_1_even` are both the layer's block-0 twiddle, which is zero.
+/// Each of their butterflies collapses to `v += u`, leaving `u` untouched.
+/// So plane 0 is never written, and its cache lines stay clean.
+fn fused_pair_zero_block<P: PackedField>(planes: [&mut [P]; 4], twiddle_1_odd: P) {
+	let [plane_0, plane_1, plane_2, plane_3] = planes;
+
+	for (x_0, x_1, x_2, x_3) in izip!(plane_0, plane_1, plane_2, plane_3) {
+		*x_2 += *x_0;
+		*x_3 += *x_1;
+		*x_1 += *x_0;
+		butterfly(x_2, x_3, twiddle_1_odd);
+	}
+}
+
+/// Processes layers `first_layer` and `first_layer + 1` in a single pass over the buffer.
+///
+/// Index the buffer by `i` in `[0, 2^log_d)`.
+/// Layer `l` pairs `i` with `i XOR 2^(log_d - 1 - l)`, under the twiddle of block `i >> (log_d -
+/// l)`.
+///
+/// Writing `a` for `first_layer`, split the index three ways:
+///
+/// ```text
+///     i = h * 2^(log_d - a)  +  m * 2^(log_d - a - 2)  +  offset
+///
+///     h < 2^a                    super-block index, which the two layers never move
+///     m < 4                      plane index, the only bits they do move
+///     offset < 2^(log_d - a - 2) position inside a plane, which they never move
+/// ```
+///
+/// The four entries sharing one `(h, offset)` are closed under both layers, and distinct pairs
+/// never interact.
+/// So a quarter of the buffer's elements can be transformed independently of the rest, which is
+/// what lets both layers run without a barrier between them.
+///
+/// Layer `a` reads the twiddle of block `h`, shared by both of its pairs.
+/// Layer `a + 1` reads blocks `2h` and `2h + 1`, one per pair.
+///
+/// ## Preconditions
+///
+/// - `2^log_d == data.len() * packing_width`
+/// - `first_layer + 2 <= log_num_shares`
+/// - `first_layer + 2 + P::LOG_WIDTH < log_d`
+/// - `domain_context` holds the twiddles of layers `first_layer` and `first_layer + 1`
+fn forward_shared_layer_pair<P: PackedField>(
+	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
+	data: &mut [P],
+	log_d: usize,
+	first_layer: usize,
+	log_num_shares: usize,
+) {
+	// check preconditions
+	debug_assert_eq!(data.len() << P::LOG_WIDTH, 1 << log_d);
+	debug_assert!(first_layer + 2 <= log_num_shares);
+	debug_assert!(first_layer + 2 + P::LOG_WIDTH < log_d);
+	debug_assert!(first_layer + 2 <= domain_context.log_domain_size());
+
+	let log_plane_len = log_d - first_layer - 2 - P::LOG_WIDTH;
+	let plane_len = 1 << log_plane_len;
+
+	// Cut every plane into equal runs, enough of them to feed each share at least one.
+	// A run never drops below one packed element.
+	let log_run_len = log_plane_len.saturating_sub(log_num_shares - first_layer);
+	let run_len = 1 << log_run_len;
+
+	// One task per (super-block, run) pair, which the borrow checker proves disjoint for us.
+	let tasks = data
+		.chunks_exact_mut(plane_len << 2)
+		.enumerate()
+		.flat_map(|(h, super_block)| {
+			let twiddle = |layer, block| P::broadcast(domain_context.twiddle(layer, block));
+			let twiddles = (
+				twiddle(first_layer, h),
+				twiddle(first_layer + 1, h << 1),
+				twiddle(first_layer + 1, (h << 1) | 1),
+			);
+
+			let (halves_0_1, halves_2_3) = super_block.split_at_mut(plane_len << 1);
+			let (plane_0, plane_1) = halves_0_1.split_at_mut(plane_len);
+			let (plane_2, plane_3) = halves_2_3.split_at_mut(plane_len);
+
+			izip!(
+				plane_0.chunks_exact_mut(run_len),
+				plane_1.chunks_exact_mut(run_len),
+				plane_2.chunks_exact_mut(run_len),
+				plane_3.chunks_exact_mut(run_len),
+			)
+			.map(move |(run_0, run_1, run_2, run_3)| ([run_0, run_1, run_2, run_3], h, twiddles))
+		})
+		.collect::<Vec<_>>();
+
+	tasks
+		.into_par_iter()
+		.for_each(|(planes, h, (twiddle_0, twiddle_1_even, twiddle_1_odd))| {
+			// `domain_context.twiddle(layer, 0)` is always zero (see `DomainContext::twiddle`).
+			// Only super-block 0 reads block 0, and it does so in both of its layers.
+			if h == 0 {
+				fused_pair_zero_block(planes, twiddle_1_odd);
+			} else {
+				fused_pair(planes, twiddle_0, twiddle_1_even, twiddle_1_odd);
+			}
+		});
+}
+
+/// Runs the shared layers of the butterfly network, two layers per pass where possible.
+///
+/// Pairing halves the passes a window of layers costs, so it halves its memory traffic.
+/// A layer that cannot be paired -- an odd one out, or a shape whose planes would fall below one
+/// packed element -- runs alone, exactly as it did before pairing existed.
+///
+/// ## Preconditions
+///
+/// - same as the routines this dispatches to
+/// - `layers.end <= log_num_shares`
+fn forward_shared_layers<P: PackedField>(
+	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
+	data: &mut [P],
+	log_d: usize,
+	layers: Range<usize>,
+	log_num_shares: usize,
+) {
+	debug_assert!(layers.end <= log_num_shares);
+
+	let mut layer = layers.start;
+	while layer < layers.end {
+		// A pair needs one more layer to pair with, and planes of at least one packed element.
+		if layers.end - layer >= 2 && layer + 2 + P::LOG_WIDTH < log_d {
+			forward_shared_layer_pair(domain_context, data, log_d, layer, log_num_shares);
+			layer += 2;
+		} else {
+			forward_shared_layer(domain_context, data, log_d, layer, log_num_shares);
+			layer += 1;
+		}
+	}
+}
+
 /// How many elements ahead [`prefetch_read`] hints the CPU to fetch.
 ///
 /// Each loop iteration does at most one packed GF(2^128) multiply-add.
@@ -600,15 +769,13 @@ impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
 		let shared_layers = skip_early..min(first_independent_layer, last_layer);
 		let independent_layers = max(first_independent_layer, skip_early)..last_layer;
 
-		for layer in shared_layers {
-			forward_shared_layer(
-				&self.domain_context,
-				data.as_mut(),
-				log_d,
-				layer,
-				actual_log_num_shares,
-			);
-		}
+		forward_shared_layers(
+			&self.domain_context,
+			data.as_mut(),
+			log_d,
+			shared_layers,
+			actual_log_num_shares,
+		);
 
 		// One might think that we could just call `forward_depth_first` with
 		// `layer=independent_layers.start`. However, this would mean that the chunk size (that we
@@ -662,7 +829,219 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 
 #[cfg(test)]
 mod tests {
+	use binius_field::{PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b};
+	use proptest::prelude::*;
+	use rand::{SeedableRng, rngs::StdRng};
+
 	use super::*;
+	use crate::{ntt::domain_context::GaoMateerPreExpanded, test_utils::random_field_buffer};
+
+	/// The shared-layer window the multithreaded transform would pick for these parameters.
+	///
+	/// Returns the window together with the share count after the transform's own clamp.
+	/// An empty window means the transform runs no shared layers at all.
+	fn shared_window<P: PackedField>(
+		log_d: usize,
+		skip_early: usize,
+		skip_late: usize,
+		log_num_shares: usize,
+	) -> (Range<usize>, usize) {
+		// Every share needs two packed elements, which caps how finely the buffer splits.
+		let actual_log_num_shares = min(log_num_shares, log_d - P::LOG_WIDTH - 1);
+		let layers = skip_early..min(actual_log_num_shares, log_d - skip_late);
+		(layers, actual_log_num_shares)
+	}
+
+	/// Asserts the fused dispatcher and the one-pass-per-layer loop agree bit for bit.
+	fn check_fused_matches_per_layer<P: PackedField<Scalar: BinaryField>>(
+		log_d: usize,
+		skip_early: usize,
+		skip_late: usize,
+		log_num_shares: usize,
+		seed: u64,
+	) {
+		let (layers, actual_log_num_shares) =
+			shared_window::<P>(log_d, skip_early, skip_late, log_num_shares);
+		if layers.is_empty() {
+			return;
+		}
+
+		let domain_context = GaoMateerPreExpanded::<P::Scalar>::generate(log_d);
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		// Same random contents down both paths, so any difference is the fusion's fault.
+		let mut fused = random_field_buffer::<P>(&mut rng, log_d);
+		let mut per_layer = fused.clone();
+
+		forward_shared_layers(
+			&domain_context,
+			fused.as_mut(),
+			log_d,
+			layers.clone(),
+			actual_log_num_shares,
+		);
+		for layer in layers {
+			forward_shared_layer(
+				&domain_context,
+				per_layer.as_mut(),
+				log_d,
+				layer,
+				actual_log_num_shares,
+			);
+		}
+
+		assert_eq!(fused, per_layer);
+	}
+
+	/// Asserts the whole multithreaded transform matches the independent reference transform.
+	fn check_transform_matches_reference<P: PackedField<Scalar: BinaryField>>(
+		log_d: usize,
+		skip_early: usize,
+		skip_late: usize,
+		log_num_shares: usize,
+		seed: u64,
+	) {
+		let domain_context = GaoMateerPreExpanded::<P::Scalar>::generate(log_d);
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		let mut actual = random_field_buffer::<P>(&mut rng, log_d);
+		let mut expected = actual.clone();
+
+		let multi_thread = NeighborsLastMultiThread {
+			domain_context: &domain_context,
+			log_base_len: 3,
+			log_num_shares,
+		};
+		let reference = NeighborsLastReference {
+			domain_context: &domain_context,
+		};
+
+		multi_thread.forward_transform(actual.as_mut_view(), skip_early, skip_late);
+		reference.forward_transform(expected.as_mut_view(), skip_early, skip_late);
+
+		assert_eq!(actual, expected);
+	}
+
+	/// Every window width from one shared layer up to five, at every start offset that fits.
+	///
+	/// Width 1 has nothing to fuse, widths 2 to 4 fuse in one window, width 5 splits into 4 plus 1.
+	/// The start offset is what shifts the super-block count, so it must move too.
+	fn sweep_window_widths<P: PackedField<Scalar: BinaryField>>(log_d: usize, seed: u64) {
+		for skip_early in 0..4 {
+			for width in 1..=5 {
+				// Layer indices only exist below the buffer's own depth.
+				if skip_early + width > log_d {
+					continue;
+				}
+				// Ending the shared phase at `skip_early + width` is what sets the window width.
+				check_fused_matches_per_layer::<P>(log_d, skip_early, 0, skip_early + width, seed);
+			}
+		}
+	}
+
+	#[test]
+	fn fused_shared_layers_match_per_layer_over_window_widths() {
+		// Fixture: 128-bit scalars at three packing widths.
+		//
+		//     1x128b -> LOG_WIDTH 0, planes are always whole packed elements
+		//     2x128b -> LOG_WIDTH 1
+		//     4x128b -> LOG_WIDTH 2, the width that first refuses the widest windows
+		for log_d in 6..13 {
+			sweep_window_widths::<PackedBinaryGhash1x128b>(log_d, 0);
+			sweep_window_widths::<PackedBinaryGhash2x128b>(log_d, 1);
+			sweep_window_widths::<PackedBinaryGhash4x128b>(log_d, 2);
+		}
+	}
+
+	#[test]
+	fn fused_shared_layers_match_per_layer_at_the_narrowest_plane() {
+		// Invariant: a window is fused only while each plane still holds two packed elements.
+		//
+		//     log_d = 8, LOG_WIDTH = 2, skip_early = 1, width = 4
+		//     plane length = 2^(8 - 1 - 4 - 2) = 2 packed elements, the smallest fusable plane
+		check_fused_matches_per_layer::<PackedBinaryGhash4x128b>(8, 1, 0, 5, 7);
+
+		// One layer deeper the plane would hold a single packed element, so this shape falls back.
+		//
+		//     log_d = 8, LOG_WIDTH = 2, skip_early = 0, width = 5 -> plane length 2^1
+		//     the same start with width 6 would need plane length 2^0, refused
+		check_fused_matches_per_layer::<PackedBinaryGhash4x128b>(8, 0, 0, 5, 8);
+	}
+
+	#[test]
+	fn multi_thread_transform_matches_the_reference() {
+		// Sweep the skips against the share count, so the shared phase starts and ends everywhere.
+		for log_d in [6, 9, 12] {
+			for skip_early in [0, 1, 2, 4] {
+				for skip_late in [0, 1, 3] {
+					if skip_early + skip_late > log_d {
+						continue;
+					}
+					for log_num_shares in [0, 1, 2, 3, 5, 1000] {
+						check_transform_matches_reference::<PackedBinaryGhash1x128b>(
+							log_d,
+							skip_early,
+							skip_late,
+							log_num_shares,
+							0,
+						);
+						check_transform_matches_reference::<PackedBinaryGhash4x128b>(
+							log_d,
+							skip_early,
+							skip_late,
+							log_num_shares,
+							1,
+						);
+					}
+				}
+			}
+		}
+	}
+
+	proptest! {
+		#[test]
+		fn prop_fused_shared_layers_match_per_layer(
+			log_d in 6..13usize,
+			skip_early in 0..5usize,
+			skip_late in 0..4usize,
+			log_num_shares in 0..8usize,
+			seed: u64,
+		) {
+			// Property: fusing a window of layers is the same linear map as running them one by
+			// one, for every shape the multithreaded transform can hand the shared phase.
+			prop_assume!(skip_early + skip_late <= log_d);
+
+			check_fused_matches_per_layer::<PackedBinaryGhash1x128b>(
+				log_d, skip_early, skip_late, log_num_shares, seed,
+			);
+			check_fused_matches_per_layer::<PackedBinaryGhash2x128b>(
+				log_d, skip_early, skip_late, log_num_shares, seed,
+			);
+			check_fused_matches_per_layer::<PackedBinaryGhash4x128b>(
+				log_d, skip_early, skip_late, log_num_shares, seed,
+			);
+		}
+
+		#[test]
+		fn prop_multi_thread_transform_matches_the_reference(
+			log_d in 1..11usize,
+			skip_early in 0..5usize,
+			skip_late in 0..4usize,
+			log_num_shares in 0..8usize,
+			seed: u64,
+		) {
+			// Property: the fused shared phase leaves the transform equal to the reference one,
+			// which shares no code with it.
+			prop_assume!(skip_early + skip_late <= log_d);
+
+			check_transform_matches_reference::<PackedBinaryGhash1x128b>(
+				log_d, skip_early, skip_late, log_num_shares, seed,
+			);
+			check_transform_matches_reference::<PackedBinaryGhash4x128b>(
+				log_d, skip_early, skip_late, log_num_shares, seed,
+			);
+		}
+	}
 
 	#[test]
 	fn test_with_middle_bit() {


### PR DESCRIPTION
Closes [BINIUS-543](https://linear.app/jimpo/issue/BINIUS-543).

Runs the multithreaded NTT's shared prefix two layers per pass instead of one.
Output is bit-identical — no protocol change.

**Stacked on #2314.** That one-line fix is the base commit here, because this PR's equivalence proptest cannot cover its natural parameter range without it. Merge #2314 first and this rebases to a single commit.

### The problem

`NeighborsLastMultiThread::forward_transform` ran its shared prefix one layer at a time:

```
for layer in shared_layers {
    forward_shared_layer(..., layer, ...);
}
```

Each call reads and writes the whole buffer and ends in a rayon barrier.
At `log_d = 20` over $\mathbb{F}_{2^{128}}$ that is a 16 MiB read-modify-write per layer.

The default prover shape runs two of them: `log_inv_rate = 1` gives `skip_early = 1`, and `log_num_shares` is `ilog2(num_threads)`, so 3 on a 10-thread machine.

The independent suffix does not have this problem — its depth-first recursion is cache-oblivious, so it already gets layer fusion for free. Only the shared prefix paid per-layer.

### The idea

Two consecutive layers touch a *contiguous window of index bits*, so a pair fits in one pass.

Index the buffer by `i` in `[0, 2^log_d)`. Layer `l` pairs `i` with `i XOR 2^(log_d - 1 - l)`, under the twiddle of block `i >> (log_d - l)`.

Writing `a` for the first layer of the pair, split the index three ways:

```
i = h * 2^(log_d - a)  +  m * 2^(log_d - a - 2)  +  offset

h < 2^a                     super-block index, which the two layers never move
m < 4                       plane index, the only bits they do move
offset < 2^(log_d - a - 2)  position inside a plane, which they never move
```

The four entries sharing one `(h, offset)` are closed under both layers, and distinct pairs never interact.
So each quad transforms on its own, with no barrier between the two layers.

Layer `a` reads the twiddle of block `h`, shared by both of its pairs; layer `a + 1` reads blocks `2h` and `2h + 1`, one per pair. That is the whole kernel:

```rust
for (x_0, x_1, x_2, x_3) in izip!(plane_0, plane_1, plane_2, plane_3) {
    butterfly(x_0, x_2, twiddle_0);
    butterfly(x_1, x_3, twiddle_0);
    butterfly(x_0, x_1, twiddle_1_even);
    butterfly(x_2, x_3, twiddle_1_odd);
}
```

### Per pair of layers

- **before:** 2 full-buffer passes, 2 rayon barriers
- **after:** 1 full-buffer pass, 0 barriers inside the pair

→ every element is loaded once, takes part in both layers, and is stored once.

### The change

```diff
-for layer in shared_layers {
-    forward_shared_layer(&self.domain_context, data.as_mut(), log_d, layer, actual_log_num_shares);
-}
+forward_shared_layers(&self.domain_context, data.as_mut(), log_d, shared_layers, actual_log_num_shares);
```

`forward_shared_layers` pairs layers where it can and falls back to the existing one-layer-per-pass routine for an odd layer out, or for a shape whose planes would fall below one packed element.

Tasks are built with `chunks_exact_mut` and `split_at_mut`, so the borrow checker proves their disjointness. **No `unsafe`, no const generics, no raw pointers.**

### Soundness

Bit-identical output, not approximately equal.
The kernel performs the same butterflies, on the same operand pairs, with the same twiddles — only the order of the memory passes changes, and addition in a binary field is XOR, so regrouping is exact.

The always-zero twiddle at block 0 (#2219) is carried forward. Super-block 0 is the only one that reads block 0, and it reads it in *both* of its layers, so two of its four butterflies collapse to `v += u` and plane 0 is never written at all — its cache lines stay clean. That case is a separate, plainly-written kernel rather than a flag.

### Scope

- **new:** `butterfly`, `fused_pair`, `fused_pair_zero_block`, `forward_shared_layer_pair`, `forward_shared_layers` — 161 lines including docs
- **changed:** one call site in `forward_transform_with_callback`
- **changed:** `crates/math/benches/ntt.rs` gains `skip_early = 1` — without it the bench matrix cannot see this phase at all, since `skip_early = 4` leaves the shared range empty at `log_num_shares = 3`
- **untouched:** `forward_shared_layer` stays as both the fallback and the test oracle
- `skip_early` / `skip_late` semantics and the `on_chunk_ready` contract are unchanged

### Verification

- fused output bit-identical to the per-layer loop, swept over `log_d` in `6..13`, `skip_early` in `0..4`, `log_num_shares` in `1..=5`, at `P::LOG_WIDTH` 0, 1 and 2 — covering the paired, odd-layer-out, and too-small-to-pair shapes
- end-to-end against `NeighborsLastReference`, the independent oracle
- two proptests: fused vs per-layer, and multithreaded vs reference
- `cargo test -p binius-math` and `--features rayon` — 172 passed both arms
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt -p binius-math -- --check` — clean

### Benchmark

Full transform, `log_d = 20`, `skip_early = 1`, 8 threads, `PackedBinaryGhash1x128b`, pre-expanded domain.
Same-binary A/B behind a temporary switch (not in the diff), arms interleaved so drift hits both equally, criterion medians:

| rep | per-layer | paired | delta |
|---|---|---|---|
| 1 | 2.5342 ms | 2.3860 ms | -5.8% |
| 2 | 2.5655 ms | 2.4025 ms | -6.4% |
| 3 | 2.5737 ms | 2.5525 ms | -0.8% |
| 4 | 2.7447 ms | 2.4133 ms | -12.1% |
| 5 | 2.6117 ms | 2.4340 ms | -6.8% |
| 6 | 2.5422 ms | 2.3934 ms | -5.9% |
| 7 | 2.5874 ms | 2.4738 ms | -4.4% |
| 8 | 2.5756 ms | 2.4261 ms | -5.8% |

Paired wins 8/8; median **-5.9%**, spread -0.8% to -12.1%.

Reproduce with:

```
cargo bench -p binius-math --features rayon --bench ntt -- \
  '1xGhash/multithread/threads=8/log_base_len=12/pre-expanded/log_d=20/skip_early=1/skip_late=0'
```

Note that plain `cargo bench -p binius-math` runs the no-rayon shim, where the "multithread" NTT executes sequentially — `--features rayon` is required for a threaded number.

Two honest caveats:

- The shared phase is ~15% of the transform at this shape, so this is a single-digit NTT win by construction.
- Task granularity is unchanged from the per-layer scheme (8 tasks at this shape, for 10 threads on an 8P+2E chip), which likely explains why the measured win falls short of the traffic ratio. Raising it is an independent follow-up.

### On generality, deliberately declined

An earlier revision of this PR fused windows of up to four layers behind `const R`/`const N`/`const H_ZERO` generics and raw pointers. It was worse code for no demonstrated gain, and it is gone:

- `const N` merely restated `1 << R`, guarded only by a `debug_assert` — `fused_group::<P, 2, 8, false>` compiled and was silently wrong.
- `const H_ZERO` doubled the monomorphisations of a fully-unrolled body to skip one store on one plane.
- The wider windows both spilled (48 and 113 stack references at `R = 3` and `R = 4`), and `R = 4` needs 32+ threads so it never ran on any machine here.

Pairing costs `ceil(r/2)` passes instead of `r`, which is the identical result at the default shape and still at least a 2x traffic reduction on wider machines. Upstream's own const-generic NTT-geometry follow-up was rejected on measurement too.

### Context

Follows #2219, which peeled the zero twiddle and prefetched this same loop.

Surfaced while mining `Layr-Labs/flock-challenge-multi` for portable ideas. Multi-layer NTT fusion is the one mechanism class still winning on that board; notably, every follow-up tuning attempted *on top of* a fused kernel there was rejected, so this deliberately lands the fusion and stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
