### PR TITLE
BINIUS-552: Prove and verify the recursive circuit

### DIFF
--- a/crates/iop-prover/src/channel/merge.rs
+++ b/crates/iop-prover/src/channel/merge.rs
@@ -619,7 +619,7 @@ mod tests {
 			assert!(
 				PackedBinaryGhash4x128b::LOG_WIDTH > 0,
 				"the fixture needs sub-packed-width oracle sizes to appear"
-			)
+			);
 		};
 		run_merge_round_trip::<PackedBinaryGhash4x128b>(&[&[3, 3], &[4, 2, 2], &[1]], false);
 	}

--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -17,7 +17,9 @@ binius-iop = { path = "../iop" }
 binius-ip = { path = "../ip" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
+binius-verifier = { path = "../verifier" }
 digest.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 binius-compute = { path = "../compute" }
@@ -25,7 +27,6 @@ binius-iop-prover = { path = "../iop-prover" }
 binius-ip-prover = { path = "../ip-prover" }
 binius-math = { path = "../math", features = ["test-utils"] }
 binius-prover = { path = "../prover" }
-binius-verifier = { path = "../verifier" }
 proptest.workspace = true
 rand.workspace = true
 sha2.workspace = true

--- a/crates/recursion/src/circuit.rs
+++ b/crates/recursion/src/circuit.rs
@@ -1,0 +1,265 @@
+// Copyright 2026 The Binius Developers
+
+//! The circuit that verifies a Binius64 proof, built once per inner shape.
+//!
+//! ```text
+//!   inner shape      ->  build    ->  circuit
+//!   circuit + proof  ->  witness  ->  values that satisfy it
+//! ```
+//!
+//! A shape is everything the protocol fixes before any proof exists: the constraint system, the
+//! FRI parameters, the oracle specs. No length in the protocol depends on a received value, so
+//! one circuit verifies every proof of that shape.
+//!
+//! [`RecursiveCircuit::build`] therefore reads a [`Verifier`] and never a proof.
+//! A proof is needed only to fill a witness.
+//!
+//! # Going deeper
+//!
+//! What `build` returns is an ordinary circuit, so it has an ordinary [`Verifier`].
+//! Building again over that verifier is one level deeper.
+//!
+//! ```text
+//!   Verifier(inner) -> build -> circuit_1 -> Verifier(circuit_1) -> build -> circuit_2
+//! ```
+//!
+//! Every level pays for the level below it in full, because the wiring claim is discharged
+//! in-circuit rather than deferred. Measured over a CRC-64 inner circuit, a level costs about
+//! fifteen times the constraint rows of the level it verifies, so the tower diverges instead of
+//! closing. Deferring that claim is what makes a fixed point possible; see `RECURSION_PLAN.md`.
+
+use std::iter;
+
+use binius_core::{constraint_system::ValueVec, word::Word};
+use binius_frontend::{Circuit, PopulateError, Wire, WitnessFiller};
+use binius_hash::StdHashSuite;
+use binius_ip::channel::WordIPVerifierChannel;
+use binius_transcript::VerifierTranscript;
+use binius_verifier::{Pcs, Verifier, config::StdChallenger};
+
+use crate::{Binius64BuilderChannel, Recorded, WitnessFillerChannel};
+
+/// Why a recursive circuit could not be built, or its witness could not be filled.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// The inner trace is opened with a scheme the in-circuit gadgets do not express.
+	#[error("the inner trace is opened with {pcs:?}, and only FRI is expressed in-circuit")]
+	UnsupportedPcs {
+		/// The scheme the inner verifier was set up with.
+		pcs: Pcs,
+	},
+
+	/// The statement handed to [`RecursiveCircuit::witness`] is the wrong length.
+	#[error("the inner statement holds {expected} words, and {actual} were supplied")]
+	StatementLength {
+		/// The inner constraint system's inout count.
+		expected: usize,
+		/// What the caller supplied.
+		actual: usize,
+	},
+
+	/// Running the verifier over a recursion channel failed.
+	#[error("verifier error: {0}")]
+	Verifier(#[from] binius_verifier::Error),
+
+	/// The oracle layer rejected the run.
+	#[error("IOP channel error: {0}")]
+	IOPChannel(#[from] binius_iop::channel::Error),
+
+	/// The replayed values leave the recorded circuit unsatisfied.
+	#[error("the recorded circuit is not satisfied by the replayed witness")]
+	Unsatisfied(PopulateError),
+}
+
+/// A Binius64 circuit that verifies Binius64 proofs of one inner shape.
+///
+/// The inner statement is the circuit's public interface. Whoever checks an outer proof reads
+/// which statement was verified, rather than trusting whoever filled the witness.
+///
+/// The shape is owned rather than borrowed, so a witness cannot be filled against a verifier
+/// that differs from the one the circuit was recorded from.
+pub struct RecursiveCircuit {
+	/// The inner shape this circuit verifies.
+	///
+	/// Held because filling a witness replays the same verifier that built the circuit.
+	/// A different one would visit different operations and desync the wire cursor.
+	verifier: Verifier<StdHashSuite>,
+
+	/// The compiled circuit, and the wires a witness must supply.
+	recorded: Recorded,
+
+	/// One public wire per inner statement word.
+	///
+	/// Each is constrained to equal the word the verifier read, so the two cannot disagree.
+	statement: Vec<Wire>,
+}
+
+impl RecursiveCircuit {
+	/// Records `verifier`'s run as a circuit that verifies any proof of its shape.
+	///
+	/// The whole inner statement is bound to public inputs. A caller wanting to expose only part
+	/// of it drives [`Binius64BuilderChannel`] directly and chooses what to
+	/// [`bind_public`](Binius64BuilderChannel::bind_public).
+	///
+	/// [`Verifier`] is [`Clone`], so a caller still needing the shape elsewhere clones it here
+	/// rather than paying for a clone this constructor does not need.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error::UnsupportedPcs`] when the inner trace is not opened with FRI.
+	///
+	/// Returns [`Error::Verifier`] when the shape itself is unsatisfiable, which a build-time
+	/// constant assertion decides before any proof exists.
+	pub fn build(verifier: Verifier<StdHashSuite>) -> Result<Self, Error> {
+		let Some(compiler) = verifier.iop_compiler().as_basefold() else {
+			return Err(Error::UnsupportedPcs {
+				pcs: verifier.pcs(),
+			});
+		};
+		let mut channel = compiler.create_channel(Binius64BuilderChannel::new());
+
+		// Invariant: on this channel `observe_words` reads the length and never the values.
+		//
+		// It allocates one witness wire per word and absorbs those wires, so the statement
+		// enters as circuit input rather than as a constant. That is what keeps one circuit good
+		// for every proof of this shape, and it is why a placeholder is sound here.
+		let n_inout = verifier.constraint_system().n_inout;
+		let statement = channel.observe_words(&vec![Word::ZERO; n_inout]);
+
+		// The verifier's own arithmetic becomes constraints, down to every assertion along the
+		// way. Discharging the wiring claim is part of that, and it is the level's largest cost.
+		verifier
+			.iop_verifier()
+			.verify(&statement, &mut channel)?
+			.check_symbolic(&mut channel)
+			.map_err(binius_verifier::Error::from)?;
+
+		let mut builder_channel = channel.finish()?;
+		let statement = builder_channel.bind_public(statement);
+
+		Ok(Self {
+			verifier,
+			recorded: builder_channel.build(),
+			statement,
+		})
+	}
+
+	/// The compiled circuit.
+	pub const fn circuit(&self) -> &Circuit {
+		&self.recorded.circuit
+	}
+
+	/// The inner shape this circuit verifies.
+	pub const fn inner(&self) -> &Verifier<StdHashSuite> {
+		&self.verifier
+	}
+
+	/// The public wires carrying the inner statement, in inout order.
+	pub fn statement(&self) -> &[Wire] {
+		&self.statement
+	}
+
+	/// The compiled circuit, and the inventory of wires a witness supplies.
+	///
+	/// The inventory names the operation that allocated each wire, so it reads as a breakdown of
+	/// what the proof had to carry.
+	pub const fn recorded(&self) -> &Recorded {
+		&self.recorded
+	}
+
+	/// Fills the witness that satisfies this circuit for one inner proof.
+	///
+	/// `inout` lands twice: on the public wires an outer proof exposes, and on the wires the
+	/// replay fills. The binding [`build`](Self::build) emitted constrains the two equal, so a
+	/// caller cannot claim one statement while verifying a proof of another.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error::StatementLength`] when `inout` is not the inner statement's length.
+	///
+	/// Returns [`Error::Verifier`] when the transcript does not carry a well-formed proof.
+	///
+	/// Returns [`Error::Unsatisfied`] when the replayed values leave the circuit unsatisfied,
+	/// which is where tampered proof data lands.
+	pub fn witness(&self, inout: &[Word], proof: Vec<u8>) -> Result<ValueVec, Error> {
+		let mut filler = self.fill(inout, proof)?;
+
+		self.recorded
+			.circuit
+			.populate_wire_witness(&mut filler)
+			.map_err(Error::Unsatisfied)?;
+
+		Ok(filler.into_value_vec())
+	}
+
+	/// Replays the proof into a filler, and hands it back before the circuit checks it.
+	///
+	/// Ordinary use wants [`witness`](Self::witness), which checks. This is the seam for a caller
+	/// that must read or perturb what the replay wrote first — a test pinning which constraint
+	/// rejects a tampered proof, say.
+	///
+	/// What comes back is filled, not checked. A caller owes it
+	/// [`populate_wire_witness`](Circuit::populate_wire_witness) before the values mean anything:
+	/// that call is what derives every internal wire and decides whether the circuit holds.
+	///
+	/// # Errors
+	///
+	/// As [`witness`](Self::witness), minus [`Error::Unsatisfied`], which only the check reaches.
+	pub fn fill(&self, inout: &[Word], proof: Vec<u8>) -> Result<WitnessFiller<'_>, Error> {
+		if inout.len() != self.statement.len() {
+			return Err(Error::StatementLength {
+				expected: self.statement.len(),
+				actual: inout.len(),
+			});
+		}
+
+		let mut filler = self.recorded.circuit.new_witness_filler();
+
+		// The public half of every binding is supplied by whoever checks the outer proof.
+		for (&wire, &word) in iter::zip(&self.statement, inout) {
+			filler[wire] = word;
+		}
+
+		self.replay(inout, proof, &mut filler)?;
+
+		Ok(filler)
+	}
+
+	/// Runs the verifier over the real transcript, writing what it reads into the recorded wires.
+	///
+	/// The build and this replay reach the same operations in the same order, so one cursor pairs
+	/// what the replay saw with the wire the build allocated for it.
+	fn replay(
+		&self,
+		inout: &[Word],
+		proof: Vec<u8>,
+		filler: &mut WitnessFiller<'_>,
+	) -> Result<(), Error> {
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		let filler_channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
+			&mut transcript,
+			filler,
+			self.recorded.inputs.clone(),
+		);
+
+		// `build` rejected any other scheme, so this shape opens a FRI trace.
+		let mut channel = self
+			.verifier
+			.iop_compiler()
+			.as_basefold()
+			.expect("build accepts only a FRI-opened shape")
+			.create_channel(filler_channel);
+
+		let statement = channel.observe_words(inout);
+		self.verifier
+			.iop_verifier()
+			.verify(&statement, &mut channel)?
+			.check_symbolic(&mut channel)
+			.map_err(binius_verifier::Error::from)?;
+
+		// Checks the replay consumed exactly the wires the build recorded, no more and no fewer.
+		channel.finish()?.finish();
+
+		Ok(())
+	}
+}

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -22,6 +22,20 @@
 //! [`bind_public`](Binius64BuilderChannel::bind_public) ties chosen ones to public inputs.
 //! That is what lets whoever checks an outer proof see which statement was verified.
 //!
