### PR TITLE
BINIUS-550: Sum Ligerito's soundness errors instead of taking the worst level

### DIFF
--- a/crates/iop/src/ligerito/common.rs
+++ b/crates/iop/src/ligerito/common.rs
@@ -1,13 +1,16 @@
 // Copyright 2026 The Binius Developers
 
+use std::iter::zip;
+
 use binius_field::BinaryField;
+use binius_transcript::fiat_shamir::MAX_SAMPLE_BITS;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use getset::CopyGetters;
 
 use super::{size_estimation, verifier_cost, verifier_cost::VerifierCost};
 use crate::{
 	merkle_tree::MerkleTreeScheme,
-	soundness::{Grinding, SoundnessRegime},
+	soundness::{Grinding, SoundnessRegime, ratio_bits, union_bits},
 };
 
 /// One committed level of the Ligerito recursion.
@@ -81,6 +84,40 @@ impl LigeritoLevel {
 		self.n_queries <= pow2_saturating(self.log_codeword_len())
 	}
 
+	/// Whether every codeword position this level holds can be drawn as a query.
+	///
+	/// A query position takes [`LigeritoLevel::log_codeword_len`] sampled bits to address.
+	/// One draw carries at most [`MAX_SAMPLE_BITS`] of them, and clamps rather than refusing.
+	/// A longer codeword would then have a tail no query reaches, free for a prover to corrupt.
+	pub const fn is_addressable(&self) -> bool {
+		self.log_codeword_len() <= MAX_SAMPLE_BITS
+	}
+
+	/// The Schwartz-Zippel error of this level's fold rounds, in bits.
+	///
+	/// Each of the `log_lanes` rounds sends a round polynomial of degree 2 in its challenge.
+	/// A wrong polynomial passes if the sampled challenge is one of its at most 2 agreements.
+	/// So the rounds together cost `2 * log_lanes / |F|`, which is [NA25] (17)'s `2 k_{i-1}/|F|`.
+	///
+	/// [NA25]: <https://eprint.iacr.org/2025/1187>
+	fn fold_round_bits(&self, log_field_size: usize) -> f64 {
+		ratio_bits(2.0 * self.log_lanes as f64, log_field_size)
+	}
+
+	/// The error of folding this level's row claims into the running sumcheck, in bits.
+	///
+	/// The `n_queries` opened rows are batched by the powers of one challenge.
+	/// One more challenge glues the result to the running claim.
+	/// That is [NA25] (17)'s `(|S_i| + 1)/|F|`.
+	///
+	/// The last level glues nothing, since its row claim is checked against the residual directly.
+	/// Charging it anyway costs a fraction of a bit and keeps one expression for every level.
+	///
+	/// [NA25]: <https://eprint.iacr.org/2025/1187>
+	fn row_batching_bits(&self, log_field_size: usize) -> f64 {
+		ratio_bits(self.n_queries as f64 + 1.0, log_field_size)
+	}
+
 	/// Proof-of-work nonces this level writes, at the given grinding depth.
 	///
 	/// One stands before each of the `log_lanes` fold challenges.
@@ -111,6 +148,7 @@ impl LigeritoLevel {
 /// - Column counts chain: `cols_{i+1} + lanes_{i+1} == cols_i`.
 /// - The rate falls down the ladder: `inv_rate_{i+1} > inv_rate_i`.
 /// - Every level is feasible: `2^(cols_i + inv_rate_i) >= queries_i`.
+/// - Every level is addressable: `cols_i + inv_rate_i <= MAX_SAMPLE_BITS`.
 ///
 /// And derives, rather than taking on faith:
 ///
@@ -181,6 +219,15 @@ impl LigeritoParams {
 				"precondition: level {i} is infeasible, it opens {} queries against a codeword of \
 				 2^{} positions",
 				level.n_queries,
+				level.log_codeword_len(),
+			);
+
+			// Invariant: a query draw wider than this is clamped, leaving the codeword's tail
+			// unreachable and so unchecked.
+			assert!(
+				level.is_addressable(),
+				"precondition: level {i} has 2^{} codeword positions, past the 2^{MAX_SAMPLE_BITS} \
+				 a query draw can address",
 				level.log_codeword_len(),
 			);
 		}
@@ -272,9 +319,9 @@ impl LigeritoParams {
 
 	/// The ceiling the correlated-agreement term puts on this ladder, over a field of that size.
 	///
-	/// Every level is an independent proximity test, so the ladder is only as sound as its worst
-	/// one.
-	/// That is normally level 0, whose codeword is the longest.
+	/// Every level is an independent proximity test, and beating any one of them is enough.
+	/// So the levels' errors add, and the ladder lands below even its weakest level.
+	/// That weakest level is normally level 0, whose codeword is the longest.
 	///
 	/// No number of queries raises this.
 	/// See [`crate::soundness`] for why, and `PROXIMITY_GAPS.md` for where it falls in practice.
@@ -312,59 +359,99 @@ impl LigeritoParams {
 	) -> f64 {
 		assert!(n_oracles > 0, "precondition: a ladder opens at least one message");
 
-		let log_n_oracles = log2_ceil_usize(n_oracles);
-		self.levels
-			.iter()
-			.enumerate()
-			.map(|(i, level)| {
-				let base = self.regime.correlated_agreement_bits(
-					level.log_msg_len(),
-					level.log_inv_rate,
-					log_field_size,
-				);
-				// Level 0 folds the lane index and the message index together.
-				let log_rows = level.log_lanes + if i == 0 { log_n_oracles } else { 0 };
-				// The worst of those fold rounds pays `2^(log_rows - 1)`.
-				base - (log_rows.saturating_sub(1)) as f64
-			})
-			.fold(f64::INFINITY, f64::min)
+		union_bits(self.per_level_correlated_agreement_bits(log_field_size, n_oracles))
 	}
 
-	/// The security this ladder reaches over a field of that size, counting both terms.
+	/// Each level's correlated-agreement term, in ladder order, before any union.
 	///
-	/// This is the worse of [`Self::correlated_agreement_bits`] and the query-phase soundness.
-	/// Each of the two is credited with the half of [`Self::grinding`] that buys it.
-	/// It can fall below [`Self::security_bits`], which is the *target* the queries were sized to.
+	/// ## Preconditions
 	///
-	/// A level grinds before every fold challenge.
-	/// So every level's algebraic term gains the same [`Grinding::challenge_bits`].
-	/// A level grinds once more before its queries are drawn.
-	/// That is where [`Grinding::query_bits`] lands.
+	/// * `n_oracles` is positive.
+	fn per_level_correlated_agreement_bits(
+		&self,
+		log_field_size: usize,
+		n_oracles: usize,
+	) -> impl Iterator<Item = f64> + '_ {
+		let log_n_oracles = log2_ceil_usize(n_oracles);
+		self.levels.iter().enumerate().map(move |(i, level)| {
+			let base = self.regime.correlated_agreement_bits(
+				level.log_msg_len(),
+				level.log_inv_rate,
+				log_field_size,
+			);
+			// Level 0 folds the lane index and the message index together.
+			let log_rows = level.log_lanes + if i == 0 { log_n_oracles } else { 0 };
+			// The worst of those fold rounds pays `2^(log_rows - 1)`.
+			base - (log_rows.saturating_sub(1)) as f64
+		})
+	}
+
+	/// The security this ladder reaches over a field of that size, counting every term.
+	///
+	/// A cheating prover needs only one term of one level to break, so all of them add.
+	/// [`crate::soundness::union_bits`] does the adding, over four terms per level:
+	///
+	/// ```text
+	///     algebra   correlated agreement, per Self::correlated_agreement_bits
+	///     queries   the rows this level opens
+	///     folds     the level's sumcheck rounds, 2 * log_lanes / |F|
+	///     rows      batching the opened rows and gluing them in, (n_queries + 1) / |F|
+	/// ```
+	///
+	/// The last two are [NA25] (17)'s per-level terms.
+	/// Both sit near `|F|` and move the total by a fraction of a bit, but they belong in the sum.
+	///
+	/// Each of the first two is credited with the half of [`Self::grinding`] that buys it.
+	/// A level grinds before each fold challenge, so its algebra gains the challenge half.
+	/// It grinds once more before its queries, which is where the query half lands.
+	///
+	/// The result can fall below [`Self::security_bits`], which is a target rather than a promise.
+	///
+	/// One term of (17) is missing, because it is not a property of the ladder.
+	/// Folding a channel's `k` relations by the powers of one coefficient costs `(k - 1)/|F|`.
+	/// The caller fixes `k` at proving time, so nothing here can see it.
+	///
+	/// [NA25]: <https://eprint.iacr.org/2025/1187>
 	pub fn achieved_security_bits(&self, log_field_size: usize) -> f64 {
 		self.batched_achieved_security_bits(log_field_size, 1)
 	}
 
 	/// The same figure when level 0 opens `n_oracles` separately committed messages at once.
 	///
