### PR TITLE
Revert packed_extension to standalone functions

### DIFF
--- a/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
@@ -14,8 +14,8 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	Divisible, Ghash128b, PackedBinaryGhash2x128b, PackedGhashSq1x256b, WideMul,
-	packed_extension::PackedExtension, packed_ghash_sq::ghash_sq_from_coords,
+	Divisible, Ghash128b, PackedBinaryGhash2x128b, PackedGhashSq1x256b, WideMul, packed_extension,
+	packed_ghash_sq::ghash_sq_from_coords,
 };
 
 /// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.
@@ -96,8 +96,8 @@ impl WideMul for GhashSqHybridWideMul<PackedGhashSq1x256b> {
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
 		// The GHASH² coordinates already sit in the two 128-bit lanes of the 256-bit value, so
 		// viewing an operand as a packed GHASH pair is a free reinterpretation.
-		let a = PackedExtension::<Ghash128b>::cast_base(Self::peel(a));
-		let b = PackedExtension::<Ghash128b>::cast_base(Self::peel(b));
+		let a = packed_extension::cast_base::<Ghash128b, _>(Self::peel(a));
+		let b = packed_extension::cast_base::<Ghash128b, _>(Self::peel(b));
 
 		WideGhashSqProduct {
 			// Diagonal `[a·e, b·f]` as one two-lane packed widening multiply.

--- a/crates/field/src/packed_extension.rs
+++ b/crates/field/src/packed_extension.rs
@@ -1,70 +1,70 @@
 // Copyright 2023-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+//! Reading a packed extension field element as a packing of its subfield.
+//!
+//! A packed extension field element and its subfield packing are the same bytes.
+//! They differ only in how wide a scalar those bytes are cut into.
+//! So every cast here is a reinterpretation rather than a conversion, and compiles to nothing.
+//!
+//! The subfield scalars come out in [`ExtensionField`] basis order:
+//!
+//! ```text
+//! cast_bases_mut(exts)  ==  exts.iter().flat_map(|ext| ext.iter_bases())
+//! ```
+//!
+//! The bare names do not say what is being cast, so call sites read best qualified by the module:
+//!
+//! ```text
+//! packed_extension::cast_base::<B1, _>(elem)
+//! ```
+
 use crate::{
 	BinaryField, ExtensionField, PackedField, arch::PackedPrimitiveType, underlier::WithUnderlier,
 };
 
-/// A packed extension field that can also be read as a packing of its subfield `FSub`.
+/// The packing of `FSub` covering the same bits as the packed extension field type `P`.
 ///
-/// `Self` and [`Self::PackedSubfield`] cover the same bits in the same order.
-/// They differ only in how wide a scalar those bits are cut into.
-/// That is what makes all four casts free reinterpretations rather than conversions.
-///
-/// The subfield scalars come out in [`ExtensionField`] basis order:
-///
-/// ```text
-/// P::cast_bases_mut(exts)  ==  exts.iter().flat_map(|ext| ext.iter_bases())
-/// ```
-pub trait PackedExtension<FSub: BinaryField>:
-	PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier
-{
-	/// The packing of `FSub` covering the same bits as `Self`.
-	type PackedSubfield: PackedField<Scalar = FSub>;
-
-	/// Reads a packed extension field element as a packed subfield element.
-	fn cast_base(self) -> Self::PackedSubfield;
-
-	/// Reads a packed extension field element in place as a packed subfield element.
-	fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield;
-
-	/// Reads a packed subfield element as a packed extension field element.
-	fn cast_ext(base: Self::PackedSubfield) -> Self;
-
-	/// Reads a slice of packed extension field elements in place as packed subfield elements.
-	fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield];
-}
-
-/// A shorthand for [`PackedExtension::PackedSubfield`].
-pub type PackedSubfield<P, FSub> = <P as PackedExtension<FSub>>::PackedSubfield;
-
 /// A transparent wrapper over an underlier holds one contiguous bit string.
 /// Cutting that same string into `FSub` scalars is exactly a [`PackedPrimitiveType`].
-impl<FSub, P> PackedExtension<FSub> for P
+pub type PackedSubfield<P, FSub> = PackedPrimitiveType<<P as WithUnderlier>::Underlier, FSub>;
+
+/// Reads a packed extension field element as a packed subfield element.
+pub fn cast_base<FSub, P>(ext: P) -> PackedSubfield<P, FSub>
 where
 	FSub: BinaryField,
 	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
-	PackedPrimitiveType<P::Underlier, FSub>: PackedField<Scalar = FSub>,
+	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
 {
-	type PackedSubfield = PackedPrimitiveType<P::Underlier, FSub>;
+	PackedSubfield::<P, FSub>::from_underlier(ext.to_underlier())
+}
 
-	#[inline]
-	fn cast_base(self) -> Self::PackedSubfield {
-		Self::PackedSubfield::from_underlier(self.to_underlier())
-	}
+/// Reads a packed extension field element in place as a packed subfield element.
+pub fn cast_base_mut<FSub, P>(packed: &mut P) -> &mut PackedSubfield<P, FSub>
+where
+	FSub: BinaryField,
+	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
+	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
+{
+	PackedSubfield::<P, FSub>::from_underlier_ref_mut(packed.to_underlier_ref_mut())
+}
 
-	#[inline]
-	fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
-		Self::PackedSubfield::from_underlier_ref_mut(self.to_underlier_ref_mut())
-	}
+/// Reads a packed subfield element as a packed extension field element.
+pub fn cast_ext<FSub, P>(base: PackedSubfield<P, FSub>) -> P
+where
+	FSub: BinaryField,
+	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
+	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
+{
+	P::from_underlier(base.to_underlier())
+}
 
