### PR TITLE
Give the fracaddcheck padded layer prover and its batch real types

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/driver.rs
+++ b/crates/ip-prover/src/fracaddcheck/driver.rs
@@ -13,7 +13,7 @@ use binius_math::{
 use binius_utils::rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use itertools::izip;
 
-use super::{FracAddCircuit, fraction::Fraction, padding::PaddedLayerProver};
+use super::{FracAddCircuit, fraction::Fraction, padding::PaddedBatch};
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
@@ -363,40 +363,23 @@ where
 	let k = selector_point.len();
 	assert!(provers.len() <= (1 << k)); // precondition
 
-	let alloc = provers[0].alloc;
-	let mut provers = provers;
-	let n_layers = provers
-		.iter()
-		.map(FracAddCircuit::n_layers)
-		.max()
-		.expect("provers is non-empty");
-	assert!(n_layers >= 1); // precondition
-	// How much depth each tree is padded by.
-	let pad_lens = provers
-		.iter()
-		.map(|prover| n_layers - prover.n_layers())
-		.collect::<Vec<_>>();
+	let mut batch = PaddedBatch::new(provers);
+	let alloc = batch.alloc();
+	let n_trees = batch.n_trees();
 
-	let n_trees = provers.len();
 	let mut claims = claimed_fractions;
 	let mut eval_point = selector_point;
 
 	// Each iteration reduces the layer whose node variables are the point's suffix past the
 	// selector coordinates. A tree the batch has not yet reached contributes a padding layer.
-	for _ in 0..n_layers {
-		let layer_provers =
-			PaddedLayerProver::pop_layer(&mut provers, &pad_lens, &claims, &eval_point[k..]);
+	for _ in 0..batch.n_layers() {
+		let layer_provers = batch.pop_layer(&claims, &eval_point[k..]);
 		let (next_claims, next_point) =
 			reduce_layer::<A, F, P, _>(alloc, layer_provers, &eval_point, k, channel);
 		claims = next_claims;
 		eval_point = next_point;
 	}
-	// A depth-0 tree is all padding, so it is passed through every round and never popped; every
-	// tree that had a layer has spent them all.
-	debug_assert!(
-		provers.iter().all(|prover| prover.n_layers() == 0),
-		"every tree with layers is exhausted after n_layers reductions"
-	);
+	batch.finish();
 
 	// `reduce_layer` pads its output to the 2^k selector slots; only the real trees remain.
 	let mut fractions = claims;

--- a/crates/ip-prover/src/fracaddcheck/driver.rs
+++ b/crates/ip-prover/src/fracaddcheck/driver.rs
@@ -13,7 +13,7 @@ use binius_math::{
 use binius_utils::rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use itertools::izip;
 
-use super::{FracAddCircuit, fraction::Fraction, padding::layer_provers};
+use super::{FracAddCircuit, fraction::Fraction, padding::PaddedLayerProver};
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
@@ -384,7 +384,8 @@ where
 	// Each iteration reduces the layer whose node variables are the point's suffix past the
 	// selector coordinates. A tree the batch has not yet reached contributes a padding layer.
 	for _ in 0..n_layers {
-		let layer_provers = layer_provers(&mut provers, &pad_lens, &claims, &eval_point[k..]);
+		let layer_provers =
+			PaddedLayerProver::pop_layer(&mut provers, &pad_lens, &claims, &eval_point[k..]);
 		let (next_claims, next_point) =
 			reduce_layer::<A, F, P, _>(alloc, layer_provers, &eval_point, k, channel);
 		claims = next_claims;

--- a/crates/ip-prover/src/fracaddcheck/padding.rs
+++ b/crates/ip-prover/src/fracaddcheck/padding.rs
@@ -20,7 +20,7 @@
 //! so the numerators are zero-padded and the denominators one-padded.
 //!
 //! The prover never materializes a padded witness.
-//! `layer_provers` wraps each tree's own layer prover in a [`ZeroPadMleCheckProver`].
+//! [`PaddedLayerProver`] wraps each tree's own layer prover in a [`ZeroPadMleCheckProver`].
 //! That wrapper corrects the unpadded layer's messages at a cost of $O(1)$ per round.
 //! A tree the batch has not reached yet has no layer to wrap.
 //! It contributes a [`ConstantFraction`] instead.
@@ -30,7 +30,7 @@ use std::iter;
 
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
-use binius_ip::fracaddcheck::FracAddEvalClaim;
+use binius_ip::{fracaddcheck::FracAddEvalClaim, sumcheck::RoundCoeffs};
 use binius_math::{batch_invert::BatchInversion, multilinear::hypercube::Hypercube};
 use either::Either;
 use itertools::izip;
@@ -40,72 +40,122 @@ use super::{
 	fraction::Fraction,
 	zero_pad_mle::{self, ConstantFraction, ZeroPadMleCheckProver},
 };
+use crate::sumcheck::common::MleCheckProver;
 
-/// The per-tree layer prover: either a real layer of the tree, or the padding layer it contributes
-/// while the batch is still above it.
-pub(super) type PaddedLayerProver<'a, A, F, P> =
-	ZeroPadMleCheckProver<F, Either<LayerProver<'a, A, F, P>, ConstantFraction<F>>>;
-
-/// Builds one padded layer prover per tree, for the layer claimed at `node_point`.
+/// The layer one tree contributes to the batch's current depth.
 ///
-/// The provers come back in input order, one per tree, so they stay aligned with `pad_lens` and
-/// `claims`. A tree the batch has not reached yet keeps every layer it has.
-pub(super) fn layer_provers<'a, A, F, P>(
-	provers: &mut [FracAddCircuit<'a, A, P>],
-	pad_lens: &[usize],
-	claims: &[Fraction<F>],
-	node_point: &[F],
-) -> Vec<PaddedLayerProver<'a, A, F, P>>
+/// Once the batch has reached the tree, that is a real layer of it.
+///
+/// Until then it is the layer standing in for one.
+/// That stand-in is the tree's own fractional sum beside the zero fraction $0/1$.
+type TreeLayer<'a, A, F, P> = Either<LayerProver<'a, A, F, P>, ConstantFraction<F>>;
+
+/// One tree's contribution to a batched layer, lifted to the batch's depth.
+///
+/// Either kind of [`TreeLayer`] is a layer of the padded tree.
+///
+/// So either one needs its messages corrected.
+/// One [`ZeroPadMleCheckProver`] does that for both.
+pub(super) struct PaddedLayerProver<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	ZeroPadMleCheckProver<F, TreeLayer<'a, A, F, P>>,
+);
+
+impl<'a, A, F, P> PaddedLayerProver<'a, A, F, P>
 where
 	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let node_len = node_point.len();
+	/// Pops one padded layer prover per tree, for the layer claimed at `node_point`.
+	///
+	/// The provers come back in input order, one per tree.
+	/// So they stay aligned with `pad_lens` and `claims`.
+	///
+	/// A tree the batch has not reached yet keeps every layer it has.
+	pub(super) fn pop_layer(
+		trees: &mut [FracAddCircuit<'a, A, P>],
+		pad_lens: &[usize],
+		claims: &[Fraction<F>],
+		node_point: &[F],
+	) -> Vec<Self> {
+		let node_len = node_point.len();
 
-	// Every tree's padding segment is a prefix of this one node point, so a single table of prefix
-	// products serves the whole batch.
-	let pad_eq_prefixes = iter::once(F::ONE)
-		.chain(node_point.iter().scan(F::ONE, |acc, &coord| {
-			*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
-			Some(*acc)
-		}))
-		.collect::<Vec<_>>();
+		// Every tree's padding segment is a prefix of this one node point, so a single table of
+		// prefix products serves the whole batch.
+		let pad_eq_prefixes = iter::once(F::ONE)
+			.chain(node_point.iter().scan(F::ONE, |acc, &coord| {
+				*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
+				Some(*acc)
+			}))
+			.collect::<Vec<_>>();
 
-	// De-padding a claim divides by the padding segment's equality weight, so the batch pays one
-	// inversion rather than one per tree.
-	let mut pad_eq_invs = pad_lens
-		.iter()
-		.map(|&pad_len| pad_eq_prefixes[pad_len.min(node_len)])
-		.collect::<Vec<_>>();
-	assert!(
-		pad_eq_invs.iter().all(|&pad_eq| pad_eq != F::ZERO),
-		"a padding coordinate of the claim point equals one"
-	);
-	BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
+		// De-padding a claim divides by the padding segment's equality weight, so the batch pays
+		// one inversion rather than one per tree.
+		let mut pad_eq_invs = pad_lens
+			.iter()
+			.map(|&pad_len| pad_eq_prefixes[pad_len.min(node_len)])
+			.collect::<Vec<_>>();
+		assert!(
+			pad_eq_invs.iter().all(|&pad_eq| pad_eq != F::ZERO),
+			"a padding coordinate of the claim point equals one"
+		);
+		BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
 
-	izip!(provers, pad_lens, claims, &pad_eq_invs)
-		.map(|(prover, &tree_pad_len, &Fraction { num, den }, &pad_eq_inv)| {
-			let pad_len = tree_pad_len.min(node_len);
-			let point = node_point[pad_len..].to_vec();
-			let [num_claim, den_claim] = zero_pad_mle::unpad_claims(pad_eq_inv, [num, den]);
+		izip!(trees, pad_lens, claims, &pad_eq_invs)
+			.map(|(tree, &tree_pad_len, &Fraction { num, den }, &pad_eq_inv)| {
+				let pad_len = tree_pad_len.min(node_len);
+				let point = node_point[pad_len..].to_vec();
+				let [num_claim, den_claim] = zero_pad_mle::unpad_claims(pad_eq_inv, [num, den]);
 
-			let inner = if node_len < tree_pad_len {
-				// The batch is still above this tree, so every variable of its layer is a padding
-				// variable and the de-padded claim is the tree's own fractional sum. The layer is
-				// that fraction beside the zero fraction 0/1, and the tree keeps all of its layers.
-				Either::Right(ConstantFraction::new(num_claim, den_claim))
-			} else {
-				Either::Left(prover.pop_layer(FracAddEvalClaim {
-					num_eval: num_claim,
-					den_eval: den_claim,
-					point,
-				}))
-			};
+				let inner = if node_len < tree_pad_len {
+					// The batch is still above this tree, so every variable of its layer is a
+					// padding variable and the de-padded claim is the tree's own fractional sum.
+					// The layer is that fraction beside the zero fraction 0/1, and the tree keeps
+					// all of its layers.
+					Either::Right(ConstantFraction::new(num_claim, den_claim))
+				} else {
+					Either::Left(tree.pop_layer(FracAddEvalClaim {
+						num_eval: num_claim,
+						den_eval: den_claim,
+						point,
+					}))
+				};
 
-			zero_pad_mle::new(pad_eq_prefixes[..=pad_len].to_vec(), node_point.to_vec(), inner)
-		})
-		.collect()
+				Self(zero_pad_mle::new(
+					pad_eq_prefixes[..=pad_len].to_vec(),
+					node_point.to_vec(),
+					inner,
+				))
+			})
+			.collect()
+	}
+}
+
+impl<A, F, P> MleCheckProver<F> for PaddedLayerProver<'_, A, F, P>
+where
+	A: Allocator,
+	F: Field,
+	P: PackedField<Scalar = F>,
+{
+	fn n_vars(&self) -> usize {
+		self.0.n_vars()
+	}
+
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
+		self.0.execute()
+	}
+
+	fn fold(&mut self, challenge: F) {
+		self.0.fold(challenge);
+	}
+
+	fn finish(self) -> Vec<F> {
+		self.0.finish()
+	}
+
+	fn eval_point(&self) -> &[F] {
+		self.0.eval_point()
+	}
 }
 
 /// Reduces a leaf claim on a zero-fraction-padded witness to the claim on the witness itself.

--- a/crates/ip-prover/src/fracaddcheck/padding.rs
+++ b/crates/ip-prover/src/fracaddcheck/padding.rs
@@ -20,10 +20,15 @@
 //! so the numerators are zero-padded and the denominators one-padded.
 //!
 //! The prover never materializes a padded witness.
-//! [`PaddedLayerProver`] wraps each tree's own layer prover in a [`ZeroPadMleCheckProver`].
+//! [`PaddedBatch`] holds the trees and how deep each one sits.
+//! Every layer it pops hands out one [`PaddedLayerProver`] per tree.
+//!
+//! Each of those wraps the tree's own layer prover in a [`ZeroPadMleCheckProver`].
 //! That wrapper corrects the unpadded layer's messages at a cost of $O(1)$ per round.
+//!
 //! A tree the batch has not reached yet has no layer to wrap.
 //! It contributes a [`ConstantFraction`] instead.
+//!
 //! [`unpad_leaf_claim`] inverts the identity above on the claims the batch outputs.
 
 use std::iter;
@@ -60,77 +65,6 @@ pub(super) struct PaddedLayerProver<'a, A: Allocator, F: Field, P: PackedField<S
 	ZeroPadMleCheckProver<F, TreeLayer<'a, A, F, P>>,
 );
 
-impl<'a, A, F, P> PaddedLayerProver<'a, A, F, P>
-where
-	A: Allocator,
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	/// Pops one padded layer prover per tree, for the layer claimed at `node_point`.
-	///
-	/// The provers come back in input order, one per tree.
-	/// So they stay aligned with `pad_lens` and `claims`.
-	///
-	/// A tree the batch has not reached yet keeps every layer it has.
-	pub(super) fn pop_layer(
-		trees: &mut [FracAddCircuit<'a, A, P>],
-		pad_lens: &[usize],
-		claims: &[Fraction<F>],
-		node_point: &[F],
-	) -> Vec<Self> {
-		let node_len = node_point.len();
-
-		// Every tree's padding segment is a prefix of this one node point, so a single table of
-		// prefix products serves the whole batch.
-		let pad_eq_prefixes = iter::once(F::ONE)
-			.chain(node_point.iter().scan(F::ONE, |acc, &coord| {
-				*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
-				Some(*acc)
-			}))
-			.collect::<Vec<_>>();
-
-		// De-padding a claim divides by the padding segment's equality weight, so the batch pays
-		// one inversion rather than one per tree.
-		let mut pad_eq_invs = pad_lens
-			.iter()
-			.map(|&pad_len| pad_eq_prefixes[pad_len.min(node_len)])
-			.collect::<Vec<_>>();
-		assert!(
-			pad_eq_invs.iter().all(|&pad_eq| pad_eq != F::ZERO),
-			"a padding coordinate of the claim point equals one"
-		);
-		BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
-
-		izip!(trees, pad_lens, claims, &pad_eq_invs)
-			.map(|(tree, &tree_pad_len, &Fraction { num, den }, &pad_eq_inv)| {
-				let pad_len = tree_pad_len.min(node_len);
-				let point = node_point[pad_len..].to_vec();
-				let [num_claim, den_claim] = zero_pad_mle::unpad_claims(pad_eq_inv, [num, den]);
-
-				let inner = if node_len < tree_pad_len {
-					// The batch is still above this tree, so every variable of its layer is a
-					// padding variable and the de-padded claim is the tree's own fractional sum.
-					// The layer is that fraction beside the zero fraction 0/1, and the tree keeps
-					// all of its layers.
-					Either::Right(ConstantFraction::new(num_claim, den_claim))
-				} else {
-					Either::Left(tree.pop_layer(FracAddEvalClaim {
-						num_eval: num_claim,
-						den_eval: den_claim,
-						point,
-					}))
-				};
-
-				Self(zero_pad_mle::new(
-					pad_eq_prefixes[..=pad_len].to_vec(),
-					node_point.to_vec(),
-					inner,
-				))
-			})
-			.collect()
-	}
-}
-
 impl<A, F, P> MleCheckProver<F> for PaddedLayerProver<'_, A, F, P>
 where
 	A: Allocator,
@@ -155,6 +89,146 @@ where
 
 	fn eval_point(&self) -> &[F] {
 		self.0.eval_point()
+	}
+}
+
+/// A batch's trees, lifted to one uniform depth by zero-fraction padding.
+///
+/// The batch runs a single layer schedule, so every tree in it must have the same depth.
+/// Padding lifts each tree to the depth of the deepest one.
+///
+/// A padded tree sits out the layers above its own root.
+/// It contributes a stand-in layer for each of them, and only then starts spending its real ones.
+///
+/// No padded layer is ever materialized.
+/// The whole padding is these two vectors, plus the $O(1)$ per-round correction each layer carries.
+pub(super) struct PaddedBatch<'a, A: Allocator, P: PackedField> {
+	/// The trees, in input order, each spending its layers deepest-first.
+	trees: Vec<FracAddCircuit<'a, A, P>>,
+	/// How much depth each tree is padded by, in tree order.
+	pad_lens: Vec<usize>,
+	/// The depth every tree is padded to, which is how many layers the schedule runs.
+	n_layers: usize,
+}
+
+impl<'a, A, F, P> PaddedBatch<'a, A, P>
+where
+	A: Allocator,
+	F: Field,
+	P: PackedField<Scalar = F>,
+{
+	/// Pads `trees` up to the depth of the deepest one.
+	///
+	/// # Preconditions
+	/// * `trees` is non-empty
+	/// * at least one tree has a layer
+	pub(super) fn new(trees: Vec<FracAddCircuit<'a, A, P>>) -> Self {
+		let n_layers = trees
+			.iter()
+			.map(FracAddCircuit::n_layers)
+			.max()
+			.expect("precondition: trees is non-empty");
+		assert!(n_layers >= 1); // precondition
+
+		let pad_lens = trees
+			.iter()
+			.map(|tree| n_layers - tree.n_layers())
+			.collect();
+
+		Self {
+			trees,
+			pad_lens,
+			n_layers,
+		}
+	}
+
+	/// How many layers the batch's schedule runs.
+	pub(super) const fn n_layers(&self) -> usize {
+		self.n_layers
+	}
+
+	/// How many trees the batch holds.
+	pub(super) const fn n_trees(&self) -> usize {
+		self.trees.len()
+	}
+
+	/// The allocator every tree's layer buffers are drawn from.
+	pub(super) fn alloc(&self) -> &'a A {
+		self.trees[0].alloc
+	}
+
+	/// Consumes the spent batch.
+	///
+	/// A depth-zero tree is all padding, so it is passed through every layer and never popped.
+	/// Every tree that had layers has spent them all.
+	pub(super) fn finish(self) {
+		debug_assert!(
+			self.trees.iter().all(|tree| tree.n_layers() == 0),
+			"every tree with layers is exhausted after n_layers reductions"
+		);
+	}
+
+	/// Pops one padded layer prover per tree, for the layer claimed at `node_point`.
+	///
+	/// The provers come back in tree order, so they stay aligned with `claims`.
+	///
+	/// A tree the batch has not reached yet keeps every layer it has.
+	pub(super) fn pop_layer(
+		&mut self,
+		claims: &[Fraction<F>],
+		node_point: &[F],
+	) -> Vec<PaddedLayerProver<'a, A, F, P>> {
+		let node_len = node_point.len();
+
+		// Every tree's padding segment is a prefix of this one node point, so a single table of
+		// prefix products serves the whole batch.
+		let pad_eq_prefixes = iter::once(F::ONE)
+			.chain(node_point.iter().scan(F::ONE, |acc, &coord| {
+				*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
+				Some(*acc)
+			}))
+			.collect::<Vec<_>>();
+
+		// De-padding a claim divides by the padding segment's equality weight, so the batch pays
+		// one inversion rather than one per tree.
+		let mut pad_eq_invs = self
+			.pad_lens
+			.iter()
+			.map(|&pad_len| pad_eq_prefixes[pad_len.min(node_len)])
+			.collect::<Vec<_>>();
+		assert!(
+			pad_eq_invs.iter().all(|&pad_eq| pad_eq != F::ZERO),
+			"a padding coordinate of the claim point equals one"
+		);
+		BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
+
+		izip!(&mut self.trees, &self.pad_lens, claims, &pad_eq_invs)
+			.map(|(tree, &tree_pad_len, &Fraction { num, den }, &pad_eq_inv)| {
+				let pad_len = tree_pad_len.min(node_len);
+				let point = node_point[pad_len..].to_vec();
+				let [num_claim, den_claim] = zero_pad_mle::unpad_claims(pad_eq_inv, [num, den]);
+
+				let inner = if node_len < tree_pad_len {
+					// The batch is still above this tree, so every variable of its layer is a
+					// padding variable and the de-padded claim is the tree's own fractional sum.
+					// The layer is that fraction beside the zero fraction 0/1, and the tree keeps
+					// all of its layers.
+					Either::Right(ConstantFraction::new(num_claim, den_claim))
+				} else {
+					Either::Left(tree.pop_layer(FracAddEvalClaim {
+						num_eval: num_claim,
+						den_eval: den_claim,
+						point,
+					}))
+				};
+
+				PaddedLayerProver(zero_pad_mle::new(
+					pad_eq_prefixes[..=pad_len].to_vec(),
+					node_point.to_vec(),
+					inner,
+				))
+			})
+			.collect()
 	}
 }
 