-	/// Only the correlated-agreement half moves.
-	/// The query counts are per level, and one query position serves every message.
-	/// So opening more messages changes nothing about how many rows are checked.
+	/// Two things move.
+	/// The correlated-agreement half pays level 0's wider row union.
+	/// And combining the messages draws `ceil(log2 n_oracles)` challenges of its own.
+	/// That adds one tensor-batching term to the sum, per [DP24].
+	///
+	/// The query counts do not move.
+	/// They are per level, and one query position serves every message at once.
 	///
 	/// ## Preconditions
 	///
 	/// * `n_oracles` is positive.
+	///
+	/// [DP24]: <https://eprint.iacr.org/2024/504>
 	pub fn batched_achieved_security_bits(&self, log_field_size: usize, n_oracles: usize) -> f64 {
-		let algebra = self.batched_correlated_agreement_bits(log_field_size, n_oracles)
-			+ self.grinding.challenge_bits() as f64;
-		// The same grind stands before every level's queries, so crediting it to the worst level
-		// is crediting it to all of them.
-		let queries = self
-			.levels
-			.iter()
-			.map(|level| level.n_queries as f64 * self.regime.bits_per_query(level.log_inv_rate))
-			.fold(f64::INFINITY, f64::min)
-			+ self.grinding.query_bits() as f64;
-		algebra.min(queries)
+		let per_level =
+			zip(self.per_level_correlated_agreement_bits(log_field_size, n_oracles), &self.levels)
+				.map(|(agreement, level)| {
+					let algebra = agreement + self.grinding.challenge_bits() as f64;
+					// One grind stands before every level's queries, so every level is credited it.
+					let queries = (level.n_queries as f64).mul_add(
+						self.regime.bits_per_query(level.log_inv_rate),
+						self.grinding.query_bits() as f64,
+					);
+					union_bits([
+						algebra,
+						queries,
+						level.fold_round_bits(log_field_size),
+						level.row_batching_bits(log_field_size),
+					])
+				});
+
+		// One tensor over the message index, drawn once for the whole batch rather than per level.
+		let batching = ratio_bits(log2_ceil_usize(n_oracles) as f64, log_field_size);
+		union_bits(per_level.chain([batching]))
 	}
 
 	/// The exact byte-size of a Ligerito proof over one committed message, without running it.
