### PR TITLE
Move the encoder's message repetition onto the field buffer

### DIFF
--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -29,6 +29,7 @@
 //! With it goes the deref-coercion design a vector and its two slice types enjoy.
 
 use std::{
+	mem::MaybeUninit,
 	ops::{Deref, DerefMut},
 	slice,
 };
@@ -41,7 +42,7 @@ use binius_field::{
 use binius_utils::{
 	buffer::{BufferData, VecLike},
 	checked_arithmetics::strict_log_2,
-	rayon::{iter::Either, prelude::*, slice::ParallelSlice},
+	rayon::{iter::Either, prelude::*, slice::ParallelSlice, task_size::task_chunk_len},
 };
 use bytemuck::zeroed_vec;
 
@@ -188,6 +189,116 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 		let mut words = alloc.alloc::<P>(src.as_ref().len());
 		words.extend_from_slice(src.as_ref());
 		FieldBuffer::new(src.log_len(), words)
+	}
+
+	/// Copies a borrowed buffer into memory drawn from `alloc`, with room reserved to grow.
+	///
+	/// The buffer spans `src.log_len()` elements and its store is sized for `2^log_capacity`.
+	/// Growing it to that many elements therefore never reallocates.
+	/// [`Self::repeat_extend`] is the growth this reserves for.
+	///
+	/// Whole packed words are copied, dead lanes and all, so the copy is bit-identical.
+	/// The copy splits into runs, so more than one worker carries a long source.
+	///
+	/// # Panics
+	///
+	/// Panics if `log_capacity` is shorter than what `src` spans.
+	#[track_caller]
+	pub fn from_view_with_capacity_in<A>(
+		alloc: &A,
+		src: FieldSlice<'_, P>,
+		log_capacity: usize,
+	) -> Self
+	where
+		A: Allocator<Vec<P> = Data>,
+	{
+		assert!(
+			log_capacity >= src.log_len(),
+			"precondition: log_capacity must be at least src.log_len()"
+		);
+
+		let mut words = alloc.alloc::<P>(1 << log_capacity.saturating_sub(P::LOG_WIDTH));
+
+		// A run is the words one worker copies at a time.
+		// It is a power of two at most the source length, so it divides the source evenly.
+		let source = src.as_ref();
+		let run = source.len().min(task_chunk_len::<P>().next_power_of_two());
+
+		let head = &mut words.spare_capacity_mut()[..source.len()];
+		(head.par_chunks_mut(run), source.par_chunks(run))
+			.into_par_iter()
+			.for_each(|(dst, src)| {
+				dst.write_copy_of_slice(src);
+			});
+
+		// SAFETY: the loop above wrote every word of the source.
+		unsafe { words.set_len(source.len()) };
+
+		FieldBuffer::new(src.log_len(), words)
+	}
+
+	/// Grows the buffer to span `2^log_len` elements, repeating what it already holds.
+	///
+	/// ```text
+	///     [x]  ->  [x | x | x | x]
+	/// ```
+	///
+	/// This is the buffer's [`Vec::extend_from_within`], split across workers.
+	/// Every copy is drawn from the live prefix, so one pass fills the whole buffer.
+	///
+	/// Returns the buffer untouched when it already spans that many elements.
+	///
+	/// # Panics
+	///
+	/// Panics if `log_len` is shorter than what the buffer already spans.
+	/// Panics if the store has no room reserved for `2^log_len` elements.
+	#[track_caller]
+	pub fn repeat_extend(&mut self, log_len: usize) {
+		assert!(
+			log_len >= self.log_len,
+			"precondition: log_len must be at least the buffer's own log_len"
+		);
+		if log_len == self.log_len {
+			return;
+		}
+
+		let total = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+		assert!(
+			total <= self.words.capacity(),
+			"precondition: the store must have room reserved for 2^log_len elements"
+		);
+
+		if self.log_len < P::LOG_WIDTH {
+			// The live elements share one word, so repeating them cycles lanes, not words.
+			let word = P::from_scalars(self.iter_scalars().cycle());
+			self.words.clear();
+			self.words.resize(total, word);
+		} else {
+			let prefix = self.words.len();
+
+			// A run is the words one worker copies at a time.
+			// It is a power of two at most the prefix, so it divides the prefix evenly.
+			let run = prefix.min(task_chunk_len::<P>().next_power_of_two());
+
+			// One borrow has to span both the prefix the copies read and the room they fill.
+			// Emptying the buffer first is what puts the whole store behind that single borrow.
+			//
+			// SAFETY: a packed field has no destructor, so forgetting the live words is a no-op.
+			unsafe { self.words.set_len(0) };
+			let store = &mut self.words.spare_capacity_mut()[..total];
+			let (head, tail) = store.split_at_mut(prefix);
+
+			// SAFETY: the split point is the length the buffer just had.
+			// So every word of `head` was written before this call.
+			let head = unsafe { &*(head as *const [MaybeUninit<P>] as *const [P]) };
+
+			repeat_words(head, tail, run);
+
+			// SAFETY: the call above wrote every word between the prefix and `total`.
+			unsafe { self.words.set_len(total) };
+		}
+
+		self.log_len = log_len;
 	}
 
 	/// Builds a buffer from scalar values, directly into memory drawn from `alloc`.
