### PR TITLE
Remove the ring-switch sumcheck-claim inner-product bench

### DIFF
--- a/crates/prover/benches/ring_switch.rs
+++ b/crates/prover/benches/ring_switch.rs
@@ -3,9 +3,8 @@
 use std::mem::size_of;
 
 use binius_compute::BufferPool;
-use binius_field::{ExtensionField, Random, arch::OptimalPackedB128};
+use binius_field::{ExtensionField, arch::OptimalPackedB128};
 use binius_math::{
-	inner_product::{inner_product_packed, inner_product_subfield},
 	multilinear::hypercube::Hypercube,
 	test_utils::{random_field_buffer, random_scalars},
 };
@@ -87,47 +86,5 @@ fn bench_suffix_tensor_pipeline(c: &mut Criterion) {
 	group.finish();
 }
 
-/// The sumcheck-claim inner product at its one real shape: `N = 2^log_packing = 128` terms.
-///
-/// In-binary A/B against `inner_product_subfield` (naive per-term reduce).
-/// `inner_product_packed` (deferred reduce) is the path `ring_switch::prove` uses in production.
-fn bench_sumcheck_claim_inner_product(c: &mut Criterion) {
-	let mut group = c.benchmark_group("ring_switch/sumcheck_claim_inner_product");
-
-	let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
-	let n = 1usize << log_packing;
-	group.throughput(Throughput::Elements(n as u64));
-
-	let mut rng = rand::rng();
-	let s_hat_u: Vec<B128> = (0..n).map(|_| B128::random(&mut rng)).collect();
-	let eq_r_double_prime: Vec<B128> = (0..n).map(|_| B128::random(&mut rng)).collect();
-
-	group.bench_function("naive_per_term_reduce", |b| {
-		b.iter(|| {
-			inner_product_subfield::<B128, B128>(
-				s_hat_u.iter().copied(),
-				eq_r_double_prime.iter().copied(),
-			)
-		});
-	});
-
-	group.bench_function("deferred_reduce", |b| {
-		b.iter(|| {
-			inner_product_packed::<B128, B128>(
-				log_packing,
-				s_hat_u.iter().copied(),
-				eq_r_double_prime.iter().copied(),
-			)
-		});
-	});
-
-	group.finish();
-}
-
-criterion_group!(
-	ring_switch,
-	bench_fold_1b_rows_split,
-	bench_suffix_tensor_pipeline,
-	bench_sumcheck_claim_inner_product
-);
+criterion_group!(ring_switch, bench_fold_1b_rows_split, bench_suffix_tensor_pipeline);
 criterion_main!(ring_switch);


### PR DESCRIPTION
Addresses [@jimpo's post-merge review comment](https://github.com/binius-zk/binius64/pull/2213#discussion_r3862579919) on #2213.

Deletes one benchmark. No production code changes.

### The problem

#2213 added `bench_sumcheck_claim_inner_product` to `crates/prover/benches/ring_switch.rs`.

It A/Bs `inner_product_subfield` against `inner_product_packed` at the one shape ring-switch uses: 128 terms.

That is 128 field multiplies and 127 XORs — microseconds, in a proof that spends milliseconds in the row fold beside it.

Benchmarking it earns nothing and costs a permanent file to maintain and run in CI.

### The change

`bench_sumcheck_claim_inner_product` and its entry in `criterion_group!` are gone, along with the imports only it used (`Random`, `inner_product_packed`, `inner_product_subfield`).

The file is now byte-identical to its pre-#2213 state:

```
criterion_group!(ring_switch, bench_fold_1b_rows_split, bench_suffix_tensor_pipeline);
```

### Scope

- **removed:** one bench function (43 lines) and three imports
- **untouched:** `bench_fold_1b_rows_split` and `bench_suffix_tensor_pipeline`, the two benches that measure operations that actually dominate
- **untouched:** the deferred-reduce path in `ring_switch::prove` and `inner_product_packed` itself — the optimization from #2213 stands, only its microbenchmark goes

### Verification

- `cargo clippy -p binius-prover --benches --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)