### PR TITLE
Revert: move powers back to a free function

### DIFF
--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -4,7 +4,7 @@
 use std::{
 	fmt::Display,
 	hash::Hash,
-	iter::{self, Product, Sum},
+	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -117,12 +117,6 @@ pub trait FieldOps:
 
 	/// Returns the one element (multiplicative identity).
 	fn one() -> Self;
-
-	/// Iterate the powers of this value, beginning with 1 (the 0'th power).
-	fn powers(&self) -> impl Iterator<Item = Self> {
-		let val = self.clone();
-		iter::successors(Some(Self::one()), move |power| Some(power.clone() * val.clone()))
-	}
 
 	/// Transpose the subfield elements in a slice of field elements.
 	///

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -117,17 +117,6 @@ generate_spread_tests_small! {
 	spread_equals_basic_spread_64x1, PackedBinaryField64x1b, BinaryField1b, SmallU<1>, 64;
 }
 
-#[test]
-fn test_field_ops_powers() {
-	// The iterator starts at the 0'th power, so entry i must equal the base raised to i.
-	let generator = Ghash128b::MULTIPLICATIVE_GENERATOR;
-	let power_values: Vec<_> = generator.powers().take(10).collect();
-
-	for (i, power) in power_values.iter().enumerate() {
-		assert_eq!(*power, generator.pow(i as u64));
-	}
-}
-
 fn check_field_ops_square_transpose<FSub, F>()
 where
 	FSub: Field,

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -28,6 +28,11 @@ pub trait FieldFn<F: Field> {
 	}
 }
 
+/// Iterate the powers of a given value, beginning with 1 (the 0'th power).
+pub fn powers<F: FieldOps>(val: F) -> impl Iterator<Item = F> {
+	iter::successors(Some(F::one()), move |power| Some(power.clone() * val.clone()))
+}
+
 /// Expands an array of field elements into all possible subset sums.
 ///
 /// For an input array `[a, b, c]`, this computes all possible sums of subsets:
