### PR TITLE
Rename AESTowerField8b to Rijndael8b

### DIFF
--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -2,7 +2,7 @@
 
 use std::array;
 
-use binius_field::{Field, Ghash128b, aes_field::AESTowerField8b};
+use binius_field::{Field, Ghash128b, aes_field::Rijndael8b};
 use criterion::{
 	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -39,7 +39,7 @@ fn bench_all_fields<Op: FieldOperation>(c: &mut Criterion) {
 	let mut group = c.benchmark_group(Op::NAME);
 	group.throughput(criterion::Throughput::Elements(BATCH_SIZE as _));
 
-	run_bench!(group, AESTowerField8b, Op);
+	run_bench!(group, Rijndael8b, Op);
 	run_bench!(group, Ghash128b, Op);
 }
 

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -15,22 +15,22 @@ use crate::{ExtensionField, Field, underlier::U1};
 // These fields represent a tower based on AES GF(2^8) field (GF(256)/x^8+x^4+x^3+x+1)
 // that is isomorphically included into binary tower, i.e.:
 //  - AESTowerField16b is GF(2^16) / (x^2 + x * x_2 + 1) where `x_2` is 0x10 from
-// BinaryField8b isomorphically projected to AESTowerField8b.
+// BinaryField8b isomorphically projected to Rijndael8b.
 //  - AESTowerField32b is GF(2^32) / (x^2 + x * x_3 + 1), where `x_3` is 0x1000 from
 //    AESTowerField16b.
 //  ...
 // `1 << 5` is the lowest single-bit element of trace 1; `1 << 7` is the only other one.
-binary_field!(pub AESTowerField8b(u8), 0xD0, 1 << 5);
+binary_field!(pub Rijndael8b(u8), 0xD0, 1 << 5);
 
-impl AESTowerField8b {
+impl Rijndael8b {
 	pub const fn new(value: u8) -> Self {
 		Self(value)
 	}
 }
 
-unsafe impl Pod for AESTowerField8b {}
+unsafe impl Pod for Rijndael8b {}
 
-impl_field_extension!(BinaryField1b(U1) < @3 => AESTowerField8b(u8));
+impl_field_extension!(BinaryField1b(U1) < @3 => Rijndael8b(u8));
 
 #[cfg(test)]
 mod tests {
@@ -48,7 +48,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_square_8(a in any::<u8>()) {
-			check_square(AESTowerField8b::from(a));
+			check_square(Rijndael8b::from(a));
 		}
 	}
 
@@ -64,7 +64,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_invert_8(a in any::<u8>()) {
-			check_invert(AESTowerField8b::from(a));
+			check_invert(Rijndael8b::from(a));
 		}
 	}
 
@@ -102,25 +102,25 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_mul_8(a in any::<u8>(), b in any::<u8>(), c in any::<u8>()) {
-			check_mul(AESTowerField8b::from(a), AESTowerField8b::from(b), AESTowerField8b::from(c));
+			check_mul(Rijndael8b::from(a), Rijndael8b::from(b), Rijndael8b::from(c));
 		}
 	}
 
 	#[test]
 	fn test_multiplicative_generators() {
-		assert!(is_binary_field_valid_generator::<AESTowerField8b>());
+		assert!(is_binary_field_valid_generator::<Rijndael8b>());
 	}
 
 	#[test]
 	fn test_serialization() {
 		let mut buffer = BytesMut::new();
 		let mut rng = StdRng::seed_from_u64(0);
-		let aes8 = AESTowerField8b::random(&mut rng);
+		let aes8 = Rijndael8b::random(&mut rng);
 
 		SerializeBytes::serialize(&aes8, &mut buffer).unwrap();
 
 		let mut read_buffer = buffer.freeze();
 
-		assert_eq!(AESTowerField8b::deserialize(&mut read_buffer).unwrap(), aes8);
+		assert_eq!(Rijndael8b::deserialize(&mut read_buffer).unwrap(), aes8);
 	}
 }

