### PR TITLE
BINIUS-553: Transpose the Blake3 message with an AVX-512 shuffle network

### DIFF
--- a/crates/hash/src/blake3_avx512.rs
+++ b/crates/hash/src/blake3_avx512.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 The Binius Developers
+
+//! x86-64 AVX-512 message transpose for the multi-lane Blake3 kernel.
+//!
+//! The lane loops hold the message as 16 words of `N` lanes, one lane per message.
+//! The input arrives the other way round: `N` blocks of 16 words, one block per lane.
+//! Turning one layout into the other is a 16x16 transpose of 32-bit words.
+//!
+//! At 16 lanes that square is exactly four 512-bit registers wide and 16 rows tall,
+//! so a fixed shuffle network moves it with no memory round trip.
+
+use std::arch::x86_64::{
+	__m512i, _mm512_loadu_si512, _mm512_setzero_si512, _mm512_shuffle_i32x4, _mm512_storeu_si512,
+	_mm512_unpackhi_epi32, _mm512_unpackhi_epi64, _mm512_unpacklo_epi32, _mm512_unpacklo_epi64,
+};
+
+use blake3::BLOCK_LEN;
+
+/// Lane count the shuffle network is built for.
+///
+/// A 64-byte block holds 16 words, so only 16 lanes make the message a square.
+/// A non-square block would need a different network per shape, which the lane loops already cover.
+const LANES: usize = 16;
+
+/// Reports whether this module has a transpose for the given lane count.
+#[inline(always)]
+pub const fn handles_lanes(n: usize) -> bool {
+	n == LANES
+}
+
+/// Transposes 16 blocks of 16 words into 16 words of 16 lanes.
+///
+/// Both buffers are 1024 contiguous bytes, read and written as 16 rows of one 512-bit register.
+///
+/// # Safety
+///
+/// - `src` must be readable for 16 rows of `BLOCK_LEN` bytes.
+/// - `dst` must be writable for 16 rows of `LANES` words.
+/// - The two regions must not overlap.
+#[inline(always)]
+unsafe fn transpose_16x16(src: *const u8, dst: *mut u32) {
+	unsafe {
+		// Row `i` of the input is lane `i`'s whole 64-byte block.
+		let mut r = [_mm512_setzero_si512(); 16];
+		for (i, row) in r.iter_mut().enumerate() {
+			*row = _mm512_loadu_si512(src.cast::<__m512i>().add(i));
+		}
+
+		// The network walks the transpose one power of two at a time.
+		// Each stage swaps blocks of size 2^k between rows 2^k apart.
+		//
+		//     stage 1: 32-bit words,  rows 1 apart
+		//     stage 2: 64-bit pairs,  rows 2 apart
+		//     stage 3: 128-bit lanes, rows 4 apart
+		//     stage 4: 128-bit lanes, rows 8 apart
+		let mut t = [_mm512_setzero_si512(); 16];
+
+		// Stage 1: interleave 32-bit words between each adjacent row pair.
+		for i in 0..8 {
+			t[2 * i] = _mm512_unpacklo_epi32(r[2 * i], r[2 * i + 1]);
+			t[2 * i + 1] = _mm512_unpackhi_epi32(r[2 * i], r[2 * i + 1]);
+		}
+
+		// Stage 2: interleave 64-bit pairs between rows two apart.
+		for i in 0..4 {
+			let (lo, hi) = (4 * i, 4 * i + 2);
+			r[4 * i] = _mm512_unpacklo_epi64(t[lo], t[hi]);
+			r[4 * i + 1] = _mm512_unpackhi_epi64(t[lo], t[hi]);
+			r[4 * i + 2] = _mm512_unpacklo_epi64(t[lo + 1], t[hi + 1]);
+			r[4 * i + 3] = _mm512_unpackhi_epi64(t[lo + 1], t[hi + 1]);
+		}
+
+		// Stage 3: exchange whole 128-bit lanes between rows four apart.
+		// Selector 0x88 takes the two low lanes of each source, 0xdd the two high lanes.
+		for i in 0..2 {
+			for j in 0..4 {
+				let (lo, hi) = (8 * i + j, 8 * i + j + 4);
+				t[8 * i + j] = _mm512_shuffle_i32x4(r[lo], r[hi], 0x88);
+				t[8 * i + j + 4] = _mm512_shuffle_i32x4(r[lo], r[hi], 0xdd);
+			}
+		}
+
+		// Stage 4: exchange 128-bit lanes between rows eight apart, completing the square.
+		for j in 0..8 {
+			r[j] = _mm512_shuffle_i32x4(t[j], t[j + 8], 0x88);
+			r[j + 8] = _mm512_shuffle_i32x4(t[j], t[j + 8], 0xdd);
+		}
+
+		// Row `w` of the output is message word `w` across all 16 lanes.
+		for (i, row) in r.iter().enumerate() {
+			_mm512_storeu_si512(dst.cast::<__m512i>().add(i), *row);
+		}
+	}
+}
+
+/// Loads one 64-byte block per lane into 16 little-endian message words.
+///
+/// Produces the same words as the portable byte-wise loader, for every input.
+/// x86-64 is little-endian, so reading a block as 32-bit words already applies the byte order.
+///
+/// # Panics
+///
+/// Panics if no transpose covers `N`.
+#[inline(always)]
+pub fn load_block_words<const N: usize>(block: &[[u8; BLOCK_LEN]; N]) -> [[u32; N]; 16] {
+	assert!(handles_lanes(N), "precondition: the lane count must have a transpose");
+
+	let mut m = [[0u32; N]; 16];
+
+	// SAFETY:
+	// - Arrays are contiguous, so the input is 16 rows of `BLOCK_LEN` bytes with no padding.
+	// - The output is 16 rows of `N` words, and the check above pins `N` to 16.
+	// - `m` is a fresh local, so it cannot alias `block`.
+	unsafe { transpose_16x16(block.as_ptr().cast::<u8>(), m.as_mut_ptr().cast::<u32>()) };
+
+	m
+}

