### PR TITLE
BINIUS-554: Stop moving the Blake3 message between rounds and on the way in

### DIFF
--- a/crates/hash/src/blake3_neon.rs
+++ b/crates/hash/src/blake3_neon.rs
@@ -3,11 +3,15 @@
 //! AArch64 NEON block compression for the multi-lane Blake3 kernel.
 
 use std::arch::aarch64::{
-	uint32x4_t, vaddq_u32, vdupq_n_u32, veorq_u32, vld1q_u32, vreinterpretq_u16_u32,
-	vreinterpretq_u32_u16, vrev32q_u16, vshlq_n_u32, vsriq_n_u32, vst1q_u32,
+	uint32x4_t, vaddq_u32, vdupq_n_u32, veorq_u32, vld1q_u8, vld1q_u32, vreinterpretq_u16_u32,
+	vreinterpretq_u32_u8, vreinterpretq_u32_u16, vreinterpretq_u32_u64, vreinterpretq_u64_u32,
+	vrev32q_u16, vshlq_n_u32, vsriq_n_u32, vst1q_u32, vtrn1q_u32, vtrn1q_u64, vtrn2q_u32,
+	vtrn2q_u64,
 };
 
-use super::{IV, MSG_PERMUTATION, N_ROUNDS};
+use blake3::BLOCK_LEN;
+
+use super::{IV, MSG_SCHEDULE};
 
 /// Widest interleave this module implements, counted in four-lane groups.
 ///
@@ -17,15 +21,16 @@ use super::{IV, MSG_PERMUTATION, N_ROUNDS};
 /// - Interleaving groups hides the latency of each one's add, xor, rotate chain.
 /// - Past four groups the spills cost more than the added parallelism returns.
 ///
-/// Throughput hashing 256-byte leaves on an Apple M1 Pro:
+/// Throughput hashing 256-byte leaves on an Apple M1 Pro, single-threaded:
 ///
 /// ```text
-///      4 lanes (1 group):  1.16 GiB/s
-///      8 lanes (2 groups): 1.77 GiB/s
-///     12 lanes (3 groups): 1.95 GiB/s   <- peak
-///     16 lanes (4 groups): 1.93 GiB/s
-///     20 lanes (5 groups): 1.53 GiB/s
+///      4 lanes (1 group):  1.02 GiB/s
+///      8 lanes (2 groups): 1.41 GiB/s
+///     12 lanes (3 groups): 1.45 GiB/s
+///     16 lanes (4 groups): 1.47 GiB/s   <- peak
 /// ```
+///
+/// A wider batch has no kernel and falls to the lane loops, which reach 1.30 GiB/s at 20 lanes.
 const MAX_GROUPS: usize = 4;
 
 /// Rotates every 32-bit lane right by 16 bits.
@@ -143,7 +148,7 @@ fn quarter_round<const S: usize>(
 	}
 }
 
-/// Applies one full Blake3 round to every four-lane group.
+/// Applies round `R` to every four-lane group.
 ///
 /// # Algorithm
 ///
