### PR TITLE
BINIUS-551: Record the full oracle schedule in the setup channel

### DIFF
--- a/crates/iop-prover/src/channel/merge.rs
+++ b/crates/iop-prover/src/channel/merge.rs
@@ -619,7 +619,7 @@ mod tests {
 			assert!(
 				PackedBinaryGhash4x128b::LOG_WIDTH > 0,
 				"the fixture needs sub-packed-width oracle sizes to appear"
-			)
+			);
 		};
 		run_merge_round_trip::<PackedBinaryGhash4x128b>(&[&[3, 3], &[4, 2, 2], &[1]], false);
 	}

--- a/crates/iop/src/channel/merge.rs
+++ b/crates/iop/src/channel/merge.rs
@@ -8,9 +8,10 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_math::multilinear::hypercube::Hypercube;
-use binius_utils::checked_arithmetics::log2_ceil_usize;
 
-use crate::channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn};
+use crate::channel::{
+	Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn, merged_log_msg_len,
+};
 
 /// A handle to an oracle received through the merging decorator.
 #[derive(Debug, Clone, Copy)]
@@ -194,11 +195,8 @@ where
 		let is_witness_dependent = order.iter().any(|&i| self.records[i].is_witness_dependent);
 
 		// Size the combined oracle to fit every oracle end to end.
-		let total_len: usize = order
-			.iter()
-			.map(|&i| 1usize << self.records[i].log_msg_len)
-			.sum();
-		let combined_log_len = log2_ceil_usize(total_len);
+		let combined_log_len =
+			merged_log_msg_len(order.iter().map(|&i| self.records[i].log_msg_len));
 
 		// Commit the whole round as one oracle on the underlying channel.
 		let outer = self
@@ -415,9 +413,11 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_field::Ghash128b;
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
+	use proptest::prelude::*;
 
 	use super::*;
-	use crate::channel::oracle_setup::OracleSetupChannel;
+	use crate::channel::{OracleSchedule, oracle_setup::OracleSetupChannel};
 
 	type F = Ghash128b;
 
@@ -455,6 +455,60 @@ mod tests {
 			IPVerifierChannel::<F>::sample(&mut channel);
 		}
 		channel.into_inner().unwrap().into_oracle_specs()
+	}
+
+	/// Replays the same rounds against a bare setup channel, with no decorator in the way.
+	///
+	/// Returns the schedule that run records.
+	fn record_schedule(rounds: &[&[usize]], is_zk: bool) -> OracleSchedule {
+		let mut channel = OracleSetupChannel::new(is_zk);
+		for sizes in rounds {
+			for &n in *sizes {
+				IOPVerifierChannel::<F>::recv_oracle(&mut channel, n, true).unwrap();
+			}
+			IPVerifierChannel::<F>::sample(&mut channel);
+		}
+		channel.into_oracle_schedule()
+	}
+
+	/// Asserts the schedule predicts exactly what the decorator commits, for one set of rounds.
+	fn assert_schedule_predicts_the_decorator(rounds: &[&[usize]]) {
+		for is_zk in [false, true] {
+			assert_eq!(
+				record_schedule(rounds, is_zk).merged_specs(),
+				record_rounds(rounds, is_zk),
+				"rounds={rounds:?} is_zk={is_zk}"
+			);
+		}
+	}
+
+	#[test]
+	fn the_schedule_predicts_what_the_decorator_commits() {
+		// Two independent routes to the same coarse spec list.
+		//
+		//     decorator: merges each round, and its inner channel records what was committed
+		//     schedule : records where the rounds fall, then merges them itself
+		//
+		// They must agree, or the schedule is not a faithful model of the decorator.
+		//
+		// Round shapes below, chosen to hit each case once:
+		//
+		//     [3, 3]    two equal oracles, summing to an exact power of two
+		//     [4, 2, 2] unequal oracles, summing to 24, so one bit of padding
+		//     [5]       a lone oracle, forwarded with no combining at all
+		assert_schedule_predicts_the_decorator(&[&[3, 3], &[4, 2, 2], &[5]]);
+	}
+
+	proptest! {
+		#[test]
+		fn prop_the_schedule_predicts_what_the_decorator_commits(
+			rounds in prop::collection::vec(prop::collection::vec(0usize..6, 1..4), 1..5),
+		) {
+			// Random round shapes reach layouts the fixed case above never does.
+			// Sizes down to 2^0 make the padding and the sort order both non-trivial.
+			let round_refs: Vec<&[usize]> = rounds.iter().map(Vec::as_slice).collect();
+			assert_schedule_predicts_the_decorator(&round_refs);
+		}
 	}
 
 	#[test]