+//! # Where to start
+//!
+//! [`RecursiveCircuit`] is the whole pipeline behind one type.
+//! It builds the circuit from an inner shape, and fills its witness from an inner proof.
+//!
+//! ```text
+//!   RecursiveCircuit::build(verifier)  ->  the circuit
+//!   RecursiveCircuit::witness(..)      ->  values that satisfy it
+//! ```
+//!
+//! What it returns is an ordinary circuit, so it proves and verifies like any other.
+//! Reach for the channels below it only to choose what a statement exposes, or to record a
+//! verifier this crate does not drive.
+//!
 //! # Status: nothing the channel hands out is free
 //!
 //! Every value a verifier reads here is derived in-circuit, or bound to something that is:
@@ -45,6 +59,7 @@
 
 pub mod challenger;
 mod channel;
+mod circuit;
 mod filler;
 mod hints;
 pub mod merkle;
@@ -52,5 +67,6 @@ mod shared;
 pub mod symbolic;
 
 pub use channel::{Binius64BuilderChannel, Commitment, Recorded};
+pub use circuit::{Error, RecursiveCircuit};
 pub use filler::WitnessFillerChannel;
 pub use symbolic::{SymbolicElem, SymbolicWord};

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -7,27 +7,26 @@
 //!        |                              |
 //!        |  verifier run symbolically   |  verifier run for real
 //!        v                              v