@@ -156,19 +161,25 @@ fn quarter_round<const S: usize>(
 /// ```
 ///
 /// Every state word is touched exactly twice, so after one round each word depends on all others.
+///
+/// Message positions come from row `R` of the schedule table.
+/// The schedule advances by changing which register a round reads, never by moving one.
 #[inline(always)]
-fn round<const S: usize>(v: &mut [[uint32x4_t; 16]; S], m: &[[uint32x4_t; 16]; S]) {
+fn round<const R: usize, const S: usize>(v: &mut [[uint32x4_t; 16]; S], m: &[[uint32x4_t; 16]; S]) {
+	// The 16 message positions this round reads, in slot order.
+	let s = MSG_SCHEDULE[R];
+
 	// Column step: the four disjoint columns of the 4x4 state matrix.
-	quarter_round(v, m, 0, 4, 8, 12, 0, 1);
-	quarter_round(v, m, 1, 5, 9, 13, 2, 3);
-	quarter_round(v, m, 2, 6, 10, 14, 4, 5);
-	quarter_round(v, m, 3, 7, 11, 15, 6, 7);
+	quarter_round(v, m, 0, 4, 8, 12, s[0], s[1]);
+	quarter_round(v, m, 1, 5, 9, 13, s[2], s[3]);
+	quarter_round(v, m, 2, 6, 10, 14, s[4], s[5]);
+	quarter_round(v, m, 3, 7, 11, 15, s[6], s[7]);
 
 	// Diagonal step: the four disjoint diagonals, which is what couples the columns together.
-	quarter_round(v, m, 0, 5, 10, 15, 8, 9);
-	quarter_round(v, m, 1, 6, 11, 12, 10, 11);
-	quarter_round(v, m, 2, 7, 8, 13, 12, 13);
-	quarter_round(v, m, 3, 4, 9, 14, 14, 15);
+	quarter_round(v, m, 0, 5, 10, 15, s[8], s[9]);
+	quarter_round(v, m, 1, 6, 11, 12, s[10], s[11]);
+	quarter_round(v, m, 2, 7, 8, 13, s[12], s[13]);
+	quarter_round(v, m, 3, 4, 9, 14, s[14], s[15]);
 }
 
 /// Compresses one 64-byte block into each of `4 * S` chaining values.
@@ -242,21 +253,15 @@ unsafe fn compress_groups<const S: usize>(
 			v[s][15] = vdupq_n_u32(flags);
 		}
 
-		// Phase 3: seven rounds, with the message schedule permuted between consecutive rounds.
-		for r in 0..N_ROUNDS {
-			round(&mut v, &m);
-
-			// The last round is followed by no further round, so its permutation is dead work.
-			if r < N_ROUNDS - 1 {
-				for s in 0..S {
-					// Each slot reads from its source in the old schedule, so copy before writing.
-					let prev = m[s];
-					for w in 0..16 {
-						m[s][w] = prev[MSG_PERMUTATION[w]];
-					}
-				}
-			}
-		}
+		// Phase 3: seven rounds, each reading the message through its own schedule row.
+		// The 16 message vectors stay in the registers Phase 1 loaded them into.
+		round::<0, S>(&mut v, &m);
+		round::<1, S>(&mut v, &m);
+		round::<2, S>(&mut v, &m);
+		round::<3, S>(&mut v, &m);
+		round::<4, S>(&mut v, &m);
+		round::<5, S>(&mut v, &m);
+		round::<6, S>(&mut v, &m);
 
 		// Phase 4: truncated output, folding the two halves of the final state together.
 		//
@@ -269,6 +274,121 @@ unsafe fn compress_groups<const S: usize>(
 			}
 		}
 	}
