### PR TITLE
Move the round-polynomial batching fold onto RoundCoeffs

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/driver.rs
+++ b/crates/ip-prover/src/fracaddcheck/driver.rs
@@ -36,15 +36,6 @@ pub struct BatchProveOutput<F> {
 	pub fractions: Vec<Fraction<F>>,
 }
 
-/// Combines the per-claim round polynomials of one fracaddcheck layer prover into a single
-/// polynomial by Horner-folding with `batch_coeff`, matching the `[num, den]` batching that
-/// [`sumcheck::batch_verify_mle`](binius_ip::sumcheck::batch_verify_mle) performs on the verifier.
-fn combine_claims<F: Field>(coeffs: Vec<RoundCoeffs<F>>, batch_coeff: F) -> RoundCoeffs<F> {
-	coeffs
-		.into_iter()
-		.rfold(RoundCoeffs::default(), |acc, c| acc * batch_coeff + &c)
-}
-
 /// Runs one batched fracaddcheck layer given its per-instance final-layer MLE-check provers.
 ///
 /// The layer runs in four steps, one function each:
@@ -138,7 +129,7 @@ fn prove_content_rounds<F, MP>(
 		// One instance's round is too small a parallel region to fill the pool alone.
 		let per_instance: Vec<RoundCoeffs<F>> = layer_provers
 			.par_iter_mut()
-			.map(|prover| combine_claims(prover.execute(), batch_coeff))
+			.map(|prover| RoundCoeffs::batch(prover.execute(), &batch_coeff))
 			.collect();
 
 		// Weight instance j's polynomial by eq_j and sum, in instance order.
@@ -259,7 +250,7 @@ where
 		SharedMleCheckProver::new(selector_store, claims_with_evaluators, outer_coords.to_vec());
 
 	for _round in 0..k {
-		let round_coeffs = combine_claims(selector_prover.execute(), batch_coeff);
+		let round_coeffs = RoundCoeffs::batch(selector_prover.execute(), &batch_coeff);
 		channel.send_many(mlecheck::RoundProof::truncate(round_coeffs).coeffs());
 
 		let challenge = channel.sample();

--- a/crates/ip-prover/src/sumcheck/drive.rs
+++ b/crates/ip-prover/src/sumcheck/drive.rs
@@ -229,9 +229,7 @@ where
 		}
 
 		// Horner-fold round polynomials into a single batched polynomial.
-		let batched_round_coeffs = all_round_coeffs
-			.into_iter()
-			.rfold(RoundCoeffs::default(), |acc, coeffs| acc * batch_coeff + &coeffs);
+		let batched_round_coeffs = RoundCoeffs::batch(all_round_coeffs, &batch_coeff);
 
 		// Commit to the batched round polynomial, then sample the next challenge.
 		Prover::ROUND_PROOF_KIND.send(batched_round_coeffs, channel);

--- a/crates/ip/src/sumcheck/common.rs
+++ b/crates/ip/src/sumcheck/common.rs
@@ -47,6 +47,19 @@ impl<F: FieldOps> RoundCoeffs<F> {
 		evaluate_univariate(&self.0, x)
 	}
 
+	/// Batches round polynomials into one, weighting polynomial `i` by `batch_coeff^i`.
+	///
+	/// The verifier weights the matching claims with the same coefficient.
+	/// Each claim therefore stays tied to its own round polynomial.
+	///
+	/// An empty input is the zero polynomial.
+	pub fn batch(polys: Vec<Self>, batch_coeff: &F) -> Self {
+		// Horner from the highest weight down: acc <- acc * batch_coeff + poly.
+		polys
+			.into_iter()
+			.rfold(Self::default(), |acc, poly| acc * batch_coeff.clone() + &poly)
+	}
+
 	/// The endpoint values $(R(0), R(1))$ of the round polynomial.
 	///
 	/// $R(0)$ is the constant coefficient $a_0$.
@@ -291,6 +304,44 @@ mod tests {
 			// Evaluate the recovered polynomial at both endpoints and confirm they sum to s.
 			assert_eq!(recovered.evaluate(&B128::ZERO) + recovered.evaluate(&B128::ONE), sum);
 		}
+	}
+
+	#[test]
+	fn batch_commutes_with_evaluation() {
+		let mut rng = rng();
+		// Invariant: the prover's batched polynomial agrees with the verifier's batched claim.
+		//
+		//     batch(R_0, .., R_{n-1})(x) == sum_i batch_coeff^i * R_i(x)
+		//
+		// The prover folds the round polynomials, the verifier folds the claim scalars.
+		// A mismatch would send a batched round proof the verifier cannot reproduce.
+		for degree in DEGREES {
+			// Mixed lengths, since batched provers need not all reach the same degree.
+			let polys = (1..=degree)
+				.map(|len| RoundCoeffs(random_scalars::<B128>(&mut rng, len + 1)))
+				.collect::<Vec<_>>();
+			let batch_coeff = B128::random(&mut rng);
+
+			let batched = RoundCoeffs::batch(polys.clone(), &batch_coeff);
+
+			// The batched polynomial reaches the degree of the longest input.
+			assert_eq!(batched.0.len(), degree + 1);
+			for x in random_scalars::<B128>(&mut rng, 4) {
+				// The verifier's side: Horner-fold the per-claim evaluations.
+				let evals = polys
+					.iter()
+					.map(|poly| poly.evaluate(&x))
+					.collect::<Vec<_>>();
+				assert_eq!(batched.evaluate(&x), evaluate_univariate(&evals, &batch_coeff));
+			}
+		}
+	}
+
+	#[test]
+	fn batching_nothing_gives_the_zero_polynomial() {
+		// A batched group with no provers must contribute nothing to the round proof.
+		let batched = RoundCoeffs::batch(Vec::new(), &B128::random(&mut rng()));
+		assert_eq!(batched, RoundCoeffs::<B128>::default());
 	}
 
 	#[test]


