### PR TITLE
BINIUS-544: Verify a Ligerito opening inside a Binius64 circuit

### DIFF
--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -10,10 +10,12 @@ use binius_field::{Field, FieldOps, Ghash128b as B128};
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_hash::StdHashSuite;
 use binius_iop::{
+	channel::grinding::GrindingVerifierChannel,
 	merkle_channel::{self, MerkleIPVerifierChannel},
 	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
+use binius_transcript::{Error as TranscriptError, MAX_GRINDING_BITS};
 
 use crate::{
 	challenger::Sha256Challenger,
@@ -71,6 +73,8 @@ pub struct Binius64BuilderChannel {
 	n_merkle_checks: usize,
 	/// Words bound to public inputs so far, so each binding gets a distinct name.
 	n_public: usize,
+	/// Proofs of work checked so far, so each gets a distinct name.
+	n_grinds: usize,
 }
 
 impl Binius64BuilderChannel {
@@ -86,6 +90,7 @@ impl Binius64BuilderChannel {
 			scheme: BinaryMerkleTreeScheme::new(),
 			n_merkle_checks: 0,
 			n_public: 0,
+			n_grinds: 0,
 		}
 	}
 
@@ -323,6 +328,38 @@ impl WordIPVerifierChannel<B128> for Binius64BuilderChannel {
 	}
 }
 
+impl GrindingVerifierChannel for Binius64BuilderChannel {
+	/// Records a proof of work as a nonce wire and one assertion over the draw it decides.
+	///
+	/// The nonce is proof data, so it enters as an input wire the replay fills.
+	/// Absorbing it is what makes the draw below depend on it.
+	///
+	/// ```text
+	///     nonce wire -> challenger -> the bits it decides -> asserted zero
+	/// ```
+	fn verify_grind(&mut self, bits: usize) -> Result<(), TranscriptError> {
+		// Zero difficulty is not a grind, so nothing is read and nothing is checked.
+		if bits == 0 {
+			return Ok(());
+		}
+		assert!(bits <= MAX_GRINDING_BITS); // precondition
+
+		// The nonce goes out as one little-endian `u64` message, which is one absorbed word.
+		let nonce = self.shared.input_wire("grind_nonce");
+		self.challenger.observe_words(&[nonce]);
+
+		// The gadget masks the draw to `bits` with a real gate.
+		// So asserting the masked wire is zero is the whole proof-of-work check.
+		let sampled = self.challenger.sample_bits(bits);
+		let n = self.n_grinds;
+		self.n_grinds += 1;
+		self.shared
+			.builder()
+			.assert_zero(format!("grind[{n}]"), sampled);
+		Ok(())
+	}
+}
+
 impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 	type Commitment = Commitment;
 
@@ -449,7 +486,7 @@ impl MerkleIPVerifierChannel<B128> for Binius64BuilderChannel {
 #[cfg(test)]
 mod tests {
 	use binius_transcript::{
-		Buf,
+		Buf, ProverTranscript,
 		fiat_shamir::{Challenger, HasherChallenger, sample_bits_reader},
 	};
 	use sha2::Sha256;
@@ -577,5 +614,84 @@ mod tests {
 			w[input.wire] = Word::ZERO;
 		}
 		recorded.circuit.populate_wire_witness(&mut w).unwrap();
+	}
+
+	/// A grind moves the Fiat-Shamir state exactly as far as the native one does.
+	///
+	/// The nonce is absorbed, and the requested bits are then sampled.
+	/// A channel that skipped either would hand the next challenge different bytes.
+	/// Pinning that challenge is what catches it.
+	#[test]
+	fn a_challenge_after_a_grind_matches_the_native_challenger() {
+		// Eight bits is a search of about 256 trials, which is instant and still a real one.
+		const BITS: usize = 8;
+
+		// The native round trip: the prover searches, the verifier checks, then both draw.
+		let mut prover = ProverTranscript::new(HasherChallenger::<Sha256>::default());
+		let nonce = prover.grind(BITS);
+		let mut native = prover.into_verifier();
+		native
+			.verify_grind(BITS)
+			.expect("the nonce the search returned meets its own difficulty");
+		let want = IPVerifierChannel::<B128>::sample(&mut native);
+
+		// The same two steps over the builder, where the nonce is a wire rather than a value.
+		let mut channel = Binius64BuilderChannel::new();
+		GrindingVerifierChannel::verify_grind(&mut channel, BITS)
+			.expect("recording a grind cannot fail");
+		let challenge = IPVerifierChannel::<B128>::sample(&mut channel);
+
+		// The challenge is pinned to a public wire carrying the native value.
+		// A divergence then fails witness population rather than a Rust comparison.
+		let claimed = {
+			let builder = channel.shared.builder();
+			let (lo, hi) = challenge.to_wires(builder);
+			let claimed = [builder.add_inout(), builder.add_inout()];
+			builder.assert_eq_v("challenge", [lo, hi], claimed);
+			claimed
+		};
+
+		drop(challenge);
+		let recorded = channel.build();
+
+		// The nonce is the one thing a replay supplies here.
+		let inputs = recorded
+			.inputs
+			.iter()
+			.map(|input| input.kind)
+			.collect::<Vec<_>>();
+		assert_eq!(inputs, ["grind_nonce"]);
+
+		let fill = |nonce: u64| {
+			let mut w = recorded.circuit.new_witness_filler();
+			w[recorded.inputs[0].wire] = Word(nonce);
+			for (wire, word) in claimed.iter().zip(element_words(u128::from(want))) {
+				w[*wire] = Word(word);
+			}
+			recorded.circuit.populate_wire_witness(&mut w)
+		};
+
+		fill(nonce).expect("the ground nonce must satisfy the assertion and reach the challenge");
+		// One away from the landing nonce lands on zero once in 2^BITS, so this is the check.
+		fill(nonce + 1)
+			.expect_err("a nonce that met no difficulty must leave the circuit unsatisfied");
+	}
+
+	/// Zero difficulty is not a grind, so it touches neither the tape nor the challenger.
+	#[test]
+	fn a_zero_difficulty_grind_records_nothing() {
+		let mut plain = Binius64BuilderChannel::new();
+		let mut ground = Binius64BuilderChannel::new();
+		GrindingVerifierChannel::verify_grind(&mut ground, 0).expect("zero difficulty cannot fail");
+
+		// Two channels that have done the same amount of nothing must draw the same challenge.
+		let (plain_lo, plain_hi) =
+			IPVerifierChannel::<B128>::sample(&mut plain).to_wires(plain.shared.builder());
+		let (ground_lo, ground_hi) =
+			IPVerifierChannel::<B128>::sample(&mut ground).to_wires(ground.shared.builder());
+		assert_eq!((plain_lo, plain_hi), (ground_lo, ground_hi));
+
+		// And no wire was allocated for a nonce that was never read.
+		assert!(ground.build().inputs.is_empty());
 	}
 }

--- a/crates/recursion/src/filler.rs
+++ b/crates/recursion/src/filler.rs
@@ -9,11 +9,14 @@ use binius_field::Ghash128b as B128;
 use binius_frontend::WitnessFiller;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
+	channel::grinding::GrindingVerifierChannel,
 	merkle_channel::{self, MerkleIPVerifierChannel, TranscriptMerkleCommitment},
 	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
-use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
+use binius_transcript::{
+	Error as TranscriptError, MAX_GRINDING_BITS, VerifierTranscript, fiat_shamir::Challenger,
+};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
 
@@ -170,6 +173,35 @@ where
 	// The build pairs up wires it already has, allocating none, so there is nothing to fill.
 	fn pack_words(&mut self, words: &[Word]) -> Vec<B128> {
 		self.transcript.borrow_mut().pack_words(words)
+	}
+}
+
+impl<T, Challenger_, H> GrindingVerifierChannel for WitnessFillerChannel<'_, '_, T, Challenger_, H>
+where
+	T: BorrowMut<VerifierTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+{
+	/// Reads the nonce the prover ground and fills the wire the build allocated for it.
+	///
+	/// The draw it decides is deliberately not checked here.
+	/// The build emitted a ZERO constraint over that draw.
+	/// So a nonce that did no work leaves the circuit unsatisfied.
+	/// It is not an error out of a witness generator.
+	fn verify_grind(&mut self, bits: usize) -> Result<(), TranscriptError> {
+		// Zero difficulty is not a grind, so the tape holds no nonce to read here.
+		if bits == 0 {
+			return Ok(());
+		}
+		assert!(bits <= MAX_GRINDING_BITS); // precondition
+
+		// Read as a message, so the native challenger observes the bytes the prover fed it.
+		let nonce: u64 = self.transcript.borrow_mut().message().read()?;
+		self.fill_word("grind_nonce", Word(nonce));
+
+		// The draw still has to happen, since it advances the native Fiat-Shamir state.
+		WordIPVerifierChannel::<B128>::sample_bits(self.transcript.borrow_mut(), bits);
+		Ok(())
 	}
 }
 

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -30,6 +30,7 @@
 //! - the two field gadgets that used to be bare hints
 //! - the Merkle commitments, by [`merkle`]
 //! - the Fiat-Shamir state, by [`challenger`]