+}
+
+/// Transposes a 4x4 square of 32-bit words held in four vector registers.
+///
+/// # Memory layout
+///
+/// Each input row is four consecutive words of one lane:
+///
+/// ```text
+///     rows[0]:  [ a_00, a_01, a_02, a_03 ]    lane 0
+///     rows[1]:  [ a_10, a_11, a_12, a_13 ]    lane 1
+///     rows[2]:  [ a_20, a_21, a_22, a_23 ]    lane 2
+///     rows[3]:  [ a_30, a_31, a_32, a_33 ]    lane 3
+/// ```
+///
+/// Each output row is one word of all four lanes:
+///
+/// ```text
+///     out[0]:   [ a_00, a_10, a_20, a_30 ]    word 0
+///     out[1]:   [ a_01, a_11, a_21, a_31 ]    word 1
+///     out[2]:   [ a_02, a_12, a_22, a_32 ]    word 2
+///     out[3]:   [ a_03, a_13, a_23, a_33 ]    word 3
+/// ```
+///
+/// # Algorithm
+///
+/// A two-stage butterfly, each stage swapping elements twice as far apart as the one before:
+///
+/// ```text
+///     stage 1:  TRN1 / TRN2 over 32-bit lanes    swaps elements 1 apart
+///     stage 2:  TRN1 / TRN2 over 64-bit lanes    swaps elements 2 apart
+/// ```
+///
+/// Both stages stay in registers, so the square never touches memory.
+#[inline(always)]
+fn transpose4x4(rows: [uint32x4_t; 4]) -> [uint32x4_t; 4] {
+	// SAFETY: this module is only reachable on aarch64 with `neon` statically enabled.
+	unsafe {
+		// Stage 1: the first form keeps the even-indexed words of a row pair, the second the odd.
+		let a = vtrn1q_u32(rows[0], rows[1]); // [ a_00, a_10, a_02, a_12 ]
+		let b = vtrn2q_u32(rows[0], rows[1]); // [ a_01, a_11, a_03, a_13 ]
+		let c = vtrn1q_u32(rows[2], rows[3]); // [ a_20, a_30, a_22, a_32 ]
+		let d = vtrn2q_u32(rows[2], rows[3]); // [ a_21, a_31, a_23, a_33 ]
+
+		// Stage 2: the same interleave one level up pairs the 64-bit halves into finished rows.
+		let (a, b) = (vreinterpretq_u64_u32(a), vreinterpretq_u64_u32(b));
+		let (c, d) = (vreinterpretq_u64_u32(c), vreinterpretq_u64_u32(d));
+		[
+			vreinterpretq_u32_u64(vtrn1q_u64(a, c)),
+			vreinterpretq_u32_u64(vtrn1q_u64(b, d)),
+			vreinterpretq_u32_u64(vtrn2q_u64(a, c)),
+			vreinterpretq_u32_u64(vtrn2q_u64(b, d)),
+		]
+	}
+}
+
+/// Reports whether this module can transpose the message for the given lane count.
+///
+/// The square the butterfly moves is four lanes wide, so the lane count must fill it.
+#[inline(always)]
+pub const fn transposes_lanes(n: usize) -> bool {
+	n > 0 && n.is_multiple_of(4)
+}
+
+/// Loads one 64-byte block per lane and transposes it into 16 rows of `N` lanes.
+///
+/// Produces the same words as the byte-wise loader, for every input.
+///
+/// # Algorithm
+///
+/// The kernel wants the message as 16 words of `N` lanes.
+/// The input arrives as `N` blocks of 16 words, which is that square transposed.
+///
+/// The square splits into a grid of independent 4x4 blocks, four lanes by four words:
+///
+/// ```text
+///     lanes 0..4, words 0..4    lanes 0..4, words 4..8    ...
+///     lanes 4..8, words 0..4    lanes 4..8, words 4..8    ...
+///     ...
+/// ```
+///
+/// # Performance
+///
+/// Each 4x4 block costs 4 vector loads, 8 shuffles, and 4 vector stores.
+/// The byte-wise loader instead moves each of the `16 * N` words on its own.
+///
+/// # Panics
+///
+/// Panics if the lane count does not fill the square.
+#[inline(always)]
+pub fn load_block_words<const N: usize>(block: &[[u8; BLOCK_LEN]; N]) -> [[u32; N]; 16] {
+	assert!(transposes_lanes(N), "precondition: the lane count must fill the 4x4 square");
+
+	let mut m = [[0u32; N]; 16];
+	// SAFETY:
+	// - Each load reads 16 bytes at `w * 16` inside a 64-byte block, so `w < 4` stays in bounds.
+	// - Byte pointers carry no alignment requirement beyond the block's own.
+	// - Each store writes 4 words at lane `g * 4` of a row of `N` words, and `g * 4 + 4 <= N`.
+	unsafe {
+		for g in 0..N / 4 {
+			for w in 0..4 {
+				// Gather four lanes of the same four words, one lane per vector.
+				// A raw 16-byte load is already four little-endian words on this target.
+				let rows = std::array::from_fn(|lane| {
+					vreinterpretq_u32_u8(vld1q_u8(block[g * 4 + lane].as_ptr().add(w * 16)))
+				});
+
+				// Scatter them back as four words of the same four lanes, one word per vector.
+				for (j, col) in transpose4x4(rows).into_iter().enumerate() {
+					vst1q_u32(m[w * 4 + j].as_mut_ptr().add(g * 4), col);
+				}
+			}
+		}
+	}
+	m
 }
 
 /// Reports whether this module has a kernel for the given lane count.