--- a/crates/ip-prover/src/fracaddcheck/padding.rs
+++ b/crates/ip-prover/src/fracaddcheck/padding.rs
@@ -20,8 +20,8 @@
 //! so the numerators are zero-padded and the denominators one-padded.
 //!
 //! The prover never materializes a padded witness.
-//! [`PaddedBatch`] holds the trees and how deep each one sits.
-//! Every layer it pops hands out one [`PaddedLayerProver`] per tree.
+//! `PaddedBatch` holds the trees and how deep each one sits.
+//! Every layer it pops hands out one `PaddedLayerProver` per tree.
 //!
 //! Each of those wraps the tree's own layer prover in a [`ZeroPadMleCheckProver`].
 //! That wrapper corrects the unpadded layer's messages at a cost of $O(1)$ per round.


### PR DESCRIPTION
Gives the fracaddcheck unequal-depth path two real types where it had a type alias and a pile of loose locals.
Pure refactor — no behavior change, no transcript change.

### The problem

A batched fracaddcheck runs one uniform layer schedule over trees of unequal depth.
Two things carried that, and neither was a type.

**One.** The per-tree padded layer prover was a type alias over a three-deep composition:

```rust
pub(super) type PaddedLayerProver<'a, A, F, P> =
    ZeroPadMleCheckProver<F, Either<LayerProver<'a, A, F, P>, ConstantFraction<F>>>;
```