--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -8,7 +8,7 @@ use super::{
 	simd_arithmetic::{VmullWideMul, packed_aes_16x8b_invert_or_zero, packed_aes_16x8b_square},
 };
 use crate::{
-	aes_field::AESTowerField8b,
+	aes_field::Rijndael8b,
 	arch::PackedPrimitiveType,
 	arithmetic_traits::{InvertOrZero, Square},
 	underlier::WithUnderlier,
@@ -29,14 +29,14 @@ pub type AesInvert16x<T> = NeonTableLookupArithmetic<T>;
 #[derive(TransparentWrapper)]
 pub struct NeonTableLookupArithmetic<T>(T);
 
-impl Square for NeonTableLookupArithmetic<PackedPrimitiveType<M128, AESTowerField8b>> {
+impl Square for NeonTableLookupArithmetic<PackedPrimitiveType<M128, Rijndael8b>> {
 	#[inline]
 	fn square(self) -> Self {
 		Self::wrap(Self::peel(self).mutate_underlier(packed_aes_16x8b_square))
 	}
 }
 
-impl InvertOrZero for NeonTableLookupArithmetic<PackedPrimitiveType<M128, AESTowerField8b>> {
+impl InvertOrZero for NeonTableLookupArithmetic<PackedPrimitiveType<M128, Rijndael8b>> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		Self::wrap(Self::peel(self).mutate_underlier(packed_aes_16x8b_invert_or_zero))

--- a/crates/field/src/arch/aarch64/simd_arithmetic.rs
+++ b/crates/field/src/arch/aarch64/simd_arithmetic.rs
@@ -11,8 +11,7 @@ use bytemuck::TransparentWrapper;
 
 use super::m128::M128;
 use crate::{
-	aes_field::AESTowerField8b, arch::portable::packed::PackedPrimitiveType,
-	arithmetic_traits::WideMul,
+	aes_field::Rijndael8b, arch::portable::packed::PackedPrimitiveType, arithmetic_traits::WideMul,
 };
 
 #[inline]
@@ -225,7 +224,7 @@ pub fn packed_aes_16x8b_reduce(wide: WideAes16x8bProduct) -> M128 {
 #[derive(TransparentWrapper)]
 pub struct VmullWideMul<T>(T);
 
-impl WideMul for VmullWideMul<PackedPrimitiveType<M128, AESTowerField8b>> {
+impl WideMul for VmullWideMul<PackedPrimitiveType<M128, Rijndael8b>> {
 	type Output = WideAes16x8bProduct;
 
 	#[inline]

--- a/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
+++ b/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
@@ -5,11 +5,11 @@ use bytemuck::TransparentWrapper;
 
 use super::packed::PackedPrimitiveType;
 use crate::{
-	AESTowerField8b,
+	Rijndael8b,
 	arithmetic_traits::{InvertOrZero, Square, WideMul},
 };
 
-/// Multiplies two `AESTowerField8b` elements (as raw bytes) via the tower-field log/exp tables.
+/// Multiplies two `Rijndael8b` elements (as raw bytes) via the tower-field log/exp tables.
 #[inline]
 fn aes_mul_8b(lhs: u8, rhs: u8) -> u8 {
 	if lhs != 0 && rhs != 0 {
@@ -76,8 +76,8 @@ const AES_LOG_TABLE: [u8; 256] = [
 #[derive(TransparentWrapper)]
 pub struct AesLookupWideMul<T>(T);
 
-impl WideMul for AesLookupWideMul<PackedPrimitiveType<u8, AESTowerField8b>> {
-	type Output = PackedPrimitiveType<u8, AESTowerField8b>;
+impl WideMul for AesLookupWideMul<PackedPrimitiveType<u8, Rijndael8b>> {
+	type Output = PackedPrimitiveType<u8, Rijndael8b>;
 
 	#[inline]
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
@@ -100,7 +100,7 @@ impl WideMul for AesLookupWideMul<PackedPrimitiveType<u8, AESTowerField8b>> {
 #[derive(TransparentWrapper)]
 pub struct BytewiseLookup<T>(T);
 
-impl Square for BytewiseLookup<PackedPrimitiveType<u8, AESTowerField8b>> {
+impl Square for BytewiseLookup<PackedPrimitiveType<u8, Rijndael8b>> {
 	#[inline]
 	fn square(self) -> Self {
 		let byte = Self::peel(self).to_underlier();
@@ -108,7 +108,7 @@ impl Square for BytewiseLookup<PackedPrimitiveType<u8, AESTowerField8b>> {
 	}
 }
 
-impl InvertOrZero for BytewiseLookup<PackedPrimitiveType<u8, AESTowerField8b>> {
+impl InvertOrZero for BytewiseLookup<PackedPrimitiveType<u8, Rijndael8b>> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		let byte = Self::peel(self).to_underlier();

--- a/crates/field/src/arch/portable/scaled_arithmetic.rs
+++ b/crates/field/src/arch/portable/scaled_arithmetic.rs
@@ -102,10 +102,10 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::{aes_field::AESTowerField8b, arch::M128};
+	use crate::{aes_field::Rijndael8b, arch::M128};
 
 	// A two-lane `ScaledUnderlier` AES packing whose `M128` lanes carry their own `WideMul`.
-	type Inner = PackedPrimitiveType<ScaledUnderlier<M128, 2>, AESTowerField8b>;
+	type Inner = PackedPrimitiveType<ScaledUnderlier<M128, 2>, Rijndael8b>;
 	type P = Scaled<Inner>;
 
 	fn packing(lo: u128, hi: u128) -> P {

--- a/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
+++ b/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
@@ -4,7 +4,7 @@
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	AESTowerField8b,
+	Rijndael8b,
 	arch::{portable::packed::PackedPrimitiveType, x86_64::simd::simd_arithmetic::TowerSimdType},
 	arithmetic_traits::{InvertOrZero, WideMul},
 	underlier::UnderlierType,
@@ -32,7 +32,7 @@ pub(super) trait GfniType: Copy + TowerSimdType {
 #[derive(TransparentWrapper)]
 pub struct Gfni<T>(T);
 
-impl<U: GfniType + UnderlierType> std::ops::Mul for Gfni<PackedPrimitiveType<U, AESTowerField8b>> {
+impl<U: GfniType + UnderlierType> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>> {
 	type Output = Self;
 
 	#[inline(always)]
@@ -49,8 +49,8 @@ impl<U: GfniType + UnderlierType> std::ops::Mul for Gfni<PackedPrimitiveType<U, 
 #[derive(TransparentWrapper)]
 pub struct GfniWideMul<T>(T);
 
-impl<U: GfniType + UnderlierType> WideMul for GfniWideMul<PackedPrimitiveType<U, AESTowerField8b>> {
-	type Output = PackedPrimitiveType<U, AESTowerField8b>;
+impl<U: GfniType + UnderlierType> WideMul for GfniWideMul<PackedPrimitiveType<U, Rijndael8b>> {
+	type Output = PackedPrimitiveType<U, Rijndael8b>;
 
 	#[inline(always)]
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
@@ -65,7 +65,7 @@ impl<U: GfniType + UnderlierType> WideMul for GfniWideMul<PackedPrimitiveType<U,
 	}
 }
 
-impl<U: GfniType + UnderlierType> InvertOrZero for Gfni<PackedPrimitiveType<U, AESTowerField8b>> {
+impl<U: GfniType + UnderlierType> InvertOrZero for Gfni<PackedPrimitiveType<U, Rijndael8b>> {
 	#[inline(always)]
 	fn invert_or_zero(self) -> Self {
 		let val_gfni = Self::peel(self).to_underlier();

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -628,7 +628,7 @@ pub(crate) mod tests {
 
 	use super::BinaryField1b as BF1;
 	use crate::{
-		AESTowerField8b, BinaryField, BinaryField1b, ExtensionField, Field, Ghash128b, GhashSq256b,
+		BinaryField, BinaryField1b, ExtensionField, Field, Ghash128b, GhashSq256b, Rijndael8b,
 		arithmetic_traits::InvertOrZero,
 	};
 
@@ -720,7 +720,7 @@ pub(crate) mod tests {
 	#[test]
 	fn test_multiplicative_generators() {
 		assert!(is_binary_field_valid_generator::<BinaryField1b>());
-		assert!(is_binary_field_valid_generator::<AESTowerField8b>());
+		assert!(is_binary_field_valid_generator::<Rijndael8b>());
 		assert!(is_binary_field_valid_generator::<Ghash128b>());
 	}
 
@@ -746,7 +746,7 @@ pub(crate) mod tests {
 			assert_eq!(trace(F::TRACE_ONE_ELEMENT), F::ONE);
 		}
 		check::<BinaryField1b>();
-		check::<AESTowerField8b>();
+		check::<Rijndael8b>();
 		check::<Ghash128b>();
 		check::<GhashSq256b>();
 	}
@@ -757,39 +757,39 @@ pub(crate) mod tests {
 	#[test]
 	fn test_trace_lands_in_the_prime_subfield() {
 		for value in 0..=u8::MAX {
-			let t = trace(AESTowerField8b::new(value));
-			assert!(t == AESTowerField8b::ZERO || t == AESTowerField8b::ONE, "value {value:#04x}");
+			let t = trace(Rijndael8b::new(value));
+			assert!(t == Rijndael8b::ZERO || t == Rijndael8b::ONE, "value {value:#04x}");
 		}
 	}
 
 	#[test]
 	fn test_field_degrees() {
 		assert_eq!(BinaryField1b::N_BITS, 1);
-		assert_eq!(AESTowerField8b::N_BITS, 8);
+		assert_eq!(Rijndael8b::N_BITS, 8);
 		assert_eq!(Ghash128b::N_BITS, 128);
 	}
 
 	#[test]
 	fn test_field_formatting() {
 		assert_eq!(format!("{}", BinaryField1b::from(1)), "0x1");
-		assert_eq!(format!("{}", AESTowerField8b::from(3)), "0x03");
+		assert_eq!(format!("{}", Rijndael8b::from(3)), "0x03");
 		assert_eq!(format!("{}", Ghash128b::new(5)), "0x00000000000000000000000000000005");
 	}
 
 	#[test]
 	fn test_inverse_on_zero() {
 		assert!(BinaryField1b::ZERO.invert_or_zero().is_zero());
-		assert!(AESTowerField8b::ZERO.invert_or_zero().is_zero());
+		assert!(Rijndael8b::ZERO.invert_or_zero().is_zero());
 		assert!(Ghash128b::ZERO.invert_or_zero().is_zero());
 	}
 
 	proptest! {
 		#[test]
 		fn test_inverse_8b(val in 1u8..) {
-			let x = AESTowerField8b::new(val);
+			let x = Rijndael8b::new(val);
 			// Safety: `val` is in `1..`, so `x` is non-zero.
 			let x_inverse = unsafe { x.invert() };
-			assert_eq!(x * x_inverse, AESTowerField8b::ONE);
+			assert_eq!(x * x_inverse, Rijndael8b::ONE);
 		}
 
 		#[test]
@@ -827,7 +827,7 @@ pub(crate) mod tests {
 	#[test]
 	fn test_subfield_extraction() {
 		assert_subfield_extraction::<BinaryField1b, Ghash128b>();
-		assert_subfield_extraction::<BinaryField1b, AESTowerField8b>();
+		assert_subfield_extraction::<BinaryField1b, Rijndael8b>();
 		assert_subfield_extraction::<Ghash128b, GhashSq256b>();
 		assert_subfield_extraction::<BinaryField1b, GhashSq256b>();
 	}
@@ -836,7 +836,7 @@ pub(crate) mod tests {
 	fn test_serialization() {
 		let mut buffer = BytesMut::new();
 		let b1 = BinaryField1b::from(0x1);
-		let b8 = AESTowerField8b::new(0x12);
+		let b8 = Rijndael8b::new(0x12);
 		let b128 = Ghash128b::new(0x147AD0369CF258BE8899AABBCCDDEEFF);
 
 		b1.serialize(&mut buffer).unwrap();
@@ -846,7 +846,7 @@ pub(crate) mod tests {
 		let mut read_buffer = buffer.freeze();
 
 		assert_eq!(BinaryField1b::deserialize(&mut read_buffer).unwrap(), b1);
-		assert_eq!(AESTowerField8b::deserialize(&mut read_buffer).unwrap(), b8);
+		assert_eq!(Rijndael8b::deserialize(&mut read_buffer).unwrap(), b8);
 		assert_eq!(Ghash128b::deserialize(&mut read_buffer).unwrap(), b128);
 	}
 }

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -17,7 +17,7 @@ use super::{
 	extension::ExtensionField,
 };
 use crate::{
-	AESTowerField8b, Field,
+	Field, Rijndael8b,
 	arch::M128,
 	underlier::{U1, WithUnderlier},
 };
@@ -88,9 +88,9 @@ impl Ghash128b {
 
 impl_field_extension!(BinaryField1b(U1) < @7 => Ghash128b(M128));
 
-impl From<AESTowerField8b> for Ghash128b {
+impl From<Rijndael8b> for Ghash128b {
 	#[inline]
-	fn from(value: AESTowerField8b) -> Self {
+	fn from(value: Rijndael8b) -> Self {
 		// Raw GHASH values as `u128`, converted to the `M128` underlier at the lookup site so the
 		// table needs no const `M128` construction.
 		const LOOKUP_TABLE: [u128; 256] = [
@@ -496,8 +496,8 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_conversion_from_aes_consistency(a in any::<u8>(), b in any::<u8>()) {
-			let a_val = AESTowerField8b::new(a);
-			let b_val = AESTowerField8b::new(b);
+			let a_val = Rijndael8b::new(a);
+			let b_val = Rijndael8b::new(b);
 			let converted_a = Ghash128b::from(a_val);
 			let converted_b = Ghash128b::from(b_val);
 			assert_eq!(Ghash128b::from(a_val * b_val), converted_a * converted_b);

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -261,13 +261,13 @@ mod tests {
 	use rand::prelude::*;
 
 	use crate::{
-		AESTowerField8b, BinaryField1b, Ghash128b, PackedAESBinaryField1x8b,
-		PackedAESBinaryField16x8b, PackedAESBinaryField32x8b, PackedAESBinaryField64x8b,
-		PackedBinaryField1x1b, PackedBinaryField2x1b, PackedBinaryField4x1b, PackedBinaryField8x1b,
+		BinaryField1b, Ghash128b, PackedAESBinaryField1x8b, PackedAESBinaryField16x8b,
+		PackedAESBinaryField32x8b, PackedAESBinaryField64x8b, PackedBinaryField1x1b,
+		PackedBinaryField2x1b, PackedBinaryField4x1b, PackedBinaryField8x1b,
 		PackedBinaryField16x1b, PackedBinaryField32x1b, PackedBinaryField64x1b,
 		PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b,
 		PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
-		SlicedGhashSq1x256b, SlicedGhashSq2x256b, SlicedGhashSq4x256b,
+		Rijndael8b, SlicedGhashSq1x256b, SlicedGhashSq2x256b, SlicedGhashSq4x256b,
 	};
 
 	trait PackedFieldTest {
@@ -290,7 +290,7 @@ mod tests {
 		test.run::<PackedBinaryField512x1b>();
 
 		// AES
-		test.run::<AESTowerField8b>();
+		test.run::<Rijndael8b>();
 		test.run::<PackedAESBinaryField1x8b>();
 		test.run::<PackedAESBinaryField16x8b>();
 		test.run::<PackedAESBinaryField32x8b>();

--- a/crates/field/src/packed_aes.rs
+++ b/crates/field/src/packed_aes.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use crate::{
-	aes_field::AESTowerField8b,
+	aes_field::Rijndael8b,
 	arch::{
 		AesInvert1x, AesInvert16x, AesInvert32x, AesInvert64x, AesSquare1x, AesSquare16x,
 		AesSquare32x, AesSquare64x, AesWideMul1x, AesWideMul16x, AesWideMul32x, AesWideMul64x,
@@ -13,7 +13,7 @@ use crate::{
 
 define_packed_binary_field!(
 	PackedAESBinaryField1x8b,
-	AESTowerField8b,
+	Rijndael8b,
 	u8,
 	(MulFromWideMul),
 	(AesSquare1x),
@@ -22,7 +22,7 @@ define_packed_binary_field!(
 );
 define_packed_binary_field!(
 	PackedAESBinaryField16x8b,
-	AESTowerField8b,
+	Rijndael8b,
 	M128,
 	(MulFromWideMul),
 	(AesSquare16x),
@@ -31,7 +31,7 @@ define_packed_binary_field!(
 );
 define_packed_binary_field!(
 	PackedAESBinaryField32x8b,
-	AESTowerField8b,
+	Rijndael8b,
 	M256,
 	(MulFromWideMul),
 	(AesSquare32x),
@@ -40,7 +40,7 @@ define_packed_binary_field!(
 );
 define_packed_binary_field!(
 	PackedAESBinaryField64x8b,
-	AESTowerField8b,
+	Rijndael8b,
 	M512,
 	(MulFromWideMul),
 	(AesSquare64x),
@@ -69,12 +69,12 @@ mod tests {
 		// not the packed widening path under test.
 		for a in 0..=u8::MAX {
 			for b in 0..=u8::MAX {
-				let expected = crate::AESTowerField8b::new(a) * crate::AESTowerField8b::new(b);
+				let expected = crate::Rijndael8b::new(a) * crate::Rijndael8b::new(b);
 
 				let a_packed =
-					crate::PackedAESBinaryField16x8b::broadcast(crate::AESTowerField8b::new(a));
+					crate::PackedAESBinaryField16x8b::broadcast(crate::Rijndael8b::new(a));
 				let b_packed =
-					crate::PackedAESBinaryField16x8b::broadcast(crate::AESTowerField8b::new(b));
+					crate::PackedAESBinaryField16x8b::broadcast(crate::Rijndael8b::new(b));
 				let reduced = crate::PackedAESBinaryField16x8b::reduce(
 					crate::PackedAESBinaryField16x8b::wide_mul(a_packed, b_packed),
 				);

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -6,11 +6,11 @@ use std::iter;
 use proptest::prelude::*;
 
 use crate::{
-	AESTowerField8b, BinaryField1b, ExtensionField, Field, Ghash128b, PackedAESBinaryField16x8b,
+	BinaryField1b, ExtensionField, Field, Ghash128b, PackedAESBinaryField16x8b,
 	PackedAESBinaryField32x8b, PackedAESBinaryField64x8b, PackedBinaryField64x1b,
 	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b,
 	PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
-	SlicedGhashSq2x256b,
+	Rijndael8b, SlicedGhashSq2x256b,
 	field::FieldOps,
 	underlier::{SmallU, WithUnderlier},
 };
@@ -18,7 +18,7 @@ use crate::{
 #[test]
 fn test_field_text_debug() {
 	assert_eq!(format!("{:?}", BinaryField1b::ONE), "BinaryField1b(0x1)");
-	assert_eq!(format!("{:?}", AESTowerField8b::new(127)), "AESTowerField8b(0x7f)");
+	assert_eq!(format!("{:?}", Rijndael8b::new(127)), "Rijndael8b(0x7f)");
 	assert_eq!(
 		format!(
 			"{:?}",
@@ -29,7 +29,7 @@ fn test_field_text_debug() {
 		"Packed1x128([0x000007ffffffffffffffffffffffffff])"
 	);
 	assert_eq!(
-		format!("{:?}", PackedAESBinaryField16x8b::broadcast(AESTowerField8b::new(123))),
+		format!("{:?}", PackedAESBinaryField16x8b::broadcast(Rijndael8b::new(123))),
 		"Packed16x8([0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b])"
 	);
 }
@@ -104,9 +104,9 @@ generate_spread_tests! {
 	spread_equals_basic_spread_1x128, PackedBinaryGhash1x128b, Ghash128b, u128, 1;
 
 	// 8-bit configurations
-	spread_equals_basic_spread_64x8, PackedAESBinaryField64x8b, AESTowerField8b, u8, 64;
-	spread_equals_basic_spread_32x8, PackedAESBinaryField32x8b, AESTowerField8b, u8, 32;
-	spread_equals_basic_spread_16x8, PackedAESBinaryField16x8b, AESTowerField8b, u8, 16;
+	spread_equals_basic_spread_64x8, PackedAESBinaryField64x8b, Rijndael8b, u8, 64;
+	spread_equals_basic_spread_32x8, PackedAESBinaryField32x8b, Rijndael8b, u8, 32;
+	spread_equals_basic_spread_16x8, PackedAESBinaryField16x8b, Rijndael8b, u8, 16;
 }
 
 generate_spread_tests_small! {
@@ -175,7 +175,7 @@ where
 
 #[test]
 fn test_scalar_field_ops_square_transpose_aes8b_over_1b() {
-	check_field_ops_square_transpose::<BinaryField1b, AESTowerField8b>();
+	check_field_ops_square_transpose::<BinaryField1b, Rijndael8b>();
 }
 
 #[test]

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -8,7 +8,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, ValueTable},
 	word::Word,
 };
-use binius_field::{AESTowerField8b as B8, Field, PackedField};
+use binius_field::{Field, PackedField, Rijndael8b as B8};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::sumcheck::{

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -232,7 +232,7 @@ mod tests {
 		constraint_system::{AndConstraint, InoutSegment},
 		word::Word,
 	};
-	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
+	use binius_field::{Field, PackedBinaryGhash1x128b, Random, Rijndael8b};
 	use binius_math::{
 		multilinear::{Multilinear, hypercube::Hypercube},
 		test_utils::random_scalars,
@@ -337,8 +337,7 @@ mod tests {
 		let key_collection = KeyCollection::build(&cs, InoutSegment::Hidden);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
-		let domain_subspace =
-			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let domain_subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
 		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
 		// The Zero claim closes at its own constraint point, as wide as the ZERO set. Its value is
@@ -488,8 +487,7 @@ mod tests {
 		let key_collection = KeyCollection::build(&cs, InoutSegment::Hidden);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
-		let domain_subspace =
-			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let domain_subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
 		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
 		let r_rho = random_scalars::<B128>(&mut rng, log_instances);

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -522,7 +522,7 @@ mod tests {
 	use assert_matches::assert_matches;
 	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_core::constraint_system::{AndConstraint, Shift, ShiftVariant, ValueVec};
-	use binius_field::{AESTowerField8b as B8, PackedBinaryGhash1x128b, Random};
+	use binius_field::{PackedBinaryGhash1x128b, Random, Rijndael8b as B8};
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_ip::channel::Error as ChannelError;
 	use binius_math::{

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -237,7 +237,7 @@ impl<F: BinaryField> Default for BinarySubspace<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{AESTowerField8b as B8, Field, Ghash128b as B128};
+	use binius_field::{Field, Ghash128b as B128, Rijndael8b as B8};
 
 	use super::*;
 

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -331,7 +331,7 @@ impl<F: BinaryField> DomainContext for GaoMateerPreExpanded<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{AESTowerField8b, GhashSq256b};
+	use binius_field::{GhashSq256b, Rijndael8b};
 
 	use super::*;
 	use crate::test_utils::B128;
@@ -401,7 +401,7 @@ mod tests {
 		}
 
 		// The domain cannot exceed the field's degree over F_2, so each field gets its own size.
-		check::<AESTowerField8b>(8);
+		check::<Rijndael8b>(8);
 		check::<B128>(5);
 		check::<GhashSq256b>(5);
 	}

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -8,7 +8,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
 	word::Word,
 };
-use binius_field::{AESTowerField8b, Field, Ghash128b, Random, arch::OptimalPackedB128};
+use binius_field::{Field, Ghash128b, Random, Rijndael8b, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_math::{
 	BinarySubspace, multilinear::hypercube::Hypercube, univariate::EvaluationDomain,
@@ -122,7 +122,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::ZERO; 4];
 		let key_collection = KeyCollection::build(&cs, InoutSegment::Public);
-		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 		let mut group = c.benchmark_group(format!(
 			"shift_reduction_log2_{log_message_len_bytes}_bytes_{message_len_bytes}"
@@ -267,7 +267,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// words with their key ranges, and each fold pads to `log2_ceil(len)` variables.
 	let public_words = value_vec.public();
 	let hidden_words = value_vec.non_public();
-	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+	let subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
 	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -51,9 +51,8 @@ use std::{array, marker::PhantomData};
 
 use binius_core::Word;
 use binius_field::{
-	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, Divisible,
-	PackedAESBinaryField64x8b as Packed64xB8, PackedField, WithUnderlier, arch::M128,
-	util::expand_subset_sums_array,
+	BinaryField, BinaryField1b as B1, Divisible, PackedAESBinaryField64x8b as Packed64xB8,
+	PackedField, Rijndael8b as B8, WithUnderlier, arch::M128, util::expand_subset_sums_array,
 };
 use binius_math::{
 	BinarySubspace, FieldBuffer,

--- a/crates/prover/src/and_reduction/prove.rs
+++ b/crates/prover/src/and_reduction/prove.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b as B8, BinaryField, PackedField};
+use binius_field::{BinaryField, PackedField, Rijndael8b as B8};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::BinarySubspace;
 use binius_utils::checked_arithmetics::log2_ceil_usize;

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b as B8, BinaryField, PackedField};
+use binius_field::{BinaryField, PackedField, Rijndael8b as B8};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
@@ -275,7 +275,7 @@ mod test {
 
 	use binius_compute::GlobalAllocator;
 	use binius_core::word::Word;
-	use binius_field::{AESTowerField8b, arch::OptimalPackedB128};
+	use binius_field::{Rijndael8b, arch::OptimalPackedB128};
 	use binius_math::{
 		BinarySubspace, FieldBuffer, multilinear::Multilinear, univariate::EvaluationDomain,
 	};
@@ -301,11 +301,8 @@ mod test {
 		let log_num_rows = 6;
 		let mut rng = StdRng::seed_from_u64(0);
 
-		let small_field_zerocheck_challenges = [
-			AESTowerField8b::new(2),
-			AESTowerField8b::new(4),
-			AESTowerField8b::new(16),
-		];
+		let small_field_zerocheck_challenges =
+			[Rijndael8b::new(2), Rijndael8b::new(4), Rijndael8b::new(16)];
 		let first_mlv = random_words(log_num_rows, &mut rng);
 		let second_mlv = random_words(log_num_rows, &mut rng);
 		// The prover receives only the A and B columns.
@@ -315,7 +312,7 @@ mod test {
 			.collect();
 
 		// Agreed-upon proof parameter
-		let prover_message_domain = BinarySubspace::<AESTowerField8b>::with_dim(SKIPPED_VARS + 1);
+		let prover_message_domain = BinarySubspace::<Rijndael8b>::with_dim(SKIPPED_VARS + 1);
 		let verifier_message_domain = prover_message_domain.isomorphic();
 
 		// Prover is instantiated

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -5,8 +5,9 @@ use std::{array, borrow::Cow, iter};
 
 use binius_core::word::Word;
 use binius_field::{
-	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, ExtensionField, Field,
-	PackedAESBinaryField64x8b as Packed64xB8, PackedField, WideMul, util::expand_subset_sums_array,
+	BinaryField, BinaryField1b as B1, ExtensionField, Field,
+	PackedAESBinaryField64x8b as Packed64xB8, PackedField, Rijndael8b as B8, WideMul,
+	util::expand_subset_sums_array,
 };
 use binius_math::{BinarySubspace, multilinear::hypercube::Hypercube};
 use binius_utils::rayon::{self, iter::Either, prelude::*};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -215,7 +215,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
-	use binius_field::{AESTowerField8b, Ghash128b, PackedBinaryGhash2x128b, Random};
+	use binius_field::{Ghash128b, PackedBinaryGhash2x128b, Random, Rijndael8b};
 	use binius_math::{
 		BinarySubspace,
 		multilinear::{Multilinear, hypercube::Hypercube},
@@ -255,7 +255,7 @@ mod tests {
 			let shift = ShiftChallenge::new(r_s.clone(), r_v.clone());
 
 			// Method 1: the claim phase 3 starts from, with the carried constant set to one.
-			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+			let subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 			let l_tilde = subspace.lagrange_evals_buffer(r_zhat_prime);
 			let claimed = ShiftIndSumcheck::<P, _>::new(
 				&GlobalAllocator,

--- a/crates/prover/src/protocols/shift/shift_ind.rs
+++ b/crates/prover/src/protocols/shift/shift_ind.rs
@@ -477,7 +477,7 @@ mod tests {
 	#[test]
 	fn claimed_sum_is_the_weighted_indicator_sum() {
 		use binius_compute::GlobalAllocator;
-		use binius_field::{AESTowerField8b, PackedBinaryGhash2x128b, Random};
+		use binius_field::{PackedBinaryGhash2x128b, Random, Rijndael8b};
 
 		type P = PackedBinaryGhash2x128b;
 
@@ -488,8 +488,7 @@ mod tests {
 		let variant = random_scalars::<B128>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
 
 		let g_eval = B128::random(&mut rng);
-		let subspace =
-			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic::<B128>();
+		let subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic::<B128>();
 		let l_tilde = subspace.lagrange_evals(&r_zhat_prime);
 		let shift = ShiftChallenge::new(amount, variant);
 		let point = ShiftChallengePoint::new(&bit, &shift);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -8,7 +8,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, Operand, ValueVec},
 	word::Word,
 };
-use binius_field::{AESTowerField8b as B8, Field, PackedField};
+use binius_field::{Field, PackedField, Rijndael8b as B8};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::channel::IOPProverChannel;
 use binius_ip::sumcheck::SumcheckOutput;

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -11,7 +11,7 @@ use binius_core::{
 	},
 	word::Word,
 };
-use binius_field::{AESTowerField8b, BinaryField};
+use binius_field::{BinaryField, Rijndael8b};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
@@ -378,7 +378,7 @@ fn test_shift_prove_and_verify() {
 		// `r_zhat_prime` so the verifier can compute `h_op_evals` once for both.
 		let r_zhat_prime = F::random(&mut rng);
 
-		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 		let bitand_evals = compute_bitand_images(&cs.and_constraints, &value_vec).map(|image| {
 			evaluate_image(

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -2,7 +2,7 @@
 //! Specifies standard trait implementations and parameters.
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, BinaryField1b, Ghash128b};
+use binius_field::{BinaryField, BinaryField1b, Ghash128b, Rijndael8b};
 use binius_hash::StdDigest;
 use binius_transcript::fiat_shamir::{Challenger, HasherChallenger};
 use binius_utils::checked_arithmetics::checked_log_2;
@@ -26,8 +26,8 @@ pub type StdChallenger = HasherChallenger<StdDigest>;
 /// log2 of the number of [`Word`]s packed into one field element.
 pub const LOG_WORDS_PER_ELEM: usize = checked_log_2(B128::N_BITS) - Word::LOG_BITS;
 
-pub const PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES: [AESTowerField8b; 3] = [
-	AESTowerField8b::new(0x2),
-	AESTowerField8b::new(0x4),
-	AESTowerField8b::new(0x10),
+pub const PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES: [Rijndael8b; 3] = [
+	Rijndael8b::new(0x2),
+	Rijndael8b::new(0x4),
+	Rijndael8b::new(0x10),
 ];

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -23,7 +23,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
 	word::Word,
 };
-use binius_field::{AESTowerField8b as B8, ExtensionField, FieldOps};
+use binius_field::{ExtensionField, FieldOps, Rijndael8b as B8};
 use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::{
 	channel::{IPVerifierChannel, WordIPVerifierChannel},

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -7,7 +7,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
 	word::Word,
 };
-use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps};
+use binius_field::{BinaryField, ExtensionField, FieldOps, Rijndael8b as B8};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::channel::{IOPVerifierChannel, OracleSpec, oracle_setup::OracleSetupChannel};
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};


### PR DESCRIPTION
Closes BINIUS-98.

`AESTowerField8b` is the GF(2^8) Rijndael field. The tower it was named for no longer exists in the codebase — there is no `AESTowerField16b`/`32b`/etc. any more — so the `TowerField` part of the name no longer says anything. Rename it to `Rijndael8b`, which also lines up with the `Ghash128b` naming used for the other concrete field.

Pure mechanical rename: 105 occurrences replaced one-for-one (verified by before/after occurrence count), plus the import re-sorting `cargo fmt` derives from the new name. No behavior change.

### Notes

Two adjacent inconsistencies left alone as out of scope, happy to fold either in if you'd prefer:

- The `PackedAESBinaryField{1,16,32,64}x8b` types and the `aes_field` / `packed_aes` module names still say AES.
- `crates/field/src/aes_field.rs` has a pre-existing comment describing `AESTowerField16b` / `AESTowerField32b` / `BinaryField8b`, none of which exist in the tree.

I was unable to build or test locally (no C compiler in my environment, so every build script fails to link) — relying on CI for verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)