--- a/crates/hash/src/blake3_portable.rs
+++ b/crates/hash/src/blake3_portable.rs
@@ -41,9 +41,11 @@ use super::{
 	},
 };
 
-/// Hand-written vector kernel for the block compression, used in place of the lane loops below.
+/// Hand-written vector kernels for the message load and the block compression.
 ///
-/// Kept private so it stays an implementation detail of this module.
+/// They stand in for the byte-wise loader and the lane loops below.
+///
+/// Kept private so they stay an implementation detail of this module.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[path = "blake3_neon.rs"]
 mod neon;
@@ -77,6 +79,46 @@ const MSG_PERMUTATION: [usize; 16] = [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9,
 /// The 7-round count of the Blake3 keyed permutation.
 const N_ROUNDS: usize = 7;
 
+/// Message word that each of a round's 16 slots reads, one row per round.
+///
+/// Blake3 advances the message between rounds by one fixed permutation.
+/// Applying that permutation `r` times gives the words round `r` reads:
+///
+/// ```text
+///     row 0:   0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15    <- the message in order
+///     row 1:   2  6  3 10  7  0  4 13  1 11 12  5  9 14 15  8    <- permuted once
+///     row 2:   3  4 10 12 13  2  7 14  6  5  9  0 11 15  8  1    <- permuted twice
+///     ...
+/// ```
+///
+/// # Why compose it here
+///
+/// Permuting the words a round reads is the same as permuting the words themselves.
+/// Settling that at compile time leaves the 16 message words loaded once and never moved.
+const MSG_SCHEDULE: [[usize; 16]; N_ROUNDS] = {
+	let mut schedule = [[0usize; 16]; N_ROUNDS];
+
+	// Row 0: the first round consumes the message in its natural order.
+	let mut w = 0;
+	while w < 16 {
+		schedule[0][w] = w;
+		w += 1;
+	}
+
+	// Row r: reading the row above through the permutation applies it one more time.
+	let mut r = 1;
+	while r < N_ROUNDS {
+		let mut w = 0;
+		while w < 16 {
+			schedule[r][w] = schedule[r - 1][MSG_PERMUTATION[w]];
+			w += 1;
+		}
+		r += 1;
+	}
+
+	schedule
+};
+
 /// Applies one Blake3 quarter-round across all `N` lanes.
 ///
 /// The state words at positions `a, b, c, d` are mixed with two message words per lane.
@@ -104,29 +146,24 @@ fn quarter_round<const N: usize>(
 	}
 }
 
-/// Applies one full Blake3 round: four column mixes, then four diagonal mixes.
+/// Applies round `R`: four column mixes, then four diagonal mixes.
 ///
-/// Message words are consumed in order `m[0..16]`, two per quarter-round.
+/// The two message words each quarter-round folds in come from row `R` of the schedule table.
 #[inline(always)]