-//!   recursive circuit  <----------  its witness  ->  validated
+//!   recursive circuit  <----------  its witness  ->  proved  ->  verified
 //! ```
 //!
 //! One verifier runs over both channels and reaches the same operations in the same order.
-//! The circuit the first produced is satisfied by the witness the second filled.
+//! The circuit the first produced is satisfied by the witness the second filled, and that
+//! circuit is then proved and verified like any other.
 //!
-//! The Merkle commitments are checked in-circuit, so tampering with their advice is rejected here.
-//! The Fiat-Shamir state is not, so a challenge is still whatever the replay supplies.
-
-use std::iter;
+//! Everything the verifier reads is derived in-circuit or bound to something that is: the
+//! Fiat-Shamir state, the Merkle commitments, the query indices, the proof of work. What a
+//! replay still supplies is the proof itself and the statement, which is why tampering with
+//! either is rejected here.
 
 use binius_core::{constraint_system::ValueVec, word::Word};
 use binius_field::arch::OptimalPackedB128;
 use binius_frontend::{
 	Circuit, CircuitBuilder, CircuitStat, MAX_ASSERTION_FAILURES, PopulateError, Wire,
-	WitnessFiller,
 };
 use binius_hash::StdHashSuite;
-use binius_ip::channel::WordIPVerifierChannel;
 use binius_prover::Prover;
