### PR TITLE
Make the one-padded prodcheck layer prover's constructor an associated fn

### DIFF
--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -6,7 +6,8 @@ use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
-	FieldBuffer, FieldVec, line::extrapolate_line, multilinear::hypercube::Hypercube,
+	FieldBuffer, FieldVec, batch_invert::BatchInversion, line::extrapolate_line,
+	multilinear::hypercube::Hypercube,
 };
 use binius_utils::{
 	buffer::VecLike,
@@ -556,24 +557,57 @@ fn layer_provers<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 ) -> Vec<OnePadMleCheckProver<F, impl MleCheckProver<F> + use<'a, A, F, P>>> {
 	let node_len = node_point.len();
 
-	izip!(provers, pad_lens, products, claims)
-		.map(|(prover, &pad_len, &product, &claim)| {
+	// Every tree's padding segment is a prefix of this one node point, so a single table of prefix
+	// products serves the whole batch.
+	let pad_eq_prefixes = iter::once(F::ONE)
+		.chain(node_point.iter().scan(F::ONE, |acc, &coord| {
+			*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
+			Some(*acc)
+		}))
+		.collect::<Vec<_>>();
+
+	// De-padding a claim divides by the padding segment's equality weight, so the batch pays one
+	// inversion rather than one per tree.
+	let mut pad_eq_invs = pad_lens
+		.iter()
+		.map(|&pad_len| pad_eq_prefixes[pad_len.min(node_len)])
+		.collect::<Vec<_>>();
+	assert!(
+		pad_eq_invs.iter().all(|&pad_eq| pad_eq != F::ZERO),
+		"a padding coordinate of the claim point equals one"
+	);
+	BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
+
+	izip!(provers, pad_lens, products, claims, &pad_eq_invs)
+		.map(|(prover, &tree_pad_len, &product, &claim, &pad_eq_inv)| {
 			let alloc = prover.alloc;
+			let pad_len = tree_pad_len.min(node_len);
 			// While the batch is still above this tree, the layer is a one-padding of the tree's
 			// product, whose two children are that product and the constant one. Only once the
 			// batch reaches the tree does it start consuming its layers.
-			let layer = if node_len < pad_len {
+			let layer = if node_len < tree_pad_len {
 				FieldBuffer::from_values_in(alloc, &[product, F::ONE])
 			} else {
 				let layer = prover.pop_layer();
 				assert_eq!(
 					layer.log_len(),
-					node_len - pad_len + 1,
+					node_len - tree_pad_len + 1,
 					"precondition: the witness has exactly n_layers variables"
 				);
 				layer
 			};
-			one_pad_mle::new(alloc, layer, pad_len.min(node_len), node_point.to_vec(), claim)
+
+			let inner = bivariate_product_mle::new_split_half(
+				alloc,
+				layer,
+				node_point[pad_len..].to_vec(),
+				one_pad_mle::unpad_claim(pad_eq_inv, claim),
+			);
+			OnePadMleCheckProver::new(
+				pad_eq_prefixes[..=pad_len].to_vec(),
+				node_point.to_vec(),
+				inner,
+			)
 		})
 		.collect()
 }

--- a/crates/ip-prover/src/prodcheck/one_pad_mle.rs
+++ b/crates/ip-prover/src/prodcheck/one_pad_mle.rs
@@ -13,14 +13,13 @@
 //! [`OnePadMleCheckProver`] wraps the unpadded layer's own MLE-check and corrects its messages at a
 //! cost of $O(1)$ per round.
 
-use std::{iter, mem};
+use std::mem;
 
-use binius_compute::Allocator;
-use binius_field::{Field, PackedField};
+use binius_field::Field;
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldVec, multilinear::hypercube::Hypercube};
+use binius_math::multilinear::hypercube::Hypercube;
 
-use crate::sumcheck::{bivariate_product_mle, common::MleCheckProver};
+use crate::sumcheck::common::MleCheckProver;
 
 /// The one-padding selector $\textsf{sel}(s, v) = 1 + (v - 1) s$.
 ///
@@ -84,77 +83,68 @@ enum Phase<F, Inner> {
 	},
 }
 