-fn round<const N: usize>(v: &mut [[u32; N]; 16], m: &[[u32; N]; 16]) {
-	// Columns.
-	quarter_round(v, 0, 4, 8, 12, &m[0], &m[1]);
-	quarter_round(v, 1, 5, 9, 13, &m[2], &m[3]);
-	quarter_round(v, 2, 6, 10, 14, &m[4], &m[5]);
-	quarter_round(v, 3, 7, 11, 15, &m[6], &m[7]);
-	// Diagonals.
-	quarter_round(v, 0, 5, 10, 15, &m[8], &m[9]);
-	quarter_round(v, 1, 6, 11, 12, &m[10], &m[11]);
-	quarter_round(v, 2, 7, 8, 13, &m[12], &m[13]);
-	quarter_round(v, 3, 4, 9, 14, &m[14], &m[15]);
-}
+fn round<const R: usize, const N: usize>(v: &mut [[u32; N]; 16], m: &[[u32; N]; 16]) {
+	// The 16 message words this round reads, in slot order.
+	let s = MSG_SCHEDULE[R];
 
-/// Permutes the message words in place for the next round.
-#[inline(always)]
-fn permute<const N: usize>(m: &mut [[u32; N]; 16]) {
-	// The permutation reads each slot from its source, so build into a fresh array.
-	let permuted: [[u32; N]; 16] = array::from_fn(|i| m[MSG_PERMUTATION[i]]);
-	*m = permuted;
+	// Columns.
+	quarter_round(v, 0, 4, 8, 12, &m[s[0]], &m[s[1]]);
+	quarter_round(v, 1, 5, 9, 13, &m[s[2]], &m[s[3]]);
+	quarter_round(v, 2, 6, 10, 14, &m[s[4]], &m[s[5]]);
+	quarter_round(v, 3, 7, 11, 15, &m[s[6]], &m[s[7]]);
+	// Diagonals.
+	quarter_round(v, 0, 5, 10, 15, &m[s[8]], &m[s[9]]);
+	quarter_round(v, 1, 6, 11, 12, &m[s[10]], &m[s[11]]);
+	quarter_round(v, 2, 7, 8, 13, &m[s[12]], &m[s[13]]);
+	quarter_round(v, 3, 4, 9, 14, &m[s[14]], &m[s[15]]);
 }
 
 /// Loads one 64-byte block per lane into 16 little-endian message words.
@@ -140,13 +177,19 @@ fn load_block_words<const N: usize>(block: &[[u8; BLOCK_LEN]; N]) -> [[u32; N]; 
 		return avx512::load_block_words(block);
 	}
 
+	#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+	if neon::transposes_lanes(N) {
+		return neon::load_block_words(block);
+	}
+
 	load_block_words_portable(block)
 }
 
 /// Loads one 64-byte block per lane into 16 little-endian message words, one word at a time.
 ///
-/// Every target without a hand-written transpose runs this, and it is the reference the vector
-/// kernels are tested against.
+/// Every target without a hand-written transpose runs this.
+///
+/// It is also the reference the vector kernels are tested against.
 #[inline(always)]
 fn load_block_words_portable<const N: usize>(block: &[[u8; BLOCK_LEN]; N]) -> [[u32; N]; 16] {
 	let mut m = [[0u32; N]; 16];
@@ -223,14 +266,15 @@ fn compress_block_portable<const N: usize>(
 		[flags; N],
 	];
 
-	// Run 7 rounds; permute the message between all but the last.
-	let mut m = *block;
-	for r in 0..N_ROUNDS {
-		round(&mut v, &m);
-		if r < N_ROUNDS - 1 {
-			permute(&mut m);
-		}
-	}
+	// Run 7 rounds, each reading the message through its own schedule row.
+	// Nothing rewrites the message, so it stays exactly where the caller built it.
+	round::<0, N>(&mut v, block);
+	round::<1, N>(&mut v, block);
+	round::<2, N>(&mut v, block);
+	round::<3, N>(&mut v, block);
+	round::<4, N>(&mut v, block);
+	round::<5, N>(&mut v, block);
+	round::<6, N>(&mut v, block);
 
 	// Truncated output: h_i = v_i XOR v_{i+8}, feeding the next block or the final digest.
 	for i in 0..8 {
@@ -679,6 +723,73 @@ mod tests {
 
 		// Compression is bit-exact, so the two must agree on all 8 words of all N lanes.
 		assert_eq!(got, want, "vector kernel diverged from the lane loops at {N} lanes");
+	}
+
+	/// Transposes one random block set through both loaders and pins the words together.
+	#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+	fn check_neon_transpose<const N: usize>(rng: &mut StdRng) {
+		// Fresh random bytes per lane, so no two lanes hold the same word by accident.
+		let mut blocks = [[0u8; BLOCK_LEN]; N];
+		for block in blocks.iter_mut() {
+			rng.fill_bytes(block);
+		}
+
+		// A transpose only permutes words, so the two loaders must agree on all 16 rows.
+		assert_eq!(
+			super::neon::load_block_words(&blocks),
+			load_block_words_portable(&blocks),
+			"the shuffle network diverged from the byte-wise loader at {N} lanes"
+		);
+	}
+
+	#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+	#[test]
+	fn test_neon_transpose_matches_portable() {
+		// Invariant: a word's output row is its word index, and its output lane is its block index.
+		//
+		// Fixture: word `w` of lane `l` carries the value `l * 16 + w`, so all 16 * N are distinct.
+		//
+		//     lane 0 block:  [  0,  1,  2, ...,  15 ]
+		//     lane 1 block:  [ 16, 17, 18, ...,  31 ]
+		//     ...
+		//     output row w:  [  w, 16 + w, 32 + w, ... ]
+		//
+		// Distinct values are what makes a swapped row or lane show up as a wrong value.
+		let mut blocks = [[0u8; BLOCK_LEN]; 16];
+		for (lane, block) in blocks.iter_mut().enumerate() {
+			for (w, word) in block.chunks_exact_mut(4).enumerate() {
+				word.copy_from_slice(&((lane * 16 + w) as u32).to_le_bytes());
+			}
+		}
+
+		// Every one of the 16 rows must read back its own coordinate, at every lane.
+		let m = super::neon::load_block_words(&blocks);
+		for (w, row) in m.iter().enumerate() {
+			for (lane, got) in row.iter().enumerate() {
+				assert_eq!(*got, (lane * 16 + w) as u32, "row {w}, lane {lane}");
+			}
+		}
+
+		// Random blocks at every width the network claims, from one square up to four.
+		let mut rng = StdRng::seed_from_u64(23);
+		check_neon_transpose::<4>(&mut rng);
+		check_neon_transpose::<8>(&mut rng);
+		check_neon_transpose::<12>(&mut rng);
+		check_neon_transpose::<16>(&mut rng);
+	}
+
+	#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+	proptest! {
+		#[test]
+		fn neon_transpose_matches_portable_proptest(seed in any::<u64>()) {
+			// The fixed block above pins the coordinates.
+			// This sweeps arbitrary bytes at every width instead.
+			let mut rng = StdRng::seed_from_u64(seed);
+			check_neon_transpose::<4>(&mut rng);
+			check_neon_transpose::<8>(&mut rng);
+			check_neon_transpose::<12>(&mut rng);
+			check_neon_transpose::<16>(&mut rng);
+		}
 	}
 
 	#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]


