### PR TITLE
BINIUS-507: Combine a merged round's witness-dependence with OR

### DIFF
--- a/crates/iop-prover/src/channel/merge.rs
+++ b/crates/iop-prover/src/channel/merge.rs
@@ -90,10 +90,10 @@ struct Group<P: PackedField, A: Allocator, Oracle> {
 /// A round of a single oracle needs no combining.
 /// It is forwarded unchanged, at zero cost.
 ///
-/// Every oracle in a round must declare the same witness-dependence.
+/// A round is masked as a whole, never partly.
 ///
-/// A commitment is masked as a whole, never partly.
-/// So mixing witness-carrying and structural oracles in one round is not supported.
+/// So a round carrying any witness data is masked in full by the underlying channel.
+/// The verifier-side decorator is where that choice is made.
 ///
 /// # Timing
 ///

--- a/crates/iop/src/channel/merge.rs
+++ b/crates/iop/src/channel/merge.rs
@@ -92,10 +92,10 @@ struct Record<Oracle> {
 /// A round of a single oracle needs no combining.
 /// It is forwarded unchanged, at zero cost.
 ///
-/// Every oracle in a round must declare the same witness-dependence.
+/// A round is witness-dependent as soon as any of its oracles is.
 ///
 /// A commitment is masked as a whole, never partly.
-/// So mixing witness-carrying and structural oracles in one round is not supported.
+/// So a structural oracle sharing a round with a witness-carrying one is masked too.
 ///
 /// # Timing
 ///
@@ -188,15 +188,10 @@ where
 
 		// One commitment is masked as a whole, never partly.
 		//
-		// Every oracle in the round must agree on its witness-dependence.
-		let is_witness_dependent = self.records[order[0]].is_witness_dependent;
-		assert!(
-			order
-				.iter()
-				.all(|&i| self.records[i].is_witness_dependent == is_witness_dependent),
-			"MergeVerifierChannel: every oracle merged into one round must share \
-			 is_witness_dependent"
-		);
+		// So the combined oracle is witness-dependent as soon as any constituent is.
+		// A structural oracle sharing the round is masked along with it, which costs
+		// randomness but never correctness.
+		let is_witness_dependent = order.iter().any(|&i| self.records[i].is_witness_dependent);
 
 		// Size the combined oracle to fit every oracle end to end.
 		let total_len: usize = order
@@ -506,18 +501,21 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "must share is_witness_dependent")]
-	fn heterogeneous_witness_dependence_panics() {
+	fn mixed_witness_dependence_masks_the_whole_round() {
 		// One oracle depends on the witness.
 		// The other does not.
 		//
 		// One commitment cannot be masked for one and not the other.
-		// Mixing the two in a round must be rejected.
+		// So the round as a whole is masked, and the combined spec is zero-knowledge.
 		let fine_specs = [OracleSpec::new(2), OracleSpec::new(2)];
 		let mut channel = MergeVerifierChannel::new(OracleSetupChannel::new(true), &fine_specs);
 		channel.recv_oracle(2, true).unwrap();
 		channel.recv_oracle(2, false).unwrap();
 		let _ = IPVerifierChannel::<F>::sample(&mut channel);
+
+		// 2^2 + 2^2 = 2^3, masked because one constituent carries witness data.
+		let coarse = channel.into_inner().unwrap().into_oracle_specs();
+		assert_eq!(coarse, vec![OracleSpec::new_zk(3)]);
 	}
 
 	#[test]


### PR DESCRIPTION
Follow-up to [BINIUS-507](https://linear.app/jimpo/issue/BINIUS-507) and #2209, addressing [this review comment](https://github.com/binius-zk/binius64/pull/2209#discussion_r3866701052).

The combined oracle's witness-dependence is the logical OR of its constituents', not a property they all have to agree on.

### The problem

`MergeVerifierChannel::flush` asserted that every oracle in a round declared the same `is_witness_dependent`, and passed that shared value to the underlying channel.

That assert is stricter than the mechanism requires. It rejects a perfectly sound round — one witness-carrying oracle plus one structural oracle — with a panic, at the exact moment a real protocol driver would most naturally produce one.

### The idea

Masking is what `is_witness_dependent` buys, and a physical commitment is masked **as a whole, never partly**.

So there is only one honest aggregate:

```
combined.is_witness_dependent = OR over the round's oracles
```

A round carrying any witness data is masked in full. A structural oracle sharing that round is masked along with it, which costs a little randomness and never costs correctness.

### Soundness

Masking is a prover-side zero-knowledge measure, not a soundness one.

- The verifier's claim on each constituent is unchanged: it is still the same inner product against the same block of the combined oracle.
- Masking the combined commitment is handled by the underlying channel, uniformly for the whole oracle, exactly as it already is for a single-oracle round.
- Over-masking a structural oracle hides information that was never secret. It cannot make an accepting proof out of a false claim.

The reverse direction is the one that would be a real bug — AND-ing, or taking the first oracle's flag, would leave witness data unmasked. OR is the safe side.

### The change

```
-let is_witness_dependent = self.records[order[0]].is_witness_dependent;
-assert!(order.iter().all(|&i| self.records[i].is_witness_dependent == is_witness_dependent), ...);
+let is_witness_dependent = order
+    .iter()
+    .any(|&i| self.records[i].is_witness_dependent);
```

### Scope

- **changed:** the witness-dependence aggregation in `crates/iop/src/channel/merge.rs`, and the type-level docs on both decorators that claimed the stricter rule
- **changed test:** `heterogeneous_witness_dependence_panics` becomes `mixed_witness_dependence_masks_the_whole_round`, asserting the combined spec comes out zero-knowledge
- **left untouched:** the prover side's logic — it tracks no witness-dependence, since the verifier-side decorator is where the coarse spec is decided

### Verification

- `cargo check -p binius-iop -p binius-iop-prover --all-targets` — clean
- nightly `cargo fmt --all --check` — clean
- `cargo test -p binius-iop -p binius-iop-prover channel::merge` — 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)