@@ -727,14 +838,42 @@ impl<P: PackedField> FromIterator<P::Scalar> for FieldBuffer<P> {
 	}
 }
 
+/// Fills `tail` with copies of `head`, `run` words at a time.
+///
+/// ```text
+///     head            tail
+///     [x]      ->     [x | x | x]
+/// ```
+///
+/// Every destination run draws from one contiguous run of `head`.
+/// So a worker copying one run never reads outside it.
+///
+/// # Preconditions
+///
+/// * `head.len()` is a power of two, and `run` is a power of two at most that
+/// * `tail.len()` is a multiple of `head.len()`
+fn repeat_words<P: PackedField>(head: &[P], tail: &mut [MaybeUninit<P>], run: usize) {
+	debug_assert!(head.len().is_power_of_two());
+	debug_assert!(run.is_power_of_two() && run <= head.len());
+	debug_assert_eq!(tail.len() % head.len(), 0);
+
+	tail.par_chunks_mut(run).enumerate().for_each(|(i, dst)| {
+		// Run `i` of the tail sits one whole head past run `i` of the buffer.
+		// The head length is a power of two, so masking that position gives its source.
+		let source = (i * run) & (head.len() - 1);
+		dst.write_copy_of_slice(&head[source..source + dst.len()]);
+	});
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_field::packed::get_packed_slice;
 	use proptest::prelude::*;
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::test_utils::{B128, Packed128b};
+	use crate::test_utils::{B128, Packed128b, random_field_buffer};
 
 	type P = Packed128b;
 	type F = B128;
@@ -808,6 +947,115 @@ mod tests {
 		assert_eq!(widened.get(0), F::new(0));
 		assert_eq!(widened.get(1), F::new(1));
 		assert!((2..8).all(|i| widened.get(i) == F::ZERO));
+
+		// Reserving room copies the source and leaves the buffer at the source's own length.
+		let reserved: FieldVec<P, A> =
+			FieldBuffer::from_view_with_capacity_in(alloc, src.as_view(), 6);
+		assert_eq!(reserved.log_len(), 4);
+		assert_eq!(reserved.as_view(), src.as_view());
+
+		// Growing into that reserved room repeats the source, four copies over.
+		let mut repeated = reserved;
+		repeated.repeat_extend(6);
+		assert_eq!(repeated.log_len(), 6);
+		assert!((0..64).all(|i| repeated.get(i) == F::new((i % 16) as u128)));
+
+		// A source narrower than one packed word repeats its live lanes, never its dead ones.
+		//
+		//     source (log_len 1)    [0, 1 | dead, dead]
+		//     result (log_len 3)    [0, 1 | 0, 1] [0, 1 | 0, 1]
+		let mut cycled: FieldVec<P, A> =
+			FieldBuffer::from_view_with_capacity_in(alloc, small.as_view(), 3);
+		cycled.repeat_extend(3);
+		assert_eq!(cycled.log_len(), 3);
+		assert!((0..8).all(|i| cycled.get(i) == F::new((i % 2) as u128)));
+	}
+
+	/// Pins `repeat_words` against the definition: word `i` of the tail is word `i mod n` of head.
+	fn check_repeat_words(log_head: usize, log_copies: usize) {
+		let head: Vec<P> = (0..1 << log_head)
+			.map(|i| P::broadcast(F::new(i)))
+			.collect();
+
+		// Every run width the caller can pass, from one word up to the whole head.
+		// A run under the head length is what splits a fill across workers.
+		for log_run in 0..=log_head {
+			let mut tail = vec![MaybeUninit::uninit(); head.len() * ((1 << log_copies) - 1)];
+			repeat_words(&head, &mut tail, 1 << log_run);
+
+			for (i, word) in tail.iter().enumerate() {
+				// SAFETY: the call above wrote every word of the tail.
+				let word = unsafe { word.assume_init() };
+				assert_eq!(word, head[i % head.len()], "log_run={log_run} i={i}");
+			}
+		}
+	}
+
+	#[test]
+	fn repeat_words_tiles_the_head_at_every_run_width() {
+		// Heads of 1 to 16 words, each repeated 1 to 8 times over.
+		for log_head in 0..5 {
+			for log_copies in 0..4 {
+				check_repeat_words(log_head, log_copies);
+			}
+		}
+	}
+
+	/// Pins `repeat_extend` against the definition, in scalars rather than words.
+	fn check_repeat_extend(log_src: usize, log_dst: usize) {
+		let mut rng = StdRng::seed_from_u64(0);
+		let src = random_field_buffer::<P>(&mut rng, log_src);
+
+		let mut buffer: FieldVec<P, GlobalAllocator> =
+			FieldBuffer::from_view_with_capacity_in(&GlobalAllocator, src.as_view(), log_dst);
+		buffer.repeat_extend(log_dst);
+
+		assert_eq!(buffer.log_len(), log_dst);
+		for i in 0..1 << log_dst {
+			let expected = src.get(i % (1 << log_src));
+			assert_eq!(buffer.get(i), expected, "log_src={log_src} log_dst={log_dst} i={i}");
+		}
+	}
+
+	#[test]
+	fn repeat_extend_repeats_the_live_scalars() {
+		// A packed word holds 4 lanes here, so `log_src` 0 and 1 exercise the sub-word path,
+		// and a `log_dst` that stays under the width exercises repeating inside one word.
+		for log_src in 0..5 {
+			for log_dst in log_src..7 {
+				check_repeat_extend(log_src, log_dst);
+			}
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: log_len must be at least the buffer's own log_len")]
+	fn repeat_extend_rejects_shrinking() {
+		let mut buffer: FieldVec<P, GlobalAllocator> = FieldBuffer::from_view_with_capacity_in(
+			&GlobalAllocator,
+			FieldBuffer::<P>::zeros(4).as_view(),
+			5,
+		);
+		buffer.repeat_extend(3);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: the store must have room reserved")]
+	fn repeat_extend_rejects_a_store_without_room() {
+		let mut buffer: FieldVec<P, GlobalAllocator> = FieldBuffer::from_view_with_capacity_in(
+			&GlobalAllocator,
+			FieldBuffer::<P>::zeros(4).as_view(),
+			4,
+		);
+		buffer.repeat_extend(5);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition: log_capacity must be at least src.log_len()")]
+	fn from_view_with_capacity_rejects_a_capacity_below_the_source() {
+		let src = FieldBuffer::<P>::zeros(4);
+		let _: FieldVec<P, GlobalAllocator> =
+			FieldBuffer::from_view_with_capacity_in(&GlobalAllocator, src.as_view(), 3);
 	}
 
 	#[test]

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -5,23 +5,16 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
-use std::{iter, marker::PhantomData, ptr};
+use std::{iter, marker::PhantomData};
 
 use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
-use binius_utils::{
-	buffer::VecLike,
-	rayon::{prelude::*, task_size::task_chunk_len},
-};
 use getset::CopyGetters;
 
 use super::{
 	FieldBuffer, FieldSlice, FieldSliceMut, binary_subspace::BinarySubspace, ntt::AdditiveNTT,
 };
-use crate::{
-	bit_reverse::bit_reverse_indices,
-	ntt::{DomainContext, NeighborsLastMultiThread, domain_context::GaoMateerOnTheFly},
-};
+use crate::ntt::{DomainContext, NeighborsLastMultiThread, domain_context::GaoMateerOnTheFly};
 
 /// [Reed–Solomon] codes over binary fields.
 ///
@@ -139,35 +132,18 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		)
 		.entered();
 
-		// Repeat the message to fill the entire buffer.
+		// The forward transform below skips its first `log_inv_rate` layers.
+		// Each skipped layer would butterfly a coefficient with a zero pad:
+		//
+		//     u += v * twiddle; v += u;   with v = 0   =>   (c, 0) -> (c, c)
+		//
+		// That is one doubling per layer, so repeating the message does the skipped work.
 		let log_output_len = self.log_dim() + log_batch_size + self.log_inv_rate;
-		let output_data = if data.log_len() < P::LOG_WIDTH {
-			let mut scalars = data.iter_scalars().collect::<Vec<_>>();
-			bit_reverse_indices(&mut scalars);
-			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
-			let len = 1 << log_output_len.saturating_sub(P::LOG_WIDTH);
-			let mut output = alloc.alloc::<P>(len);
-			output.resize(len, elem_0);
-			output
-		} else {
-			// The forward transform below skips its first `log_inv_rate` layers.
-			// Each skipped layer would butterfly a coefficient with a zero pad:
-			//
-			//     u += v * twiddle; v += u;   with v = 0   =>   (c, 0) -> (c, c)
-			//
-			// That is one doubling per layer, so repeating the message does the skipped work.
-			let output_packed_len = 1 << (log_output_len - P::LOG_WIDTH);
+		let mut output = FieldBuffer::from_view_with_capacity_in(alloc, data, log_output_len);
 
-			// A run is the words one worker copies at a time.
-			// It is a power of two at most the message length, so it divides the message evenly.
-			let run = data
-				.as_ref()
-				.len()
-				.min(task_chunk_len::<P>().next_power_of_two());
-
-			repeated_message_buffer(data, output_packed_len, run, alloc)
-		};
-		let mut output = FieldBuffer::new(log_output_len, output_data);
+		// Permute the message once, then repeat it, so every copy inherits the permutation.
+		output.as_mut_view().bit_reverse();
+		output.repeat_extend(log_output_len);
 
 		ntt.forward_transform(output.as_mut_view(), self.log_inv_rate, log_batch_size);
 		output
@@ -218,24 +194,15 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		.entered();
 
 		let log_output_len = self.log_dim() + log_batch_size + self.log_inv_rate;
-		let output_data = if data.log_len() < P::LOG_WIDTH {
-			let mut scalars = data.iter_scalars().collect::<Vec<_>>();
-			bit_reverse_indices(&mut scalars);
-			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
-			let len = 1 << log_output_len.saturating_sub(P::LOG_WIDTH);
-			let mut output = alloc.alloc::<P>(len);
-			output.resize(len, elem_0);
-			on_chunk_ready(0, &output);
-			return FieldBuffer::new(log_output_len, output);
-		} else {
-			let output_packed_len = 1 << (log_output_len - P::LOG_WIDTH);
-			let run = data
-				.as_ref()
-				.len()
-				.min(task_chunk_len::<P>().next_power_of_two());
-			repeated_message_buffer(data, output_packed_len, run, alloc)
-		};
-		let mut output = FieldBuffer::new(log_output_len, output_data);
+		let mut output = FieldBuffer::from_view_with_capacity_in(alloc, data, log_output_len);
+		output.as_mut_view().bit_reverse();
+		output.repeat_extend(log_output_len);
+
+		// A message inside one packed word leaves the chunked transform nothing to split.
+		if data.log_len() < P::LOG_WIDTH {
+			on_chunk_ready(0, output.as_ref());
+			return output;
+		}
 
 		ntt.forward_transform_with_callback(
 			output.as_mut_view(),
@@ -326,85 +293,6 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		folded.as_mut_view().bit_reverse();
 		folded
 	}
-}
-
-/// Builds a buffer of `total` words holding the bit-reversed message, repeated.
-///
-/// # Overview
-///
-/// ```text
-///     [msg]  ->  [rev msg | rev msg | rev msg | rev msg]
-/// ```
-///
-/// The leading copy is filled from the message, then permuted.
-/// Every later copy is filled from that leading copy, so the permutation runs once.
-/// Both fills split into runs, so more than one worker carries a long message.
-///
-/// # Arguments
-///
-/// * `msg` - the message to repeat
-/// * `total` - word count of the returned buffer
-/// * `run` - words one worker copies at a time
-///
-/// # Preconditions
-///
-/// * `msg` holds at least one whole word, and `total` is a multiple of its word count
-/// * `run` is a power of two, and at most the message's word count
-fn repeated_message_buffer<P: PackedField, A: Allocator>(
-	msg: FieldSlice<'_, P>,
-	total: usize,
-	run: usize,
-	alloc: &A,
-) -> A::Vec<P> {
-	let msg_len = msg.as_ref().len();
-	debug_assert!(msg_len.is_power_of_two());
-	debug_assert!(run.is_power_of_two() && run <= msg_len);
-	debug_assert_eq!(total % msg_len, 0);
-
-	let mut output = alloc.alloc::<P>(total);
-
-	// Copy the message into the leading copy.
-	let head = &mut output.spare_capacity_mut()[..msg_len];
-	(head.par_chunks_mut(run), msg.as_ref().par_chunks(run))
-		.into_par_iter()
-		.for_each(|(dst, src)| {
-			// SAFETY:
-			// - The two runs have equal length: one position, two buffers of one length.
-			// - They live in different buffers, so they cannot overlap.
-			unsafe {
-				ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<P>(), src.len());
-			}
-		});
-	// SAFETY: the loop above wrote every one of the leading `msg_len` words.
-	unsafe { output.set_len(msg_len) };
-
-	// Permute the leading copy, so the copies below inherit it.
-	FieldSliceMut::from_slice(msg.log_len(), &mut output).bit_reverse();
-
-	// The source is read through an address rather than a borrow.
-	// That is what lets the workers read the leading copy while the rest is held mutably.
-	let msg_ptr = output.as_ptr() as usize;
-	let tail = &mut output.spare_capacity_mut()[..total - msg_len];
-	tail.par_chunks_mut(run).enumerate().for_each(|(i, dst)| {
-		// Run `i` of the tail sits one whole message past run `i` of the buffer.
-		// The message length is a power of two, so masking that position gives its source.
-		let src_offset = (i * run) & (msg_len - 1);
-
-		// SAFETY:
-		// - The offset is masked into the leading copy, and a run divides it evenly.
-		// - So the source run lies inside the leading copy, which is initialized.
-		// - Nothing writes the leading copy here, and the destination lies past it.
-		// - The address stays live because the buffer outlives this loop.
-		unsafe {
-			let msg = msg_ptr as *const P;
-			ptr::copy_nonoverlapping(msg.add(src_offset), dst.as_mut_ptr().cast::<P>(), dst.len());
-		}
-	});
-
-	// SAFETY: the loop above wrote every word between the leading copy and `total`.
-	unsafe { output.set_len(total) };
-
-	output
 }
 
 #[cfg(test)]
@@ -556,50 +444,6 @@ mod tests {
 		test_lift_duplicate_identity_helper::<PackedBinaryGhash1x128b>(0, 4, 3);
 		// Same lifts with a wider packing width.
 		test_lift_duplicate_identity_helper::<PackedBinaryGhash4x128b>(4, 8, 2);
-	}
-
-	// One serial copy of the message, one permutation, then a chain of doublings.
-	// That is the plain form of the same construction, so it pins the run-split form.
-	fn repeated_message_buffer_reference<P: PackedField>(
-		msg: FieldSlice<'_, P>,
-		total: usize,
-	) -> Vec<P> {
-		let mut output = Vec::with_capacity(total);
-		output.extend_from_slice(msg.as_ref());
-
-		FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()).bit_reverse();
-
-		while output.len() < total {
-			output.extend_from_within(..);
-		}
-		output
-	}
-
-	#[test]
-	fn test_repeated_message_buffer_matches_the_doubling_chain() {
-		let mut rng = StdRng::seed_from_u64(0);
-
-		// Fixture state: messages of 1 to 16 words, each repeated 1 to 8 times over.
-		for log_msg in 0..5 {
-			for log_copies in 0..4 {
-				let msg = random_field_buffer::<PackedBinaryGhash1x128b>(&mut rng, log_msg);
-				let total = (1 << log_msg) << log_copies;
-				let expected = repeated_message_buffer_reference(msg.as_view(), total);
-
-				// Every run width a caller can pass, from one word up to the whole message.
-				// A run under the message length is what splits a fill across workers.
-				// The encoder only reaches that on a message above one mebibyte.
-				for log_run in 0..=log_msg {
-					let built = repeated_message_buffer(
-						msg.as_view(),
-						total,
-						1 << log_run,
-						&GlobalAllocator,
-					);
-					assert_eq!(built, expected, "log_msg={log_msg} log_run={log_run}");
-				}
-			}
-		}
 	}
 
 	/// Checks the adjoint identity at one shape, over the packing `P`.


### PR DESCRIPTION
Moves the Reed-Solomon encoder's message repetition onto `FieldBuffer`, where it belongs, and deletes the duplicated sub-word branch it could not cover.
Pure refactor — the codeword is byte-identical and the copy traffic is unchanged.

### The problem

`reed_solomon.rs` carried a private helper, `repeated_message_buffer`, that copied a message, permuted it, and tiled the result across the codeword.

Nothing about copying and tiling a buffer is Reed-Solomon.
`FIELD_BUFFER_ARCHITECTURE.md` §4 already gives the test for this — *is the operation meaningful for a buffer that is not a multilinear?*
`bit_reverse` passed that test and became an inherent method in #2283; repeating a buffer passes it just as cleanly.

Three symptoms of the misplacement:

- **The signature leaked internals.** `run` is a rayon chunking detail, and both call sites computed it identically. A caller had to know rayon's task sizing to call the function. It also took `total` in *packed words*, while every other buffer API takes `log_len` in *elements*, and returned a bare `A::Vec<P>` that both call sites immediately re-wrapped.

- **It did not cover its own domain.** It required a whole word of message, so `data.log_len() < P::LOG_WIDTH` was handled by a *separate* hand-written branch — duplicated across `encode_batch` and `encode_batch_with_callback`.

- **The source was read through an integer.** `let msg_ptr = output.as_ptr() as usize` was the workaround for `*const P` not being `Send`, but an integer round-trip destroys pointer provenance.

### The idea

The fusion exists for one reason: the permutation runs **once**, on the leading copy, before it is tiled.

```
[msg]  ->  [rev msg]  ->  [rev msg | rev msg | rev msg | rev msg]
            permute        tile
```

So the caller needs a seam between "copy in" and "tile out", not a single fused call.
That is `Vec::with_capacity` + `extend_from_within` — the exact shape the old test's own reference implementation already had.

### The change

Two container-level methods on `FieldBuffer`, in the `Data: VecLike<P>` impl next to `zeros_in` / `from_view_in` / `zero_extend_in`:

```rust
FieldBuffer::from_view_with_capacity_in(alloc, src, log_capacity) -> Self  // parallel copy, room reserved
FieldBuffer::repeat_extend(&mut self, log_len)                            // parallel tile into that room
```

The encoder becomes three lines, with the permutation in the seam:

```
-let output_data = if data.log_len() < P::LOG_WIDTH {
-    /* collect scalars, bit_reverse_indices, from_scalars(cycle), resize */
-} else {
-    let run = data.as_ref().len().min(task_chunk_len::<P>().next_power_of_two());
-    repeated_message_buffer(data, output_packed_len, run, alloc)
-};
-let mut output = FieldBuffer::new(log_output_len, output_data);
+let mut output = FieldBuffer::from_view_with_capacity_in(alloc, data, log_output_len);
+output.as_mut_view().bit_reverse();
+output.repeat_extend(log_output_len);
```

### What the split buys

- **`run` leaves the API.** Each method picks its own chunk width. To keep the run-splitting *testable* — the masked-offset arithmetic is the part worth pinning — it moves to a private free `fn repeat_words(head, tail, run)`, exercised at every run width from one word up to the whole head.

- **The sub-word case is absorbed.** `repeat_extend` cycles lanes when the buffer sits inside one packed word and tiles whole words otherwise. That deletes both copies of the hand-written branch. `bit_reverse` already routes a sub-width buffer to `bit_reverse_packed_naive`, so `bit_reverse_indices` over collected scalars was doing the same permutation the long way round.

- **The pointer laundering is gone.** Emptying the store first (`set_len(0)`) puts the prefix the copies read *and* the room they fill behind a single borrow, split with `split_at_mut`. The source is then a plain `&[P]` — `Sync` for free, disjoint from the destination by construction. Both `ptr::copy_nonoverlapping` calls become safe `write_copy_of_slice`. One narrow cast survives, standing in for the still-unstable `slice_assume_init_ref`.

### Soundness

- The codeword is byte-identical: same words copied, same permutation, same order.
- `test_encode_batch_below_packing_width` pins the unified sub-word path against a reference full-size NTT on zero-padded coefficients, which is what confirms `bit_reverse` and `bit_reverse_indices` agree at that shape.
- `transposed_encoding_is_the_adjoint_of_encoding` independently pins the repeat against the sum-of-repeats it transposes to.

### Scope

- **new:** `FieldBuffer::from_view_with_capacity_in`, `FieldBuffer::repeat_extend`, private `repeat_words` — all in `crates/math/src/field_buffer/mod.rs`.
- **changed:** the two encode functions in `crates/math/src/reed_solomon.rs`; net −112 lines there.
- **moved:** the pinning test follows the code, and gains the definition-level scalar check plus the three precondition panics.
- **left untouched:** `encode_batch_with_callback` still skips the transform for a sub-word message, exactly as before — see below.

### Two pre-existing things this does not fix

- `bit_reverse.rs:131` and `:327` use the same `as usize` idiom. Under `MIRIFLAGS=-Zmiri-strict-provenance` the encode path now fails *there* rather than in the code this PR deletes. Worth the same treatment in a follow-up.
- `encode_batch_with_callback` returns early without running the transform when `data.log_len() < P::LOG_WIDTH`, while `encode_batch` runs it at that shape. For e.g. `log_dim=1, log_inv_rate=3` the codeword exceeds one packed word and the transform is not a no-op, so the two look like they disagree. Behavior is preserved here rather than changed under cover of a refactor.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-math --no-deps --document-private-items` — clean.
- nightly `cargo fmt --all` — clean.
- `binius-math`: 176 tests pass with `rayon` **on** and **off**, since the sequential shim is a different code path.
- `binius-iop-prover`: 78 tests pass (the FRI commit path is the caller).
- Miri over the new `unsafe`, on the no-rayon shim: 4/4 pass under `-Zmiri-strict-provenance`, and again with `-Zmiri-tree-borrows`. The deleted integer round-trip is what made strict provenance unreachable before.

### Benchmark

`encode_batch`, `log_dim=20` at rate 1/2, multi-threaded NTT, Apple M1 Pro, criterion with `--baseline`:

| | before | after | change |
|---|---|---|---|
| encode | 6.248 ms | 6.231 ms | −0.45% (p = 0.42) |

No change in performance detected, which is the expected result: `write_copy_of_slice` lowers to the same `copy_nonoverlapping` the old code called directly, and the allocation and copy traffic are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