@@ -168,6 +173,17 @@ mod tests {
 
 	use super::*;
 	use crate::{Ghash128b, Random};
+
+	#[test]
+	fn test_powers_against_pow() {
+		// The iterator starts at the 0'th power, so entry i must equal the base raised to i.
+		let generator = Ghash128b::MULTIPLICATIVE_GENERATOR;
+		let power_values: Vec<_> = powers(generator).take(10).collect();
+
+		for (i, power) in power_values.iter().enumerate() {
+			assert_eq!(*power, generator.pow(i as u64));
+		}
+	}
 
 	type F = Ghash128b;
 

--- a/crates/iop-prover/src/ligerito/induced_weight.rs
+++ b/crates/iop-prover/src/ligerito/induced_weight.rs
@@ -6,7 +6,7 @@ use std::iter::zip;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField, PackedField};
+use binius_field::{BinaryField, PackedField, util::powers};
 use binius_iop::ligerito::{InducedBasis, LigeritoLevel};
 use binius_math::{
 	FieldBuffer, FieldVec, ReedSolomonCode,
@@ -132,7 +132,7 @@ where
 		// A position can be drawn twice, so the powers landing on it accumulate rather than
 		// overwrite.
 		let mut weights = FieldBuffer::zeros_in(alloc, self.level.log_codeword_len());
-		for (&index, power) in zip(&self.indices, self.alpha.powers()) {
+		for (&index, power) in zip(&self.indices, powers(self.alpha)) {
 			weights.set(index, weights.get(index) + power);
 		}
 

--- a/crates/iop/src/ligerito/induced_basis.rs
+++ b/crates/iop/src/ligerito/induced_basis.rs
@@ -51,7 +51,11 @@
 //! It needs a packed field, so a verifier written against a channel cannot reach it at all.
 //! [`InducedBasis::pair`] is how a terminal level pairs `w` with a message it holds in the clear.
 
-use binius_field::{BinaryField, PackedField, field::FieldOps, util::expand_subset_products};
+use binius_field::{
+	BinaryField, PackedField,
+	field::FieldOps,
+	util::{expand_subset_products, powers},
+};
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_math::{
 	inner_product::inner_product_scalars,
@@ -130,7 +134,7 @@ impl<F: FieldOps> InducedBasis<F> {
 			.collect::<Vec<_>>();
 
 		// Powers of the batching challenge, one per opened row.
-		let batching = alpha.powers().take(indices.len()).collect();
+		let batching = powers(alpha).take(indices.len()).collect();
 
 		Self {
 			factors,
@@ -198,7 +202,7 @@ impl<F: FieldOps> InducedBasis<F> {
 
 		Self {
 			factors,
-			batching: alpha.powers().take(indices.len()).collect(),
+			batching: powers(alpha.clone()).take(indices.len()).collect(),
 			n_vars: log_dim,
 		}
 	}

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -375,7 +375,7 @@ mod tests {
 	use binius_field::{
 		BinaryField1b, ExtensionField, Field,
 		arch::{OptimalB128, OptimalPackedB128},
-		field::FieldOps,
+		util::powers,
 	};
 	use binius_ip::{channel::IPVerifierChannel, logup_star};
 	use binius_math::{
@@ -531,7 +531,7 @@ mod tests {
 			// gamma^i within the table — the same power series serves every table — scattered onto
 			// its cube.
 			let mut pushforward = vec![F::ZERO; 1usize << m];
-			for (looker, power) in iter::zip(&table.lookers, gamma.powers()) {
+			for (looker, power) in iter::zip(&table.lookers, powers(gamma)) {
 				for (&j, &eq) in iter::zip(&looker.index, &looker.eq_r) {
 					pushforward[j] += power * eq;
 				}

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -12,7 +12,7 @@
 use std::iter;
 
 use binius_compute::Allocator;
-use binius_field::{BinaryField, Divisible, Field, PackedField};
+use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
 use binius_math::{FieldBuffer, FieldSlice, FieldVec, multilinear::hypercube::Hypercube};
 use binius_utils::{
 	buffer::VecLike,
@@ -100,7 +100,7 @@ where
 		.map(|table| table.lookers.len())
 		.max()
 		.expect("tables is non-empty");
-	let scales = gamma.powers().take(max_table_lookers).collect::<Vec<_>>();
+	let scales = powers(gamma).take(max_table_lookers).collect::<Vec<_>>();
 	let flat = tables
 		.iter()
 		.flat_map(|table| iter::zip(&table.lookers, &scales))

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -11,7 +11,7 @@
 use std::{iter, ops::Deref};
 
 use binius_compute::Allocator;
-use binius_field::{Field, PackedField, field::FieldOps};
+use binius_field::{Field, PackedField, util::powers};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_math::{
 	FieldVec, field_buffer::FieldBuffer, multilinear::hypercube::Hypercube,
@@ -74,7 +74,7 @@ pub fn expand_libra_eval<A: Allocator, P: PackedField>(
 
 	for (j, &r_j) in challenge_point.iter().enumerate() {
 		let base_idx = j * row_stride;
-		for (k, power) in r_j.powers().take(degree + 1).enumerate() {
+		for (k, power) in powers(r_j).take(degree + 1).enumerate() {
 			buffer.set(base_idx + k, power);
 		}
 	}

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -4,7 +4,7 @@
 
 use std::{iter, slice};
 
-use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps};
+use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps, util::powers};
 use binius_math::{
 	multilinear::{evaluate::evaluate_inplace_scalars, hypercube::Hypercube},
 	univariate::evaluate_univariate,
@@ -176,7 +176,9 @@ where
 		.map(|table| table.lookers.len())
 		.max()
 		.expect("tables is non-empty");
-	let looker_powers = gamma.powers().take(max_table_lookers).collect::<Vec<_>>();
+	let looker_powers = powers(gamma.clone())
+		.take(max_table_lookers)
+		.collect::<Vec<_>>();
 
 	// Sample one logUp challenge per table. Distinct challenges are what make the single root check
 	// certify every table separately: a table's contribution to the root fraction is a rational

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_field::{Field, field::FieldOps};
+use binius_field::{Field, field::FieldOps, util::powers};
 use binius_math::multilinear::hypercube::Hypercube;
 
 use crate::{
@@ -243,7 +243,7 @@ pub fn libra_eval<F: FieldOps>(
 		.map(|(eq_j_val, r_j)| {
 			eq_k.iter()
 				.take(degree + 1)
-				.zip(r_j.powers())
+				.zip(powers(r_j.clone()))
 				.map(|(eq_k_val, r_j_power)| eq_j_val.clone() * eq_k_val.clone() * r_j_power)
 				.sum::<F>()
 		})

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -177,7 +177,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{Field, Ghash128b, Random};
+	use binius_field::{Field, Ghash128b, Random, util::powers};
 	use proptest::prelude::*;
 	use rand::prelude::*;
 
@@ -192,7 +192,7 @@ mod tests {
 
 	/// The definition of [`evaluate_univariate`], written out as a sum over powers.
 	fn evaluate_univariate_with_powers<F: Field>(coeffs: &[F], x: F) -> F {
-		inner_product(coeffs.iter().copied(), x.powers().take(coeffs.len()))
+		inner_product(coeffs.iter().copied(), powers(x).take(coeffs.len()))
 	}
 
 	/// The textbook Lagrange basis: one weight per point, each built with its own inversion.

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -5,7 +5,7 @@ use std::{cmp::max, marker::PhantomData};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, PackedField};
+use binius_field::{BinaryField, Field, PackedField, util::powers};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::hypercube::Hypercube,
@@ -109,7 +109,7 @@ impl<F: Field> PreparedOperatorData<F> {
 			r_x_prime,
 		} = operator_data;
 		let r_x_prime_tensor = Hypercube::One.expand(&r_x_prime).build::<F>();
-		let lambda_powers: Vec<F> = lambda.powers().skip(1).take(ARITY).collect();
+		let lambda_powers: Vec<F> = powers(lambda).skip(1).take(ARITY).collect();
 		Self {
 			batched_eval: inner_product(evals, lambda_powers.iter().copied()),
 			r_zhat_prime,

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -306,7 +306,7 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let x_val = B128::random(&mut rng);
-		let expected_vals = binius_field::field::FieldOps::powers(&x_val)
+		let expected_vals = binius_field::util::powers(x_val)
 			.skip(1)
 			.take(4)
 			.collect::<Vec<_>>();

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -4,7 +4,10 @@
 use std::iter;
 
 use binius_core::constraint_system::Operand;
-use binius_field::{BinaryField, FieldOps, WideMul, util::FieldFn};
+use binius_field::{
+	BinaryField, FieldOps, WideMul,
+	util::{FieldFn, powers},
+};
 use binius_math::multilinear::hypercube::Hypercube;
 use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
@@ -269,7 +272,10 @@ fn operand_shift_scalar_table<E: FieldOps>(
 	lambda: &E,
 	arity: usize,
 ) -> Vec<E> {
-	let lambda_powers = lambda.powers().skip(1).take(arity).collect::<Vec<_>>();
+	let lambda_powers = powers(lambda.clone())
+		.skip(1)
+		.take(arity)
+		.collect::<Vec<_>>();
 	let mut table = Vec::with_capacity(shift_scalars.len() * arity);
 	for shift_scalar in shift_scalars {
 		for lambda_power in &lambda_powers {


### PR DESCRIPTION
Reverts #2232 (BINIUS-518), at [@jimpo's request](https://github.com/binius-zk/binius64/pull/2232#issuecomment-5426038230):

> I don't like this, please revert.
>
> My general preference is to avoid trait methods where the default is never overridden. If there's some generic code and it needs to be overridden for certain trait impls, it can be a trait method. Otherwise, a standalone function is better. I'll put that in the style guide.

That guidance has since landed as #2326, so this brings the code back in line with it.

`FieldOps::powers` goes back to `binius_field::util::powers`, and its test back to `util.rs` beside it. Same iterator, same values, same order.

Nothing overrode the default, which is exactly the case the rule is about.

### The change

```diff
 // field.rs
-fn powers(&self) -> impl Iterator<Item = Self> {
-    let val = self.clone();
-    iter::successors(Some(Self::one()), move |power| Some(power.clone() * val.clone()))
-}

 // util.rs
+pub fn powers<F: FieldOps>(val: F) -> impl Iterator<Item = F> {
+    iter::successors(Some(F::one()), move |power| Some(power.clone() * val.clone()))
+}
```

Call sites go back to `powers(x)` from `x.powers()`, and re-import `binius_field::util::powers`.

### Not a plain `git revert`

The commit does not reverse-apply — the surrounding code has moved since #2232 merged. Reverse-applying it conflicts in 7 of 12 files. So this is the same revert written against today's code, with three things worth calling out.

**Three new call sites.** The `ligerito` modules gained `.powers()` callers after #2232, so they convert too:

- `crates/iop/src/ligerito/induced_basis.rs` (two sites)
- `crates/iop-prover/src/ligerito/induced_weight.rs`

**The free function takes its argument by value**, so each receiver had to be checked rather than mechanically rewritten:

| site | `F` bound there | form |
|---|---|---|
| `induced_basis::new` | `Copy` | `powers(alpha)` |
| `induced_basis`, other constructor | `Clone` only, `alpha: &F` | `powers(alpha.clone())` |
| `induced_weight` | `Copy` | `powers(self.alpha)` |

Getting this wrong is caught either way — by `clippy::clone_on_copy` if the clone is redundant, or by `E0507` if it is required.

**One signature drifted.** `operand_shift_scalar_table` in `monster.rs` now takes `lambda: &E` where the pre-#2232 code took it by value, so that site clones.

### Scope

- **moved:** the `powers` iterator, from `FieldOps` in `field.rs` back to `util.rs`
- **moved:** its test, from `tests.rs::test_field_ops_powers` back to `util.rs::test_powers_against_pow`
- **changed:** 12 call sites across `binius-math`, `binius-ip`, `binius-ip-prover`, `binius-iop`, `binius-iop-prover`, `binius-prover`, `binius-verifier` and `binius-spartan-frontend`
- **left untouched:** `spartan_frontend::circuits::powers`, a different function that builds power *wires* from a builder

### Verification

- `cargo clippy --all-targets --all-features -- -D warnings` on all nine touched crates — clean, checked per crate by exit code
- `cargo +nightly fmt --all` — clean
- `cargo test` on all nine — pass

### One thing left on the table

The by-value signature is why two call sites clone. Taking `&F` instead would drop both clones while still being a standalone function, so it would satisfy the rule this reverts to. Not done here — this is a revert, and that would be a new decision rather than a restoration. Happy to follow up if it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)