--- a/crates/hash/src/blake3_portable.rs
+++ b/crates/hash/src/blake3_portable.rs
@@ -48,6 +48,13 @@ use super::{
 #[path = "blake3_neon.rs"]
 mod neon;
 
+/// Hand-written vector transpose for the message load, used in place of the byte-wise loader below.
+///
+/// Kept private so it stays an implementation detail of this module.
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+#[path = "blake3_avx512.rs"]
+mod avx512;
+
 /// Blake3 domain-separation flag marking the first block of a chunk.
 const CHUNK_START: u32 = 1 << 0;
 
@@ -123,8 +130,25 @@ fn permute<const N: usize>(m: &mut [[u32; N]; 16]) {
 }
 
 /// Loads one 64-byte block per lane into 16 little-endian message words.
+///
+/// The words arrive one block per lane and are consumed one word per lane, so this is a transpose.
+/// Where a vector kernel covers the lane count it moves the square with shuffles instead of loads.
 #[inline(always)]
 fn load_block_words<const N: usize>(block: &[[u8; BLOCK_LEN]; N]) -> [[u32; N]; 16] {
+	#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+	if avx512::handles_lanes(N) {
+		return avx512::load_block_words(block);
+	}
+
+	load_block_words_portable(block)
+}
+
+/// Loads one 64-byte block per lane into 16 little-endian message words, one word at a time.
+///
+/// Every target without a hand-written transpose runs this, and it is the reference the vector
+/// kernels are tested against.
+#[inline(always)]
+fn load_block_words_portable<const N: usize>(block: &[[u8; BLOCK_LEN]; N]) -> [[u32; N]; 16] {
 	let mut m = [[0u32; N]; 16];
 	for lane in 0..N {
 		for (w, slot) in m.iter_mut().enumerate() {
@@ -550,6 +574,81 @@ mod tests {
 			check_parallel_compression::<4>(&pairs);
 			check_parallel_compression::<8>(&pairs);
 			check_parallel_compression::<16>(&pairs);
+		}
+	}
+
+	/// Transposes one random block through both loaders and pins the vector words to the byte-wise
+	/// words.
+	///
+	/// # Arguments
+	///
+	/// * `rng` - source of the random block bytes.
+	#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+	fn check_avx512_transpose<const N: usize>(rng: &mut StdRng) {
+		use rand::RngExt;
+
+		// Every lane gets its own random bytes.
+		// Sharing bytes across lanes would hide a network that reads the wrong row.
+		let block: [[u8; BLOCK_LEN]; N] = array::from_fn(|_| array::from_fn(|_| rng.random()));
+
+		// Reference: the byte-wise loader every target without a transpose runs.
+		let want = load_block_words_portable(&block);
+
+		// Candidate: the shuffle network, over the same bytes.
+		let got = super::avx512::load_block_words(&block);
+
+		// A transpose only permutes words, so the two must agree on all 16 words of all N lanes.
+		assert_eq!(got, want, "vector transpose diverged from the byte-wise loader at {N} lanes");
+	}
+
+	#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+	#[test]
+	fn test_avx512_transpose_matches_portable() {
+		let mut rng = StdRng::seed_from_u64(13);
+
+		// A misplaced row shows up only when the bytes differ, so repeat over fresh random blocks.
+		for _ in 0..64 {
+			check_avx512_transpose::<16>(&mut rng);
+		}
+	}
+
+	#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+	#[test]
+	fn test_avx512_transpose_places_every_word() {
+		// A counting block makes each word its own (lane, word) coordinate.
+		// Any swapped row or lane then shows up as a wrong coordinate, not just wrong bytes.
+		let block: [[u8; BLOCK_LEN]; 16] = array::from_fn(|lane| {
+			array::from_fn(|byte| {
+				let word = byte / 4;
+				// Word `w` of lane `l` is the value `l * 16 + w`, little-endian.
+				match byte % 4 {
+					0 => (lane * 16 + word) as u8,
+					_ => 0,
+				}
+			})
+		});
+
+		let m = super::avx512::load_block_words(&block);
+
+		// Word `w` of lane `l` must land at `m[w][l]`.
+		for lane in 0..16 {
+			for word in 0..16 {
+				assert_eq!(
+					m[word][lane],
+					(lane * 16 + word) as u32,
+					"word {word} of lane {lane} landed wrongly"
+				);
+			}
+		}
+	}
+
+	#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+	proptest! {
+		#[test]
+		fn avx512_transpose_matches_portable_proptest(seed in any::<u64>()) {
+			// The fixed cases above pin the layout; this sweeps arbitrary bytes.
+			let mut rng = StdRng::seed_from_u64(seed);
+			check_avx512_transpose::<16>(&mut rng);
 		}
 	}
 

