### PR TITLE
Put the shift prover back on standalone functions

### DIFF
--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -16,7 +16,7 @@ use binius_math::{
 use binius_prover::{
 	fold_word::BitAxisFolder,
 	protocols::shift::{
-		KeyCollection, OperatorClaims, OperatorData, ShiftProver,
+		self, KeyCollection, OperatorClaims, OperatorData,
 		monster::shift_operator_table,
 		phase_1::{Phase1Output, SparseShiftRows},
 		phase_2::run_sumcheck,
@@ -151,7 +151,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 				let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 
-				ShiftProver::<_, P, _>::new(&mut prover_transcript, &alloc).prove(
+				shift::prove::<_, P, _, _>(
 					&key_collection,
 					value_vec.public(),
 					value_vec.non_public(),
@@ -162,6 +162,8 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 						binmul: OperatorData::zero_claim(r_zhat_prime),
 					},
 					&subspace,
+					&mut prover_transcript,
+					&alloc,
 				)
 			});
 		});
@@ -185,7 +187,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 
-		ShiftProver::<_, P, _>::new(&mut prover_transcript, &&BufferPool::new()).prove(
+		shift::prove::<_, P, _, _>(
 			&key_collection,
 			value_vec.public(),
 			value_vec.non_public(),
@@ -196,6 +198,8 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				binmul: OperatorData::zero_claim(r_zhat_prime),
 			},
 			&subspace,
+			&mut prover_transcript,
+			&&BufferPool::new(),
 		);
 
 		let setup_verifier_transcript = prover_transcript.into_verifier();

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -14,6 +14,6 @@ mod shift_ind;
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
 pub use key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation};
 pub use phase_2::ShiftOutput;
-pub use prove::{OperatorData, PreparedOperatorData, ShiftProver};
+pub use prove::{OperatorData, PreparedOperatorData, prove};
 pub use segment_words::SegmentWords;
 pub use shift_ind::{ShiftChallenge, ShiftChallengePoint, ShiftIndOutput, ShiftIndSumcheck};

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -20,9 +20,63 @@ use binius_verifier::protocols::shift::LOG_SHIFT_COUNT;
 use tracing::instrument;
 
 use super::{
-	key_collection::DenseShiftEncoding, monster::shift_operator_table, outer::OuterShiftStage,
+	SegmentWords,
+	claims::PreparedOperatorClaims,
+	key_collection::{DenseShiftEncoding, KeyCollection},
+	monster::shift_operator_table,
+	outer::OuterShiftStage,
 	shift_ind::ShiftChallenge,
 };
+
+/// Proves the first phase of the shift reduction.
+///
+/// Builds the witness-and-batching multilinear for both segments and concatenates their rows.
+/// One sumcheck then runs over their product, against a weight table that is never materialized.
+///
+/// # Arguments
+///
+/// - `key_collection`: the prover's key collection for the constraint system.
+/// - `words`: the value-vector words.
+/// - `prepared`: the prepared claim of each operation, indexed by the operation a key names.
+/// - `oblong_weights`: the weights of the reduction's first factor, one per bit position.
+/// - `channel`: the prover channel the interactive rounds run over.
+/// - `alloc`: the allocator the intermediate buffers are drawn from.
+///
+/// # Returns
+///
+/// The challenge point split into its axes, alongside the leftover weights.
+/// Also the two evaluations this phase reduced to.
+#[instrument(skip_all, name = "prover_phase_1")]
+pub fn prove_phase_1<F, P, Channel, A>(
+	key_collection: &KeyCollection,
+	words: SegmentWords<'_>,
+	prepared: &PreparedOperatorClaims<F>,
+	oblong_weights: &[F],
+	channel: &mut Channel,
+	alloc: &A,
+) -> Phase1Output<F>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+	A: Allocator,
+{
+	// Accumulate the witness-and-batching rows of the public and hidden segments separately.
+	// The public words are the prefix of the value vector.
+	// Each segment's key ranges are relative to its own segment.
+	let public = key_collection
+		.public
+		.build_g::<_, P>(words.public, prepared);
+	let hidden = key_collection
+		.hidden
+		.build_g::<_, P>(words.hidden, prepared);
+	let g = SparseShiftRows::from_segments([
+		(&public, &key_collection.public.dense_shift_enc),
+		(&hidden, &key_collection.hidden.dense_shift_enc),
+	]);
+
+	g.run_phase_1_sumcheck(oblong_weights, prepared.batched_eval(), channel, alloc)
+}
 
 /// The number of variables the shift-and-bit phases of the reduction span: the bit position
 /// within a word, the inner shift slot, and the outer shift slot.

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::iter;
+use std::{cmp::max, iter};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -23,6 +23,97 @@ use binius_utils::{
 };
 use binius_verifier::protocols::shift::evaluate_words_mle;
 use tracing::instrument;