--- a/crates/iop/src/channel/mod.rs
+++ b/crates/iop/src/channel/mod.rs
@@ -8,8 +8,11 @@ pub mod naive;
 pub mod oracle_setup;
 pub mod size_tracking;
 
+use std::iter;
+
 use binius_field::Field;
 use binius_ip::channel::IPVerifierChannel;
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use crate::{basefold, ligerito};
 
@@ -57,6 +60,106 @@ impl OracleSpec {
 			log_msg_len,
 			is_zk: true,
 		}
+	}
+}
+
+/// The length of the one oracle a round's oracles are committed as.
+///
+/// The oracles lie end to end, so this is the smallest power of two covering their total.
+fn merged_log_msg_len(log_msg_lens: impl IntoIterator<Item = usize>) -> usize {
+	let total_len: usize = log_msg_lens.into_iter().map(|n| 1usize << n).sum();
+	log2_ceil_usize(total_len)
+}
+
+/// Every oracle an IOP commits, grouped into the rounds they are committed in.
+///
+/// A round is the run of oracles sent between two challenge samples.
+///
+/// A challenge can only be derived once the commitments before it are absorbed.
+///
+/// So a round closes the moment its challenge is drawn, and takes no further members.
+///
+/// ```text
+/// recv, recv, sample, recv, sample, recv, recv, recv
+/// \__________/        \__/          \______________/
+///    round 0         round 1           round 2
+/// ```
+///
+/// A flat spec list cannot say where those boundaries fall.
+///
+/// A caller that commits a whole round as one oracle needs them.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct OracleSchedule {
+	/// Every oracle, in arrival order, across all rounds.
+	specs: Vec<OracleSpec>,
+
+	/// The exclusive end of each closed round, as an index into `specs`.
+	///
+	/// Round `r` spans `specs[ends[r - 1]..ends[r]]`, and round `0` starts at `0`.
+	///
+	/// Anything past the last entry is in the round still open.
+	ends: Vec<usize>,
+}
+
+impl OracleSchedule {
+	/// Creates an empty schedule.
+	pub const fn new() -> Self {
+		Self {
+			specs: Vec::new(),
+			ends: Vec::new(),
+		}
+	}
+
+	/// Appends one oracle to the round currently open.
+	pub fn push(&mut self, spec: OracleSpec) {
+		self.specs.push(spec);
+	}
+
+	/// Closes the round currently open, so later oracles start a new one.
+	///
+	/// Does nothing when no oracle has arrived since the last close.
+	///
+	/// Calling it wherever a challenge could be drawn is therefore always safe.
+	pub fn end_round(&mut self) {
+		let open_start = self.ends.last().copied().unwrap_or(0);
+		if self.specs.len() > open_start {
+			self.ends.push(self.specs.len());
+		}
+	}
+
+	/// Every oracle in the schedule, in arrival order, with round boundaries dropped.
+	pub fn specs(&self) -> &[OracleSpec] {
+		&self.specs
+	}
+
+	/// Consumes the schedule and returns every oracle, with round boundaries dropped.
+	pub fn into_specs(self) -> Vec<OracleSpec> {
+		self.specs
+	}
+
+	/// The number of closed rounds.
+	pub const fn n_rounds(&self) -> usize {
+		self.ends.len()
+	}
+
+	/// The oracles of each closed round, in commit order.
+	pub fn rounds(&self) -> impl Iterator<Item = &[OracleSpec]> {
+		let starts = iter::once(0).chain(self.ends.iter().copied());
+		iter::zip(starts, self.ends.iter().copied()).map(|(start, end)| &self.specs[start..end])
+	}
+
+	/// One spec per round: the oracle that round's oracles are committed as.
+	///
+	/// This is the coarser list an underlying channel is configured with.
+	///
+	/// A round is masked as a whole, so its oracle is zero-knowledge if any member is.
+	pub fn merged_specs(&self) -> Vec<OracleSpec> {
+		self.rounds()
+			.map(|round| OracleSpec {
+				log_msg_len: merged_log_msg_len(round.iter().map(|spec| spec.log_msg_len)),
+				is_zk: round.iter().any(|spec| spec.is_zk),
+			})
+			.collect()
 	}
 }
 