--- a/crates/iop-prover/src/channel/merge.rs
+++ b/crates/iop-prover/src/channel/merge.rs
@@ -619,7 +619,7 @@ mod tests {
 			assert!(
 				PackedBinaryGhash4x128b::LOG_WIDTH > 0,
 				"the fixture needs sub-packed-width oracle sizes to appear"
-			)
+			);
 		};
 		run_merge_round_trip::<PackedBinaryGhash4x128b>(&[&[3, 3], &[4, 2, 2], &[1]], false);
 	}


### PR DESCRIPTION
Closes [BINIUS-553](https://linear.app/jimpo/issue/BINIUS-553).

Moves the Blake3 multi-lane message transpose from scalar loads into an AVX-512 shuffle network.
Output is bit-identical to `blake3::hash` — no protocol change, no new soundness assumption.

### The problem

The kernel holds the message as 16 words of `N` lanes, one lane per message.
The input arrives the other way round: `N` blocks of 16 words, one block per lane.
Converting between the two layouts is a 16x16 transpose of 32-bit words.

`load_block_words` does that transpose one word at a time.
Per 64-byte block it reads 256 words and scatters them across 16 separate rows.

That runs **once per compression** — on every leaf block and every Merkle inner node.
On an AMD Zen 5 it is about a fifth of the kernel's runtime.

### The idea

At 16 lanes the square is exactly 16 rows of one 512-bit register.
So a fixed shuffle network can move it entirely in registers, with no memory round trip.

The network walks the transpose one power of two at a time:

```
stage 1: 32-bit words,  rows 1 apart    vpunpckldq  / vpunpckhdq
stage 2: 64-bit pairs,  rows 2 apart    vpunpcklqdq / vpunpckhqdq
stage 3: 128-bit lanes, rows 4 apart    vshufi32x4
stage 4: 128-bit lanes, rows 8 apart    vshufi32x4
```

### Per 64-byte block

- **before:** 256 scalar loads, then 256 scattered stores
- **after:** 16 vector loads, 64 shuffles, 16 vector stores

### How this relates to `zooko/blake3-sme2` — and what it is *not*

The idea is borrowed from that repo, where SME2 gets this same transpose **for free**: it writes 16 blocks as rows into a ZA tile and reads the columns straight back out.

- This PR ports the *observation* — that the transpose is a real cost in a multi-buffer Blake3 — not the code.
- That code is ARM SME2 assembly for Apple M4; AVX-512 has no ZA tile, so the shuffle network is the closest equivalent.
- Nothing about the compression core changes here. Only the message load does.

### The change

```
- fn load_block_words(..)          // byte-wise loader, the only path
+ fn load_block_words(..)          // dispatches on lane count
+ fn load_block_words_portable(..) // byte-wise loader, now the tested reference
```

The new module is gated on `target_feature = "avx512f"` and claims only 16 lanes, mirroring the existing aarch64 NEON hook.
16 is the width `Blake3HashSuite` ships, and the only lane count that makes the block square.

### Soundness

A transpose only permutes words, so the compression input is unchanged.
Three tests pin the network equal to the byte-wise loader, and the pre-existing `blake3::hash` equality tests now route through it.

### Scope

- **new:** `crates/hash/src/blake3_avx512.rs`
- **changed:** `load_block_words` in `blake3_portable.rs` becomes a dispatcher
- **left untouched:** the compression core, the aarch64 NEON path, and every lane count other than 16 — all still take the byte-wise loader

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-hash --all-targets`, run **both** with and without `avx512f` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` and `tools/check_copyright_notice.py` — clean
- `cargo test -p binius-hash --lib`: 30/30 with AVX-512; the 8 Blake3 tests still pass with the module cfg'd out
- New tests: a fixed-random equality check, a coordinate-counting block that catches a swapped row or lane, and a proptest

### Benchmark

The repo's own `blake3_portable` bench, single-threaded and pinned to one core so the kernel is not masked by memory bandwidth, built with `-C target-cpu=native`.
`portable_16` is the path this PR touches; `portable_4` is untouched and acts as a control.

| leaf (elems) | before | after | change |
|---|---|---|---|
| 1 | 812.2 MiB/s | 964.1 MiB/s | +18.6% |
| 2 | 1.535 GiB/s | 1.805 GiB/s | +17.7% |
| 3 | 2.208 GiB/s | 2.583 GiB/s | +17.4% |
| 4 | 2.802 GiB/s | 3.218 GiB/s | +14.9% |
| 8 | 3.163 GiB/s | 3.657 GiB/s | +15.7% |
| 16 | 3.405 GiB/s | 3.989 GiB/s | +17.1% |
| 32 | 3.514 GiB/s | 4.116 GiB/s | +17.1% |
| 64 | 3.577 GiB/s | 4.186 GiB/s | +17.2% |

The control moved +0.1% to +5.7% over the same runs, so read the real effect as roughly +12% to +17%.

Two honest caveats:
- On the default multi-threaded bench the win largely washes out at ~20 GiB/s, which reads as bandwidth-bound rather than as the change not working.
- Machine was an AMD Ryzen 9 9950X3D (Zen 5). Numbers on Intel AVX-512 parts will differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)