### PR TITLE
[field] Fold SerializeBytes/DeserializeBytes/FixedSizeSerializeBytes into binary_field!

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -7,10 +7,6 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use binius_utils::{
-	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
-	bytes::{Buf, BufMut},
-};
 use bytemuck::{Pod, Zeroable};
 
 use super::{
@@ -101,28 +97,9 @@ impl_field_extension!(BinaryField1b(U1) < @3 => AESTowerField8b(u8));
 
 mul_by_binary_field_1b!(AESTowerField8b);
 
-impl SerializeBytes for AESTowerField8b {
-	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		self.0.serialize(write_buf)
-	}
-}
-
-impl DeserializeBytes for AESTowerField8b {
-	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
-	where
-		Self: Sized,
-	{
-		Ok(Self(DeserializeBytes::deserialize(read_buf)?))
-	}
-}
-
-impl FixedSizeSerializeBytes for AESTowerField8b {
-	const BYTE_SIZE: usize = 1;
-}
-
 #[cfg(test)]
 mod tests {
-	use binius_utils::{SerializeBytes, bytes::BytesMut};
+	use binius_utils::{DeserializeBytes, SerializeBytes, bytes::BytesMut};
 	use proptest::{arbitrary::any, proptest};
 	use rand::prelude::*;
 

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -218,6 +218,10 @@ impl DeserializeBytes for M128 {
 
 		Ok(Self::from(read_buf.get_u128_le()))
 	}
+}
+
+impl FixedSizeSerializeBytes for M128 {
+	const BYTE_SIZE: usize = 16;
 }
 
 impl_divisible_bitmask!(M128, 1, 2, 4);

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -3,7 +3,7 @@
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr};
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -88,6 +88,10 @@ impl DeserializeBytes for M128 {
 		assert_enough_data_for(&read_buf, std::mem::size_of::<Self>())?;
 		Ok(Self(read_buf.get_u128_le()))
 	}
+}
+
+impl FixedSizeSerializeBytes for M128 {
+	const BYTE_SIZE: usize = 16;
 }
 
 unsafe impl Zeroable for M128 {}

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -149,6 +149,10 @@ impl DeserializeBytes for M128 {
 
 		Ok(Self::from(read_buf.get_u128_le()))
 	}
+}
+
+impl FixedSizeSerializeBytes for M128 {
+	const BYTE_SIZE: usize = 16;
 }
 
 impl_divisible_memcast!(M128, u128, u64, u32, u16, u8);

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -134,6 +134,10 @@ impl DeserializeBytes for M128 {
 
 		Ok(Self::from(raw_value))
 	}
+}
+
+impl FixedSizeSerializeBytes for M128 {
+	const BYTE_SIZE: usize = 16;
 }
 
 impl_divisible_bitmask!(M128, 1, 2, 4);

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -170,6 +170,10 @@ impl DeserializeBytes for M256 {
 
 		Ok(Self::from(raw_values))
 	}
+}
+
+impl FixedSizeSerializeBytes for M256 {
+	const BYTE_SIZE: usize = 32;
 }
 
 impl_divisible_bitmask!(M256, 1, 2, 4);

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -7,10 +7,6 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use binius_utils::{
-	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
-	bytes::{Buf, BufMut},
-};
 use bytemuck::Zeroable;
 
 use super::{UnderlierType, WithUnderlier, extension::ExtensionField};