@@ -472,7 +559,7 @@ mod tests {
 
 	// A three-level ladder that satisfies every invariant, used as the base for the rejection
 	// tests below. Message 2^12, lanes 3/2/1, rates 1/2 -> 1/4 -> 1/8, residual 2^6.
-	fn valid_levels() -> Vec<LigeritoLevel> {
+	pub(super) fn valid_levels() -> Vec<LigeritoLevel> {
 		vec![
 			LigeritoLevel::new(9, 3, 1, SoundnessRegime::UniqueDecoding, 100, Grinding::NONE),
 			LigeritoLevel::new(7, 2, 2, SoundnessRegime::UniqueDecoding, 100, Grinding::NONE),
@@ -620,15 +707,17 @@ mod tests {
 		let query_ground = bare.clone().with_grinding(Grinding::new(0, 7));
 		assert!((query_ground.correlated_agreement_bits(128) - ceiling).abs() < 1e-9);
 
-		// What moves is the total, by exactly the bits ground, since the row term binds.
+		// What moves is the total, by very nearly the bits ground, since the row term binds.
+		// It is not the full seven: the slacker term's error stays where it was, and the union
+		// still carries it.
 		let ground_bits = query_ground.achieved_security_bits(128);
-		assert!((ground_bits - base - 7.0).abs() < 1e-9, "{ground_bits} {base}");
+		assert!((6.9..=7.0).contains(&(ground_bits - base)), "{ground_bits} {base}");
 		assert!(ground_bits < ceiling, "the row term still binds after the grind");
 
-		// The same depth on the other side buys nothing here, because it lands on the term that
-		// was already the slacker of the two.
+		// The same depth on the other side buys almost nothing here, because it lands on the term
+		// that was already the slacker of the two.
 		let challenge_ground = bare.with_grinding(Grinding::new(7, 0));
-		assert!((challenge_ground.achieved_security_bits(128) - base).abs() < 1e-9);
+		assert!(challenge_ground.achieved_security_bits(128) - base < 0.01);
 	}
 
 	#[test]
@@ -680,12 +769,19 @@ mod tests {
 		//     1 message  -> 2^3 rows folded -> union 2^2
 		//     4 messages -> 2^5 rows folded -> union 2^4, two bits worse
 		//     5 messages -> 2^6 rows folded -> union 2^5, three bits worse
-		assert_eq!(params.batched_correlated_agreement_bits(128, 4), alone - 2.0);
-		assert_eq!(params.batched_correlated_agreement_bits(128, 5), alone - 3.0);
+		//
+		// The ladder's figure moves by less than level 0 does, and that is the point of summing:
+		// the deeper levels do not pay the batch, and their unmoved errors cushion the total.
+		let four = params.batched_correlated_agreement_bits(128, 4);
+		let five = params.batched_correlated_agreement_bits(128, 5);
+		assert!((alone - 2.0..alone).contains(&four), "{four} against {alone}");
+		assert!((alone - 3.0..four).contains(&five), "{five} against {four}");
 
-		// The queries are unchanged, since one position serves every message.
+		// The queries are unchanged, since one position serves every message. They bind here, so
+		// the total does not move at all.
 		let queries = params.achieved_security_bits(128);
-		assert_eq!(params.batched_achieved_security_bits(128, 4), queries.min(alone - 2.0));
+		assert!(queries < four);
+		assert!((params.batched_achieved_security_bits(128, 4) - queries).abs() < 0.01);
 	}
 
 	#[test]
@@ -707,28 +803,6 @@ mod tests {
 		level.n_queries = 513;
 		assert!(!level.is_feasible());
 	}
-	#[test]
-	fn scratch_grind_offsets_batching() {
-		use binius_field::Ghash128b as B128;
-
-		use crate::merkle_tree::BinaryMerkleTreeScheme;
-		let scheme = BinaryMerkleTreeScheme::<B128, binius_hash::StdHashSuite>::new();
-		let (regime, _) =
-			SoundnessRegime::optimal_unique_decoding(120, 24, 1, 128).expect("reachable");
-		let (params, _) =
-			LigeritoParams::optimal_ladder::<B128, _>(&scheme, 24, 1, regime, 120, Grinding::NONE)
-				.expect("feasible");
-		for bits in [0usize, 1, 2, 3] {
-			let g = params.clone().with_grinding(Grinding::new(bits, 0));
-			println!(
-				"INT grind={bits} k=1 {:.2} k=2 {:.2} k=4 {:.2} k=8 {:.2}",
-				g.batched_achieved_security_bits(128, 1),
-				g.batched_achieved_security_bits(128, 2),
-				g.batched_achieved_security_bits(128, 4),
-				g.batched_achieved_security_bits(128, 8),
-			);
-		}
-	}
 
 	/// Challenge grinding buys back exactly what batching costs.
 	///
@@ -738,32 +812,32 @@ mod tests {
 	/// So a caller who wants both can price them against each other.
 	#[test]
 	fn a_challenge_grind_buys_back_what_batching_costs() {
-		use binius_field::Ghash128b as B128;
-		use binius_hash::StdHashSuite;
+		// Fixture state: the ladder above, opening enough rows that the query term cannot bind.
+		// What is left binding is the ceiling, and the ceiling is the only term batching moves.
+		// At a query count where the rows bind instead, neither lever shows at all.
+		let levels = valid_levels()
+			.into_iter()
+			.map(|level| LigeritoLevel {
+				n_queries: 400,
+				..level
+			})
+			.collect();
+		let params = LigeritoParams::new(levels, SoundnessRegime::UniqueDecoding, 100);
+		let alone = params.achieved_security_bits(128);
 
-		use crate::merkle_tree::BinaryMerkleTreeScheme;
-
-		// Fixture state: a 2^24 message at 120 bits over B128, where the ceiling binds. At the
-		// shipped 96-bit target the query term binds instead and neither lever shows at all.
-		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
-		let (regime, _) = SoundnessRegime::optimal_unique_decoding(120, 24, 1, 128)
-			.expect("120 bits is reachable with a constant loss");
-		let (params, _) =
-			LigeritoParams::optimal_ladder::<B128, _>(&scheme, 24, 1, regime, 120, Grinding::NONE)
-				.expect("a 120-bit ladder exists for one message");
-
-		for log_k in 0..4 {
+		for log_k in 1..4 {
 			let k = 1usize << log_k;
-			// Unground, each doubling of the oracle count takes one bit off the target.
+			// Each doubling of the oracle count widens level 0's row union by one more bit.
 			let unground = params.batched_achieved_security_bits(128, k);
-			assert!(unground < 120.0 || k == 1, "k={k} kept {unground:.2}");
+			assert!(unground < alone, "k={k} kept {unground:.2}");
 
-			// Ground by that many bits, the batch reaches the target again.
+			// Grinding the challenge side by that many bits buys the loss back, because both the
+			// loss and the grind land on the same term.
 			let ground = params
 				.clone()
 				.with_grinding(Grinding::new(log_k, 0))
 				.batched_achieved_security_bits(128, k);
-			assert!(ground >= 120.0, "k={k} ground to {ground:.2}");
+			assert!(ground >= alone, "k={k} ground to {ground:.2} against {alone:.2}");
 		}
 	}
 }

--- a/crates/iop/src/ligerito/compiler.rs
+++ b/crates/iop/src/ligerito/compiler.rs
@@ -336,12 +336,21 @@ mod tests {
 		let scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
 		let (regime, _) = SoundnessRegime::optimal_unique_decoding(120, 24, 1, 128)
 			.expect("120 bits is reachable with a constant loss");
-		let (params, _) =
-			LigeritoParams::optimal_ladder::<B128, _>(&scheme, 24, 1, regime, 120, Grinding::NONE)
-				.expect("a 120-bit ladder exists for one message");
+		// The target sits just under this regime's ceiling, so the ceiling is what binds and the
+		// batch's wider row union is visible in the total. At the shipped 96-bit target the rows
+		// bind instead, and batching costs nothing worth refusing.
+		let (params, _) = LigeritoParams::optimal_ladder::<B128, _>(
+			&scheme,
+			24,
+			1,
+			regime,
+			119,
+			Grinding::new(2, 0),
+		)
+		.expect("a 119-bit ladder exists for one message");
 
-		// One oracle clears 120, so the shortfall below is caused by the batch and nothing else.
-		assert!(params.achieved_security_bits(128) >= 120.0);
+		// One oracle clears 119, so the shortfall below is caused by the batch and nothing else.
+		assert!(params.achieved_security_bits(128) >= 119.0);
 
 		let spec = OracleSpec::new(params.log_msg_len());
 		LigeritoVerifierCompiler::<B128>::new(vec![spec, spec], params);

--- a/crates/iop/src/ligerito/size_estimation.rs
+++ b/crates/iop/src/ligerito/size_estimation.rs
@@ -167,6 +167,19 @@ const fn residual_size(log_residual_dim: usize, sizes: &ByteSizes) -> usize {
 	sizes.digest + (1 << log_residual_dim) * sizes.value
 }
 
+/// What one search run aims at.
+///
+/// The two figures differ because a ladder's soundness error is the sum of its levels'.
+/// So each level has to clear more than the ladder is asked for.
+/// How much more depends on how many levels there turn out to be.
+#[derive(Debug, Clone, Copy)]
+struct Targets {
+	/// The soundness the finished ladder must reach, and what it is tagged with.
+	security_bits: usize,
+	/// The raised figure each individual level is sized against.
+	per_level_bits: usize,
+}
+
 /// Everything the ladder search needs that does not vary between subproblems.
 struct Search<'a, F, MerkleScheme> {
 	/// The Merkle scheme whose branch sizes price every level.
@@ -177,8 +190,8 @@ struct Search<'a, F, MerkleScheme> {
 	n_queries: Vec<usize>,
 	/// The regime the query counts and the soundness ceiling are derived in.
 	regime: SoundnessRegime,
-	/// The target every level must reach, in bits.
-	security_bits: usize,
+	/// What this run aims at, per level and overall.
+	targets: Targets,
 	/// The proof of work every level pays, which both terms of the target are credited with.
 	grinding: Grinding,
 	/// Ties `F` to the Merkle scheme without storing a value of it.
@@ -190,10 +203,11 @@ where
 	F: BinaryField,
 	MerkleScheme: MerkleTreeScheme<F>,
 {
-	/// Whether a level can reach [`Self::security_bits`] at all.
+	/// Whether a level can reach [`Targets::per_level_bits`] at all.
 	///
-	/// Two independent ways to fail, and neither is fixable by opening more rows.
-	/// A level cannot sample more distinct positions than its codeword has.
+	/// Three independent ways to fail, and none is fixable by opening more rows.
+	/// A level cannot open more rows than its codeword has positions.
+	/// Nor can it hold more positions than a single query draw can address.
 	/// And its correlated-agreement term is a ceiling set by the codeword length and the field.
 	/// Proof of work raises that ceiling, which is why the challenge grind is credited here.
 	fn reaches_target(&self, level: &LigeritoLevel) -> bool {
@@ -209,7 +223,9 @@ where
 		// adds it, so a level priced here is a level that really reaches the target.
 		let algebra = base - (level.log_lanes.saturating_sub(1)) as f64
 			+ self.grinding.challenge_bits() as f64;
-		level.is_feasible() && algebra >= self.security_bits as f64
+		level.is_feasible()
+			&& level.is_addressable()
+			&& algebra >= self.targets.per_level_bits as f64
 	}
 
 	/// The best level to commit next, given `log_total` message elements left and a rate floor.
@@ -346,18 +362,86 @@ where
 	F: BinaryField,
 	MerkleScheme: MerkleTreeScheme<F>,
 {
-	assert!(
-		(1..=MAX_LOG_INV_RATE).contains(&l0_log_inv_rate),
-		"precondition: l0_log_inv_rate must be in 1..={MAX_LOG_INV_RATE}, got {l0_log_inv_rate}"
-	);
 	assert!(security_bits > 0, "precondition: security_bits must be positive");
+
+	// Two knobs, because the byte-optimal ladder *at* a per-level target is not the byte-optimal
+	// ladder that *reaches* the target once its levels are summed.
+	//
+	// Headroom raises what each level must clear. A rate ceiling bounds how many levels there can
+	// be, since the rate strictly rises down the ladder, and fewer levels means a shorter sum.
+	// Neither alone finds the best ladder: headroom leaves the search picking the deepest shape it
+	// can afford, and a ceiling alone leaves every level sized too thin.
+	let candidates = (0..=MAX_SEARCH_HEADROOM).flat_map(|headroom| {
+		(l0_log_inv_rate..=MAX_LOG_INV_RATE).filter_map(move |max_log_inv_rate| {
+			let (params, size) = ladder_at_target::<F, _>(
+				merkle_scheme,
+				log_n,
+				l0_log_inv_rate,
+				max_log_inv_rate,
+				regime,
+				Targets {
+					security_bits,
+					per_level_bits: security_bits + headroom,
+				},
+				grinding,
+			)?;
+			// The per-level target is a proxy. This is the property that actually has to hold.
+			(params.achieved_security_bits(F::N_BITS) >= security_bits as f64)
+				.then_some((params, size))
+		})
+	});
+	candidates.min_by_key(|&(_, size)| size)
+}
+
+/// Headroom, in bits, past which raising the per-level target cannot help.
+///
+/// The rate strictly rises down a ladder, so it holds at most [`MAX_LOG_INV_RATE`] levels.
+/// Each contributes four error terms, and the batch adds one more.
+/// A union of `4 * MAX_LOG_INV_RATE + 1` terms falls under `log2(45) < 6` bits below its smallest.
+/// So six bits always suffice, and eight leaves margin.
+/// A search still short of the target at eight is short for a reason headroom does not fix.
+const MAX_SEARCH_HEADROOM: usize = 8;
+
+/// The byte-optimal ladder whose every level reaches [`Targets::per_level_bits`].
+///
+/// [`optimal_ladder`] raises that figure until the ladder's own sum clears the real target.
+/// That real target is [`Targets::security_bits`], and it is what the parameters are tagged with.
+///
+/// No level commits at a rate above `max_log_inv_rate`, which is what bounds the ladder's depth.
+/// The rate strictly rises, so a ceiling `r` above the floor admits at most `r + 1` levels.
+///
+/// ## Preconditions
+///
+/// * `l0_log_inv_rate` is in `1..=max_log_inv_rate`.
+/// * `max_log_inv_rate` is at most [`MAX_LOG_INV_RATE`].
+fn ladder_at_target<F, MerkleScheme>(
+	merkle_scheme: &MerkleScheme,
+	log_n: usize,
+	l0_log_inv_rate: usize,
+	max_log_inv_rate: usize,
+	regime: SoundnessRegime,
+	targets: Targets,
+	grinding: Grinding,
+) -> Option<(LigeritoParams, usize)>
+where
+	F: BinaryField,
+	MerkleScheme: MerkleTreeScheme<F>,
+{
+	assert!(
+		(1..=max_log_inv_rate).contains(&l0_log_inv_rate),
+		"precondition: l0_log_inv_rate must be in 1..={max_log_inv_rate}, got {l0_log_inv_rate}"
+	);
+	assert!(
+		max_log_inv_rate <= MAX_LOG_INV_RATE,
+		"precondition: max_log_inv_rate must be at most {MAX_LOG_INV_RATE}"
+	);
 
 	// Query counts depend only on the rate, so derive them once. Index 0 is unused: rate 1 is
 	// not a proximity test at all.
 	//
 	// The query grind closes part of the target before a row is opened, so the rows cover only
 	// what is left of it.
-	let from_queries = security_bits.saturating_sub(grinding.query_bits());
+	let from_queries = targets.per_level_bits.saturating_sub(grinding.query_bits());
 	let search = Search::<F, MerkleScheme> {
 		merkle_scheme,
 		sizes: ByteSizes::new::<F, MerkleScheme>(),
@@ -368,7 +452,7 @@ where
 			})
 			.collect(),
 		regime,
-		security_bits,
+		targets,
 		grinding,
 		_field: PhantomData,
 	};
@@ -378,10 +462,10 @@ where
 	// may follow" without a bounds check.
 	let mut best = vec![vec![None::<Decision>; MAX_LOG_INV_RATE + 2]; log_n + 1];
 	for log_total in 0..=log_n {
-		for rate_floor in 1..=MAX_LOG_INV_RATE {
+		for rate_floor in 1..=max_log_inv_rate {
 			// Every tabulated subproblem is reached by recursing, so it is never level 0.
 			best[log_total][rate_floor] =
-				search.choose_level(&best, log_total, rate_floor, MAX_LOG_INV_RATE, DEEPER_LEVEL);
+				search.choose_level(&best, log_total, rate_floor, max_log_inv_rate, DEEPER_LEVEL);
 		}
 	}
 
@@ -409,13 +493,13 @@ where
 			.expect("a recursing decision was scored against a solved subproblem");
 	}
 
-	let params = LigeritoParams::new(levels, regime, security_bits).with_grinding(grinding);
+	let params = LigeritoParams::new(levels, regime, targets.security_bits).with_grinding(grinding);
 	Some((params, estimated_size))
 }
 
 #[cfg(test)]
 mod tests {
-	use binius_field::Ghash128b as B128;
+	use binius_field::{BinaryField, Ghash128b as B128};
 	use binius_hash::StdHashSuite;
 	use proptest::prelude::*;
 
@@ -453,25 +537,26 @@ mod tests {
 		}
 		for level in levels {
 			assert!(level.is_feasible());
+			assert!(level.is_addressable());
 			assert!(level.log_lanes >= 1);
 			assert!(level.log_lanes <= MAX_LOG_LANES);
 			assert!(level.log_inv_rate <= MAX_LOG_INV_RATE);
-			// Query grinding closes part of the target before a row is opened, so the rows only
-			// cover what is left of it.
+			// Levels are sized against the caller's target raised by headroom, so a level opens at
+			// least what the bare target would ask of it, and generally a little more.
 			let from_queries = params
 				.security_bits()
 				.saturating_sub(params.grinding().query_bits());
-			assert_eq!(
-				level.n_queries,
-				params.regime().n_queries(from_queries, level.log_inv_rate)
-			);
+			assert!(level.n_queries >= params.regime().n_queries(from_queries, level.log_inv_rate));
 		}
 		assert_eq!(params.log_residual_dim(), levels.last().expect("non-empty").log_msg_cols);
+		// The headroom exists for exactly this: the whole ladder reaches the target, not merely
+		// each level of it taken alone.
+		assert!(params.achieved_security_bits(B128::N_BITS) >= params.security_bits() as f64);
 	}
 
 	/// The lossy regime both reference Ligerito implementations ship a conjecture-free profile in.
 	/// Priced here over this repo's own field.
-	fn lossy_regime(log_n: usize) -> SoundnessRegime {
+	pub(super) fn lossy_regime(log_n: usize) -> SoundnessRegime {
 		let (regime, _) = SoundnessRegime::optimal_unique_decoding(120, log_n, 1, 128)
 			.expect("120 bits is reachable with a constant loss");
 		regime
@@ -479,33 +564,60 @@ mod tests {
 
 	#[test]
 	fn a_ladder_that_grinds_reaches_a_target_the_algebra_alone_cannot() {
-		// Invariant: the correlated-agreement term is a ceiling no query count raises, and over
-		// B128 it falls short of 128 bits. Proof of work is the only lever that moves it, so a
-		// 128-bit ladder exists exactly when enough of it is paid.
+		// Invariant: the correlated-agreement term is a ceiling no query count raises. Proof of
+		// work is the only lever that moves it, so a target just above the bare ceiling exists
+		// exactly when enough of it is paid.
 		//
-		// Fixture state: a 2^24 message at L0 rate 1/2, in the lossy unique-decoding regime whose
-		// ceiling is a flat 124.5 bits at every size.
+		// Fixture state: a 2^24 message at L0 rate 1/2, in the lossy unique-decoding regime, whose
+		// ceiling at this shape is 120.4 bits.
 		let merkle_scheme = test_merkle_scheme();
 		let regime = lossy_regime(24);
 		let ladder = |grinding| {
-			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, regime, 128, grinding)
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, regime, 119, grinding)
 		};
 
 		// A level also pays the fold row union, so the ceiling a real ladder has to clear sits
-		// below the flat 124.5 and the first grind that buys anything is larger than the 3.5 bits
-		// the bare ceiling is short by.
-		for challenge_bits in 0..8 {
-			assert!(ladder(Grinding::new(challenge_bits, 0)).is_none(), "{challenge_bits}");
-		}
+		// below the bare 120.4 and 119 bits is out of reach with no work at all.
+		assert!(ladder(Grinding::NONE).is_none());
 
-		let grinding = Grinding::new(11, 0);
-		let (params, size) = ladder(grinding).expect("eleven bits of work reach 128");
+		let grinding = Grinding::new(2, 0);
+		let (params, size) = ladder(grinding).expect("two bits of work reach 119");
 		assert_invariants(&params);
 		assert_eq!(params.grinding(), grinding);
 		// The bits the ladder reports are the bits its transcript pays for, and they clear the
 		// target rather than merely approaching it.
-		assert!(params.achieved_security_bits(128) >= 128.0);
+		assert!(params.achieved_security_bits(128) >= 119.0);
 		assert_eq!(size, params.proof_size(&merkle_scheme));
+	}
+
+	#[test]
+	fn a_target_the_row_batching_term_caps_is_out_of_reach_at_any_grind() {
+		// Invariant: opening rows is not free of algebra. A level batches its `n_queries` row
+		// claims into the running sumcheck by the powers of one challenge, and that step alone
+		// costs `(n_queries + 1)/|F|` no matter how the rest is configured.
+		//
+		// At ~300 rows over B128 that is `log2(301) = 8.2` bits gone, so no level opening this
+		// many rows exceeds about 119.8 bits. Grinding cannot buy it back: it lifts the two terms
+		// it stands in front of, and this is neither of them.
+		let merkle_scheme = test_merkle_scheme();
+		let regime = lossy_regime(24);
+		let ladder = |target, challenge_bits| {
+			LigeritoParams::optimal_ladder::<B128, _>(
+				&merkle_scheme,
+				24,
+				1,
+				regime,
+				target,
+				Grinding::new(challenge_bits, 0),
+			)
+		};
+
+		// 119 is reachable, and one bit more is not, at any depth of work the transcript allows.
+		assert!(ladder(119, 2).is_some());
+		for challenge_bits in [0, 2, 8, 16, binius_transcript::MAX_GRINDING_BITS] {
+			assert!(ladder(120, challenge_bits).is_none(), "{challenge_bits}");
+			assert!(ladder(128, challenge_bits).is_none(), "{challenge_bits}");
+		}
 	}
 
 	#[test]
@@ -515,39 +627,35 @@ mod tests {
 		// headroom. Query bits close part of the target outright, which lets every level open
 		// fewer rows. Neither does the other's work.
 		//
-		// Fixture state: the same 2^24 message at 128 bits in the lossy regime.
+		// Fixture state: the same 2^24 message at 118 bits in the lossy regime.
 		let merkle_scheme = test_merkle_scheme();
 		let regime = lossy_regime(24);
 		let ladder = |grinding| {
-			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, regime, 128, grinding)
-				.expect("the profiles below all reach 128 bits")
+			LigeritoParams::optimal_ladder::<B128, _>(&merkle_scheme, 24, 1, regime, 118, grinding)
+				.expect("the profiles below all reach 118 bits")
 				.0
 		};
 
-		// More challenge bits, wider lanes, and a smaller proof at every step.
-		let widening = (8..=11)
+		// More challenge bits, a deeper ladder, and a smaller proof at every step. With too few,
+		// the only shape that clears the target is one level over a cleartext residual.
+		let widening = (2..=6)
 			.map(|challenge_bits| ladder(Grinding::new(challenge_bits, 0)))
 			.collect::<Vec<_>>();
 		for pair in widening.windows(2) {
-			assert!(pair[1].levels()[0].log_lanes >= pair[0].levels()[0].log_lanes);
+			assert!(pair[1].n_levels() >= pair[0].n_levels());
 			assert!(pair[1].proof_size(&merkle_scheme) < pair[0].proof_size(&merkle_scheme));
-		}
-		// And the row count never moves, because the query phase was never the binding term.
-		let rows = widening[0].levels()[0].n_queries;
-		for params in &widening {
-			assert_eq!(params.levels()[0].n_queries, rows);
 		}
 
 		// Query bits do the opposite: the same shape, fewer rows, a smaller proof.
-		let bare = ladder(Grinding::new(11, 0));
+		let bare = ladder(Grinding::new(6, 0));
 		// Seventeen bits is what one reference implementation grinds before drawing positions.
-		let ground = ladder(Grinding::new(11, 17));
+		let ground = ladder(Grinding::new(6, 17));
 		assert_eq!(ground.n_levels(), bare.n_levels());
 		assert_eq!(ground.levels()[0].log_lanes, bare.levels()[0].log_lanes);
-		assert_eq!(bare.levels()[0].n_queries, 312);
-		assert_eq!(ground.levels()[0].n_queries, 270);
+		assert_eq!(bare.levels()[0].n_queries, 298);
+		assert_eq!(ground.levels()[0].n_queries, 257);
 		assert!(ground.proof_size(&merkle_scheme) < bare.proof_size(&merkle_scheme));
-		assert!(ground.achieved_security_bits(128) >= 128.0);
+		assert!(ground.achieved_security_bits(128) >= 118.0);
 	}
 
 	#[test]
@@ -574,7 +682,9 @@ mod tests {
 		// slacker of the two.
 		let (bare_bits, ground_bits) =
 			(bare.achieved_security_bits(128), ground.achieved_security_bits(128));
-		assert!((bare_bits - ground_bits).abs() < 1e-9, "{bare_bits} {ground_bits}");
+		// Not to the last bit: the grind does lift the slacker term, and the union still carries
+		// it. What it does not do is move the total by anything like the four bits it cost.
+		assert!((bare_bits - ground_bits).abs() < 0.1, "{bare_bits} {ground_bits}");
 		assert!(bare_bits >= 96.0);
 	}
 
@@ -618,13 +728,9 @@ mod tests {
 		let merkle_scheme = test_merkle_scheme();
 
 		// Level 0's lane count comes out at 3 or 4, matching the arity `fri`'s own optimizer picks.
-		let expected = [
-			(17, 161_488),
-			(20, 236_944),
-			(24, 348_272),
-			(28, 472_928),
-			(30, 542_800),
-		];
+		// The list stops at 2^28. Past it the only ladders that reach 96 bits are degenerate, which
+		// the ceiling test below pins instead.
+		let expected = [(17, 162_672), (20, 241_104), (24, 354_608), (28, 521_136)];
 		for (log_n, bytes) in expected {
 			let (_, size) = LigeritoParams::optimal_ladder::<B128, _>(
 				&merkle_scheme,
@@ -673,7 +779,9 @@ mod tests {
 		// Unique decoding only: the Johnson regime has no feasible ladder over this field, which
 		// the test above pins.
 		for regime in [UDR] {
-			for log_n in [17, 20, 24, 28] {
+			// The trend needs a shape where every L0 rate still has a real ladder. Past 2^24 the
+			// lower rates run out of ceiling, which the assertion after this loop pins.
+			for log_n in [17, 20, 24] {
 				// The trend holds while the ladder still has rate room below L0 to recurse into.
 				let sizes = (1..=4)
 					.map(|l0_log_inv_rate| {
@@ -715,6 +823,28 @@ mod tests {
 				};
 				assert_eq!(capped.n_levels(), 1);
 				assert!(capped_size > sizes[3], "regime={regime:?} log_n={log_n}");
+			}
+
+			// At 2^28 the trend inverts outright. A lower L0 rate is a longer codeword, and a
+			// longer codeword has a worse correlated-agreement ceiling. By this size that ceiling
+			// is what binds, so every step down in rate costs headroom the extra rate step cannot
+			// repay, and only 1/2 leaves room for a ladder at all.
+			let sizes = (1..=4)
+				.map(|l0_log_inv_rate| {
+					LigeritoParams::optimal_ladder::<B128, _>(
+						&merkle_scheme,
+						28,
+						l0_log_inv_rate,
+						regime,
+						SECURITY_BITS,
+						Grinding::NONE,
+					)
+					.expect("feasible")
+					.1
+				})
+				.collect::<Vec<_>>();
+			for pair in sizes.windows(2) {
+				assert!(pair[1] > pair[0], "regime={regime:?} sizes={sizes:?}");
 			}
 		}
 	}
@@ -841,36 +971,32 @@ mod tests {
 			)
 			.is_some()
 		};
-		assert!(ladder(32, 96));
-		assert!(!ladder(33, 96));
+		assert!(ladder(30, 96));
+		assert!(!ladder(32, 96));
 
-		// And the cutoff is not a cliff: the shape degenerates well before it. At log_n = 32 the
+		// And the cutoff is not a cliff: the shape degenerates well before it. At log_n = 30 the
 		// only levels that still clear the target fold one lane at a time, so the search is forced
 		// into a huge cleartext residual rather than a ladder. Pinning that keeps a caller from
 		// reading the returned size as a usable configuration.
-		let (_, degenerate) = LigeritoParams::optimal_ladder::<B128, _>(
-			&merkle_scheme,
-			32,
-			1,
-			UDR,
-			SECURITY_BITS,
-			Grinding::NONE,
-		)
-		.expect("log_n = 32 still has a ladder, of a sort");
-		let (_, sane) = LigeritoParams::optimal_ladder::<B128, _>(
-			&merkle_scheme,
-			30,
-			1,
-			UDR,
-			SECURITY_BITS,
-			Grinding::NONE,
-		)
-		.expect("log_n = 30 has a real ladder");
+		let size = |log_n, target| {
+			LigeritoParams::optimal_ladder::<B128, _>(
+				&merkle_scheme,
+				log_n,
+				1,
+				UDR,
+				target,
+				Grinding::NONE,
+			)
+			.expect("a ladder exists at these shapes")
+			.1
+		};
+		let degenerate = size(30, SECURITY_BITS);
+		let sane = size(28, SECURITY_BITS);
 		assert!(degenerate > 100 * sane, "degenerate={degenerate} sane={sane}");
 
 		// Raising the target lowers that boundary, which is the whole point of tracking the term.
-		assert!(ladder(28, 100));
-		assert!(!ladder(29, 100));
+		assert!(ladder(27, 100));
+		assert!(!ladder(28, 100));
 
 		// And 128 bits is out of reach at every size, as `crate::soundness` documents.
 		for log_n in [12, 20, 28] {
@@ -976,9 +1102,18 @@ mod tests {
 
 			let lig_udr = ladder(UDR).expect("a unique-decoding ladder is feasible at these sizes");
 
-			// A ladder beats FRI at the same L0 rate, in the same regime. This is the honest
-			// comparison, since equal L0 rate means equal L0 encoding cost.
-			assert!(lig_udr < baseline, "log_n={log_n} lig={lig_udr} fri={baseline}");
+			// A ladder beats FRI at the same L0 rate, in the same regime, while a ladder that
+			// reaches the target is still a ladder. This is the honest comparison, since equal L0
+			// rate means equal L0 encoding cost.
+			//
+			// Past 2^28 it stops beating FRI, and by a wide margin: level 0's ceiling no longer
+			// leaves room for a ladder's worth of levels, so the only shape that reaches 96 bits
+			// is one level over a cleartext residual.
+			if log_n <= 28 {
+				assert!(lig_udr < baseline, "log_n={log_n} lig={lig_udr} fri={baseline}");
+			} else {
+				assert!(lig_udr > 100 * baseline, "log_n={log_n} lig={lig_udr} fri={baseline}");
+			}
 			// Rows (3), (4) and (6) price a regime this field cannot support. They are printed
 			// because the plan document tabulates them, and asserted only on their query counts.
 			assert!(fri_size(log_n, 1, JOHNSON) < baseline, "log_n={log_n}");

--- a/crates/iop/src/soundness.rs
+++ b/crates/iop/src/soundness.rs
@@ -3,14 +3,17 @@
 //! Soundness accounting for Reed-Solomon proximity tests.
 //!
 //! A proximity test bounds the chance that a word far from the code survives.
-//! Two independent terms bound it, and the protocol's security is the worse of the two.
+//! Two independent terms bound it, and a cheating prover wins by beating either one.
 //!
 //! ```text
-//!     bits    = min(algebra, queries)
+//!     bits    = union_bits([algebra, queries])
 //!
 //!     algebra = -log2(eps_ca)                + challenge_grind   <- code, field, proof of work
 //!     queries = -n_queries * log2(1 - delta) + query_grind       <- one query at a time
 //! ```
+//!
+//! The two are combined by [`union_bits`], not by taking the smaller.
+//! Independent chances to cheat add up, so a pair of 96-bit terms is 95 bits, not 96.
 //!
 //! The right-hand term is the one everybody counts.
 //! Sampling `n_queries` positions catches a `delta`-far word all but `(1 - delta)^n_queries` of the
@@ -111,6 +114,36 @@
 use binius_transcript::MAX_GRINDING_BITS;
 
 use crate::fri::calculate_n_test_queries;
+
+/// Combines independent soundness errors, each given in bits, into the bits their union reaches.
+///
+/// A cheating prover wins if *any* one of the events fires, so their probabilities add.
+/// Adding probabilities is not the same as keeping the smallest bit count:
+///
+/// ```text
+///     union_bits([b_0, b_1, ...]) = -log2( sum_i 2^-b_i )
+/// ```
+///
+/// The result never exceeds the smallest term, and never falls more than `log2(n)` below it.
+/// A term of infinity is an event that cannot fire, and drops out.
+/// An empty iterator has nothing to go wrong, so it returns infinity.
+pub fn union_bits(terms: impl IntoIterator<Item = f64>) -> f64 {
+	let total = terms.into_iter().map(|bits| (-bits).exp2()).sum::<f64>();
+	-total.log2()
+}
+
+/// The bits of soundness an error of `count / |F|` reaches over a field of that size.
+///
+/// This is the shape every Schwartz-Zippel and linear-batching term takes.
+/// A `count` of zero is a step that draws no challenge, so nothing about it can go wrong.
+/// It returns infinity, which [`union_bits`] then ignores.
+pub fn ratio_bits(count: f64, log_field_size: usize) -> f64 {
+	if count <= 0.0 {
+		f64::INFINITY
+	} else {
+		log_field_size as f64 - count.log2()
+	}
+}
 
 /// Proof-of-work bits ground into a transcript, split by the term each one buys back.
 ///
@@ -346,10 +379,11 @@ impl SoundnessRegime {
 		log_field_size as f64 - exceptional.log2()
 	}
 
-	/// The security a configuration actually reaches: the worse of its two terms.
+	/// The security a configuration actually reaches, counting both of its terms.
 	///
 	/// See the module documentation for what the two terms are, and why only one of them responds
 	/// to `n_queries`.
+	/// They are independent chances to cheat, so [`union_bits`] adds them instead of keeping one.
 	///
 	/// # Panics
 	/// Those of [`Self::proximity_parameter`].
@@ -365,14 +399,21 @@ impl SoundnessRegime {
 			+ grinding.challenge_bits() as f64;
 		let queries =
 			n_queries as f64 * self.bits_per_query(log_inv_rate) + grinding.query_bits() as f64;
-		algebra.min(queries)
+		union_bits([algebra, queries])
 	}
 
-	/// The smallest query count reaching `security_bits`, or `None` if the algebra caps below it.
+	/// The smallest query count whose [`Self::achieved_security_bits`] reaches `security_bits`.
+	///
+	/// The two terms add, so the rows do not have the whole target to themselves.
+	/// What is left for them is whatever error budget the algebra has not already spent:
+	///
+	/// ```text
+	///     budget = 2^-security_bits - 2^-algebra
+	/// ```
 	///
 	/// A `None` is not a parameter that needs more queries.
-	/// It is a configuration that cannot reach the target at all, because
-	/// [`Self::correlated_agreement_bits`] plus `grinding`'s challenge side is still under it.
+	/// It is a configuration no query count reaches, because the algebra alone spent the budget.
+	/// That happens once the algebraic term sits at or below the target.
 	/// Widen the field, grind harder, or lower the target.
 	///
 	/// Grinding past `security_bits` on the query side returns zero queries.
@@ -390,11 +431,14 @@ impl SoundnessRegime {
 	) -> Option<usize> {
 		let algebra = self.correlated_agreement_bits(log_msg_len, log_inv_rate, log_field_size)
 			+ grinding.challenge_bits() as f64;
-		if algebra < security_bits as f64 {
+		let budget = (-(security_bits as f64)).exp2() - (-algebra).exp2();
+		if budget <= 0.0 {
 			return None;
 		}
-		// Query grinding closes part of the target on its own, so the rows only cover the rest.
-		let from_queries = security_bits.saturating_sub(grinding.query_bits());
+		// Rounding the bit target up can only over-provision, which is the safe direction.
+		let from_queries = (-budget.log2()).ceil() as usize;
+		// Query grinding closes part of that on its own, so the rows only cover the rest.
+		let from_queries = from_queries.saturating_sub(grinding.query_bits());
 		Some(self.n_queries(from_queries, log_inv_rate))
 	}
 
@@ -602,23 +646,26 @@ mod tests {
 				SoundnessRegime::UniqueDecoding.correlated_agreement_bits(log_msg_len, 1, B128);
 			assert!((ceiling - expected).abs() < 0.01, "log_msg_len={log_msg_len} {ceiling}");
 
-			// The query count clears the target, and the algebra clears it too, so 96 holds.
-			let queries = SoundnessRegime::UniqueDecoding.plan_queries(
-				96,
-				log_msg_len,
-				1,
-				B128,
-				Grinding::NONE,
-			);
-			assert_eq!(queries, Some(232));
+			// The rows cover the target minus whatever error the algebra has already spent, so
+			// the count creeps up as the ceiling closes in: 234 rows until 2^32, then 237.
+			let queries = SoundnessRegime::UniqueDecoding
+				.plan_queries(96, log_msg_len, 1, B128, Grinding::NONE)
+				.expect("96 bits is reachable at every size here");
+			assert_eq!(queries, if log_msg_len < 32 { 234 } else { 237 });
+
+			// Planning and reporting agree: a count planned for 96 bits reaches 96 bits.
 			let achieved = SoundnessRegime::UniqueDecoding.achieved_security_bits(
 				log_msg_len,
 				1,
 				B128,
-				232,
+				queries,
 				Grinding::NONE,
 			);
 			assert!(achieved >= 96.0, "log_msg_len={log_msg_len} achieved={achieved}");
+
+			// The bare query count is what the rows would cost if the algebra were free, and it
+			// is strictly cheaper. That gap is exactly what the union charges.
+			assert!(queries > SoundnessRegime::UniqueDecoding.n_queries(96, 1));
 		}
 	}
 
@@ -681,7 +728,7 @@ mod tests {
 			assert!((ceiling - 124.46).abs() < 0.01, "log_msg_len={log_msg_len} {ceiling}");
 		}
 
-		// 120 bits is reachable, at 292 queries, independent of the witness size. That is the
+		// 120 bits is reachable, at 298 queries, independent of the witness size. That is the
 		// target and regime the reference Ligerito implementation ships for its own
 		// conjecture-free profile, which is a useful outside check on this arithmetic.
 		for log_msg_len in [20, 24, 28, 32] {
@@ -689,7 +736,7 @@ mod tests {
 				SoundnessRegime::optimal_unique_decoding(120, log_msg_len, 1, B128)
 					.expect("120 bits is reachable with a constant loss");
 			assert!(matches!(regime, SoundnessRegime::UniqueDecodingWithLoss { .. }));
-			assert_eq!(queries, 292);
+			assert_eq!(queries, 298);
 		}
 	}
 
@@ -836,8 +883,8 @@ mod tests {
 		let ground = regime
 			.plan_queries(96, 24, 1, B128, Grinding::new(0, 17))
 			.expect("grinding does not make it unreachable");
-		assert_eq!(bare, 232);
-		assert_eq!(ground, 191);
+		assert_eq!(bare, 234);
+		assert_eq!(ground, 193);
 
 		// But it does not touch the ceiling, so an out-of-reach target stays out of reach.
 		let lossy = best_lossy();
@@ -854,7 +901,10 @@ mod tests {
 		let rows = regime
 			.plan_queries(96, 24, 1, B128, Grinding::new(17, 0))
 			.expect("96 bits is reachable");
-		assert_eq!(rows, regime.n_queries(96, 1));
+		let bare = regime
+			.plan_queries(96, 24, 1, B128, Grinding::NONE)
+			.expect("96 bits is reachable");
+		assert_eq!(rows, bare);
 
 		// And it shows up in the achieved figure exactly once, on the side it belongs to.
 		let queries = 1 << 30;

--- a/crates/transcript/src/fiat_shamir/sampling.rs
+++ b/crates/transcript/src/fiat_shamir/sampling.rs
@@ -31,8 +31,18 @@ pub trait CanSampleBits<T> {
 	fn sample_bits(&mut self, bits: usize) -> T;
 }
 
+/// The widest index a single [`CanSampleBits`] draw can address.
+///
+/// A draw returns a `u32`, so it addresses at most `2^32` positions.
+/// A wider request is clamped to this rather than refused, which is a deliberate contract.
+///
+/// The clamp is fine for a caller that just wants some bits.
+/// It is not fine for one addressing a domain: the clamped draw never reaches the range's tail.
+/// Such a caller must hold its own log-size to this ceiling before it draws.
+pub const MAX_SAMPLE_BITS: usize = u32::BITS as usize;
+
 pub fn sample_bits_reader<Reader: Buf>(mut reader: Reader, bits: usize) -> u32 {
-	let bits = bits.min(u32::BITS as usize);
+	let bits = bits.min(MAX_SAMPLE_BITS);
 
 	let bytes_to_sample = size_of::<u32>();
 


### PR DESCRIPTION
Closes [BINIUS-550](https://linear.app/jimpo/issue/BINIUS-550).

Ligerito's parameter selection combined its soundness errors by taking the smallest bit-count. It should add them. No protocol or transcript change — this is parameter selection and reporting only.

### The problem

A ladder runs one proximity test per level, and a cheating prover wins by beating **any one** of them.
So the levels' errors add.

The accounting kept the minimum bit-count across levels instead, which reports only the *largest* single error.
The doc comment said so outright, and that sentence was the bug:

> "Every level is an independent proximity test, so the ladder is only as sound as its worst one."

Independent tests union-bound by summing. `max` is not a union bound.

### What it cost

A four-level ladder at 96 bits. Every level is sized to the same target, so they all land in the same place:

| rate | bits/query | queries | that level's bits |
|---|---|---|---|
| 2^-1 | 0.4150 | 232 | 96.29 |
| 2^-2 | 0.6781 | 142 | 96.29 |
| 2^-3 | 0.8301 | 116 | 96.29 |
| 2^-4 | 0.9125 | 106 | 96.73 |

```
reported   min(96.29, 96.29, 96.29, 96.73)              = 96.29
real       -log2(3 * 2^-96.29 + 2^-96.73)               = 94.39
```

**1.90 bits optimistic**, and the loss grows as `log2(levels)`.

### The terms that were never charged at all

Three of [NA25] equation (17)'s per-level terms had no expression anywhere: the fold rounds' Schwartz–Zippel error, the row batching, and the tensor batching across oracles.

Two are negligible. The third is not:

```
row batching   (n_queries + 1) / |F|
at 300 rows    128 - log2(301) = 119.8 bits
```

Batching a level's row claims by the powers of one challenge caps that level near **119.8 bits** over $\mathbb{F}_{2^{128}}$, whatever else is configured. Grinding cannot buy it back — it stands in front of the other two terms, not this one. So the 128-bit lossy grinding profiles were never 128-bit.

### The change

- **`union_bits`, `ratio_bits`** in `soundness.rs` — combine errors in probability space, `-log2(sum 2^-b_i)`.
- Every ladder figure unions four terms per level, then unions the levels, then the batch's tensor term.
- **`plan_queries` solves the union exactly.** The rows no longer get the whole target — only the budget the algebra has not already spent:

```
budget = 2^-security_bits - 2^-algebra
```

  `None` now means the algebra alone spent it, which is the honest condition.
- **The search verifies the real target.** The byte-optimal ladder *at* a per-level target is not the byte-optimal ladder that *reaches* it, so a single headroom knob is not enough: it leaves the search picking the deepest shape it can afford. The sweep pairs headroom with a rate ceiling, which bounds depth because the rate strictly rises down a ladder, and takes the byte minimum over what actually verifies.
- **Codeword length is held to what a query can address.** `sample_bits` clamps at 32 rather than failing, so a longer codeword would have a tail no query ever reaches — free for a prover to corrupt. Now a params invariant, with `MAX_SAMPLE_BITS` named at its source so callers can hold themselves to it. The clamp itself is left alone — it is a deliberate contract that the recursion channel mirrors and tests at width 33, so the fix belongs at the caller, not in `sample_bits_reader`.

### What moves

- **232 to 234 queries** at 96 bits, rate 1/2.
- **Usable ladders stop at 2^28**, not 2^30. Past it, level 0's ceiling no longer leaves room for a ladder's worth of levels, and the only shape reaching 96 bits is one level over a cleartext residual. The search returns it and the tests pin it as degenerate, so nobody reads the size as usable.
- **2^28 got cheaper** — 534 KB to 521 KB — because the sweep explores shapes a single-knob search could not reach.
- **128 bits is out of reach at any grind**, capped by the row-batching term. 119 bits is reachable with 2 bits of challenge work; 120 is not, which is exactly where `128 - log2(301)` puts the cliff.

### Soundness

Strictly conservative in every direction. Errors that were previously dropped are now charged, and errors that were previously max'd are now summed. Nothing is charged less than before, and no accepted proof becomes acceptable that was not already.

`plan_queries` rounds its bit target up before converting to a query count, which can only over-provision.

One term of (17) stays uncharged, because it is not a property of the ladder: folding a channel's `k` queued relations by the powers of one coefficient costs `(k - 1)/|F|`, and the caller fixes `k` at proving time. It is documented where the batching happens.

### Scope

- **changed:** `soundness.rs`, `ligerito/common.rs`, `ligerito/size_estimation.rs`, `ligerito/compiler.rs`, `transcript/fiat_shamir/sampling.rs`
- **untouched:** the prover, the verifier, the transcript layout, and every algebraic check — no proof that verifies today stops verifying

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-iop -p binius-transcript --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS=-D warnings cargo doc --document-private-items` — clean
- nightly `fmt --all` — clean
- tests: `binius-iop` 90, `binius-iop-prover` 75, `binius-transcript` 10, `binius-verifier` 13, `binius-prover` 80, `binius-recursion` `ligerito_opening` 13 — all pass

The proptests over random ladder shapes now assert the property that was missing: the finished ladder reaches its own target, not merely each level of it.

### Provenance

Found by an audit of the Ligerito implementation against [NA25] equation (17). Two other audit findings are in the same diff (the uncharged terms, the query-draw ceiling); the rest of the audit came back clean.

[NA25]: https://eprint.iacr.org/2025/1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
