### PR TITLE
Drop the software prefetch from the NTT's shared layer

### DIFF
--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -295,33 +295,13 @@ fn forward_shared_layer<P: PackedField>(
 		.into_par_iter()
 		.for_each(|(chunk0, chunk1, twiddle)| match twiddle {
 			Some(twiddle) => {
-				for i in 0..chunk0.len() {
-					if let Some(j) = i
-						.checked_add(PREFETCH_DISTANCE)
-						.filter(|&j| j < chunk0.len())
-					{
-						prefetch_read(chunk0.as_ptr().wrapping_add(j));
-						prefetch_read(chunk1.as_ptr().wrapping_add(j));
-					}
-
-					let mut u = chunk0[i];
-					let mut v = chunk1[i];
-					u += v * twiddle;
-					v += u;
-					chunk0[i] = u;
-					chunk1[i] = v;
+				for (u, v) in iter::zip(chunk0, chunk1) {
+					butterfly(u, v, twiddle);
 				}
 			}
 			None => {
-				for i in 0..chunk0.len() {
-					if let Some(j) = i
-						.checked_add(PREFETCH_DISTANCE)
-						.filter(|&j| j < chunk0.len())
-					{
-						prefetch_read(chunk0.as_ptr().wrapping_add(j));
-					}
-
-					chunk1[i] += chunk0[i];
+				for (u, v) in iter::zip(chunk0, chunk1) {
+					*v += *u;
 				}
 			}
 		});
@@ -492,48 +472,6 @@ fn forward_shared_layers<P: PackedField>(
 			forward_shared_layer(domain_context, data, log_d, layer, log_num_shares);
 			layer += 1;
 		}
-	}
-}
-
-/// How many elements ahead [`prefetch_read`] hints the CPU to fetch.
-///
-/// Each loop iteration does at most one packed GF(2^128) multiply-add.
-/// That's cheap relative to a DRAM round trip, roughly 100-300 cycles on this hardware class.
-/// 16 elements gives the fetch several iterations of head start before the loop reaches it.
-/// That's short enough that the line isn't evicted again before use.
-const PREFETCH_DISTANCE: usize = 16;
-
-/// Hints the CPU to start fetching `ptr` into L1 cache, for reads only.
-///
-/// A pure hint: every architecture may silently ignore it.
-/// None of them can let it observe or change the program's result.
-#[inline(always)]
-fn prefetch_read<T>(ptr: *const T) {
-	#[cfg(target_arch = "x86_64")]
-	{
-		use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
-		// Safety: `_mm_prefetch` never faults, even for an invalid or out-of-bounds address.
-		// It's documented as a hint the CPU may discard, not a memory access.
-		unsafe { _mm_prefetch(ptr.cast::<i8>(), _MM_HINT_T0) };
-	}
-	#[cfg(target_arch = "aarch64")]
-	{
-		// Safety: `prfm` is a hint instruction.
-		// The ARM architecture reference manual specifies it never raises a data abort,
-		// even for an unmapped or misaligned address.
-		// So an address past a slice's end, for lookahead near a buffer's tail, is sound.
-		unsafe {
-			std::arch::asm!(
-				"prfm pldl1keep, [{ptr}]",
-				ptr = in(reg) ptr,
-				options(nostack, readonly, preserves_flags),
-			);
-		}
-	}
-	#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-	{
-		// No portable prefetch hint on this architecture; the loop still runs, just without it.
-		let _ = ptr;
 	}
 }
 


### PR DESCRIPTION
Perf gain was minimal (benched again locally), so as per your comment, I've just removed :) 