### PR DESCRIPTION
Closes [BINIUS-554](https://linear.app/jimpo/issue/BINIUS-554).

Removes two pieces of message shuffling from the multi-lane Blake3 kernel: the permutation it ran between rounds, and the word-at-a-time transpose it ran on the way in.
Output is bit-identical to `blake3::hash` — no protocol change, no new soundness assumption.

### The problem

The kernel moves the message twice before it does any mixing.

**Between rounds.**

Blake3 permutes the 16 message words between each of its 7 rounds.
The kernel runs that as a runtime loop that rewrites the message in place.

The loop does not unroll.
On aarch64 the 16-lane compression emits 192 `add.4s`, which is exactly one round's worth — so all seven rounds share one body, and the permutation runs as real data movement.

The compression also copies the whole message out of the caller's array before the first round.

**On the way in.**

The kernel wants the message as 16 words of `N` lanes.
The input arrives the other way round, as `N` blocks of 16 words.

Converting between the two layouts is a transpose, and it runs one word at a time.
#2353 replaced that with a shuffle network on AVX-512 and left aarch64 on the byte-wise path.

### The idea

**Compose the permutation at compile time.**

Permuting the words a round reads is the same as permuting the words themselves.
So the whole schedule collapses into a fixed 7x16 table:

```
row 0:   0  1  2  3 ... 15      the message in order
row 1:   2  6  3 10 ...  8      permuted once
row 2:   3  4 10 12 ...  1      permuted twice
```

Unrolling the seven rounds then makes the schedule pure register renaming.
The message is read straight from the caller's array and never rewritten.

**Transpose in registers on aarch64.**

NEON has no 16-lane square, but a 4x4 square fits in four registers.
A two-stage butterfly moves it with no memory round trip:

```
stage 1:  TRN1 / TRN2 over 32-bit lanes    swaps elements 1 apart
stage 2:  TRN1 / TRN2 over 64-bit lanes    swaps elements 2 apart
```

### Per 64-byte block, at 16 lanes

- **permutation, before:** 384 vector moves; **after:** none
- **message load, before:** 256 scalar loads, then 256 scattered stores
- **message load, after:** 64 vector loads, 128 shuffles, 64 vector stores

### The change

```
- for r in 0..N_ROUNDS { round(&mut v, &m); if r < N_ROUNDS - 1 { permute(&mut m) } }
+ round::<0, N>(&mut v, block);  ...  round::<6, N>(&mut v, block);

- fn load_block_words(..)          // byte-wise loader, the only path on aarch64
+ fn load_block_words(..)          // dispatches on lane count
+ fn load_block_words_portable(..) // byte-wise loader, now the tested reference
```

### How this relates to `zooko/blake3-sme2` — and what it is *not*

Same source as #2353. That kernel is 2.24x faster than the `blake3` crate's NEON path on an M4, and the gap comes from three things:

- 512-bit streaming vectors, so one register holds 16 lanes instead of 4 — needs SME2 hardware.
- `xar`, a fused xor-then-rotate. NEON's `FEAT_SHA3` `XAR` is **64-bit-lane only**, so it cannot express Blake3's 32-bit rotates.
- A free message transpose, and a message register hardcoded per round so the schedule costs nothing.

Only the third transfers, and that is what this PR ports.
No assembly is copied, and the compression core is untouched.

Worth recording for later: SVE2 *does* have a 32-bit-lane `XAR`, which would fuse each xor-and-rotate pair into one instruction. That needs an M4 or Neoverse V2 to even test, so it is out of scope here.

### Soundness

A permutation composed at compile time is the same permutation.
A transpose only reorders words.

Neither touches the compression arithmetic, so the compression input is unchanged and the output stays bit-identical to `blake3::hash`.

### Scope

- **changed, every target:** the round driver and the message schedule in `blake3_portable.rs`
- **changed, aarch64 only:** the same driver in `blake3_neon.rs`, plus a new 4x4 transpose
- **left untouched:** the compression arithmetic, and the byte-wise loader, which becomes the tested reference rather than being replaced
- **overlaps #2353:** both turn the message loader into a dispatcher, so whichever lands second folds the other's branch into the same function

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-hash --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` and `tools/check_copyright_notice.py` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-hash --document-private-items` — clean
- `cargo test -p binius-hash --lib`: 31/31, including the pre-existing `blake3::hash` equality tests, which now route through both changes
- New tests: a coordinate-carrying block that catches a swapped row or lane, and a proptest pinning the network to the byte-wise loader at 4, 8, 12, and 16 lanes

### Benchmark

The repo's own `blake3_portable` bench on an Apple M1 Pro, single-threaded (`RAYON_NUM_THREADS=1`) so the kernel is not masked by memory bandwidth.
Criterion `--save-baseline` / `--baseline`, so before and after are one paired run on one machine state.
16 lanes is the width `Blake3HashSuite` ships; 4 and 8 are there as controls.

| lanes | leaf | before | after | change |
|---|---|---|---|---|
| 4 | 64 B | 837.1 MiB/s | 880.0 MiB/s | +5.6% |
| 8 | 64 B | 1.133 GiB/s | 1.166 GiB/s | +3.4% |
| **16** | **64 B** | **1.114 GiB/s** | **1.270 GiB/s** | **+13.9%** |
| 4 | 1024 B | 1.042 GiB/s | 1.044 GiB/s | no change |
| 8 | 1024 B | 1.389 GiB/s | 1.495 GiB/s | +7.0% |
| **16** | **1024 B** | **1.262 GiB/s** | **1.502 GiB/s** | **+20.0%** |

Each half of the change, measured the same way against its own pristine baseline, at 16 lanes:

| change | 64 B leaf | 1024 B leaf |
|---|---|---|
| precomputed schedule | +6.1% | +7.6% |
| NEON transpose | +9.2% | +12.0% |
| both | +13.9% | +20.0% |

Two honest caveats:

- On the default multi-threaded bench the win is not resolvable — 3.83 vs 3.56 GiB/s over a −2.7% to +4.9% interval, which reads as bandwidth-bound rather than as the change not working.
- The transpose on its own costs about 2.4% at 4 lanes, where the compression is latency-bound and has spare issue slots for the scalar loads. The schedule change more than repays that, so the combined 4-lane result is positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)