+
+use super::{
+	SegmentWords, claims::PreparedOperatorClaims, key_collection::KeyCollection,
+	phase_1::Phase1Output,
+};
+use crate::fold_word::BitAxisFolder;
+
+/// Proves the second phase of the shift protocol reduction.
+///
+/// Folds the value-vector words by the bit-position challenge.
+/// Builds the constraint-matrix multilinear's two segments.
+/// Then runs a sumcheck between them, with a sparse first round over the segment selector.
+///
+/// # Arguments
+///
+/// - `key_collection`: the prover's key collection for the constraint system.
+/// - `words`: the value-vector words.
+/// - `prepared`: the prepared claim of each operation, indexed by the operation a key names.
+/// - `phase_1_output`: the challenges and evaluation the first phase produced.
+/// - `shift_ind_eval`: the scalar weighting every shift key.
+/// - `epsilon`: the claim this phase's rounds prove.
+/// - `channel`: the prover channel the interactive rounds run over.
+/// - `alloc`: the allocator the intermediate buffers are drawn from.
+///
+/// `shift_ind_eval` is the product of the two indicator evaluations.
+/// Those are what the earlier bit-index phases reduced to.
+///
+/// # Returns
+///
+/// The combined challenges with the witness evaluation, and the wiring multilinear's evaluation.
+#[allow(clippy::too_many_arguments)]
+#[instrument(skip_all, name = "prove_phase_2")]
+pub fn prove_phase_2<F, P, Channel, A>(
+	key_collection: &KeyCollection,
+	words: SegmentWords<'_>,
+	prepared: &PreparedOperatorClaims<F>,
+	phase_1_output: Phase1Output<F>,
+	shift_ind_eval: F,
+	epsilon: F,
+	channel: &mut Channel,
+	alloc: &A,
+) -> ShiftOutput<F>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+	A: Allocator,
+{
+	let Phase1Output {
+		r_j,
+		inner,
+		outer,
+		psi: _,
+		gamma: _,
+		g_eval: _,
+	} = phase_1_output;
+
+	let r_j_tensor = Hypercube::One.expand(&r_j).build::<F>();
+
+	// Fold each segment separately.
+	// The combined witness is never materialized.
+	// Each fold is zero-padded to enough variables to cover its own segment's length.
+	// Both columns fold against the same round tensor, so the tables are built once.
+	let folder = BitAxisFolder::new(r_j_tensor.as_ref());
+	let public_folded = folder.fold::<P, _>(alloc, words.public);
+	let hidden_folded = folder.fold::<P, _>(alloc, words.hidden);
+
+	let (public_monster, hidden_monster) =
+		key_collection.build_monster_segments(alloc, prepared, shift_ind_eval, &inner, &outer);
+
+	// Both halves of the sumcheck share one word-index space, spanning the wider segment.
+	// The hidden segment is normally the wider one.
+	// A system with more public words than private values inverts that.
+	// So the hidden half is zero-extended to match.
+	let log_segment_words = max(public_folded.log_len(), hidden_folded.log_len());
+	let hidden_folded = hidden_folded.zero_extend_in(alloc, log_segment_words);
+	let hidden_monster = hidden_monster.zero_extend_in(alloc, log_segment_words);
+
+	run_sumcheck(
+		&public_folded,
+		hidden_folded,
+		&public_monster,
+		hidden_monster,
+		shift_ind_eval,
+		words.public,
+		r_j,
+		epsilon,
+		channel,
+		alloc,
+	)
+}
 
 /// A witness or constraint-matrix buffer, split into the public and hidden segments the
 /// phase-2 sumcheck's selector variable chooses between.

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,8 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{cmp::max, marker::PhantomData};
-
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
@@ -11,17 +9,15 @@ use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::hypercube::Hypercube,
 	univariate::EvaluationDomain,
 };