+//! - the proof of work, whose nonce is absorbed and whose draw is asserted zero
 //!
 //! An opened leaf is hashed and climbed to a decommitted layer the root fixes.
 //! A committed vector has its tree rebuilt over it.

--- a/crates/recursion/tests/ligerito_opening.rs
+++ b/crates/recursion/tests/ligerito_opening.rs
@@ -1,0 +1,902 @@
+// Copyright 2026 The Binius Developers
+
+//! A Ligerito opening proved natively, then verified inside a Binius64 circuit.
+//!
+//! ```text
+//!   prover:    native, writing one real transcript
+//!   verifier:  the same code over the builder channel, emitting gates instead of checking values
+//! ```
+//!
+//! A satisfied constraint system is then the statement "this transcript opens this claim".
+//! An outer proof can check that statement, which is what makes this one step of recursion.
+//!
+//! The sibling test over the FRI-based scheme sets out the shared machinery in full.
+//! What follows is what a ladder adds to it.
+//!
+//! # Why the ladder is expressible at all
+//!
+//! Every level does three things a channel already speaks.
+//!
+//! ```text
+//!   fold rounds     a received element, then a challenge drawn after it
+//!   query rows      a masked bit sample per position, and the leaves under them
+//!   induced basis   one bit-decomposed sum over fixed constants per position
+//! ```
+//!
+//! Nothing asks the channel to invert a value it received.
+//! Nothing asks it to materialize the weight vector a level's rows induce.
+//!
+//! The second is settled by the types rather than by discipline.
+//! Materializing that vector needs a packed field, and the element a circuit carries is not one.
+//! So the dense route is unreachable from the verifier's body, and this file compiling says so.
+//!
+//! # What the residual costs
+//!
+//! The last level sends its remaining matrix in the clear, against its own commitment.
+//! A circuit rebuilds that whole tree, one leaf per element.
+//! So the cleartext residual is the only part of a ladder growing as `2^r`.
+//! Everything else grows as a logarithm.
+//!
+//! The sweep at the end of this file prices that difference.
+//!
+//! # Proof of work
+//!
+//! A ground nonce enters as a wire, is absorbed, and the draw it decides is asserted zero.
+//! That is the same check the native verifier makes, phrased as a constraint.
+
+use std::iter;
+
+use binius_compute::GlobalAllocator;
+use binius_core::word::Word;
+use binius_field::{Ghash128b as B128, PackedBinaryGhash1x128b};
+use binius_frontend::{CircuitStat, MAX_ASSERTION_FAILURES, PopulateError, Wire};
+use binius_hash::{StdDigest, StdHashSuite};
+use binius_iop::{
+	ligerito::{LigeritoLevel, LigeritoParams, LigeritoVerifier},
+	merkle_channel::MerkleIPVerifierChannel,
+	merkle_tree::{BinaryMerkleTreeScheme, MerkleTreeScheme},
+	soundness::{Grinding, SoundnessRegime},
+};
+use binius_iop_prover::{ligerito::LigeritoProver, merkle_channel::ProverMerkleTranscriptChannel};
+use binius_ip::channel::WordIPVerifierChannel;
+use binius_ip_prover::channel::WordIPProverChannel;
+use binius_math::{
+	multilinear::Multilinear,
+	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
+	test_utils::{random_field_buffer, random_scalars},
+};
+use binius_recursion::{Binius64BuilderChannel, Recorded, WitnessFillerChannel};
+use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
+use rand::{SeedableRng, rngs::StdRng};
+
+/// The Fiat-Shamir challenger the in-circuit challenger reproduces.
+type StdChallenger = HasherChallenger<StdDigest>;
+
+/// The packed field the native prover runs over.
+type P = PackedBinaryGhash1x128b;
+
+/// Words one field element occupies on the transcript, low half first.
+const ELEMENT_WORDS: usize = 2;
+
+/// Bytes one SHA-256 digest occupies on the tape, which is what a commitment root is.
+const DIGEST_BYTES: usize = 32;
+
+/// Bytes one field element occupies on the tape.
+const ELEMENT_BYTES: usize = ELEMENT_WORDS * Word::BYTES;
+
+/// The security target the ladders here are labelled with.
+///
+/// Nothing in this file reads it.
+/// The shapes here are small enough to build a circuit from, far below any real target.
+const SECURITY_BITS: usize = 32;
+
+/// The transcript words one field element serializes to.
+fn element_words(value: B128) -> [Word; ELEMENT_WORDS] {
+	let value = u128::from(value);
+	[
+		Word::from_u64(value as u64),
+		Word::from_u64((value >> 64) as u64),
+	]
+}
+
+/// The shape of one Ligerito ladder.
+///
+/// Every field is fixed before a proof exists, so a shape is exactly what a circuit is built for.
+#[derive(Clone, Copy, Debug)]
+struct Shape {
+	/// Base-2 logarithm of the columns level 0 commits.
+	log_msg_cols: usize,
+	/// The lanes each level folds away, outermost level first.
+	lanes: &'static [usize],
+	/// Rows every level opens against its own codeword.
+	n_queries: usize,
+	/// The proof of work each level pays, at the two points a level pays one.
+	grinding: Grinding,
+}
+
+/// A two-level ladder over a `2^8` message, leaving a `2^4` residual.
+///
+/// Level 0 commits `2^6` columns and 4 lanes at rate `1/2`.
+/// Level 1 takes what that folds to, `2^4` columns and 4 lanes, at rate `1/4`.
+const NATIVE_SHAPE: Shape = Shape {
+	log_msg_cols: 6,
+	lanes: &[2, 2],
+	n_queries: 8,
+	grinding: Grinding::NONE,
+};
+
+/// What a shape fixes ahead of any proof: the ladder, and the transform its levels encode over.
+struct Setup {
+	/// The ladder, one entry per committed level.
+	params: LigeritoParams,
+	/// The additive NTT the prover encodes every level with.
+	ntt: NeighborsLastSingleThread<GaoMateerOnTheFly<B128>>,
+}
+
+impl Shape {
+	/// Base-2 logarithm of the elements the committed message holds.
+	///
+	/// Level 0 spans its columns and its lanes, and that is the whole message.
+	const fn log_msg_len(&self) -> usize {
+		self.log_msg_cols + self.lanes[0]
+	}
+
+	/// Transcript words the statement occupies: the point, then the claim.
+	const fn statement_words(&self) -> usize {
+		(self.log_msg_len() + 1) * ELEMENT_WORDS
+	}
+
+	/// Transcript words the evaluation point alone occupies.
+	const fn point_words(&self) -> usize {
+		self.log_msg_len() * ELEMENT_WORDS
+	}
+
+	/// Derives the ladder and the encoding transform, neither of which needs a witness.
+	///
+	/// Level `i` commits at inverse rate `2^(i + 1)`.
+	/// That is the strictly falling rate a ladder requires.
+	///
+	/// Level `i + 1` takes what level `i` folded to.
+	/// So its columns are level `i`'s less its own lanes.
+	fn setup(&self) -> Setup {
+		let mut log_msg_cols = self.log_msg_cols;
+		let levels = self
+			.lanes
+			.iter()
+			.enumerate()
+			.map(|(i, &log_lanes)| {
+				// Level 0 keeps the column count it was given; every deeper one loses its lanes.
+				if i > 0 {
+					log_msg_cols -= log_lanes;
+				}
+				LigeritoLevel {
+					log_msg_cols,
+					log_lanes,
+					log_inv_rate: i + 1,
+					n_queries: self.n_queries,
+				}
+			})
+			.collect();
+		let params = LigeritoParams::new(levels, SoundnessRegime::UniqueDecoding, SECURITY_BITS)
+			.with_grinding(self.grinding);
+
+		// One transform serves the whole ladder, sized for its longest codeword.
+		let ntt = NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(
+			params.max_log_codeword_len(),
+		));
+		Setup { params, ntt }
+	}
+
+	/// Proves one opening of this ladder, drawing the witness and the point from `seed`.
+	///
+	/// The statement is written to the transcript rather than handed over out of band.
+	/// That is what lets it be wires rather than build-time constants.
+	/// It also binds the proof to the one statement it was written for.
+	///
+	/// The point is observed first, since it is known before anything is committed.
+	/// The claim follows level 0's root, since it is a claim about what that root commits.
+	fn prove(&self, setup: &Setup, seed: u64) -> Opening {
+		// One seed fixes the polynomial and the point, so a transcript is reproducible.
+		let mut rng = StdRng::seed_from_u64(seed);
+		let witness = random_field_buffer::<P>(&mut rng, self.log_msg_len());
+		let eval_point: Vec<B128> = random_scalars(&mut rng, self.log_msg_len());
+		let eval_claim = witness.evaluate(&eval_point);
+
+		let mut transcript = ProverTranscript::new(StdChallenger::default());
+		let mut channel =
+			ProverMerkleTranscriptChannel::<_, StdChallenger, B128, StdHashSuite>::new(
+				&mut transcript,
+			);
+
+		let point_words = eval_point
+			.iter()
+			.flat_map(|value| element_words(*value))
+			.collect::<Vec<_>>();
+		WordIPProverChannel::<B128>::observe_words(&mut channel, &point_words);
+
+		// Encodes level 0 lane by lane and sends its Merkle root.
+		let prover =
+			LigeritoProver::commit(&setup.params, &setup.ntt, witness.as_view(), &mut channel);
+		WordIPProverChannel::<B128>::observe_words(&mut channel, &element_words(eval_claim));
+
+		prover.prove(witness.as_view(), &eval_point, eval_claim, &GlobalAllocator, &mut channel);
+		// Hand the transcript back, releasing the channel's borrow of it.
+		channel.into_transcript();
+
+		Opening {
+			eval_claim,
+			eval_point,
+			proof: transcript.finalize(),
+		}
+	}
+
+	/// Records the verifier for this ladder as a circuit, by running it over the builder channel.
+	///
+	/// No proof reaches this, and no statement either.
+	/// Observing reads only the *length* of what it is handed.
+	/// Placeholder words therefore allocate the wires a real statement later fills.
+	fn record(&self, setup: &Setup) -> VerifierCircuit {
+		let mut channel = Binius64BuilderChannel::new();
+
+		// Placeholders, for their count alone.
+		// The values never reach a gate.
+		let placeholder = vec![Word::ZERO; self.statement_words()];
+		let statement = channel.observe_words(&placeholder[..self.point_words()]);
+		let eval_point = channel.pack_words(&statement);
+
+		// Level 0's root is the caller's to receive, so the ladder is handed a commitment.
+		// One leaf holds a codeword position across every lane.
+		let level = &setup.params.levels()[0];
+		let commitment = channel
+			.recv_merkle_commitment(1 << level.log_lanes, level.log_codeword_len())
+			.expect("reading a commitment cannot fail");
+
+		let claim_words = channel.observe_words(&placeholder[self.point_words()..]);
+		let eval_claim = channel.pack_words(&claim_words)[0].clone();
+
+		// Every check the verifier makes becomes a constraint rather than a comparison.
+		// So the call cannot fail while the circuit is being built.
+		LigeritoVerifier::new(&setup.params, commitment)
+			.verify::<B128, _>(&eval_point, eval_claim, &mut channel)
+			.expect("the builder channel records rather than checks, so it cannot fail");
+
+		// The statement becomes the circuit's public interface.
+		// An outer proof can then pin what was verified rather than trust whoever filled it.
+		let public = channel.bind_public(statement.into_iter().chain(claim_words).collect());
+		let recorded = channel.build();
+		let stat = CircuitStat::collect(&recorded.circuit);
+		VerifierCircuit {
+			recorded,
+			public,
+			stat,
+		}
+	}
+}
+
+impl Setup {
+	/// The tape offset of the last residual element the ladder sends.
+	///
+	/// The residual is sent before the last level's rows are opened, so the tape ends like this:
+	///
+	/// ```text
+	///     .. -> residual root -> residual elements -> decommitted layer -> leaves and branches
+	/// ```
+	///
+	/// Everything after the residual belongs to that one opening, whose size the ladder fixes.
+	/// So the residual's last byte is the whole tape less that tail.
+	fn last_residual_byte(&self, proof_len: usize) -> usize {
+		let level = self
+			.params
+			.levels()
+			.last()
+			.expect("a ladder has at least one level");
+		let tree_depth = level.log_codeword_len();
+
+		// The same layer depth both channels pick, so the same digest count is on the tape.
+		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+		let layer_depth = scheme.optimal_verify_layer(level.n_queries, tree_depth);
+
+		// One leaf holds a codeword position across every lane, and one branch climbs to the layer.
+		let leaf_bytes = (1 << level.log_lanes) * ELEMENT_BYTES;
+		let branch_bytes = (tree_depth - layer_depth) * DIGEST_BYTES;
+		let tail =
+			(1 << layer_depth) * DIGEST_BYTES + level.n_queries * (leaf_bytes + branch_bytes);
+
+		proof_len - tail - 1
+	}
+}
+
+/// One opening proved natively: the statement it proves, and the transcript proving it.
+struct Opening {
+	/// The claimed evaluation of the committed multilinear at the point below.
+	eval_claim: B128,
+	/// The point the claim is made at, low-to-high variable order.
+	eval_point: Vec<B128>,
+	/// The proof byte tape.
+	proof: Vec<u8>,
+}
+
+impl Opening {
+	/// The statement as transcript words, in the order both halves observe it.
+	fn statement(&self) -> Vec<Word> {
+		self.eval_point
+			.iter()
+			.chain(iter::once(&self.eval_claim))
+			.flat_map(|value| element_words(*value))
+			.collect()
+	}
+}
+
+/// A circuit that verifies any opening of one fixed ladder.
+struct VerifierCircuit {
+	/// The compiled circuit and the wires a replay fills.
+	recorded: Recorded,
+	/// One public wire per statement word, each equal to what the verifier observed.
+	public: Vec<Wire>,
+	/// Constraint counts and trace size.
+	stat: CircuitStat,
+}
+
+impl VerifierCircuit {
+	/// Populates the circuit from a statement and a proof, and reports whether it is satisfied.
+	///
+	/// The statement is written twice over.
+	/// Onto the public wires here, and onto the wires the replay fills as it observes it.
+	/// The binding between them is what ties the two.
+	fn check(
+		&self,
+		shape: &Shape,
+		setup: &Setup,
+		statement: &[Word],
+		proof: &[u8],
+	) -> Result<(), PopulateError> {
+		let mut w = self.recorded.circuit.new_witness_filler();
+		for (&wire, &word) in iter::zip(&self.public, statement) {
+			w[wire] = word;
+		}
+
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof.to_vec());
+		let mut channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
+			&mut transcript,
+			&mut w,
+			self.recorded.inputs.clone(),
+		);
+		let point = channel.observe_words(&statement[..shape.point_words()]);
+		let eval_point = channel.pack_words(&point);
+		let level = &setup.params.levels()[0];
+		let commitment = channel
+			.recv_merkle_commitment(1 << level.log_lanes, level.log_codeword_len())
+			.expect("the tape carries a commitment");
+		let claim = channel.observe_words(&statement[shape.point_words()..]);
+		let eval_claim = channel.pack_words(&claim)[0];
+
+		LigeritoVerifier::new(&setup.params, commitment)
+			.verify::<B128, _>(&eval_point, eval_claim, &mut channel)
+			.expect("the replay generates a witness rather than judging one");
+		channel.finish();
+
+		self.recorded.circuit.populate_wire_witness(&mut w)
+	}
+
+	/// Populates and checks one natively proved opening.
+	fn check_opening(
+		&self,
+		shape: &Shape,
+		setup: &Setup,
+		opening: &Opening,
+	) -> Result<(), PopulateError> {
+		self.check(shape, setup, &opening.statement(), &opening.proof)
+	}
+
+	/// Asserts the circuit rejects `proof`, and returns the subcircuits whose assertions failed.
+	fn rejected(
+		&self,
+		shape: &Shape,
+		setup: &Setup,
+		opening: &Opening,
+		proof: &[u8],
+	) -> Vec<String> {
+		let error = self
+			.check(shape, setup, &opening.statement(), proof)
+			.expect_err("a corrupted proof must leave the circuit unsatisfied");
+
+		// `..` is forced:
+		// `PopulateError` is non-exhaustive.
+		// Both of its fields are checked here.
+		let PopulateError {
+			failures, total, ..
+		} = error;
+		assert!(total > 0, "an unsatisfied circuit must report a failing assertion");
+		assert_eq!(failures.len(), total.min(MAX_ASSERTION_FAILURES));
+		for failure in &failures {
+			assert!(!failure.detail.is_empty(), "a failure must carry a diagnostic");
+		}
+
+		// The leading path component names the check, which is what each test below asserts on.
+		let mut named = failures
+			.into_iter()
+			.map(|failure| {
+				failure
+					.path
+					.trim_start_matches('.')
+					.split('.')
+					.next()
+					.unwrap_or_default()
+					.trim_end_matches(|c: char| c.is_ascii_digit() || c == '[' || c == ']')
+					.to_string()
+			})
+			.collect::<Vec<_>>();
+		named.sort();
+		named.dedup();
+		named
+	}
+}
+
+#[test]
+fn a_native_opening_verifies_in_circuit() {
+	// Invariant: the circuit built from the verifier accepts a transcript the prover wrote.
+	//
+	// Fixture state: the native ladder of two levels over a 2^8 message, and one proof.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 0);
+	// Nothing about the proof reaches the builder, so the order of these two lines is immaterial.
+	let verifier = shape.record(&setup);
+
+	println!(
+		"ligerito verifier: {} gates, {} AND, {} BMUL, {} ZERO, {} committed words, {} recorded inputs",
+		verifier.stat.n_gates,
+		verifier.stat.n_and_constraints,
+		verifier.stat.n_bmul_constraints,
+		verifier.stat.n_zero_constraints,
+		verifier.stat.committed_allocated,
+		verifier.recorded.inputs.len(),
+	);
+
+	// The statement is the circuit's public interface, one wire per transcript word.
+	assert_eq!(verifier.public.len(), shape.statement_words());
+
+	// Nothing else is an input.
+	// Every recorded wire is a value read off the tape, or the statement itself.
+	// No challenge, no query index, no digest the circuit could have recomputed.
+	//
+	// The residual arrives in the clear.
+	// The FRI-based sibling calls that entry a terminal codeword.
+	let mut kinds = verifier
+		.recorded
+		.inputs
+		.iter()
+		.map(|input| input.kind)
+		.collect::<Vec<_>>();
+	kinds.sort_unstable();
+	kinds.dedup();
+	assert_eq!(
+		kinds,
+		[
+			"committed_vector",
+			"merkle_branch",
+			"merkle_layer",
+			"merkle_root",
+			"observe_words",
+			"opening",
+			"recv_one",
+		]
+	);
+
+	verifier
+		.check_opening(&shape, &setup, &opening)
+		.expect("the circuit must accept the opening the native prover proved");
+}
+
+#[test]
+fn one_circuit_verifies_two_different_openings() {
+	// Invariant: one compiled circuit verifies every opening of its ladder.
+	//
+	// Fixture state: two proofs of the native ladder, from two different seeds.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+
+	// Different witness and different evaluation point, so a different transcript throughout.
+	let first = shape.prove(&setup, 1);
+	let second = shape.prove(&setup, 2);
+	// Two openings that happened to coincide would make the rest of the test vacuous.
+	assert_ne!(first.eval_point, second.eval_point, "the two openings must differ");
+	assert_ne!(first.proof, second.proof, "the two transcripts must differ");
+	// Equal lengths are the observable half of "the layout depends only on the ladder".
+	assert_eq!(
+		first.proof.len(),
+		second.proof.len(),
+		"one ladder means one tape length, whatever the witness"
+	);
+
+	// Built once, before either proof is looked at.
+	let verifier = shape.record(&setup);
+	for (i, opening) in [&first, &second].into_iter().enumerate() {
+		verifier
+			.check_opening(&shape, &setup, opening)
+			.unwrap_or_else(|error| panic!("opening {i} must satisfy the shared circuit: {error}"));
+	}
+}
+
+#[test]
+fn a_one_level_ladder_verifies_in_circuit() {
+	// Invariant: a one-entry ladder is the protocol with no glue at all.
+	// Level 0 folds, and its rows meet the residual directly with no sumcheck to join.
+	//
+	// Fixture state: one level of 2^6 columns and 4 lanes, leaving a 2^6 residual.
+	let shape = Shape {
+		lanes: &[2],
+		..NATIVE_SHAPE
+	};
+	let setup = shape.setup();
+	assert_eq!(setup.params.n_levels(), 1);
+	assert_eq!(setup.params.log_residual_dim(), 6);
+
+	let opening = shape.prove(&setup, 9);
+	let verifier = shape.record(&setup);
+	verifier
+		.check_opening(&shape, &setup, &opening)
+		.expect("a single level must verify with no glued claim to carry");
+}
+
+#[test]
+fn a_three_level_ladder_verifies_in_circuit() {
+	// Invariant: every level below level 0 runs a plain degree-2 sumcheck and glues its rows in.
+	// Two glued bases then have to follow the fold down to the residual.
+	//
+	// Fixture state: three levels over a 2^8 message, leaving a 2^2 residual.
+	//
+	//     level 0:  2^6 cols, 4 lanes, rate 1/2
+	//     level 1:  2^4 cols, 4 lanes, rate 1/4
+	//     level 2:  2^2 cols, 4 lanes, rate 1/8
+	let shape = Shape {
+		lanes: &[2, 2, 2],
+		..NATIVE_SHAPE
+	};
+	let setup = shape.setup();
+	assert_eq!(setup.params.log_residual_dim(), 2);
+
+	let opening = shape.prove(&setup, 10);
+	let verifier = shape.record(&setup);
+	verifier
+		.check_opening(&shape, &setup, &opening)
+		.expect("two glued bases must reach the residual folded the same way both sides fold them");
+}
+
+#[test]
+fn an_odd_query_count_verifies_in_circuit() {
+	// Invariant: the openings of one commitment climb in pairs.
+	// An odd query count leaves the last one climbing alone.
+	// Both routes must reach the same layer.
+	//
+	// Fixture state: the native ladder at 7 queries, so every opened level has a leftover.
+	let shape = Shape {
+		n_queries: 7,
+		..NATIVE_SHAPE
+	};
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 11);
+	let verifier = shape.record(&setup);
+
+	verifier
+		.check_opening(&shape, &setup, &opening)
+		.expect("the leftover query must verify beside the paired ones");
+}
+
+#[test]
+fn a_ground_ladder_verifies_in_circuit() {
+	// Invariant: a nonce the prover ground is checked in-circuit at the point it was paid.
+	// The nonce is a wire.
+	// Absorbing it moves the Fiat-Shamir state.
+	// The draw it decides is asserted zero.
+	//
+	// Fixture state: the native ladder, 4 bits before each fold challenge and 3 before each query.
+	//
+	//     level i:  round message -> nonce -> 4 bits asserted zero -> fold challenge
+	//               next commitment -> nonce -> 3 bits asserted zero -> query positions
+	let shape = Shape {
+		grinding: Grinding::new(4, 3),
+		..NATIVE_SHAPE
+	};
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 12);
+	let verifier = shape.record(&setup);
+
+	// Two levels folding 2 lanes each is 4 challenge grinds, plus one query grind per level.
+	let nonces = verifier
+		.recorded
+		.inputs
+		.iter()
+		.filter(|input| input.kind == "grind_nonce")
+		.count();
+	assert_eq!(nonces, 6, "one nonce per fold round, and one per level's query draw");
+
+	verifier
+		.check_opening(&shape, &setup, &opening)
+		.expect("a ground transcript must satisfy the circuit built for that difficulty");
+}
+
+#[test]
+fn a_corrupted_nonce_fails_the_proof_of_work() {
+	// Invariant: the nonce is not advice the circuit takes on trust.
+	// It is absorbed, and the draw it decides is asserted zero, so a nonce that did no work fails.
+	//
+	// Fixture state: the native ladder paying 8 bits before every fold challenge.
+	// The first nonce byte is flipped.
+	//
+	// The tape opens with level 0's root, then its first round polynomial, then that nonce:
+	//
+	//     [0, 32)   level 0's Merkle root
+	//     [32, 48)  the first round polynomial, one element because an MLE-check recovers the rest
+	//     [48, 56)  the nonce, little-endian
+	//
+	//     before:  nonce  -> 8 sampled bits, all zero
+	//     after:   nonce' -> 8 sampled bits that land on zero once in 256
+	let shape = Shape {
+		grinding: Grinding::new(8, 0),
+		..NATIVE_SHAPE
+	};
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 13);
+	let verifier = shape.record(&setup);
+
+	let nonce = DIGEST_BYTES + ELEMENT_BYTES;
+	let paths = verifier.rejected(&shape, &setup, &opening, &corrupt(&opening.proof, nonce));
+	assert!(
+		paths.iter().any(|path| path == "grind"),
+		"a nonce that met no difficulty must fail the proof-of-work assertion: {paths:?}"
+	);
+}
+
+/// Returns `proof` with the low bit of one byte flipped.
+fn corrupt(proof: &[u8], offset: usize) -> Vec<u8> {
+	// One bit is the smallest change a sound protocol must still reject.
+	let mut proof = proof.to_vec();
+	proof[offset] ^= 1;
+	proof
+}
+
+#[test]
+fn a_corrupted_level_zero_root_is_rejected() {
+	// Invariant: the root is what every opening below it is bound to, so it cannot be moved.
+	//
+	// Fixture state: the native ladder, with the first tape byte flipped.
+	// Level 0's root is written before anything else the ladder sends.
+	//
+	//     before:  layer  -> fold -> the root the tape carries
+	//     after:   layer  -> fold -> a root it no longer matches
+	//
+	// The evaluation point is observed rather than written, so it never reaches the tape.
+	// Byte 0 is therefore inside the root.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 3);
+	let verifier = shape.record(&setup);
+
+	let paths = verifier.rejected(&shape, &setup, &opening, &corrupt(&opening.proof, 0));
+	assert!(
+		paths.iter().any(|path| path == "layer"),
+		"a corrupted root must fail the fold that binds the decommitted layer to it: {paths:?}"
+	);
+}
+
+#[test]
+fn a_corrupted_round_polynomial_moves_the_query_indices() {
+	// Invariant: a round polynomial is a *received* message, so the challenger absorbs it.
+	// Corrupting it moves the Fiat-Shamir state, and every challenge and index drawn after.
+	//
+	// Fixture state: the native ladder, with the first byte after the 32-byte root flipped.
+	//
+	//     before:  round value  -> challenge -> ... -> query indices -> the committed positions
+	//     after:   round value' -> a different challenge from that round on, indices included
+	//
+	// The opened values and siblings on the tape are untouched.
+	// The indices addressing them are not.
+	// So the openings climb to the wrong entries of the decommitted layer.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 4);
+	let verifier = shape.record(&setup);
+
+	let paths = verifier.rejected(&shape, &setup, &opening, &corrupt(&opening.proof, DIGEST_BYTES));
+	assert!(
+		paths.iter().any(|path| path == "opening"),
+		"a moved query index must fail a Merkle opening: {paths:?}"
+	);
+}
+
+#[test]
+fn a_corrupted_residual_is_rejected() {
+	// Invariant: the residual is bound two ways at once.
+	// By the tree rebuilt over it, and by the last level's rows paired against it.
+	//
+	// Fixture state: the native ladder, with the last byte of the residual flipped.
+	// The residual is sent before the last level's rows are opened.
+	// So it is not the last byte of the tape.
+	//
+	//     before:  entry  -> rebuilt tree == root, and row pairing == batched rows
+	//     after:   entry' -> a different root, and a pairing that no longer matches
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 5);
+	let verifier = shape.record(&setup);
+
+	let offset = setup.last_residual_byte(opening.proof.len());
+	let paths = verifier.rejected(&shape, &setup, &opening, &corrupt(&opening.proof, offset));
+	assert!(
+		paths.iter().any(|path| path == "vector"),
+		"a corrupted residual must fail the rebuilt tree: {paths:?}"
+	);
+	assert!(
+		paths.iter().any(|path| path == "assert_zero"),
+		"and one of the two closing checks that read it: {paths:?}"
+	);
+}
+
+#[test]
+fn a_tampered_statement_is_rejected() {
+	// Invariant: the statement is observed, so one opening's proof cannot be replayed on another.
+	// Nothing about the proof bytes changes here.
+	//
+	// Fixture state: the native ladder, one honest proof, and one altered claim.
+	//
+	//     before:  the claim the prover observed  -> its Fiat-Shamir state
+	//     after:   a claim one away               -> a different state from that point on
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 6);
+	let verifier = shape.record(&setup);
+
+	// The claim is the last element of the statement, so its low word is the second from the end.
+	let mut statement = opening.statement();
+	let low = statement.len() - ELEMENT_WORDS;
+	statement[low] = Word(statement[low].0 ^ 1);
+
+	verifier
+		.check(&shape, &setup, &statement, &opening.proof)
+		.expect_err("a tampered claim must leave the circuit unsatisfied");
+}
+
+#[test]
+fn every_corrupted_byte_across_the_tape_is_rejected() {
+	// Invariant: no region of the tape is unchecked.
+	// The tests above name the mechanism for three bytes, this one asserts there is no gap.
+	//
+	// Fixture state: the native ladder, one byte flipped at each of 32 evenly spread offsets.
+	let shape = NATIVE_SHAPE;
+	let setup = shape.setup();
+	let opening = shape.prove(&setup, 7);
+	let verifier = shape.record(&setup);
+
+	let n_probes = 32;
+	for probe in 0..n_probes {
+		// Evenly spread, so every phase of the tape is covered.
+		// The roots, the round polynomials, the layers, the openings, and the residual.
+		let offset = probe * opening.proof.len() / n_probes;
+		let paths = verifier.rejected(&shape, &setup, &opening, &corrupt(&opening.proof, offset));
+		assert!(!paths.is_empty(), "byte {offset} must be checked by something");
+	}
+}
+
+/// One ladder shape priced: what its proof costs in bytes, and what verifying it costs in gates.
+struct Priced {
+	/// Base-2 logarithm of the elements the cleartext residual holds.
+	log_residual_dim: usize,
+	/// Bytes of a real transcript for this ladder.
+	proof_bytes: usize,
+	/// AND constraints, which is where the circuit's hashing lands.
+	and: usize,
+	/// BMUL constraints, one per field multiplication the verifier performs.
+	bmul: usize,
+	/// Wires a replay has to fill, which is the proof data the circuit cannot derive.
+	inputs: usize,
+}
+
+#[test]
+fn the_cost_surface_over_residual_widths() {
+	// Invariant: the residual is what an in-circuit verifier pays for twice.
+	// Once in the tree it rebuilds over it, once in the rows it pairs against it.
+	// So shrinking it is the lever, and this measures what the lever costs.
+	//
+	// Fixture state: four ladders over one 2^12 message, each one level deeper than the last.
+	//
+	//     lanes [2]        residual 2^10   one level,   nothing glued
+	//     lanes [2,2]      residual 2^8    two levels,  one glued basis
+	//     lanes [2,2,2]    residual 2^6    three,       two glued
+	//     lanes [2,2,2,2]  residual 2^4    four,        three glued
+	//
+	// Every ladder commits the same message and opens the same rows per level.
+	// So the residual is the only thing moving.
+	let ladders: [&'static [usize]; 4] = [&[2], &[2, 2], &[2, 2, 2], &[2, 2, 2, 2]];
+
+	println!(
+		"\n{:>8} {:>9} {:>10} {:>10} {:>9} {:>9}",
+		"levels", "residual", "bytes", "AND", "BMUL", "inputs"
+	);
+	let mut rows = Vec::new();
+	for lanes in ladders {
+		let shape = Shape {
+			log_msg_cols: 10,
+			lanes,
+			..NATIVE_SHAPE
+		};
+		let setup = shape.setup();
+		// A real transcript, so the byte column is measured rather than modelled.
+		let opening = shape.prove(&setup, 20);
+		let verifier = shape.record(&setup);
+		// The circuit is only worth pricing if it accepts the proof it is priced against.
+		verifier
+			.check_opening(&shape, &setup, &opening)
+			.expect("every ladder in the sweep must verify its own proof");
+
+		let priced = Priced {
+			log_residual_dim: setup.params.log_residual_dim(),
+			proof_bytes: opening.proof.len(),
+			and: verifier.stat.n_and_constraints,
+			bmul: verifier.stat.n_bmul_constraints,
+			inputs: verifier.recorded.inputs.len(),
+		};
+		println!(
+			"{:>8} {:>9} {:>10} {:>10} {:>9} {:>9}",
+			lanes.len(),
+			format!("2^{}", priced.log_residual_dim),
+			priced.proof_bytes,
+			priced.and,
+			priced.bmul,
+			priced.inputs,
+		);
+		rows.push(priced);
+	}
+
+	// Each extra level folds two more variables away before the clear text starts.
+	for pair in rows.windows(2) {
+		assert!(
+			pair[1].log_residual_dim < pair[0].log_residual_dim,
+			"each ladder must leave a shallower residual: 2^{} then 2^{}",
+			pair[0].log_residual_dim,
+			pair[1].log_residual_dim
+		);
+	}
+
+	// A residual is hashed one element to a leaf.
+	// So quartering its width more than halves the hashing the whole verification does.
+	assert!(
+		2 * rows[1].and < rows[0].and,
+		"quartering a wide residual must more than halve the AND constraints: {} against {}",
+		rows[1].and,
+		rows[0].and
+	);
+
+	// It stops paying once the residual is narrow.
+	// The per-level work an extra level adds then outweighs the tree it removes.
+	assert!(
+		2 * rows[3].and > rows[2].and,
+		"a narrow residual must stop halving: {} against {}",
+		rows[3].and,
+		rows[2].and
+	);
+
+	// And the tape turns around at the same place, so the deepest ladder is not the smallest proof.
+	assert!(
+		rows[3].proof_bytes > rows[2].proof_bytes,
+		"the last level must cost bytes rather than save them: {} against {}",
+		rows[3].proof_bytes,
+		rows[2].proof_bytes
+	);
+
+	// The widest residual is the most expensive on every axis at once.
+	// So recursing at all pays for itself in-circuit, whatever the byte count says.
+	assert!(
+		rows[0].bmul > rows[3].bmul && rows[0].proof_bytes > rows[3].proof_bytes,
+		"a one-level ladder must cost both more multiplications and more bytes than a four-level \
+		 one"
+	);
+
+	// The wires a replay fills track the same term, since the residual arrives in the clear.
+	assert!(
+		rows[0].inputs > rows[2].inputs,
+		"a wide residual must put more proof data on the tape: {} against {}",
+		rows[0].inputs,
+		rows[2].inputs
+	);
+}


### PR DESCRIPTION
Linear: [BINIUS-544](https://linear.app/jimpo/issue/BINIUS-544/verify-a-ligerito-opening-inside-a-binius64-circuit)

Recursion means one proof checks another. In this repository that works by running the *same* verifier source twice: once over a channel that emits circuit gates instead of comparing values, and once over a channel that replays the real transcript and fills the resulting circuit's witness. A satisfied constraint system is then the statement "this transcript opens this claim", and an outer proof can check that statement.

The FRI-based commitment scheme already has this, in `crates/recursion/tests/basefold_opening.rs`. Ligerito does not. This adds it.

## What has to be true for a verifier to be expressible as a circuit

A circuit cannot do everything a native verifier can. It can select from a table, sum a subset of a table chosen by the bits of a word, sample bits, and assert a value is zero. That is the whole vocabulary. Two things in particular are out of reach, and the Ligerito design was held to both from its first commit:

- **No materializing the weight vector a level's opened rows induce.** That vector has one entry per message column, which is millions of elements at production sizes. The verifier uses a closed form costing `O(rows * log columns)` instead. This is enforced by the type system rather than by discipline: building the dense vector needs a packed field, and the element type a circuit carries is not one, so the call does not compile from the verifier's body.
- **No dividing by a value that came off the proof.** A circuit can only divide by hinting the answer and then constraining it, which costs several multiplication gates and is easy to get subtly wrong. Ligerito's round-polynomial recovery is addition, subtraction and one multiplication by a challenge — never a division.

Both held. The in-circuit verifier is a hundred lines of test scaffolding around a single call to the existing native verifier, which is exactly the outcome those two constraints were meant to buy.

## The one thing that was missing

BINIUS-539 gave the Ligerito ladder a proof of work: at two points per level, the prover searches for a nonce whose absorption drives the next few sampled bits to zero, and the verifier re-checks that cheaply. The recursion crate's two channels had no way to express that check, so a recursive verifier could not be built for any ladder that grinds.

The alternative was to restrict this work to ladders that grind nothing and refuse the rest. That would have been a real limitation, because grinding is the only lever that moves a soundness term no number of queries can reach — so the ladders worth recursing on are exactly the ones that use it.

So the check is implemented instead. In the circuit it becomes three things: the nonce enters as a wire the witness supplies, it is absorbed into the in-circuit Fiat-Shamir state, and the bits it decides are asserted zero. The masking that bounds those bits is already a real gate, so asserting the masked wire is zero is the entire check. A difficulty of zero stays exactly what the contract says it is — no nonce read, no wire allocated, no constraint emitted.

Two unit tests pin it. One draws a challenge after a grind on both the native transcript and the builder, and pins the two together, so a channel that absorbed or sampled a different number of bytes fails. The same test then fills the nonce wire one away from the value the search found and requires the circuit to become unsatisfied. The other checks that zero difficulty leaves the challenger exactly where an ungrinding channel leaves it.

## What the residual costs, measured

The ladder ends by sending its remaining matrix in the clear. A circuit has to rebuild the whole Merkle tree over that matrix, one leaf per element, and pair every opened row against it. Both terms grow as `2^r` in the residual's width while everything else in the protocol grows as a logarithm.

BINIUS-538 predicted this from a model, and the proof-size search pulls the other way, since sending columns in the clear is cheaper in bytes than committing another level. The two objectives were expected to disagree. Measured in gates, over four ladders on one `2^12` message that differ only in how deep they fold before stopping:

| levels | residual | proof bytes | AND constraints | multiplications |
|---|---|---|---|---|
| 1 | `2^10` | 19,296 | 780,797 | 10,951 |
| 2 | `2^8` | 9,664 | 253,943 | 7,603 |
| 3 | `2^6` | **8,992** | 143,113 | 6,143 |
| 4 | `2^4` | 10,368 | **134,027** | 6,139 |

Two things stand out.

**Hashing tracks the residual almost exactly.** Quartering its width more than halves the AND constraints of the entire verification, twice over. The widest residual costs 5.8x the narrowest.

**The two objectives barely disagree here.** The byte-optimal ladder is one level short of the gate-optimal one, and it is within 7% of it. That is not what the model suggested, and the reason is that the model counts only the closing check. Measured, the closing check is 84% of the multiplications at a `2^10` residual and 9% at a `2^4` one — but the per-level work the extra levels add grows at roughly the same rate the closing check shrinks. So the 6.8x cut the model predicts on its own term lands as 1.8x on the real total.

The prediction that shrinking the residual is worth paying bytes for is therefore **not** confirmed at a size a circuit can be built for. What is confirmed is the sign of the effect and the mechanism behind it. Whether it becomes a 6.8x at a production `log_n` is still a model's claim, and this is the harness that would settle it.

## What is in the diff

- `crates/recursion/src/channel.rs` — proof-of-work verification on the circuit-building channel, plus its two unit tests.
- `crates/recursion/src/filler.rs` — the replay half: read the nonce, fill the wire, advance the challenger, and let the circuit judge.
- `crates/recursion/tests/ligerito_opening.rs` — the sibling of `basefold_opening.rs`. One honest opening verified in-circuit, one circuit reused for two openings, one-level and three-level ladders, an odd query count, a ground ladder, five corruption tests each naming the check it breaks, a whole-tape sweep with no unchecked region, and the cost surface above.

Tests live under `tests/` rather than beside the code because that is where this crate already keeps its verifier round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