-use binius_recursion::{Binius64BuilderChannel, Recorded, WitnessFillerChannel};
+use binius_recursion::{Error, RecursiveCircuit};
 use binius_transcript::{ProverTranscript, VerifierTranscript};
 use binius_verifier::{Verifier, config::StdChallenger};
 
@@ -101,24 +100,19 @@ fn crc64_witness(crc64: &Crc64, message: &[u64; N_INPUT_WORDS]) -> ValueVec {
 	filler.into_value_vec()
 }
 
-/// One CRC-64 statement, proved once, for the recursion pipeline to consume.
+/// One statement, proved once, for the recursion pipeline to consume.
 struct Proved {
 	verifier: Verifier<StdHashSuite>,
 	witness: ValueVec,
 	proof: Vec<u8>,
 }
 
-/// Proves one CRC-64 statement, and checks it verifies natively.
+/// Proves one statement of `circuit`, and checks it verifies natively.
 ///
 /// A proof that fails here would make every recursion failure below ambiguous.
-fn prove_crc64() -> Proved {
-	let crc64 = crc64_circuit();
-	let message = [0x0123456789abcdef, 0xfedcba9876543210, 1, u64::MAX];
-	let witness = crc64_witness(&crc64, &message);
-
+fn prove(circuit: &Circuit, witness: ValueVec) -> Proved {
 	let verifier =
-		Verifier::<StdHashSuite>::setup(crc64.circuit.constraint_system().clone(), LOG_INV_RATE)
-			.unwrap();
+		Verifier::<StdHashSuite>::setup(circuit.constraint_system().clone(), LOG_INV_RATE).unwrap();
 	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone()).unwrap();
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -136,134 +130,129 @@ fn prove_crc64() -> Proved {
 	}
 }
 