-use tracing::instrument;
 
 use super::{
 	SegmentWords,
-	claims::{OperatorClaims, PreparedOperatorClaims},
+	claims::OperatorClaims,
 	key_collection::KeyCollection,
-	phase_1::{Phase1Output, SparseShiftRows},
-	phase_2::{ShiftOutput, run_sumcheck},
+	phase_1::prove_phase_1,
+	phase_2::{ShiftOutput, prove_phase_2},
 	shift_ind::{ShiftChallengePoint, ShiftIndSumcheck},
 };
-use crate::fold_word::BitAxisFolder;
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
 ///
@@ -119,247 +115,111 @@ impl<F: Field> PreparedOperatorData<F> {
 	}
 }
 
-/// Drives the shift protocol reduction, owning the prover channel and the allocator its
-/// intermediate buffers are drawn from.
+/// Proves the shift protocol reduction, collapsing every operation's claims into one.
 ///
-/// Every phase reads and writes the same channel and draws from the same allocator, carried
-/// here once rather than threaded through each phase's own argument list.
-pub struct ShiftProver<'a, 'alloc, A: Allocator, P, Channel> {
-	/// Ties the reduction's packed-field type to this struct, though it is never stored.
-	_p_marker: PhantomData<P>,
-	/// The channel the reduction's interactive rounds run over.
-	channel: &'a mut Channel,
-	/// The allocator the reduction's intermediate buffers are drawn from.
-	alloc: &'alloc A,
-}
-
-impl<'a, 'alloc, A: Allocator, P, Channel> ShiftProver<'a, 'alloc, A, P, Channel> {
-	/// Builds a prover over the given channel and allocator.
-	///
-	/// The packed field is not inferred from either argument, so callers usually need a
-	/// turbofish.
-	pub const fn new(channel: &'a mut Channel, alloc: &'alloc A) -> Self {
-		Self {
-			_p_marker: PhantomData,
-			channel,
-			alloc,
-		}
-	}
-}
-
-impl<'alloc, A, F, P, Channel> ShiftProver<'_, 'alloc, A, P, Channel>
+/// The result is a single multilinear evaluation claim on the witness.
+/// It is reached in five prover phases.
+/// A shifted value index names two shifts applied in sequence.
+/// The reduction peels them off from the output end inward:
+///
+/// 1. bind the outer shift slot, then the inner one, then the bit position within a word;
+/// 2. bind the bit index of the intermediate word, where the two shift indicators meet;
+/// 3. bind the output bit index the reduction's first factor attaches to;
+/// 4. reduce what is left to a witness evaluation, against the constraint-matrix multilinear.
+///
+/// # Arguments
+///
+/// - `key_collection`: the prover's key collection for the constraint system.
+/// - `public_words`: the constants followed by the inout values, as the circuit declares them.
+/// - `hidden_words`: the private values, as the circuit declares them.
+/// - `claims`: the operand evaluation claim of each operation.
+/// - `domain_subspace`: the univariate evaluation domain.
+/// - `channel`: the prover channel the interactive rounds run over.
+/// - `alloc`: the allocator the intermediate buffers are drawn from.
+///
+/// # Returns
+///
+/// The final challenges with the witness evaluation.
+/// Also the wiring multilinear's evaluation, for the caller to send.
+pub fn prove<F, P, Channel, A>(
+	key_collection: &KeyCollection,
+	public_words: &[Word],
+	hidden_words: &[Word],
+	claims: OperatorClaims<F>,
+	domain_subspace: &BinarySubspace<F>,
+	channel: &mut Channel,
+	alloc: &A,
+) -> ShiftOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	/// Proves the shift protocol reduction, collapsing every operation's claims into one.
-	///
-	/// The result is a single multilinear evaluation claim on the witness, reached in five
-	/// prover phases.
-	/// A shifted value index names two shifts applied in sequence, and the reduction peels
-	/// them off from the output end inward:
-	///
-	/// 1. bind the outer shift slot, then the inner one, then the bit position within a word;
-	/// 2. bind the bit index of the intermediate word, where the two shift indicators meet;
-	/// 3. bind the output bit index the reduction's first factor attaches to;
-	/// 4. reduce what is left to a witness evaluation, against the constraint-matrix multilinear.
-	///
-	/// # Arguments
-	///
-	/// - `key_collection`: the prover's key collection for the constraint system.
-	/// - `public_words`: the constants followed by the inout values, as the circuit declares them.
-	/// - `hidden_words`: the private values, as the circuit declares them.
-	/// - `claims`: the operand evaluation claim of each operation.
-	/// - `domain_subspace`: the univariate evaluation domain.
-	///
-	/// # Returns
-	///
-	/// The final challenges with the witness evaluation, and the wiring multilinear's
-	/// evaluation for the caller to send.
-	pub fn prove(
-		&mut self,
-		key_collection: &KeyCollection,
-		public_words: &[Word],
-		hidden_words: &[Word],
-		claims: OperatorClaims<F>,
-		domain_subspace: &BinarySubspace<F>,
-	) -> ShiftOutput<F> {
-		// The segments are passed as the circuit declares them, at whatever length that is.
-		// Neither phase needs them padded.
-		let words = SegmentWords {
-			public: public_words,
-			hidden: hidden_words,
-		};
+	// The segments are passed as the circuit declares them, at whatever length that is.
+	// Neither phase needs them padded.
+	let words = SegmentWords {
+		public: public_words,
+		hidden: hidden_words,
+	};
 
-		// One batching coefficient per operation, expanded along with its constraint point.
-		// SOUNDNESS: this must draw in the same order the verifier draws in.
-		let prepared = {
-			let _scope = tracing::debug_span!("Expand tensor queries").entered();
-			claims.prepare(|| self.channel.sample())
-		};
+	// One batching coefficient per operation, expanded along with its constraint point.
+	// SOUNDNESS: this must draw in the same order the verifier draws in.
+	let prepared = {
+		let _scope = tracing::debug_span!("Expand tensor queries").entered();
+		claims.prepare(|| channel.sample())
+	};
 
-		// The weights the reduction's first factor carries, one per bit position.
-		// Phase 1 and phase 3 both need them, so they are computed once here, drawn from the
-		// BitAnd claim.
-		let oblong_weights = domain_subspace.lagrange_evals_buffer(prepared.bitand.r_zhat_prime);
+	// The weights the reduction's first factor carries, one per bit position.
+	// Phase 1 and phase 3 both need them, so they are computed once here.
+	// All four operations share `r_zhat_prime`, so it is drawn from the BitAnd claim.
+	let oblong_weights = domain_subspace.lagrange_evals_buffer(prepared.bitand.r_zhat_prime);
 
-		// Phase 1: bind the shift variant, the shift amount, and the bit position.
-		let phase_1_output = self.phase1(key_collection, words, &prepared, oblong_weights.as_ref());
+	// Phase 1: bind the shift variant, the shift amount, and the bit position.
+	let phase_1_output = prove_phase_1::<_, P, _, _>(
+		key_collection,
+		words,
+		&prepared,
+		oblong_weights.as_ref(),
+		channel,
+		alloc,
+	);
 
-		// Phases 2 and 3 bind the two bit indices the shift indicators chain through: first
-		// the intermediate word's, then the reduction's first-factor output bit.
-		//
-		// Phase 2 runs against phase 1's leftover weights, carrying phase 1's evaluation as a
-		// constant.
-		let inner = ShiftIndSumcheck::<P, _>::new(
-			self.alloc,
-			&phase_1_output.psi,
-			&ShiftChallengePoint::new(&phase_1_output.r_j, &phase_1_output.inner),
-			phase_1_output.g_eval,
-		);
-		debug_assert_eq!(inner.beta(), phase_1_output.gamma);
-		let inner_output = inner.prove(self.channel, self.alloc);
+	// Phases 2 and 3 bind the two bit indices the shift indicators chain through.
+	// Phase 2 takes the intermediate word's, phase 3 the reduction's first-factor output bit.
+	//
+	// Phase 2 runs against phase 1's leftover weights, carrying its evaluation as a constant.
+	let inner = ShiftIndSumcheck::<P, _>::new(
+		alloc,
+		&phase_1_output.psi,
+		&ShiftChallengePoint::new(&phase_1_output.r_j, &phase_1_output.inner),
+		phase_1_output.g_eval,
+	);
+	debug_assert_eq!(inner.beta(), phase_1_output.gamma);
+	let inner_output = inner.prove(channel, alloc);
 
-		// Phase 3 runs against the reduction's first-factor weights, carrying what phase 2
-		// fixed.
-		// Its own weights evaluate to a factor the verifier recomputes independently, so no
-		// division is needed between phases.
-		let outer = ShiftIndSumcheck::<P, _>::new(
-			self.alloc,
-			oblong_weights.as_ref(),
-			&ShiftChallengePoint::new(&inner_output.point, &phase_1_output.outer),
-			inner_output.ind_eval * phase_1_output.g_eval,
-		);
-		debug_assert_eq!(outer.beta(), inner_output.eval);
-		let outer_output = outer.prove(self.channel, self.alloc);
+	// Phase 3 runs against the reduction's first-factor weights, carrying what phase 2 fixed.
+	// Its own weights evaluate to a factor the verifier recomputes independently.
+	// So no division is needed between phases.
+	let outer = ShiftIndSumcheck::<P, _>::new(
+		alloc,
+		oblong_weights.as_ref(),
+		&ShiftChallengePoint::new(&inner_output.point, &phase_1_output.outer),
+		inner_output.ind_eval * phase_1_output.g_eval,
+	);
+	debug_assert_eq!(outer.beta(), inner_output.eval);
+	let outer_output = outer.prove(channel, alloc);
 
-		// Phase 4 reduces to the final challenges and witness evaluation, against the
-		// constraint-matrix multilinear scaled by the three bit-index factors above.
-		self.phase2(
-			key_collection,
-			words,
-			&prepared,
-			phase_1_output,
-			outer_output.weights_eval * outer_output.ind_eval * inner_output.ind_eval,
-			outer_output.eval,
-		)
-	}
-
-	/// Proves the first phase of the shift reduction.
-	///
-	/// Builds the witness-and-batching multilinear for both segments, concatenates their
-	/// rows, and runs one sumcheck over their product with a weight table that is never
-	/// formed as a table.
-	///
-	/// # Arguments
-	///
-	/// - `oblong_weights`: the weights of the reduction's first factor, one per bit position,
-	///   pushed through both shift slots to build the weight table this phase's sumcheck runs
-	///   against.
-	#[instrument(skip_all, name = "prover_phase_1")]
-	fn phase1(
-		&mut self,
-		key_collection: &KeyCollection,
-		words: SegmentWords<'_>,
-		prepared: &PreparedOperatorClaims<F>,
-		oblong_weights: &[F],
-	) -> Phase1Output<F> {
-		// Accumulate the witness-and-batching rows of the public and hidden segments
-		// separately.
-		// The public words are the prefix of the value vector, and each segment's key ranges
-		// are relative to its own segment.
-		let public = key_collection
-			.public
-			.build_g::<_, P>(words.public, prepared);
-		let hidden = key_collection
-			.hidden
-			.build_g::<_, P>(words.hidden, prepared);
-		let g = SparseShiftRows::from_segments([
-			(&public, &key_collection.public.dense_shift_enc),
-			(&hidden, &key_collection.hidden.dense_shift_enc),
-		]);
-
-		g.run_phase_1_sumcheck(oblong_weights, prepared.batched_eval(), self.channel, self.alloc)
-	}
-
-	/// Proves the second phase of the shift protocol reduction.
-	///
-	/// Folds the value-vector words by the bit-position challenge, builds the
-	/// constraint-matrix multilinear's two segments, and runs a sumcheck between them with a
-	/// sparse first round over the segment selector.
-	///
-	/// # Arguments
-	///
-	/// - `key_collection`: the prover's key collection for the constraint system.
-	/// - `words`: the value-vector words.
-	/// - `prepared`: the prepared claim of each operation, indexed by the operation a key names.
-	/// - `phase_1_output`: the challenges and evaluation the first phase produced.
-	/// - `shift_ind_eval`: the scalar weighting every shift key, the product of the two indicator
-	///   evaluations the earlier bit-index phases reduced to.
-	/// - `epsilon`: the claim this phase's rounds prove.
-	///
-	/// # Returns
-	///
-	/// The combined challenges with the witness evaluation, and the wiring multilinear's
-	/// evaluation.
-	#[instrument(skip_all, name = "prove_phase_2")]
-	fn phase2(
-		&mut self,
-		key_collection: &KeyCollection,
-		words: SegmentWords<'_>,
-		prepared: &PreparedOperatorClaims<F>,
-		phase_1_output: Phase1Output<F>,
-		shift_ind_eval: F,
-		epsilon: F,
-	) -> ShiftOutput<F> {
-		let Phase1Output {
-			r_j,
-			inner,
-			outer,
-			psi: _,
-			gamma: _,
-			g_eval: _,
-		} = phase_1_output;
-
-		let r_j_tensor = Hypercube::One.expand(&r_j).build::<F>();
-
-		// Fold each segment separately.
-		// The combined witness is never materialized: each fold is zero-padded to enough
-		// variables to cover its own segment's length.
-		// Both columns fold against the same round tensor, so the tables are built once.
-		let folder = BitAxisFolder::new(r_j_tensor.as_ref());
-		let public_folded = folder.fold::<P, _>(self.alloc, words.public);
-		let hidden_folded = folder.fold::<P, _>(self.alloc, words.hidden);
-
-		let (public_monster, hidden_monster) = key_collection.build_monster_segments(
-			self.alloc,
-			prepared,
-			shift_ind_eval,
-			&inner,
-			&outer,
-		);
-
-		// Both halves of the sumcheck share one word-index space, spanning the wider of the
-		// two segments.
-		// The hidden segment is normally wider, but a system with more public words than
-		// private values inverts that, so the hidden half is zero-extended to match.
-		let log_segment_words = max(public_folded.log_len(), hidden_folded.log_len());
-		let hidden_folded = hidden_folded.zero_extend_in(self.alloc, log_segment_words);
-		let hidden_monster = hidden_monster.zero_extend_in(self.alloc, log_segment_words);
-
-		run_sumcheck(
-			&public_folded,
-			hidden_folded,
-			&public_monster,
-			hidden_monster,
-			shift_ind_eval,
-			words.public,
-			r_j,
-			epsilon,
-			self.channel,
-			self.alloc,
-		)
-	}
+	// Phase 4 reduces to the final challenges and witness evaluation.
+	// It runs against the constraint-matrix multilinear, scaled by the three factors above.
+	prove_phase_2::<_, P, _, _>(
+		key_collection,
+		words,
+		&prepared,
+		phase_1_output,
+		outer_output.weights_eval * outer_output.ind_eval * inner_output.ind_eval,
+		outer_output.eval,
+		channel,
+		alloc,
+	)
 }

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -38,7 +38,7 @@ use crate::{
 	pcs_compiler::PcsProverCompiler,
 	protocols::{
 		binmul, intmul,
-		shift::{KeyCollection, OperatorClaims, OperatorData, ShiftOutput, ShiftProver},
+		shift::{self, KeyCollection, OperatorClaims, OperatorData, ShiftOutput},
 	},
 	ring_switch,
 };