Being an alias, the whole composition shows up in every signature, every rustdoc entry, and every trait-bound error.
And `Either::Left` / `Either::Right` at the construction site carry no meaning — you have to read the comment beside them to learn which arm is which.

**Two.** The batch itself was five loose locals in the driver:

```rust
let alloc = provers[0].alloc;
let n_layers = provers.iter().map(FracAddCircuit::n_layers).max().expect(..);
let pad_lens = provers.iter().map(|p| n_layers - p.n_layers()).collect::<Vec<_>>();
let n_trees = provers.len();
...
PaddedLayerProver::pop_layer(&mut provers, &pad_lens, &claims, &eval_point[k..]);
```

`trees` and `pad_lens` must stay index-aligned, and nothing but the order they were built in enforced that.
The builder was a free function whose name shadowed itself at its only call site, and which said nothing about the fact that it *pops a layer off every tree it is handed*.

### The change

**The alias becomes a newtype, and the `Either` gets a name.**

```rust
type TreeLayer<'a, A, F, P> = Either<LayerProver<'a, A, F, P>, ConstantFraction<F>>;

pub(super) struct PaddedLayerProver<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
    ZeroPadMleCheckProver<F, TreeLayer<'a, A, F, P>>,
);
```

`TreeLayer` is where the meaning lands: a real layer of the tree once the batch has reached it, or the layer standing in for one until then — that tree's own fractional sum beside the zero fraction $0/1$.