--- a/crates/iop/src/channel/oracle_setup.rs
+++ b/crates/iop/src/channel/oracle_setup.rs
@@ -15,7 +15,7 @@ use binius_field::{
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 
-use crate::channel::{Error, IOPVerifierChannel, OracleSpec, TransparentEvalFn};
+use crate::channel::{Error, IOPVerifierChannel, OracleSchedule, OracleSpec, TransparentEvalFn};
 
 /// A dummy field element for [`OracleSetupChannel`], generic over the field `F` it stands in for.
 ///
@@ -125,17 +125,30 @@ impl<F: Field> FieldOps for DummyElem<F> {
 
 /// An [`IOPVerifierChannel`] that records the [`OracleSpec`] of each received oracle.
 ///
-/// This performs no verification: `recv_*` methods return dummy values, and sampling, observation,
-/// and `assert_zero` are no-ops. Drive an IOP verifier with this channel and then read the
-/// recorded specs via [`into_oracle_specs`](Self::into_oracle_specs).
+/// This performs no verification.
 ///
-/// The channel is configured with a single `is_zk` flag (the protocol-level zero-knowledge
-/// choice). Each `recv_oracle(log_msg_len, is_witness_dependent)` records
-/// `OracleSpec { log_msg_len, is_zk: self.is_zk && is_witness_dependent }`.
+/// Every receive returns a dummy value, and sampling, observing, and asserting are no-ops.
+///
+/// Drive an IOP verifier with it, then read back what it recorded.
+///
+/// The channel carries one protocol-level zero-knowledge flag.
+///
+/// An oracle is zero-knowledge only if that flag is set and the oracle is witness-dependent.
+///
+/// # What is recorded
+///
+/// Two views of the same dry run, differing only in whether round boundaries survive.
+///
+/// - The flat sequence of oracles, in arrival order.
+/// - That same sequence, grouped into the rounds the oracles are committed in.
+///
+/// A round closes wherever a challenge could be drawn.
+///
+/// That is where a decorator committing a round as one oracle stops taking members.
 #[derive(Debug, Default, Clone)]
 pub struct OracleSetupChannel {
 	is_zk: bool,
-	oracle_specs: Vec<OracleSpec>,
+	schedule: OracleSchedule,
 }
 
 impl OracleSetupChannel {
@@ -143,18 +156,28 @@ impl OracleSetupChannel {
 	pub const fn new(is_zk: bool) -> Self {
 		Self {
 			is_zk,
-			oracle_specs: Vec::new(),
+			schedule: OracleSchedule::new(),
 		}
 	}
 
 	/// Returns the oracle specs recorded so far.
 	pub fn oracle_specs(&self) -> &[OracleSpec] {
-		&self.oracle_specs
+		self.schedule.specs()
 	}
 
 	/// Consumes the channel and returns the recorded oracle specs, in the order received.
 	pub fn into_oracle_specs(self) -> Vec<OracleSpec> {
-		self.oracle_specs
+		self.schedule.into_specs()
+	}
+
+	/// Consumes the channel and returns the recorded oracles, grouped by commit round.
+	///
+	/// The round left open at the end of the dry run is closed here.
+	///
+	/// So every recorded oracle belongs to some round.
+	pub fn into_oracle_schedule(mut self) -> OracleSchedule {
+		self.schedule.end_round();
+		self.schedule
 	}
 }
 
@@ -176,6 +199,8 @@ impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
 	}
 
 	fn sample(&mut self) -> DummyElem<F> {
+		// A challenge follows the commitments it is derived from, so it ends their round.
+		self.schedule.end_round();
 		DummyElem(PhantomData)
 	}
 
@@ -210,6 +235,8 @@ impl<F: BinaryField> WordIPVerifierChannel<F> for OracleSetupChannel {
 
 	// The recorded oracle shapes do not depend on which leaves a protocol would query.
 	fn sample_bits(&mut self, _bits: usize) -> Word {
+		// A sampled word is a challenge like any other, so it ends the open round too.
+		self.schedule.end_round();
 		Word::ZERO
 	}
 
@@ -233,7 +260,8 @@ impl<F: Field> IOPVerifierChannel<F> for OracleSetupChannel {
 		log_msg_len: usize,
 		is_witness_dependent: bool,
 	) -> Result<Self::Oracle, Error> {
-		self.oracle_specs.push(OracleSpec {
+		// A non-witness-dependent oracle is never masked, whatever the protocol-level flag says.
+		self.schedule.push(OracleSpec {
 			log_msg_len,
 			is_zk: self.is_zk && is_witness_dependent,
 		});
@@ -246,6 +274,139 @@ impl<F: Field> IOPVerifierChannel<F> for OracleSetupChannel {
 		_transparent: TransparentEvalFn<Self::Elem>,
 		_claim: Self::Elem,
 	) -> Result<(), Error> {
+		// Opening an oracle needs every commitment in place, so nothing may still be queued.
+		self.schedule.end_round();
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::Ghash128b;
+
+	use super::*;
+
+	type F = Ghash128b;
+
+	/// Draws a challenge, which is what closes a round.
+	fn sample(channel: &mut OracleSetupChannel) {
+		IPVerifierChannel::<F>::sample(channel);
+	}
+
+	/// Receives one witness-carrying oracle of the given length.
+	fn recv(channel: &mut OracleSetupChannel, log_msg_len: usize) {
+		IOPVerifierChannel::<F>::recv_oracle(channel, log_msg_len, true)
+			.expect("the setup channel never fails");
+	}
+
+	#[test]
+	fn a_challenge_ends_the_open_round() {
+		let mut channel = OracleSetupChannel::new(false);
+
+		// Two oracles, a challenge, then one more.
+		//
+		//     recv 3, recv 3, sample, recv 4, sample
+		//     \____________/          \____/
+		//        round 0              round 1
+		recv(&mut channel, 3);
+		recv(&mut channel, 3);
+		sample(&mut channel);
+		recv(&mut channel, 4);
+		sample(&mut channel);
+
+		let schedule = channel.into_oracle_schedule();
+		assert_eq!(schedule.n_rounds(), 2);
+		assert_eq!(
+			schedule.rounds().collect::<Vec<_>>(),
+			vec![
+				[OracleSpec::new(3), OracleSpec::new(3)].as_slice(),
+				[OracleSpec::new(4)].as_slice(),
+			]
+		);
+	}
+
+	#[test]
+	fn the_final_round_closes_without_a_challenge() {
+		let mut channel = OracleSetupChannel::new(false);
+
+		// The run ends with an oracle, not a challenge.
+		// That trailing oracle is still a round of its own.
+		recv(&mut channel, 2);
+		sample(&mut channel);
+		recv(&mut channel, 5);
+
+		let schedule = channel.into_oracle_schedule();
+		assert_eq!(schedule.n_rounds(), 2);
+		assert_eq!(schedule.rounds().last(), Some([OracleSpec::new(5)].as_slice()));
+	}
+
+	#[test]
+	fn a_sampled_word_ends_the_open_round_too() {
+		let mut channel = OracleSetupChannel::new(false);
+
+		// Query indices are drawn as words rather than as field elements.
+		// That is still a challenge, so it still closes the round before it.
+		recv(&mut channel, 3);
+		WordIPVerifierChannel::<F>::sample_bits(&mut channel, 4);
+		recv(&mut channel, 2);
+
+		assert_eq!(channel.into_oracle_schedule().n_rounds(), 2);
+	}
+
+	#[test]
+	fn back_to_back_challenges_make_no_empty_round() {
+		let mut channel = OracleSetupChannel::new(false);
+
+		// A protocol may draw several challenges in a row with nothing committed between them.
+		// Only the first of those closes anything.
+		recv(&mut channel, 3);
+		sample(&mut channel);
+		sample(&mut channel);
+		sample(&mut channel);
+
+		assert_eq!(channel.into_oracle_schedule().n_rounds(), 1);
+	}
+
+	#[test]
+	fn a_run_with_no_oracles_has_no_rounds() {
+		let mut channel = OracleSetupChannel::new(false);
+
+		// A challenge alone commits nothing, so it closes nothing.
+		sample(&mut channel);
+
+		let schedule = channel.into_oracle_schedule();
+		assert_eq!(schedule.n_rounds(), 0);
+		assert!(schedule.specs().is_empty());
+	}
+
+	#[test]
+	fn dropping_the_boundaries_leaves_the_flat_sequence() {
+		let mut channel = OracleSetupChannel::new(false);
+
+		// Grouping is the only thing the schedule adds.
+		// The oracles themselves, and their order, must survive it untouched.
+		recv(&mut channel, 3);
+		sample(&mut channel);
+		recv(&mut channel, 1);
+		recv(&mut channel, 4);
+
+		let flat = channel.clone().into_oracle_specs();
+		assert_eq!(channel.into_oracle_schedule().into_specs(), flat);
+	}
+
+	#[test]
+	fn a_round_is_masked_if_any_of_its_oracles_is() {
+		// Protocol-level zero-knowledge is on, but not every oracle carries witness data.
+		//
+		//     round 0: [structural 2^3, witness 2^3] -> 2^4, masked because one member is
+		//     round 1: [structural 2^2]              -> 2^2, nothing to hide
+		let mut channel = OracleSetupChannel::new(true);
+		IOPVerifierChannel::<F>::recv_oracle(&mut channel, 3, false).unwrap();
+		IOPVerifierChannel::<F>::recv_oracle(&mut channel, 3, true).unwrap();
+		sample(&mut channel);
+		IOPVerifierChannel::<F>::recv_oracle(&mut channel, 2, false).unwrap();
+
+		let merged = channel.into_oracle_schedule().merged_specs();
+		assert_eq!(merged, vec![OracleSpec::new_zk(4), OracleSpec::new(2)]);
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-551](https://linear.app/jimpo/issue/BINIUS-551/record-full-oracleschedule-in-oraclesetupchannel).

Teaches the setup channel to record *where the commit rounds fall*, not just which oracles were committed.

No caller reads the schedule yet. This is the record two follow-ups need.

### The problem

The setup channel is a dry run: drive a verifier with it, and it writes down the shape of every oracle the protocol commits. What it writes down is a flat list.

That list loses the one thing the merge decorator cares about — the **round boundaries**. A round is the run of oracles between two challenge samples, and it is what gets committed as a single oracle.

```
recv, recv, sample, recv, sample, recv, recv, recv
\__________/        \__/          \______________/
   round 0         round 1           round 2
```

Two open questions on #2209 both bottom out here:

- [prover side](https://github.com/binius-zk/binius64/pull/2209#discussion_r3866854716) — `send_oracle` copies each incoming buffer into a holding buffer, because the round's layout is unknown until the round closes. Knowing the schedule up front means writing straight into the combined buffer instead.
- [verifier side](https://github.com/binius-zk/binius64/pull/2209#discussion_r3866764499) — the decorator cannot cross-check its own remaining specs against the inner channel's, because it has no way to say which round a given spec belongs to.

### The idea

Record the boundaries alongside the specs, in the one place that already sees both.

```rust
pub struct OracleSchedule {
    specs: Vec<OracleSpec>,
    ends: Vec<usize>,     // exclusive end of each closed round, indexing `specs`
}
```

Flat storage plus round ends, so the flat view stays a zero-cost `&[OracleSpec]` and the grouped view is a slice per round.

The setup channel closes a round wherever a challenge could be drawn — which is exactly where the merge decorator stops taking members into a round:

| site | why it closes a round |
|---|---|
| `sample` | a challenge follows the commitments it is derived from |
| `sample_bits` | a sampled word is a challenge like any other |
| `verify_oracle_relation` | opening needs every commitment already in place |
| end of the dry run | the trailing round has no challenge after it |

`end_round` is a no-op on an empty round, so consecutive challenges never manufacture one, and mirroring every flush site is always safe.

### What it derives

`merged_specs` produces the coarse, one-per-round list that a merge decorator's *underlying* channel has to be configured with. Nothing computed that before.

```
round [2^4, 2^2, 2^2]  ->  total 24  ->  2^5, one bit of padding
```

A round is masked as a whole, so its oracle is zero-knowledge as soon as any member is.

The rule that sizes a merged oracle now lives in one place. Both `merged_specs` and the verifier decorator's `flush` call it, instead of each spelling out `log2_ceil(sum of 2^n)`.

### Scope

- **new:** `OracleSchedule` in `crates/iop/src/channel/mod.rs`, and `into_oracle_schedule` on the setup channel
- **changed:** the setup channel stores a schedule instead of a bare `Vec`; `oracle_specs` and `into_oracle_specs` are unchanged projections of it, so the three existing callers are untouched
- **changed:** the verifier decorator's `flush` calls the shared sizing rule
- **left untouched:** the prover decorator's `flush`, which #2350 is currently rewriting. It adopts the shared rule in the follow-up rather than conflicting here.
- **left untouched:** every consumer. Wiring the schedule into the decorators is the next step, not this one.

### Tests

The load-bearing one is a **proptest that pins the schedule against the decorator**. Two independent routes to the same coarse list, over random round shapes:

```
decorator: merges each round, and its inner channel records what was committed
schedule : records where the rounds fall, then merges them itself
```

They must agree, or the schedule is not a faithful model of what the decorator does. Only the sizing rule is shared between the two paths; the sort order and the zero-knowledge derivation are reached independently.

Alongside it, the boundary cases: a challenge closes the open round, a sampled word does too, the trailing round closes without a challenge, back-to-back challenges make no empty round, a run with no oracles has no rounds, dropping the boundaries leaves the flat sequence untouched, and a round is masked when any single member is.

### Verification

| check | result |
|---|---|
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo test -p binius-iop -p binius-iop-prover` | 190 passed, 0 failed |
| `cargo +nightly-2026-07-01 fmt --all --check` | clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-iop --document-private-items --no-deps` | clean |

### The second commit

`cargo clippy --workspace --all-targets --all-features -- -D warnings` already fails on `main` at `0c1bfac5`, before anything in this branch: an unterminated `assert!` inside a `const` block at `crates/iop-prover/src/channel/merge.rs:619`.

`main` keeps a green check because the clippy step is skipped on `push`, where the workflow only warms the build cache — so nothing re-lints `main` after a merge.

#2350 and #2351 each carry the same one-line fix. Whichever lands first makes this commit a no-op on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