@@ -289,7 +289,7 @@ impl IOPProver {
 				eval: _,
 			},
 			wiring_eval,
-		} = ShiftProver::<_, P, _>::new(&mut *channel, alloc).prove(
+		} = shift::prove::<_, P, _, _>(
 			&self.key_collection,
 			witness.public(),
 			witness.non_public(),
@@ -300,6 +300,8 @@ impl IOPProver {
 				binmul: binmul_claim,
 			},
 			&subspace,
+			&mut *channel,
+			alloc,
 		);
 		drop(shift_guard);
 

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -22,7 +22,7 @@ use binius_math::{
 };
 use binius_prover::{
 	fold_word::BitAxisFolder,
-	protocols::shift::{KeyCollection, OperatorClaims, OperatorData, ShiftProver},
+	protocols::shift::{self, KeyCollection, OperatorClaims, OperatorData},
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -448,19 +448,20 @@ fn test_shift_prove_and_verify() {
 			r_x_prime: r_x_prime_binmul.clone(),
 		};
 
-		let prover_output = ShiftProver::<_, P, _>::new(&mut prover_transcript, &GlobalAllocator)
-			.prove(
-				&key_collection,
-				value_vec.public(),
-				value_vec.non_public(),
-				OperatorClaims {
-					zero: prover_zero_data.clone(),
-					bitand: prover_bitand_data.clone(),
-					intmul: prover_intmul_data.clone(),
-					binmul: prover_binmul_data.clone(),
-				},
-				&subspace,
-			);
+		let prover_output = shift::prove::<_, P, _, _>(
+			&key_collection,
+			value_vec.public(),
+			value_vec.non_public(),
+			OperatorClaims {
+				zero: prover_zero_data.clone(),
+				bitand: prover_bitand_data.clone(),
+				intmul: prover_intmul_data.clone(),
+				binmul: prover_binmul_data.clone(),
+			},
+			&subspace,
+			&mut prover_transcript,
+			&GlobalAllocator,
+		);
 
 		// The full reduction sends this after the public segment's evaluation claim; driving the
 		// shift alone, it follows the reduction directly.


### PR DESCRIPTION
@jimpo Reverting #2233 as you preferred.

### In one line

`ShiftProver` goes away, `prove` is a free function again, and the two phase functions go back to the files named after them.

### The struct earned nothing

You put it exactly right: one function was ever called on it. `ShiftProver` held two fields — a channel and an allocator — and a `PhantomData<P>` to pin a type parameter the fields did not mention. That last part is the tell. A struct that needs a marker field to carry its own generics is not modelling anything; it is a parameter list wearing a hat.

The call sites paid for it too. Because `P` could not be inferred from either field, every caller needed a turbofish just to name the packed field:

```rust
- ShiftProver::<_, P, _>::new(&mut channel, alloc).prove(&keys, public, hidden, claims, &subspace)
+ shift::prove::<_, P, _, _>(&keys, public, hidden, claims, &subspace, &mut channel, alloc)
```

Same width, one fewer concept.

### The phase functions go home

`prove_phase_1` and `prove_phase_2` had become private `phase1`/`phase2` methods in `prove.rs`, which pulled both phases' bodies out of `phase_1.rs` and `phase_2.rs`. They are free functions in those files again, each sitting next to the helpers it calls — `prove_phase_1` beside `SparseShiftRows`, `prove_phase_2` beside `run_sumcheck`.

That is the part of the revert I would argue for on its own merits, separately from the struct. `prove.rs` drops from 365 lines to 225 and reads as what it is: a driver that calls four phases in order.

### What is not reverted, and why

Two methods on `SparseShiftRows` stay methods:

```rust
g.run_phase_1_sumcheck(oblong_weights, sum, channel, alloc)
g.round_coeffs(h, claim)
```

`SparseShiftRows` is a genuine data structure — a sparse row list with an index vector, a value vector, and a row count — carrying nine methods including `from_segments`, `fold`, `rows`, and `into_bit_multilinear`. Both of the above already took it as their first argument by value or by reference. So these are methods on the data, not on a bag of parameters, which is the distinction your comment draws. Say the word if you want them free too and I will fold that in.

The doc comments from #2233 are also kept. They were rewritten to the house style in that PR and none of that depended on the struct.

### On IntMul

You mentioned you would prefer `IntMulProver` as standalone functions as well. That is a separate crate-local refactor with its own five phases and its own callers, so I have left it out of this PR rather than widen a revert into a second rewrite. Happy to do it next if you want it — just say so and I will open it against a clean `main`.

### Scope

- **deleted:** `ShiftProver`, its `new`, its `PhantomData`, and the `pub use` of it
- **restored:** `shift::prove`, `phase_1::prove_phase_1`, `phase_2::prove_phase_2` as free functions
- **changed:** four call sites — `prover/src/prove.rs`, `prover/tests/shift.rs`, and two in `prover/benches/shift_reduction.rs`
- **untouched:** `m4-prover`, which imports the phase helpers directly and needed no change; every phase's arithmetic, Fiat-Shamir draw order, and transcript write

Pure refactor, no behaviour change. Net 279 in, 265 out, and `prove.rs` 140 lines shorter.

### Verification

Run against a clean `main` in an isolated worktree.

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy -p binius-prover -p binius-m4-prover --all-targets --all-features -- -D warnings` — clean
- `cargo test -p binius-prover` — pass, including the `shift` integration test that drives the reduction end to end against the verifier
- `cargo test -p binius-m4-prover` — pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