-/// Creates the prover for one padded product-check layer.
+/// Divides the padding back out of a padded layer's claim.
+///
+/// The padded layer's evaluation is the unpadded one pushed through the padding selector at $q$.
+/// So recovering the unpadded claim is one more selector, at $q^{-1}$.
+///
+/// Callers seed the inner prover with the result.
+/// For a layer that is *all* padding it is the tree's own product.
 ///
 /// # Arguments
 ///
-/// * `layer` - The unpadded child layer, whose low and high halves on its highest variable are the
-///   two multilinears whose product this layer reduces.
-/// * `pad_len` - Length of `eval_point`'s padding segment. Zero leaves the inner reduction
-///   uncorrected.
-/// * `eval_point` - The padded layer's claim point, `[padding | real]`.
-/// * `claim` - The padded layer's claimed evaluation at `eval_point`.
-///
-/// # Preconditions
-///
-/// * `layer.log_len() >= 1`
-/// * `eval_point.len() == layer.log_len() - 1 + pad_len`
-///
-/// # Panics
-///
-/// Panics if the padding segment's equality weight $q$ is zero, which requires one of its
-/// coordinates — all verifier challenges — to equal one, and so happens with probability at most
-/// $\nu / |K|$.
-pub fn new<'alloc, A, F, P>(
-	alloc: &'alloc A,
-	layer: FieldVec<P, A>,
-	pad_len: usize,
-	eval_point: Vec<F>,
-	claim: F,
-) -> OnePadMleCheckProver<F, impl MleCheckProver<F> + 'alloc>
-where
-	A: Allocator,
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	assert!(layer.log_len() >= 1); // precondition
-	let n_real_rounds = layer.log_len() - 1;
-	assert_eq!(eval_point.len(), pad_len + n_real_rounds); // precondition
-
-	// Prefix products over the padding segment, so both the round polynomials' `e` factors and the
-	// claim's `q` are lookups.
-	let pad_eq_prefixes = iter::once(F::ONE)
-		.chain(eval_point[..pad_len].iter().scan(F::ONE, |acc, &coord| {
-			*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
-			Some(*acc)
-		}))
-		.collect::<Vec<_>>();
-	let pad_eq = pad_eq_prefixes[pad_len];
-	assert!(pad_eq != F::ZERO, "a padding coordinate of the claim point equals one");
-
-	// The padded claim is `sel(q, z)` for the unpadded claim `z`, so the inner prover starts from
-	// the preimage.
-	let inner_claim = F::ONE + (claim - F::ONE) * pad_eq.invert_or_zero();
-	let inner = bivariate_product_mle::new_split_half(
-		alloc,
-		layer,
-		eval_point[pad_len..].to_vec(),
-		inner_claim,
-	);
-
-	let mut prover = OnePadMleCheckProver {
-		eval_point,
-		pad_len,
-		round: 0,
-		pad_eq_prefixes,
-		phase: Phase::Real(inner),
-	};
-	// A layer with no real variables starts in the padding phase.
-	prover.advance();
-	prover
+/// * `pad_eq_inv` - The inverse of the padding segment's equality weight $q$.
+/// * `claim` - The padded layer's claimed evaluation.
+pub fn unpad_claim<F: Field>(pad_eq_inv: F, claim: F) -> F {
+	select(pad_eq_inv, claim)
 }
 
 impl<F: Field, Inner: MleCheckProver<F>> OnePadMleCheckProver<F, Inner> {
+	/// Creates the prover for one padded product-check layer.
+	///
+	/// Entry `i` of `pad_eq_prefixes` is $\prod_{c < i} \textsf{eq}(0, \rho_{\text{pa}, c})$.
+	///
+	/// Its length fixes the padding segment at one less.
+	/// A single-entry table therefore leaves the inner reduction uncorrected.
+	///
+	/// Every tree of a batch shares one claim point.
+	/// So one table of prefix products serves all of them.
+	///
+	/// The inner prover runs over the real segment of the claim point.
+	/// Its claim is the padded one with the padding divided back out by [`unpad_claim`].
+	///
+	/// # Arguments
+	///
+	/// * `pad_eq_prefixes` - Equality weights of the claim point's padding segment.
+	/// * `eval_point` - The padded layer's claim point, `[padding | real]`.
+	/// * `inner` - The unpadded layer's MLE-check.
+	///
+	/// # Preconditions
+	///
+	/// * `pad_eq_prefixes` is non-empty and its last entry is non-zero
+	/// * `eval_point.len() + 1 >= pad_eq_prefixes.len()`
+	/// * `inner.n_vars() == eval_point.len() + 1 - pad_eq_prefixes.len()`
+	pub fn new(pad_eq_prefixes: Vec<F>, eval_point: Vec<F>, inner: Inner) -> Self {
+		let pad_len = pad_eq_prefixes
+			.len()
+			.checked_sub(1)
+			.expect("precondition: non-empty");
+		assert!(eval_point.len() >= pad_len); // precondition
+		assert_ne!(pad_eq_prefixes[pad_len], F::ZERO); // precondition
+		assert_eq!(inner.n_vars(), eval_point.len() - pad_len); // precondition
+
+		let mut prover = Self {
+			eval_point,
+			pad_len,
+			round: 0,
+			pad_eq_prefixes,
+			phase: Phase::Real(inner),
+		};
+		// A layer with no real variables starts in the padding phase.
+		prover.advance();
+		prover
+	}
+
 	/// The number of rounds that reduce the unpadded layer's real variables.
 	const fn n_real_rounds(&self) -> usize {
 		self.eval_point.len() - self.pad_len
@@ -262,8 +252,10 @@ impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for OnePadMleCheckPro
 // produce the same round polynomials and the same child evaluations.
 #[cfg(test)]
 mod tests {
+	use std::iter;
+
 	use binius_compute::GlobalAllocator;
-	use binius_field::{Random, field::FieldOps};
+	use binius_field::{Random, arithmetic_traits::InvertOrZero, field::FieldOps};
 	use binius_math::{
 		FieldBuffer,
 		multilinear::Multilinear,
@@ -272,14 +264,15 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
+	use crate::sumcheck::bivariate_product_mle;
 
 	type P = Packed128b;
 	type F = <P as FieldOps>::Scalar;
 
 	/// Materializes `OnePad_{pad_len}` of a layer, whose variables are `[real | split]`.
 	///
-	/// The padding variables land below the real ones, matching the claim-point layout [`new`]
-	/// expects.
+	/// The padding variables land below the real ones.
+	/// That matches the claim-point layout [`OnePadMleCheckProver::new`] expects.
 	fn one_pad_layer(layer: &FieldBuffer<P>, pad_len: usize) -> FieldBuffer<P> {
 		let values = (0..1 << (layer.log_len() + pad_len))
 			.map(|index| {
@@ -303,6 +296,16 @@ mod tests {
 		FieldBuffer::<P>::from_values(&products).evaluate(eval_point)
 	}
 
+	/// Prefix products over the first `pad_len` coordinates of `eval_point`.
+	fn pad_eq_prefixes(eval_point: &[F], pad_len: usize) -> Vec<F> {
+		iter::once(F::ONE)
+			.chain(eval_point[..pad_len].iter().scan(F::ONE, |acc, &coord| {
+				*acc *= Hypercube::One.eq_one_var(F::ZERO, coord);
+				Some(*acc)
+			}))
+			.collect()
+	}
+
 	/// Runs the padded prover and the reference prover over the materialized padded layer in
 	/// lockstep.
 	fn assert_matches_padded_reference(layer: FieldBuffer<P>, pad_len: usize) {
@@ -316,7 +319,16 @@ mod tests {
 
 		let mut reference =
 			bivariate_product_mle::new_split_half(&alloc, padded_layer, eval_point.clone(), claim);
-		let mut prover = new(&alloc, layer, pad_len, eval_point, claim);
+
+		let prefixes = pad_eq_prefixes(&eval_point, pad_len);
+		let pad_eq_inv = prefixes[pad_len].invert_or_zero();
+		let inner = bivariate_product_mle::new_split_half(
+			&alloc,
+			layer,
+			eval_point[pad_len..].to_vec(),
+			unpad_claim(pad_eq_inv, claim),
+		);
+		let mut prover = OnePadMleCheckProver::new(prefixes, eval_point, inner);
 
 		for round in 0..n_vars {
 			assert_eq!(prover.n_vars(), n_vars - round);


### PR DESCRIPTION
Moves `one_pad_mle`'s free `new` into an `impl` block, by giving it the same shape its fractional-addition sibling already has.
Pure refactor — no behavior change.

### The problem

`crates/ip-prover/src/prodcheck/one_pad_mle.rs` defines `OnePadMleCheckProver<F, Inner>` beside a *free* `new`.

The free function is not a stylistic accident, it is forced.
Today's `new` builds the inner prover itself, via `bivariate_product_mle::new_split_half`.
That returns an opaque `impl MleCheckProver<F>`, so the constructor has to return `OnePadMleCheckProver<F, impl MleCheckProver<F> + 'alloc>`.

An inherent associated function cannot do that.
`Self` fixes `Inner`, so the return type may not leave it unconstrained.
The constructor therefore had to live outside the type.

### The idea

The fractional-addition analog of this exact wrapper, `crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs`, already solved this.

Its `new(pad_eq_prefixes, eval_point, inner)` **takes** the inner prover instead of building it.
So it is generic in `Inner`, and nothing is opaque.

Do the same here, and the constructor becomes a legal associated function:

```
- pub fn new(alloc, layer, pad_len, eval_point, claim)
-     -> OnePadMleCheckProver<F, impl MleCheckProver<F> + 'alloc>
+ impl<F: Field, Inner: MleCheckProver<F>> OnePadMleCheckProver<F, Inner> {
+     pub fn new(pad_eq_prefixes: Vec<F>, eval_point: Vec<F>, inner: Inner) -> Self
+ }
```

### What moves where

The old `new` conflated two jobs. They separate cleanly:

- **wrapping the padding correction** stays in `one_pad_mle` — that is what the type is for;
- **building the inner bivariate-product reduction**, and de-padding its claim, moves to the only caller, `prodcheck::layer_provers`.

De-padding gets a named home on the way out, mirroring `zero_pad_mle::unpad_claims`:

```
pub fn unpad_claim<F: Field>(pad_eq_inv: F, claim: F) -> F {
    select(pad_eq_inv, claim)
}
```

The padding identity now lives in one place instead of being re-derived at the call site.

### The duplicated work this removes

`layer_provers` builds one prover per tree for a single layer, and every tree shares that layer's node point.

The old code rebuilt the same table of padding prefix products inside every tree's `new`, over the same coordinates.
It also paid one field inversion per tree to de-pad that tree's claim.

The sibling already hoists both, and now this does too:

- **before:** one prefix-product scan per tree, plus $n$ inversions
- **after:** one scan for the batch, plus one `BatchInversion` over the $n$ weights

This is a real removal of duplicated work, but it sits far off the hot path — a handful of scalar operations per layer against a reduction over the whole layer buffer. No speedup is claimed and none was measured.

### Scope

- **changed:** `crates/ip-prover/src/prodcheck/one_pad_mle.rs` — constructor becomes associated, `unpad_claim` added
- **changed:** `crates/ip-prover/src/prodcheck/mod.rs` — `layer_provers` builds the inner prover, hoists the prefix table and the inversion
- **untouched:** the verifier side, the module layout, and every round-polynomial formula

### Correctness

This is a pure refactor, and the evidence is that nothing observable moved.

- `one_pad_mle`'s own test still checks the prover against an ordinary MLE-check over an explicitly materialized one-padded layer, round polynomial by round polynomial, and child evaluation by child evaluation. It passes unchanged apart from the new constructor signature.
- The prefix table the caller slices per tree, `pad_eq_prefixes[..=pad_len]`, is exactly the table the old `new` built from `eval_point[..pad_len]`.
- `invert_nonzero` on a weight the batch has already asserted non-zero equals the old `invert_or_zero`.
- Hashing the finalized prover transcript of every `test_unequal_depths_*` case gives byte-identical results before and after (depths `[1,1,1]`, `[3]`, `[2,4,5]`, `[1,2,5,5]`, `[1,6]`).

### Verification

- `cargo +nightly fmt --all` — clean
- `cargo clippy -p binius-ip-prover --all-features --all-targets -- -D warnings` — clean
- `cargo test -p binius-ip-prover` — 94 passed, 0 failed
- `cargo test -p binius-ip-prover --features rayon` — 94 passed, 0 failed

Scoped to the touched crate deliberately; no workspace-wide build was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)