### PR TITLE
Revert: move proof_size back off FRIParams

### DIFF
--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -7,7 +7,7 @@ use binius_compute::GlobalAllocator;
 use binius_field::{BinaryField, Field, Ghash128b as B128, PackedBinaryGhash1x128b, PackedField};
 use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::{
-	fri::{CodewordSpec, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
+	fri::{self, CodewordSpec, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
 	merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
 };
 use binius_ip::channel::IPVerifierChannel;
@@ -699,17 +699,17 @@ where
 fn test_proof_size_higher_arity() {
 	let (proof_bytes, params, scheme) =
 		generate_fri_proof::<B128, PackedBinaryGhash1x128b>(8, 2, 0, &[3, 2, 1]);
-	assert_eq!(proof_bytes.len(), params.proof_size(&scheme));
+	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
 }
 
 #[test]
 fn test_proof_size_interleaved() {
 	let (proof_bytes, params, scheme) = generate_fri_proof::<B128, Packed128b>(6, 2, 2, &[3, 2, 1]);
-	assert_eq!(proof_bytes.len(), params.proof_size(&scheme));
+	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
 }
 
 #[test]
 fn test_proof_size_no_folding() {
 	let (proof_bytes, params, scheme) = generate_fri_proof::<B128, Packed128b>(4, 2, 2, &[]);
-	assert_eq!(proof_bytes.len(), params.proof_size(&scheme));
+	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
 }

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -313,71 +313,6 @@ where
 	pub const fn log_msg_len(&self) -> usize {
 		self.max_log_msg_len + self.log_n_oracles
 	}
-
-	/// Exact byte-size of a FRI proof, including the initial commitment.
-	///
-	/// The size follows from the parameters alone, so the prover need not run.
-	///
-	/// Counted on the message channel:
-	/// - the initial codeword commitment;
-	/// - one commitment per fold round.
-	///
-	/// Counted on the decommitment channel:
-	/// - the terminal codeword, sent in the clear;
-	/// - the Merkle layer digests and the per-query branch digests;
-	/// - the field elements of every opened coset.
-	pub fn proof_size<VCS: MerkleTreeScheme<F>>(&self, vcs: &VCS) -> usize {
-		let digest_size = std::mem::size_of::<VCS::Digest>();
-
-		// Serialized byte-size of a single field element.
-		let value_size = {
-			let mut buf = Vec::new();
-			F::default()
-				.serialize(&mut buf)
-				.expect("default element can be serialized to a resizable buffer");
-			buf.len()
-		};
-
-		let n_test_queries = self.n_test_queries();
-
-		// One digest per input oracle, one per fold round, one for the terminal codeword.
-		let commitment_msg_size = (self.input_oracles().len() + self.n_oracles()) * digest_size;
-
-		// Terminal codeword sent in the clear: 2^(log_terminal_dim + log_inv_rate) field elements.
-		let log_terminal_dim = self.n_final_challenges();
-		let log_inv_rate = self.rs_code().log_inv_rate();
-		let terminate_codeword_size = (1 << (log_terminal_dim + log_inv_rate)) * value_size;
-
-		let mut merkle_sizes = 0;
-		let mut coset_values_size = 0;
-
-		// Per query, an oracle sends one coset of `2^arity` elements and a Merkle branch.
-		// The layer depth must be chosen for the tree it indexes.
-		let mut open = |log_n_cosets: usize, arity: usize| {
-			let layer_depth = vcs.optimal_verify_layer(n_test_queries, log_n_cosets);
-			merkle_sizes += vcs.proof_size(1 << log_n_cosets, n_test_queries, layer_depth);
-			coset_values_size += n_test_queries * (1 << arity) * value_size;
-		};
-
-		// Input oracles are opened one after another, each against its own commitment.
-		// So a batch of N sends N multi-proofs, not one.
-		//
-		// An oracle's codeword sits `log_lift` below the reduced dimension.
-		let log_dim = self.rs_code().log_dim();
-		for spec in self.input_oracles() {
-			open(log_dim - spec.log_lift + log_inv_rate, spec.log_batch_size());
-		}
-
-		// Then one per fold round.
-		// The outer oracle-combine challenges cost nothing: they recombine values already opened.
-		let mut log_n_cosets = self.index_bits();
-		for &arity in self.fold_arities() {
-			log_n_cosets -= arity;
-			open(log_n_cosets, arity);
-		}
-
-		commitment_msg_size + terminate_codeword_size + merkle_sizes + coset_values_size
-	}
 }
 
 struct ChooseBatchSizeAndAritiesOutput {
@@ -862,7 +797,7 @@ mod tests {
 	use binius_hash::StdHashSuite;
 
 	use super::*;
-	use crate::merkle_tree::BinaryMerkleTreeScheme;
+	use crate::{fri::proof_size, merkle_tree::BinaryMerkleTreeScheme};
 
 	type TestMerkleScheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 
@@ -916,7 +851,7 @@ mod tests {
 		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
 		let (params, _) =
 			FRIParams::optimal_for_batch(merkle_scheme, oracles, log_inv_rate, n_test_queries);
-		params.proof_size(merkle_scheme)
+		proof_size(&params, merkle_scheme)
 	}
 
 	// Invariant: the size the arity search minimizes is the size a prover actually sends.
@@ -971,7 +906,7 @@ mod tests {
 					let digests = (oracles.len() + 1 + params.fold_arities().len()) * digest_size;
 					assert_eq!(
 						estimate + digests,
-						params.proof_size(&merkle_scheme),
+						proof_size(&params, &merkle_scheme),
 						"oracles={oracles:?} log_inv_rate={log_inv_rate} \
 						 n_test_queries={n_test_queries} arities={:?}",
 						params.fold_arities(),

--- a/crates/iop/src/fri/mod.rs
+++ b/crates/iop/src/fri/mod.rs
@@ -27,8 +27,10 @@ pub(crate) mod batch;
 mod common;
 mod error;
 pub mod fold;
+mod size_estimation;
 pub mod verify;
 
 pub use common::*;
 pub use error::*;
 pub use fold::FRIFoldVerifier;
+pub use size_estimation::proof_size;

--- a/crates/iop/src/fri/size_estimation.rs
+++ b/crates/iop/src/fri/size_estimation.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 The Binius Developers
+
+use binius_field::BinaryField;
+
+use super::common::FRIParams;
+use crate::merkle_tree::MerkleTreeScheme;
+
+/// Exact byte-size of a FRI proof, including the initial commitment.
+///
+/// The size follows from the parameters alone, so the prover need not run.
+///
+/// Counted on the message channel:
+/// - the initial codeword commitment;
+/// - one commitment per fold round.
+///
+/// Counted on the decommitment channel:
+/// - the terminal codeword, sent in the clear;
+/// - the Merkle layer digests and the per-query branch digests;
+/// - the field elements of every opened coset.
+pub fn proof_size<F, VCS>(params: &FRIParams<F>, vcs: &VCS) -> usize
+where
+	F: BinaryField,
+	VCS: MerkleTreeScheme<F>,
+{
+	let digest_size = std::mem::size_of::<VCS::Digest>();
+
+	// Serialized byte-size of a single field element.
+	let value_size = {
+		let mut buf = Vec::new();
+		F::default()
+			.serialize(&mut buf)
+			.expect("default element can be serialized to a resizable buffer");
+		buf.len()
+	};
+
+	let n_test_queries = params.n_test_queries();
+
+	// One digest per input oracle, one per fold round, one for the terminal codeword.
+	let commitment_msg_size = (params.input_oracles().len() + params.n_oracles()) * digest_size;
+
+	// Terminal codeword sent in the clear: 2^(log_terminal_dim + log_inv_rate) field elements.
+	let log_terminal_dim = params.n_final_challenges();
+	let log_inv_rate = params.rs_code().log_inv_rate();
+	let terminate_codeword_size = (1 << (log_terminal_dim + log_inv_rate)) * value_size;
+
+	let mut merkle_sizes = 0;
+	let mut coset_values_size = 0;
+
+	// Per query, an oracle sends one coset of `2^arity` elements and a Merkle branch.
+	// The layer depth must be chosen for the tree it indexes.
+	let mut open = |log_n_cosets: usize, arity: usize| {
+		let layer_depth = vcs.optimal_verify_layer(n_test_queries, log_n_cosets);
+		merkle_sizes += vcs.proof_size(1 << log_n_cosets, n_test_queries, layer_depth);
+		coset_values_size += n_test_queries * (1 << arity) * value_size;
+	};
+
+	// Input oracles are opened one after another, each against its own commitment.
+	// So a batch of N sends N multi-proofs, not one.
+	//
+	// An oracle's codeword sits `log_lift` below the reduced dimension.
+	let log_dim = params.rs_code().log_dim();
+	for spec in params.input_oracles() {
+		open(log_dim - spec.log_lift + log_inv_rate, spec.log_batch_size());
+	}
+
+	// Then one per fold round.
+	// The outer oracle-combine challenges cost nothing: they recombine values already opened.
+	let mut log_n_cosets = params.index_bits();
+	for &arity in params.fold_arities() {
+		log_n_cosets -= arity;
+		open(log_n_cosets, arity);
+	}
+
+	commitment_msg_size + terminate_codeword_size + merkle_sizes + coset_values_size
+}

--- a/crates/iop/src/ligerito/size_estimation.rs
+++ b/crates/iop/src/ligerito/size_estimation.rs
@@ -420,7 +420,11 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::{channel::OracleSpec, fri::FRIParams, merkle_tree::BinaryMerkleTreeScheme};
+	use crate::{
+		channel::OracleSpec,
+		fri::{FRIParams, proof_size},
+		merkle_tree::BinaryMerkleTreeScheme,
+	};
 
 	type TestMerkleScheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 
@@ -908,7 +912,7 @@ mod tests {
 				log_inv_rate,
 				regime.n_queries(SECURITY_BITS, log_inv_rate),
 			);
-			params.proof_size(&merkle_scheme)
+			proof_size(&params, &merkle_scheme)
 		};
 		// The best constant rate FRI can pick, paired with the rate that won it.
 		let fri_best = |log_n: usize, regime: SoundnessRegime| {


### PR DESCRIPTION
Reverts #2244, at [@jimpo's request](https://github.com/binius-zk/binius64/pull/2244#issuecomment-5427689543):

> I'd like to change this back. Unnecessary coupling, at odds with the single-responsibility principle.

`proof_size` goes back to a free function in `crates/iop/src/fri/size_estimation.rs`, taking the params and the scheme as arguments rather than hanging off `FRIParams`.

```diff
-params.proof_size(&vcs)
+proof_size(&params, &vcs)
```

The computation is untouched, line for line.

### The doc comment is kept

#2244 rewrote the doc while moving the function, and that part is worth keeping, so it stays on the restored free function.

Before — one sentence wrapped across two lines, and two more wrapped inside their bullets:

```
/// Computes the exact byte-size of a FRI proof (including the initial commitment) without running
/// the prover.
///
/// This accounts for:
/// - **Message channel**: the initial codeword commitment and all round commitments (digests
///   observed by Fiat-Shamir).
/// - **Decommitment channel**: the terminal codeword, Merkle layer digests, per-query branch
///   digests, and per-query coset field values.
```

After — one clause per line, and the two channels each get their own list instead of being crammed into a bullet:

```
/// Exact byte-size of a FRI proof, including the initial commitment.
///
/// The size follows from the parameters alone, so the prover need not run.
///
/// Counted on the message channel:
/// - the initial codeword commitment;
/// - one commitment per fold round.
///
/// Counted on the decommitment channel:
/// - the terminal codeword, sent in the clear;
/// - the Merkle layer digests and the per-query branch digests;
/// - the field elements of every opened coset.
```

### Two call sites the revert could not know about

Both landed after #2244 merged, so they use the method form and convert here too:

- `fri::common`'s `proof_size_at_rate` test helper
- the FRI-vs-Ligerito size comparison in `ligerito::size_estimation`, which needed the `fri::proof_size` import added back

### Scope

- **restored:** `crates/iop/src/fri/size_estimation.rs`, plus its `mod` and `pub use` lines in `fri/mod.rs`
- **removed:** the `proof_size` method from the `impl FRIParams` block in `common.rs`
- **changed:** 6 call sites — 3 in `binius-iop-prover`'s tests, 2 in `binius-iop`'s, 1 helper
- **kept:** the rewritten doc comment, and the function body exactly as it computes today

### Verification

- `cargo clippy --all-targets --all-features -- -D warnings` on `binius-iop` and `binius-iop-prover` — clean, checked per crate by exit code
- `cargo +nightly fmt --all` — clean
- `cargo test` on both — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