**The batch becomes a type that owns the trees and their pad lengths together.**

```rust
pub(super) struct PaddedBatch<'a, A: Allocator, P: PackedField> {
    trees: Vec<FracAddCircuit<'a, A, P>>,
    pad_lens: Vec<usize>,
    n_layers: usize,
}
```

The alignment invariant is now established once, in `PaddedBatch::new`, instead of being re-assumed at every call. Popping a layer becomes what it always was — a mutation of the batch:

```diff
- PaddedLayerProver::pop_layer(&mut provers, &pad_lens, &claims, &eval_point[k..])
+ batch.pop_layer(&claims, &eval_point[k..])
```

`n_layers`, `n_trees`, `alloc`, and the end-of-loop exhaustion check move onto the type too, the last as `finish`, which the driver calls to retire the spent batch.

### No allocation is added

`batch_prove_unequal_depths` already took `provers: Vec<FracAddCircuit<..>>` **by value**, and already collected `pad_lens` into its own `Vec`.
Both are *moved* into `PaddedBatch` — a three-word header copy each, heap buffers untouched.
The old `&mut [FracAddCircuit]` was borrowing a `Vec` the caller already owned, not avoiding one.

### Soundness

Nothing about the reduction moved.
`pop_layer`'s body is the old function verbatim, reading two struct fields instead of two arguments.
The newtype forwards all five `MleCheckProver` methods straight through.

Every round polynomial and every child evaluation is bit-identical, so the transcript is unchanged.

### Scope

- **new:** the `TreeLayer` alias, the `PaddedLayerProver` newtype and its delegating `MleCheckProver` impl, and `PaddedBatch`.
- **changed:** the free `layer_provers` becomes `PaddedBatch::pop_layer`; `batch_prove_unequal_depths` sheds five locals and a `debug_assert!`.
- untouched: `zero_pad_mle`, the verifier side, and the prodcheck twin.

### Verification

- `cargo clippy -p binius-ip-prover --all-features --all-targets` — clean.
- `cargo +nightly fmt --all` — clean.
- `cargo test -p binius-ip-prover`, with and without `--features rayon` — 94 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