Addresses [@jimpo's review comment](https://github.com/binius-zk/binius64/pull/2219#issuecomment-5425497478) on #2219:

> What's the end to end perf impact of the specialized twiddle thing? ... Prefetching is a separate change, which looks fine. I'd like to see the E2E benchmark results for both though. I'm generally under the impression that HW-predicted prefetching is pretty good.

Removes the prefetch. Keeps the zero-twiddle skip. No arithmetic changes, so every codeword is bit-identical.

### The prefetch is on a path the dispatcher rarely reaches

The layer-fusion work that landed after #2219 restructured this file. `forward_shared_layers` now processes **two** layers per pass via `forward_shared_layer_pair`, and falls back to `forward_shared_layer` — the prefetched one — only for an odd layer out:

```
while layer < layers.end:
    if two layers remain and planes stay >= 1 packed element:
        forward_shared_layer_pair(..)     // fused, no prefetch
        layer += 2
    else:
        forward_shared_layer(..)          // the prefetched fallback
        layer += 1
```

The shared window is `skip_early..min(log_num_shares, log_d - skip_late)`, and Reed-Solomon encoding passes `skip_early = log_inv_rate`.

Instrumenting the dispatch at `log_dim=20` on 10 threads (`log_num_shares = 4`):

| rate | shared layers | dispatch | prefetched path |
|---|---|---|---|
| 1/2 | `1..4` | pair(1,2) + single(3) | 1 of 3 shared layers |
| 1/4 | `2..4` | pair(2,3) | **never runs** |
| 1/8 | `3..4` | single(3) | 1 of 1 |
| 1/16 | — | window empty | never runs |

At `log_d = 21` the shared window is 3 layers out of 20, so at rate 1/2 the prefetched code covers roughly one twentieth of the transform's butterflies, and at rate 1/4 none of them.

### The benchmark cannot resolve it either way

This is the honest answer to the request for numbers.

`reed_solomon_encode_by_rate/log_dim=20/log_inv_rate=1`, alternating the two variants back to back on an idle machine:

| run | variant | time (95% CI) |
|---|---|---|
| 1 | with prefetch | 7.84 - 9.71 ms |
| 2 | without | 6.58 - 7.10 ms |
| 3 | with prefetch | 6.32 - 6.86 ms |
| 4 | without | 7.00 - 7.80 ms |

Identical code varies by up to 25% between runs and the two variants interleave. Criterion's verdict on the clean A/B (run 3 as baseline, run 4 as candidate) is *"No change in performance detected."*

An end-to-end proof only dilutes a component this small further, so no E2E number would be more informative than this one. I am not claiming the removal is faster — I am claiming the prefetch was never shown to be, and cannot be shown to be here.

### So the case for removal is structural

- Roughly 40 lines, including a hand-written `prfm` inline-asm block and an `_mm_prefetch` intrinsic behind **two `unsafe` blocks**, on a path that at the prover's rate may not execute at all.
- A `checked_add(PREFETCH_DISTANCE).filter(..)` branch in the innermost loop, on every iteration.
- `PREFETCH_DISTANCE = 16` elements is 4 cache lines at 16 bytes per element, and the hint is re-issued every iteration — about 4 prefetch instructions per line, 3 of them redundant.
- The access pattern is two strictly ascending unit-stride streams, which is the case every hardware stride prefetcher handles. This is jimpo's point, and I agree with it.
- The `None` arm prefetched only `chunk0`, while `chunk1[i] += chunk0[i]` read-modify-writes `chunk1` — the stream with the most to gain got no hint.

### The loops collapse onto the existing helper

With the prefetch gone, both arms are exactly the `butterfly` helper defined a few lines below, so they can just say so:

```diff
 Some(twiddle) => {
-    for i in 0..chunk0.len() {
-        if let Some(j) = i.checked_add(PREFETCH_DISTANCE).filter(|&j| j < chunk0.len()) {
-            prefetch_read(chunk0.as_ptr().wrapping_add(j));
-            prefetch_read(chunk1.as_ptr().wrapping_add(j));
-        }
-        let mut u = chunk0[i];
-        let mut v = chunk1[i];
-        u += v * twiddle;
-        v += u;
-        chunk0[i] = u;
-        chunk1[i] = v;
+    for (u, v) in iter::zip(chunk0, chunk1) {
+        butterfly(u, v, twiddle);
     }
 }
```

That also drops four indexed accesses per iteration in favour of iteration, matching how `forward_depth_first` and `forward_breadth_first` already write their butterflies.

### What is kept

The zero-twiddle skip from #2219 stays. `domain_context.twiddle(layer, 0)` is zero, so block 0's butterfly collapses to `v += u` and `u` is never written.

Worth noting for the other half of jimpo's question: the fusion work independently re-derived this idea as `fused_pair_zero_block`, and its doc names the real reason as memory traffic rather than the saved multiply — *"plane 0 is never written, and its cache lines stay clean."* That is the stronger argument, and #2219 undersold it by framing the win as eliminated multiplies. Counted as multiplies it is small: the fraction of butterflies losing their multiply is `2^(1-s)/(n-s)` for `skip_early = s` and `log_d = n`, which is 5.0% at rate 1/2 and 2.5% at rate 1/4.

### Scope

- **removed:** `PREFETCH_DISTANCE`, `prefetch_read`, and the two prefetch call sites — with them, both `unsafe` blocks in this file's shared-layer code
- **changed:** the two loops in `forward_shared_layer`, now expressed via `butterfly`
- **untouched:** `forward_shared_layer_pair` and the rest of the fused path, which never had a prefetch
- **untouched:** the zero-twiddle skip, in all three of its sites

### Verification

- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-math --lib ntt` — 30 passed

The existing tests are the correctness gate and they are strong ones: `prop_multi_thread_transform_matches_the_reference` and `prop_fused_shared_layers_match_per_layer` pin this path bit for bit against `NeighborsLastReference`, which shares no code with it, across the whole space of `log_d`, `skip_early`, `skip_late`, and share counts. No new test is warranted — the change removes a hint that could not affect a result, and the arithmetic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)