-	#[inline]
-	fn cast_ext(base: Self::PackedSubfield) -> Self {
-		Self::from_underlier(base.to_underlier())
-	}
-
-	#[inline]
-	fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
-		Self::PackedSubfield::from_underliers_ref_mut(Self::to_underliers_ref_mut(packed))
-	}
+/// Reads a slice of packed extension field elements in place as packed subfield elements.
+pub fn cast_bases_mut<FSub, P>(packed: &mut [P]) -> &mut [PackedSubfield<P, FSub>]
+where
+	FSub: BinaryField,
+	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
+	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
+{
+	PackedSubfield::<P, FSub>::from_underliers_ref_mut(P::to_underliers_ref_mut(packed))
 }

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -38,7 +38,7 @@ use crate::{
 		portable::packed_macros::{portable_macros::*, *},
 	},
 	arithmetic_traits::{InvertOrZero, Square},
-	packed_extension::PackedExtension,
+	packed_extension,
 	sliced_packed_field::SlicedPackedField,
 	underlier::{UnderlierType, WithUnderlier},
 };
@@ -236,14 +236,14 @@ where
 /// reinterpretation followed by two lane reads.
 #[inline]
 pub(crate) fn ghash_sq_coords(elem: PackedGhashSq1x256b) -> [Ghash128b; 2] {
-	let coords = PackedExtension::<Ghash128b>::cast_base(elem);
+	let coords = packed_extension::cast_base::<Ghash128b, _>(elem);
 	[coords.get(0), coords.get(1)]
 }
 
 /// Assembles a width-one GHASH² element `a + b·Y` from its GHASH coordinates `[a, b]`.
 #[inline]
 pub(crate) fn ghash_sq_from_coords(coords: [Ghash128b; 2]) -> PackedGhashSq1x256b {
-	PackedExtension::<Ghash128b>::cast_ext(PackedBinaryGhash2x128b::from_scalars(coords))
+	packed_extension::cast_ext::<Ghash128b, _>(PackedBinaryGhash2x128b::from_scalars(coords))
 }
 
 /// [`Square`] strategy for [`PackedGhashSq1x256b`].
