### PR TITLE
[field] Fix broken intra-doc links in ghash_sq.rs

### DIFF
--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -8,13 +8,14 @@
 //!
 //! The field is backed by [`M256`], with the low 128 bits holding the coefficient of `1` (`a`) and
 //! the high 128 bits holding the coefficient of `Y` (`b`). This is the same layout as
-//! [`PackedBinaryGhash2x128b`] (two GHASH lanes in an `M256`) and matches the `{1, Y}` basis used
-//! by the `ExtensionField<Ghash128b>` implementation.
+//! [`PackedBinaryGhash2x128b`](crate::PackedBinaryGhash2x128b) (two GHASH lanes in an `M256`) and
+//! matches the `{1, Y}` basis used by the `ExtensionField<Ghash128b>` implementation.
 //!
 //! Reducing with `Y² = X·Y + X` multiplies by `X` (a left shift) rather than by `X⁻¹`, and the
 //! multiply-by-`X` folds into the reduction. Multiplication batches the two GHASH products that
-//! share the AVX2 256-bit CLMUL into a single [`PackedBinaryGhash2x128b`] multiply (the
-//! `mul_m256i_hybrid` algorithm).
+//! share the AVX2 256-bit CLMUL into a single
+//! [`PackedBinaryGhash2x128b`](crate::PackedBinaryGhash2x128b) multiply (the `mul_m256i_hybrid`
+//! algorithm).
 
 use std::{
 	fmt::{Debug, Display, Formatter},


### PR DESCRIPTION
## Summary
- `main`'s docs build (`cargo doc --workspace --all-features`) fails with `unresolved link to 'PackedBinaryGhash2x128b'`. #2344 moved that type's only local import behind `#[cfg(test)]` (and later into `mod tests` entirely), but the module-level doc comment still referenced it as a bare `[`PackedBinaryGhash2x128b`]` intra-doc link — which rustdoc, not building with `cfg(test)`, can no longer resolve.
- Fixes both occurrences by linking to the type's crate-root path explicitly: `` [`PackedBinaryGhash2x128b`](crate::PackedBinaryGhash2x128b) ``.

## Test plan
- [x] `cargo doc --workspace --all-features --no-deps` (previously failed, now succeeds)
- [x] `cargo check -p binius-field --all-features`
- [x] `cargo clippy -p binius-field --all-features --all-targets`
- [x] `cargo fmt -p binius-field -- --check`