### PR DESCRIPTION
Gives the prover's claim-batching fold one home, on the type it operates on.
Pure refactor — no behavior change, no transcript change.

### The problem

A batched sumcheck proves several claims in one round loop.
It draws one coefficient $r$ and folds the per-claim round polynomials into a single one:

```
batched(X) = sum_i r^i * R_i(X)
```

That fold was written twice, in two crates' worth of distance apart:

- `sumcheck/drive.rs` — inline in the batched round loop.
- `fracaddcheck/driver.rs` — as a private `combine_claims` helper.

Nothing in that helper is specific to fracaddcheck.
It is a Horner fold over `RoundCoeffs`, sitting in a file about the fracaddcheck layer schedule.

### The idea

The fold is the prover's mirror of what the verifier already does.
`batch_verify_mle` folds the *claim scalars* with the same coefficient, through `evaluate_univariate`.
So the operation belongs on `RoundCoeffs`, beside `evaluate`, where both sides can see it.

### The change

```diff
- fn combine_claims<F: Field>(coeffs: Vec<RoundCoeffs<F>>, batch_coeff: F) -> RoundCoeffs<F> {
-     coeffs.into_iter().rfold(RoundCoeffs::default(), |acc, c| acc * batch_coeff + &c)
- }
+ // crates/ip/src/sumcheck/common.rs
+ impl<F: FieldOps> RoundCoeffs<F> {
+     pub fn batch(polys: Vec<Self>, batch_coeff: &F) -> Self { .. }
+ }
```

Three call sites now use it — one in `drive.rs`, two in the fracaddcheck driver.
The signature takes `batch_coeff` by reference, matching `evaluate(&self, x: &F)` in the same impl block.

### Soundness

The fold is byte-for-byte the same operation, so the transcript is unchanged.
The new test pins the identity the prover and verifier must agree on:

```
batch(R_0, .., R_{n-1})(x) == sum_i r^i * R_i(x)
```

Left side is what the prover sends; right side is what the verifier reconstructs from the claims.
Checked over mixed-degree inputs, since batched provers need not all reach the same degree.

### Scope

- **new:** `RoundCoeffs::batch`, plus two tests — the evaluation identity and the empty batch.
- **changed:** three call sites.
- **deleted:** `fracaddcheck::driver::combine_claims`.
- untouched: the verifier side, and every round proof on the wire.

### Verification

- `cargo clippy -p binius-ip -p binius-ip-prover --all-features --all-targets` — clean.
- `cargo +nightly fmt --all` — clean.
- `cargo test -p binius-ip -p binius-ip-prover`, with and without `--features rayon` — 109 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)