@@ -255,7 +255,7 @@ impl Square for GhashSqSquare<PackedGhashSq1x256b> {
 	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two.
 	#[inline]
 	fn square(self) -> Self {
-		let sq = Square::square(PackedExtension::<Ghash128b>::cast_base(Self::peel(self)));
+		let sq = Square::square(packed_extension::cast_base::<Ghash128b, _>(Self::peel(self)));
 
 		let x_t2 = sq.get(1).mul_x();
 		Self::wrap(ghash_sq_from_coords([sq.get(0) + x_t2, x_t2]))

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -4,7 +4,7 @@
 use binius_utils::checked_arithmetics::checked_log_2;
 
 use super::packed::PackedField;
-use crate::{BinaryField, ExtensionField, PackedExtension};
+use crate::{BinaryField, ExtensionField, PackedSubfield, WithUnderlier, packed_extension};
 
 /// Transpose square blocks of elements within packed field elements in place.
 ///
@@ -111,9 +111,13 @@ pub fn transpose_square_blocks_array<P: PackedField, const LOG_N: usize, const S
 pub fn square_transforms_extension_field<F, FE>(values: &mut [FE])
 where
 	F: BinaryField,
-	FE: PackedExtension<F>,
+	FE: PackedField<Scalar: ExtensionField<F>> + WithUnderlier,
+	PackedSubfield<FE, F>: PackedField<Scalar = F>,
 {
-	transpose_square_blocks(FE::Scalar::LOG_DEGREE, FE::cast_bases_mut(values));
+	transpose_square_blocks(
+		FE::Scalar::LOG_DEGREE,
+		packed_extension::cast_bases_mut::<F, FE>(values),
+	);
 }
 
 #[cfg(test)]

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -6,11 +6,12 @@ use std::{array, iter, ops::Deref};
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{
-	ExtensionField, PackedExtension, PackedField,
+	ExtensionField, PackedField,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, InputWrappingTransformationFactory,
 		LinearTransformationFactory, OutputWrappingTransformationFactory, Transformation,
 	},
+	packed_extension,
 };
 use binius_ip_prover::{
 	channel::IPProverChannel,
@@ -138,7 +139,7 @@ where
 					iter::repeat_with(|| {
 						array::from_fn(|_| {
 							rows.next()
-								.map(PackedExtension::<B1>::cast_base)
+								.map(packed_extension::cast_base::<B1, _>)
 								.unwrap_or_default()
 						})
 					})
@@ -394,7 +395,7 @@ mod test {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		ExtensionField, Field, Ghash128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
-		PackedExtension, PackedField, PackedSubfield,
+		PackedField, PackedSubfield, packed_extension,
 	};
 	use binius_math::{
 		FieldBuffer,
@@ -593,7 +594,7 @@ mod test {
 			bit_matrix
 				.as_ref()
 				.iter()
-				.map(|&bits_packed| <P as PackedExtension<B1>>::cast_ext(bits_packed))
+				.map(|&bits_packed| packed_extension::cast_ext::<B1, P>(bits_packed))
 				.collect(),
 		);
 		let (eq_lo, eq_hi) = expand_tensor_factors(suffix);


### PR DESCRIPTION
@jimpo Reverting #2237 as asked.

### In one line

The four `cast_*` functions and the concrete `PackedSubfield` alias come back, the `PackedExtension` trait and its blanket impl go, and call sites qualify by module instead.

### What the revert restores

`packed_extension.rs` is back to four standalone functions, each carrying the bound explicitly:

```rust
pub type PackedSubfield<P, FSub> = PackedPrimitiveType<<P as WithUnderlier>::Underlier, FSub>;

pub fn cast_base<FSub, P>(ext: P) -> PackedSubfield<P, FSub>
pub fn cast_base_mut<FSub, P>(packed: &mut P) -> &mut PackedSubfield<P, FSub>
pub fn cast_ext<FSub, P>(base: PackedSubfield<P, FSub>) -> P
pub fn cast_bases_mut<FSub, P>(packed: &mut [P]) -> &mut [PackedSubfield<P, FSub>]
```

`PackedSubfield` goes back to being a concrete alias rather than a projection through the trait, so `arch_optimal.rs`'s `OptimalPackedB1` and `ring_switch.rs`'s test both keep resolving to the same type they did before.

### Namespacing, your way

You suggested qualifying the call sites instead, so that is what they do now:

```rust
packed_extension::cast_base::<Ghash128b, _>(elem)
packed_extension::cast_ext::<B1, P>(bits_packed)
```

That reads better than the trait form it replaces, since the module name says where the cast comes from and the turbofish says what it casts to. It also stays usable as a bare function path where one is wanted:

```rust
rows.next().map(packed_extension::cast_base::<B1, _>)
```

All eight call sites across `transpose.rs`, `packed_ghash_sq.rs`, `arch/x86_64/arithmetic/ghash_sq.rs`, and `ring_switch.rs` are converted.

### What the revert costs

One thing, and it is the only thing the trait genuinely bought. `square_transforms_extension_field` goes back to restating the bound:

```rust
 where
 	F: BinaryField,
-	FE: PackedExtension<F>,
+	FE: PackedField<Scalar: ExtensionField<F>> + WithUnderlier,
+	PackedSubfield<FE, F>: PackedField<Scalar = F>,
```

That third line has to be there because `PackedSubfield` is a type alias and an alias cannot carry its own bound. It is one function, so it is a fair price.

### The doc comments stay

The rewritten prose from #2237 is kept and re-homed. The shared invariant — that a packed extension element and its subfield packing are the same bytes, cut into different scalar widths — is now stated once in a module doc rather than repeated on each function or attached to the alias, and the module doc records the qualified call-site convention so the next reader follows it:

```rust
//! A packed extension field element and its subfield packing are the same bytes.
//! They differ only in how wide a scalar those bytes are cut into.
//! So every cast here is a reinterpretation rather than a conversion, and compiles to nothing.
```

### One thing still open

`cast_base_mut` has zero call sites in the repo — it did before #2237 and it does now. #2237 flagged it and the question was never settled. Happy to drop it in a one-line follow-up if you want the surface trimmed; leaving it alone here so this PR is a revert and nothing else.

### Scope

- **deleted:** the `PackedExtension` trait and its blanket impl
- **restored:** four free functions, and `PackedSubfield` as a concrete alias
- **changed:** eight call sites, all now module-qualified
- no `unsafe` added or removed; the casts still go through the existing `WithUnderlier` conversions

### Verification

Run against a clean `main` in an isolated worktree.

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy -p binius-field -p binius-prover --all-targets --all-features -- -D warnings` — clean
- `cargo test -p binius-field` and `cargo test -p binius-prover` — pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean

The two GFNI call sites sit behind `#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2"))]`, so a plain check on ARM compiles nothing there. Type-checked explicitly with `RUSTFLAGS="-C target-feature=+avx2,+vpclmulqdq" cargo check -p binius-field --target x86_64-apple-darwin` — clean. Re-confirmed with a `compile_error!` probe that this is the command that actually reaches the file: the probe fires with those flags and stays silent without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