-/// The recursive circuit, and the public wires the inner statement was bound to.
-struct Recording {
-	recorded: Recorded,
-	/// One inout wire per inner statement word, each constrained to equal what the verifier read.
-	public: Vec<Wire>,
+/// Proves one CRC-64 statement.
+fn prove_crc64() -> Proved {
+	let crc64 = crc64_circuit();
+	let message = [0x0123456789abcdef, 0xfedcba9876543210, 1, u64::MAX];
+	let witness = crc64_witness(&crc64, &message);
+	prove(&crc64.circuit, witness)
 }
 
-/// Records the verifier run as a circuit, with the whole inner statement made public.
-///
-/// The builder channel is wrapped in the same BaseFold layer the transcript channel gets.
-/// What the verifier does over it becomes the circuit.
-fn record(proved: &Proved) -> Recording {
-	let builder_channel = Binius64BuilderChannel::new();
-	// The circuit is written against the FRI opening, so the compiler is asked for by name.
-	let mut channel = proved
-		.verifier
-		.iop_compiler()
-		.as_basefold()
-		.expect("the recursion circuit verifies a FRI opening")
-		.create_channel(builder_channel);
-	// The statement is observed by the caller, and what comes back is what the verifier reads.
-	// On this channel those are wires, so the recorded circuit takes the statement as input
-	// rather than baking it in.
-	let statement = channel.observe_words(proved.witness.inout());
-	proved
-		.verifier
-		.iop_verifier()
-		.verify(&statement, &mut channel)
-		.expect("the symbolic run records rather than checks, so it cannot fail")
-		.check_symbolic(&mut channel)
-		.expect("the symbolic run records rather than checks, so it cannot fail");
-
-	// Binding every word is this caller's choice, not the channel's.
-	// One that exposed only part of its inner statement would bind only that part.
-	let mut builder_channel = channel.finish().unwrap();
-	let public = builder_channel.bind_public(statement);
-	Recording {
-		recorded: builder_channel.build(),
-		public,
-	}
-}
-
-/// Replays the verifier over the real transcript, filling every wire the build recorded.
-fn replay(proved: &Proved, recorded: &Recorded, filler: &mut WitnessFiller<'_>) {
-	let mut transcript = VerifierTranscript::new(StdChallenger::default(), proved.proof.clone());
-	let filler_channel = WitnessFillerChannel::<_, StdChallenger, StdHashSuite>::new(
-		&mut transcript,
-		filler,
-		recorded.inputs.clone(),
-	);
-	let mut channel = proved
-		.verifier
-		.iop_compiler()
-		.as_basefold()
-		.expect("the recursion circuit verifies a FRI opening")
-		.create_channel(filler_channel);
-	let inout = channel.observe_words(proved.witness.inout());
-	proved
-		.verifier
-		.iop_verifier()
-		.verify(&inout, &mut channel)
-		.unwrap()
-		.check_symbolic(&mut channel)
-		.unwrap();
-	channel.finish().unwrap().finish();
+/// A circuit's constraint rows, which is what one level's cost is compared on.
+const fn rows(stat: &CircuitStat) -> usize {
+	stat.n_and_constraints + stat.n_bmul_constraints + stat.n_zero_constraints
 }
 
 #[test]
 fn recursive_circuit_is_satisfied_by_a_real_proof() {
 	let proved = prove_crc64();
-	let Recording { recorded, public } = record(&proved);
-	let witness = &proved.witness;
+	let recursive = RecursiveCircuit::build(proved.verifier.clone()).unwrap();
 
-	let stat = CircuitStat::collect(&recorded.circuit);
+	let stat = CircuitStat::collect(recursive.circuit());
 	println!(
 		"recursive circuit: {} gates, {} AND, {} BMUL, {} ZERO, {} recorded inputs",
 		stat.n_gates,
 		stat.n_and_constraints,
 		stat.n_bmul_constraints,
 		stat.n_zero_constraints,
-		recorded.inputs.len(),
+		recursive.recorded().inputs.len(),
 	);
 	assert!(stat.n_bmul_constraints > 0, "the verifier's field arithmetic should be recorded");
 
-	// The statement still reaches the verifier as wires the replay fills, one per inout word.
+	// The statement reaches the verifier as wires the replay fills, one per inout word.
+	let inout = proved.witness.inout();
 	assert_eq!(
-		recorded
+		recursive
+			.recorded()
 			.inputs
 			.iter()
 			.filter(|input| input.kind == "observe_words")
 			.count(),
-		witness.inout().len()
+		inout.len()
 	);
 	// One public wire was bound beside each of them.
-	assert_eq!(public.len(), witness.inout().len());
+	assert_eq!(recursive.statement().len(), inout.len());
 
-	// The decommitted layer is on wires now, which is what the opened leaves are matched against.
+	// The decommitted layer is on wires, which is what the opened leaves are matched against.
 	assert!(
-		recorded
+		recursive
+			.recorded()
 			.inputs
 			.iter()
 			.any(|input| input.kind == "merkle_layer"),
 		"the query phase must record the layer it decommits to"
 	);
 
-	// --- its witness ---------------------------------------------------------------------------
-	// Whoever checks the outer proof supplies the public half of each binding.
-	let mut filler = recorded.circuit.new_witness_filler();
-	for (&wire, &word) in iter::zip(&public, witness.inout()) {
-		filler[wire] = word;
-	}
+	let witness = recursive.witness(inout, proved.proof).unwrap();
 
-	// The same verifier runs again over the real transcript, and every value the circuit cannot
-	// derive is written into the wire the build recorded for it.
-	replay(&proved, &recorded, &mut filler);
-
-	recorded
-		.circuit
-		.populate_wire_witness(&mut filler)
-		.expect("the recorded circuit is satisfied by the replayed witness");
-
-	// The point of the change: the circuit's public interface *is* the inner statement.
+	// The point of the binding: the circuit's public interface *is* the inner statement.
 	// An outer proof can pin what was verified instead of trusting the filler.
 	assert_eq!(
-		filler.into_value_vec().inout(),
 		witness.inout(),
+		inout,
 		"the recursive circuit's public values must be the statement it verifies"
 	);
+}
+
+#[test]
+fn the_recursive_circuit_proves_and_verifies() {
+	// Invariant: the recursive circuit is an ordinary circuit, so it proves like any other.
+	//
+	// This is the step that makes the pipeline recursion rather than verification-in-circuit:
+	// what comes out is a proof, of the same kind that went in, carrying the same statement.
+	let inner = prove_crc64();
+	let recursive = RecursiveCircuit::build(inner.verifier.clone()).unwrap();
+	let witness = recursive
+		.witness(inner.witness.inout(), inner.proof.clone())
+		.unwrap();
+
+	// Proving verifies natively too, so a wrong witness fails here rather than silently.
+	let outer = prove(recursive.circuit(), witness);
+
+	println!("inner proof {} bytes -> outer proof {} bytes", inner.proof.len(), outer.proof.len());
+
+	// The outer statement is the inner one, so whoever checks the outer proof learns what was
+	// verified without ever seeing the inner proof.
+	assert_eq!(
+		outer.witness.inout(),
+		inner.witness.inout(),
+		"the outer proof must carry the inner statement"
+	);
+}
+
+#[test]
+#[ignore = "builds a 50M-gate circuit; run explicitly to re-measure per-level growth"]
+fn one_more_level_costs_far_more_than_the_level_below() {
+	// Invariant: discharging the wiring claim in-circuit is proportional to the inner system.
+	//
+	// A level's cost is dominated by a term proportional to the rows of the level beneath it, so
+	// the tower diverges: `rows(n+1) / rows(n)` sits far above one and does not fall with depth.
+	// That ratio is the whole reason the claim has to be deferred instead.
+	//
+	//     depth 1: verifies the CRC-64 proof
+	//     depth 2: verifies depth 1's proof
+	let inner = prove_crc64();
+
+	let depth1 = RecursiveCircuit::build(inner.verifier.clone()).unwrap();
+	let witness1 = depth1
+		.witness(inner.witness.inout(), inner.proof.clone())
+		.unwrap();
+	let rows1 = rows(&CircuitStat::collect(depth1.circuit()));
+
+	// Depth 2 reads only depth 1's *shape*, so depth 1 need not be proved to measure this.
+	let verifier1 =
+		Verifier::<StdHashSuite>::setup(depth1.circuit().constraint_system().clone(), LOG_INV_RATE)
+			.unwrap();
+	let depth2 = RecursiveCircuit::build(verifier1).unwrap();
+	let rows2 = rows(&CircuitStat::collect(depth2.circuit()));
+
+	let growth = rows2 as f64 / rows1 as f64;
+	println!("rows: depth1 {rows1} -> depth2 {rows2} = {growth:.2}x");
+
+	// A closing tower would sit at or below one. Pinning a floor documents that it does not, and
+	// turns the day this drops into a test failure worth reading.
+	assert!(growth > 5.0, "inline discharge is expected to diverge, measured {growth:.2}x");
+	assert_eq!(witness1.inout(), inner.witness.inout());
 }
 
 /// Flips one bit of the first recorded wire of `kind`, and returns why the circuit then fails.
@@ -271,22 +260,21 @@ fn recursive_circuit_is_satisfied_by_a_real_proof() {
 /// The wire is tampered after an honest replay, so only that bit differs from a good witness.
 fn reject_tampered(kind: &'static str) -> Vec<String> {
 	let proved = prove_crc64();
-	let Recording { recorded, public } = record(&proved);
-	let mut filler = recorded.circuit.new_witness_filler();
-	for (&wire, &word) in iter::zip(&public, proved.witness.inout()) {
-		filler[wire] = word;
-	}
-	replay(&proved, &recorded, &mut filler);
+	let recursive = RecursiveCircuit::build(proved.verifier.clone()).unwrap();
+	let mut filler = recursive
+		.fill(proved.witness.inout(), proved.proof)
+		.unwrap();
 
-	let input = recorded
+	let input = recursive
+		.recorded()
 		.inputs
 		.iter()
 		.find(|input| input.kind == kind)
 		.unwrap_or_else(|| panic!("the verifier must record at least one {kind} wire"));
 	filler[input.wire] = Word(filler[input.wire].0 ^ 1);
 
-	let error = recorded
-		.circuit
+	let error = recursive
+		.circuit()
 		.populate_wire_witness(&mut filler)
 		.expect_err("a tampered witness must leave the circuit unsatisfied");
 
@@ -344,18 +332,17 @@ fn a_public_input_that_disagrees_with_the_statement_is_rejected() {
 	//     before:  public word == the word the replay filled
 	//     after:   public word != it, and the equality the binding emitted breaks
 	let proved = prove_crc64();
-	let Recording { recorded, public } = record(&proved);
-	let mut filler = recorded.circuit.new_witness_filler();
-	for (&wire, &word) in iter::zip(&public, proved.witness.inout()) {
-		filler[wire] = word;
-	}
-	replay(&proved, &recorded, &mut filler);
+	let recursive = RecursiveCircuit::build(proved.verifier.clone()).unwrap();
+	let mut filler = recursive
+		.fill(proved.witness.inout(), proved.proof)
+		.unwrap();
 
 	// Mutation: flip one bit of the first public word, leaving the replay's own wire alone.
-	filler[public[0]] = Word(filler[public[0]].0 ^ 1);
+	let bound = recursive.statement()[0];
+	filler[bound] = Word(filler[bound].0 ^ 1);
 
-	let error = recorded
-		.circuit
+	let error = recursive
+		.circuit()
 		.populate_wire_witness(&mut filler)
 		.expect_err("a public input that disagrees must leave the circuit unsatisfied");
 
@@ -371,4 +358,54 @@ fn a_public_input_that_disagrees_with_the_statement_is_rejected() {
 		failures[0].path
 	);
 	assert!(!failures[0].detail.is_empty(), "a failure must carry a diagnostic");
+}
+
+#[test]
+fn a_statement_of_the_wrong_length_is_rejected() {
+	// Invariant: the statement's length is the inner system's, and nothing else is accepted.
+	//
+	// A short statement would otherwise bind only a prefix, leaving the rest of the public
+	// interface to whoever filled the witness.
+	let proved = prove_crc64();
+	let recursive = RecursiveCircuit::build(proved.verifier.clone()).unwrap();
+	let inout = proved.witness.inout();
+
+	let error = recursive
+		.witness(&inout[..inout.len() - 1], proved.proof)
+		.expect_err("a statement one word short must be rejected");
+
+	assert!(
+		matches!(
+			error,
+			Error::StatementLength { expected, actual }
+				if expected == inout.len() && actual == inout.len() - 1
+		),
+		"expected a length mismatch, got {error}"
+	);
+}
+
+#[test]
+fn a_malformed_proof_is_rejected_rather_than_crashing() {
+	// Invariant: how much a replay reads is fixed by the shape, never by what it reads.
+	//
+	// So a truncated tape runs out of bytes rather than out of recorded wires, and the transcript
+	// reports that as an error. A shape-dependent read would instead walk off the wire cursor and
+	// take the process down, which is why this is worth pinning.
+	let proved = prove_crc64();
+	let recursive = RecursiveCircuit::build(proved.verifier.clone()).unwrap();
+	let inout = proved.witness.inout();
+
+	// Half a tape, then no tape at all.
+	for proof in [proved.proof[..proved.proof.len() / 2].to_vec(), Vec::new()] {
+		let len = proof.len();
+		let error = recursive
+			.witness(inout, proof)
+			.expect_err("a malformed proof must be rejected");
+		// Reaching here at all is the invariant: an error came back, nothing unwound.
+		// The variant still has to name the tape, not the statement, or the wrong check fired.
+		assert!(
+			!matches!(error, Error::StatementLength { .. } | Error::UnsupportedPcs { .. }),
+			"a {len}-byte tape must fail on the tape, got {error}"
+		);
+	}
 }


### PR DESCRIPTION
Closes [BINIUS-552](https://linear.app/jimpo/issue/BINIUS-552).

Adds `RecursiveCircuit`: builds the circuit that verifies a Binius64 proof, fills its witness, and — new here — lets that circuit be proved and verified like any other. Also measures what one more level costs.

### The problem

`crates/recursion` stopped one step short of recursion.

It built a circuit that verifies a proof, replayed the proof to fill the witness, and checked the circuit was satisfied. Then it stopped.

Nothing ever proved that circuit. So the pipeline produced a *satisfied circuit*, never a *proof of a verification* — and recursion is exactly the second thing.

Two consequences:

- No depth-2 anything. Nothing verified a proof of the recursive circuit, so nobody knew whether a level composes.
- The glue lived inside `tests/recursion_end_to_end.rs`. A caller outside the crate had to reimplement channel wrapping, statement observation, public binding, and replay by hand.

### The idea

Split the pipeline along the seam the protocol already has.

```
inner shape      ->  build    ->  circuit
circuit + proof  ->  witness  ->  values that satisfy it
```

The seam matters: **`build` needs only the shape, never a proof.** A shape is the constraint system, the FRI parameters, the oracle specs — everything fixed before a proof exists. No length in the protocol depends on a received value, so one circuit verifies *every* proof of that shape.

And what `build` returns is an ordinary circuit, so it has an ordinary `Verifier`. Building again over that verifier is one level deeper, for free:

```
Verifier(inner) -> build -> circuit_1 -> Verifier(circuit_1) -> build -> circuit_2
```

That is what makes the depth-2 measurement a short test rather than a project.

### The change

```
- let mut channel = compiler.create_channel(Binius64BuilderChannel::new());   // in a test
- let statement = channel.observe_words(witness.inout());                     // by hand
- ... verify, check_symbolic, finish, bind_public, new_witness_filler, replay ...
+ let recursive = RecursiveCircuit::build(verifier)?;
+ let witness = recursive.witness(inout, proof)?;
```

### What it measures

Depth 1 proves and verifies: inner proof 34,688 bytes to outer proof 286,816 bytes, both carrying the same statement.

Depth 2 builds:

| level | AND | BMUL | ZERO | rows |
|---|---|---|---|---|
| inner CRC-64 | 256 | 0 | 508 | 764 |
| depth 1 | 403,996 | 365,235 | 109,708 | 878,939 |
| depth 2 | 2,876,045 | 8,258,066 | 1,850,080 | 12,984,191 |

**One level costs 14.77x the constraint rows of the level it verifies.**

That is divergence, and it is expected. The wiring ("monster") claim is discharged in-circuit, at a cost proportional to the inner system — measured separately at 6.0 BMUL per inner constraint row, stable to 1% over a 256x range. A tower closes only when the ratio sits at or below one, so no fixed point exists while the claim is paid inline.

The test pins a **floor**, not a ceiling (`growth > 5.0`), so the day deferral lands it fails and says why. It is `#[ignore]`d because it builds a 50M-gate circuit.

### Soundness

No protocol change. Three points the new API relies on:

- **`build`'s placeholder statement is sound.** On the builder channel, `observe_words` reads its argument's *length* and never its values — it allocates one witness wire per word and absorbs the wires. The statement enters as circuit input, not a baked constant, which is what keeps one circuit good for every proof of the shape. A test asserts the recorded `observe_words` count equals the inout length.
- **The statement's length is not guessed.** It is the inner system's `n_inout`, the same value `IOPVerifier::verify` rejects a mismatch against, so a wrong length fails in `build` rather than silently.
- **`fill` returns an unchecked filler by design**, so negative tests can perturb what the replay wrote. Its docs state the caller owes `populate_wire_witness`; `witness` is the checked path.

### Scope

- **new:** `crates/recursion/src/circuit.rs` — `RecursiveCircuit` with `build`, `witness`, `fill`, and accessors
- **changed:** `binius-verifier` moves from `dev-dependencies` to `dependencies`. Recording the verifier is what this crate is for. Acyclic and contained: nothing in the workspace depends on `binius-recursion`
- **changed:** the end-to-end test drives the public API, so no crypto glue is duplicated between library and test
- **new tests:** prove-and-verify, depth-2 growth (ignored), wrong-length statement, malformed proof
- **untouched:** the channels, the challenger, the Merkle gadgets, and every existing negative test

### Drive-by, and why it is here

The second commit adds one semicolon in `crates/iop-prover/src/channel/merge.rs` — a file this PR otherwise does not touch.

`clippy::semicolon_if_nothing_returned` fires on a `const { assert!(..) }` block in `multi_round_round_trip_narrow_packing`, and CI lints with `-D warnings`. It is pre-existing on `main` (this branch is based on `0c1bfac5`) and it fails clippy for **every** PR against main, this one included. The lint only appears under `--all-targets`, since the block sits in a test module, which is how it reached main.

Happy to split it into its own PR if you would rather keep this one single-purpose — say so and I will.

### Verification

- nightly `cargo fmt --all --check`, `cargo clippy -p binius-recursion --all-targets`, `cargo doc -p binius-recursion --no-deps` — all clean
- `cargo test -p binius-recursion` — 31 tests pass (7 in the end-to-end suite, 1 ignored by design)
- the ignored depth-2 test run explicitly — passes, reporting the 14.77x above
- `cargo clippy -p binius-recursion --all-targets --all-features -- -D warnings` — clean, i.e. this crate passes under CI's exact flags
- **Not verifiable locally:** `--workspace` anything, and clippy on `binius-iop-prover`. No C compiler is installed here, so `alloca`'s build script fails and those targets cannot build. The semicolon fix above therefore rests on CI, not on a local run — it is the exact lint, at the exact line, CI reported, and it is the only occurrence of the pattern in the workspace. Nothing depends on `binius-recursion`, so the dependency move cannot reach another crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