@@ -72,6 +68,23 @@ macro_rules! binary_field {
 
 		unsafe impl $crate::underlier::WithUnderlier for $name {
 			type Underlier = $typ;
+		}
+
+		// Serialization forwards to the underlier.
+		impl binius_utils::SerializeBytes for $name {
+			fn serialize(&self, write_buf: impl binius_utils::bytes::BufMut) -> Result<(), binius_utils::SerializationError> {
+				self.0.serialize(write_buf)
+			}
+		}
+
+		impl binius_utils::DeserializeBytes for $name {
+			fn deserialize(read_buf: impl binius_utils::bytes::Buf) -> Result<Self, binius_utils::SerializationError> {
+				Ok(Self(binius_utils::DeserializeBytes::deserialize(read_buf)?))
+			}
+		}
+
+		impl binius_utils::FixedSizeSerializeBytes for $name {
+			const BYTE_SIZE: usize = <$typ as binius_utils::FixedSizeSerializeBytes>::BYTE_SIZE;
 		}
 
 		impl Neg for $name {
@@ -585,28 +598,6 @@ pub(crate) use impl_field_extension;
 
 // The trace over the prime field is the identity here, so `ONE` is the only trace-1 element.
 binary_field!(pub BinaryField1b(U1), U1::new(0x1), U1::new(0x1));
-
-macro_rules! serialize_deserialize {
-	($bin_type:ty) => {
-		impl SerializeBytes for $bin_type {
-			fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-				self.0.serialize(write_buf)
-			}
-		}
-
-		impl DeserializeBytes for $bin_type {
-			fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError> {
-				Ok(Self(DeserializeBytes::deserialize(read_buf)?))
-			}
-		}
-	};
-}
-
-serialize_deserialize!(BinaryField1b);
-
-impl FixedSizeSerializeBytes for BinaryField1b {
-	const BYTE_SIZE: usize = 1;
-}
 
 impl BinaryField1b {
 	pub const fn new(value: U1) -> Self {

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -10,10 +10,6 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use binius_utils::{
-	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
-	bytes::{Buf, BufMut},
-};
 use bytemuck::{Pod, Zeroable};
 
 use super::{
@@ -94,25 +90,6 @@ impl Ghash128b {
 impl_field_extension!(BinaryField1b(U1) < @7 => Ghash128b(M128));
 
 mul_by_binary_field_1b!(Ghash128b);
-
-impl SerializeBytes for Ghash128b {
-	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		self.0.serialize(write_buf)
-	}
-}
-
-impl DeserializeBytes for Ghash128b {
-	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
-	where
-		Self: Sized,
-	{
-		Ok(Self(DeserializeBytes::deserialize(read_buf)?))
-	}
-}
-
-impl FixedSizeSerializeBytes for Ghash128b {
-	const BYTE_SIZE: usize = 16;
-}
 
 impl From<AESTowerField8b> for Ghash128b {
 	#[inline]

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -22,10 +22,6 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use binius_utils::{
-	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
-	bytes::{Buf, BufMut},
-};
 use bytemuck::{Pod, Zeroable};
 
 use super::{
@@ -90,27 +86,9 @@ impl Mul<Ghash128b> for GhashSq256b {
 	}
 }
 
-impl SerializeBytes for GhashSq256b {
-	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		self.0.serialize(write_buf)
-	}
-}
-
-impl DeserializeBytes for GhashSq256b {
-	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
-	where
-		Self: Sized,
-	{
-		Ok(Self(DeserializeBytes::deserialize(read_buf)?))
-	}
-}
-
-impl FixedSizeSerializeBytes for GhashSq256b {
-	const BYTE_SIZE: usize = 32;
-}
-
 #[cfg(test)]
 mod tests {
+	use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes, SerializeBytes};
 	use proptest::prelude::*;
 
 	use super::*;

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	checked_arithmetics::checked_log_2,
 };
@@ -261,6 +261,10 @@ impl<U: DeserializeBytes, const N: usize> DeserializeBytes for ScaledUnderlier<U
 	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError> {
 		<[U; N]>::deserialize(read_buf).map(Self)
 	}
+}
+
+impl<U: FixedSizeSerializeBytes, const N: usize> FixedSizeSerializeBytes for ScaledUnderlier<U, N> {
+	const BYTE_SIZE: usize = U::BYTE_SIZE * N;
 }
 
 #[cfg(test)]

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	SerializationError, SerializeBytes,
+	FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	checked_arithmetics::checked_log_2,
 	serialization::DeserializeBytes,
@@ -257,6 +257,10 @@ impl<const N: usize> DeserializeBytes for SmallU<N> {
 	{
 		Ok(Self::new(DeserializeBytes::deserialize(read_buf)?))
 	}
+}
+
+impl<const N: usize> FixedSizeSerializeBytes for SmallU<N> {
+	const BYTE_SIZE: usize = 1;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `AESTowerField8b`, `Ghash128b`, `GhashSq256b`, and `BinaryField1b` each hand-wrote an identical trio of `SerializeBytes`/`DeserializeBytes`/`FixedSizeSerializeBytes` impls that just forwarded to their underlier (`self.0.serialize(...)`, `Self(DeserializeBytes::deserialize(...)?)`, a hardcoded `BYTE_SIZE`). Move these into the `binary_field!` macro's `@base` branch so every type it generates gets them for free, and delete the duplicated boilerplate (plus the now-dead `serialize_deserialize!` helper macro) from the four call sites.
- `FixedSizeSerializeBytes::BYTE_SIZE` delegates to `<$typ as FixedSizeSerializeBytes>::BYTE_SIZE`, which required teaching that trait to the underliers that lacked it: `SmallU<N>` (1 byte), `M128` on x86_64/aarch64/wasm32/portable (16 bytes), `M256` on x86_64 (32 bytes), and a generic `ScaledUnderlier<U, N>` impl (`U::BYTE_SIZE * N`) that covers the portable-derived `M256`/`M512` used on aarch64/wasm32/the portable fallback.
- The macro body reaches these traits via fully-qualified `binius_utils::` paths rather than relying on `use` imports, since `macro_rules!` resolves unqualified paths at the call site rather than the definition site — this lets the four call sites drop their serialization imports instead of keeping them alive only to feed the macro expansion.

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy -p binius-field --all-features --all-targets`
- [x] `cargo test -p binius-field --all-features` (252 tests, including serialization roundtrip tests for `BinaryField1b`, `AESTowerField8b`, `Ghash128b`, `GhashSq256b`)
- [x] `cargo fmt -p binius-field -- --check`
- [ ] aarch64/wasm32 `M128` `FixedSizeSerializeBytes` impls could not be cross-compile-checked in this environment (no target toolchains available); they mirror the already-verified x86_64/portable pattern exactly.
