### PR TITLE
Drop the stale proptest vec import in ghash

### DIFF
--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -384,7 +384,7 @@ impl From<AESTowerField8b> for Ghash128b {
 
 #[cfg(test)]
 mod tests {
-	use proptest::{collection::vec, prelude::any, proptest};
+	use proptest::{prelude::any, proptest};
 
 	use super::*;
 	use crate::{


### PR DESCRIPTION
One-line fix. `main` currently fails `wasm-tests` on every open pull request.

### The problem

[#2330](https://github.com/binius-zk/binius64/pull/2330) removed the `serialize_slice` override and the proptest that pinned it against the per-element loop.

That proptest was the only user of `proptest::collection::vec`:

```
- fn test_ghash_serialize_slice_matches_loop(values in vec(any::<u128>(), 0..300)) {
```

The import stayed behind, so `binius-field`'s test build now carries a dead import.

### Why CI only noticed now

`wasm-tests` is gated `if: github.event_name != 'push'`, so it never runs on a push to `main`.
#2330 merged green because the one job that compiles this crate's tests with warnings denied does not run on merges.

Every pull request opened since then has been red on `wasm-tests`, with a failure that has nothing to do with its own diff:

```
error: unused import: `collection::vec`
   --> crates/field/src/ghash.rs:387:17
```

Nothing about this is wasm-specific — the import is dead on every target.

### The change

```diff
- use proptest::{collection::vec, prelude::any, proptest};
+ use proptest::{prelude::any, proptest};
```

`any` and `proptest` are still used by the other proptests in the module.

### Verification

- `RUSTFLAGS=-D warnings cargo test -p binius-field --lib` — 246 pass
- `RUSTFLAGS=-D warnings cargo test -p binius-field --target wasm32-wasip1` — 243 pass, which is the job that was failing
- nightly `fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)