### PR TITLE
BINIUS-555: Export the wiring claim instead of discharging it

### DIFF
--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -73,6 +73,8 @@ pub struct Binius64BuilderChannel {
 	n_merkle_checks: usize,
 	/// Words bound to public inputs so far, so each binding gets a distinct name.
 	n_public: usize,
+	/// Elements bound to public inputs so far, so each binding gets a distinct name.
+	n_public_elems: usize,
 	/// Proofs of work checked so far, so each gets a distinct name.
 	n_grinds: usize,
 }
@@ -90,6 +92,7 @@ impl Binius64BuilderChannel {
 			scheme: BinaryMerkleTreeScheme::new(),
 			n_merkle_checks: 0,
 			n_public: 0,
+			n_public_elems: 0,
 			n_grinds: 0,
 		}
 	}
@@ -113,6 +116,37 @@ impl Binius64BuilderChannel {
 			.map(|(i, word)| {
 				let public = builder.add_inout();
 				builder.assert_eq(format!("{}", first + i), word.to_wire(&builder), public);
+				public
+			})
+			.collect()
+	}
+
+	/// Binds elements to fresh public inputs, returning the two inout wires each occupies.
+	///
+	/// An element is its low and high half, so each contributes a `(lo, hi)` pair, in that order.
+	/// The returned wires therefore run twice the length of `elems`.
+	///
+	/// As with [`bind_public`](Self::bind_public), each element keeps the wires that derived it
+	/// and gains public wires equal to them. The replay supplies the public half, so the equality
+	/// is also a cross-check: the value the circuit derived and the value the replay computed have
+	/// to agree, and a desync between the two runs fails here rather than silently later.
+	///
+	/// This is how a claim leaves the circuit unchecked but pinned: whoever reads the outer proof
+	/// sees the values the verifier derived, and owes whatever check was skipped inside.
+	pub fn bind_public_elems(&mut self, elems: &[SymbolicElem]) -> Vec<Wire> {
+		// Numbered across calls, so a failing binding names which element it was.
+		let first = self.n_public_elems;
+		self.n_public_elems += elems.len();
+
+		// One named subcircuit, so a broken binding is traceable to this gadget.
+		let builder = self.shared.builder().subcircuit("bind_public_elem");
+		elems
+			.iter()
+			.enumerate()
+			.flat_map(|(i, elem)| {
+				let (lo, hi) = elem.to_wires(&builder);
+				let public = [builder.add_inout(), builder.add_inout()];
+				builder.assert_eq_v(format!("{}", first + i), [lo, hi], public);
 				public
 			})
 			.collect()

--- a/crates/recursion/src/channel.rs
+++ b/crates/recursion/src/channel.rs
@@ -126,13 +126,14 @@ impl Binius64BuilderChannel {
 	/// An element is its low and high half, so each contributes a `(lo, hi)` pair, in that order.
 	/// The returned wires therefore run twice the length of `elems`.
 	///
-	/// As with [`bind_public`](Self::bind_public), each element keeps the wires that derived it
-	/// and gains public wires equal to them. The replay supplies the public half, so the equality
-	/// is also a cross-check: the value the circuit derived and the value the replay computed have
-	/// to agree, and a desync between the two runs fails here rather than silently later.
+	/// Each element keeps the wires that derived it, and gains public wires equal to them.
 	///
-	/// This is how a claim leaves the circuit unchecked but pinned: whoever reads the outer proof
-	/// sees the values the verifier derived, and owes whatever check was skipped inside.
+	/// The replay supplies the public half.
+	/// So the equality is also a cross-check between the two runs.
+	/// A desync fails here rather than silently later.
+	///
+	/// This is how a claim leaves the circuit unchecked but pinned.
+	/// Whoever reads the outer proof sees the values the verifier derived.
 	pub fn bind_public_elems(&mut self, elems: &[SymbolicElem]) -> Vec<Wire> {
 		// Numbered across calls, so a failing binding names which element it was.
 		let first = self.n_public_elems;

--- a/crates/recursion/src/circuit.rs
+++ b/crates/recursion/src/circuit.rs
@@ -23,21 +23,34 @@
 //!   Verifier(inner) -> build -> circuit_1 -> Verifier(circuit_1) -> build -> circuit_2
 //! ```
 //!
-//! Every level pays for the level below it in full, because the wiring claim is discharged
-//! in-circuit rather than deferred. Measured over a CRC-64 inner circuit, a level costs about
-//! fifteen times the constraint rows of the level it verifies, so the tower diverges instead of
-//! closing. Deferring that claim is what makes a fixed point possible; see `RECURSION_PLAN.md`.
+//! How much a level costs depends on what it does with the inner wiring claim, which is what
+//! [`Discharge`] selects.
+//!
+//! - [`Discharge::InCircuit`] evaluates the claim as constraints. That walks every inner
+//!   constraint, so a level costs about fifteen times the rows of the level it verifies, and the
+//!   tower diverges.
+//! - [`Discharge::Deferred`] puts the claim on public wires instead and leaves it unchecked. The
+//!   claim is logarithmic in the inner system, so the cost proportional to it disappears.
+//!
+//! Deferring moves work rather than removing it. Whoever holds the outer proof owes the check,
+//! and [`RecursiveCircuit::check_deferred`] is it. Nothing anywhere verifies the claim unless
+//! that runs.
 
 use std::iter;
 
 use binius_core::{constraint_system::ValueVec, word::Word};
+use binius_field::Ghash128b as B128;
 use binius_frontend::{Circuit, PopulateError, Wire, WitnessFiller};
 use binius_hash::StdHashSuite;
 use binius_ip::channel::WordIPVerifierChannel;
 use binius_transcript::VerifierTranscript;
-use binius_verifier::{Pcs, Verifier, config::StdChallenger};
+use binius_verifier::{
+	Pcs, Verifier,
+	config::StdChallenger,
+	protocols::shift::{DeferredWiringClaim, WiringEvalShape},
+};
 
-use crate::{Binius64BuilderChannel, Recorded, WitnessFillerChannel};
+use crate::{Binius64BuilderChannel, Recorded, WitnessFillerChannel, merkle::element_words};
 
 /// Why a recursive circuit could not be built, or its witness could not be filled.
 #[derive(Debug, thiserror::Error)]
@@ -69,6 +82,30 @@ pub enum Error {
 	/// The replayed values leave the recorded circuit unsatisfied.
 	#[error("the recorded circuit is not satisfied by the replayed witness")]
 	Unsatisfied(PopulateError),
+
+	/// [`RecursiveCircuit::check_deferred`] was called on a circuit that checks in-circuit.
+	#[error("this circuit discharges the wiring claim in-circuit, so nothing is left to check")]
+	NothingDeferred,
+}
+
+/// What a recursive circuit does with the inner proof's wiring claim.
+///
+/// The claim says the wiring multilinear evaluates to a stated value. Discharging it means
+/// evaluating that multilinear, which walks every constraint of the inner system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Discharge {
+	/// Evaluate the claim as constraints, inside the circuit.
+	///
+	/// Self-contained: an outer proof of this circuit needs nothing checked beside it. The cost
+	/// is proportional to the inner system, so a tower of these cannot close.
+	#[default]
+	InCircuit,
+
+	/// Put the claim on public wires and leave it unchecked.
+	///
+	/// The claim is logarithmic in the inner system, so this is the cheap half of the trade. It
+	/// is only sound if someone settles the claim: see [`RecursiveCircuit::check_deferred`].
+	Deferred,
 }
 
 /// A Binius64 circuit that verifies Binius64 proofs of one inner shape.
@@ -92,6 +129,26 @@ pub struct RecursiveCircuit {
 	///
 	/// Each is constrained to equal the word the verifier read, so the two cannot disagree.
 	statement: Vec<Wire>,
+
+	/// The wiring claim this circuit exported, when it exported one.
+	///
+	/// `None` under [`Discharge::InCircuit`], where the claim was checked instead.
+	deferred: Option<Deferred>,
+}
+
+/// A wiring claim a recursive circuit exported rather than checked.
+struct Deferred {
+	/// How the claim's flat input splits back into its sections.
+	///
+	/// Fixed by the inner system, so it is build-time data and travels with the circuit rather
+	/// than with each proof.
+	shape: WiringEvalShape,
+
+	/// The inout wires carrying the claim: two per element, `(lo, hi)`.
+	///
+	/// The claim's inputs come first, in the order the wiring multilinear reads them, and the
+	/// claimed evaluation is the last element.
+	wires: Vec<Wire>,
 }
 
 impl RecursiveCircuit {
@@ -111,6 +168,20 @@ impl RecursiveCircuit {
 	/// Returns [`Error::Verifier`] when the shape itself is unsatisfiable, which a build-time
 	/// constant assertion decides before any proof exists.
 	pub fn build(verifier: Verifier<StdHashSuite>) -> Result<Self, Error> {
+		Self::build_with(verifier, Discharge::InCircuit)
+	}
+
+	/// Records `verifier`'s run, settling the inner wiring claim the way `discharge` says.
+	///
+	/// See [`Discharge`] for what the choice costs, and what it obliges.
+	///
+	/// # Errors
+	///
+	/// As [`build`](Self::build).
+	pub fn build_with(
+		verifier: Verifier<StdHashSuite>,
+		discharge: Discharge,
+	) -> Result<Self, Error> {
 		let Some(compiler) = verifier.iop_compiler().as_basefold() else {
 			return Err(Error::UnsupportedPcs {
 				pcs: verifier.pcs(),
@@ -126,21 +197,47 @@ impl RecursiveCircuit {
 		let n_inout = verifier.constraint_system().n_inout;
 		let statement = channel.observe_words(&vec![Word::ZERO; n_inout]);
 
-		// The verifier's own arithmetic becomes constraints, down to every assertion along the
-		// way. Discharging the wiring claim is part of that, and it is the level's largest cost.
-		verifier
-			.iop_verifier()
-			.verify(&statement, &mut channel)?
-			.check_symbolic(&mut channel)
-			.map_err(binius_verifier::Error::from)?;
+		// The verifier's own arithmetic becomes constraints, down to every assertion along the way.
+		let claim = verifier.iop_verifier().verify(&statement, &mut channel)?;
+
+		// The wiring claim is the one piece whose cost tracks the inner system, so it is the one
+		// piece worth a choice.
+		let exported = match discharge {
+			Discharge::InCircuit => {
+				claim
+					.check_symbolic(&mut channel)
+					.map_err(binius_verifier::Error::from)?;
+				None
+			}
+			Discharge::Deferred => Some(claim.defer()),
+		};
 
 		let mut builder_channel = channel.finish()?;
+
+		// The inner statement is bound first, so it occupies the front of the outer statement and
+		// an exported claim follows it. `check_deferred` reads that layout back.
 		let statement = builder_channel.bind_public(statement);
+		let deferred = exported.map(|claim| {
+			let DeferredWiringClaim {
+				shape,
+				inputs,
+				claimed,
+			} = claim;
+			let elems = inputs
+				.into_iter()
+				.chain(iter::once(claimed))
+				.collect::<Vec<_>>();
+			Deferred {
+				shape,
+				wires: builder_channel.bind_public_elems(&elems),
+			}
+		});
 
 		Ok(Self {
 			verifier,
 			recorded: builder_channel.build(),
 			statement,
+			deferred,
 		})
 	}
 
@@ -157,6 +254,109 @@ impl RecursiveCircuit {
 	/// The public wires carrying the inner statement, in inout order.
 	pub fn statement(&self) -> &[Wire] {
 		&self.statement
+	}
+
+	/// The inout wires carrying the exported wiring claim, or `None` if it was checked in-circuit.
+	///
+	/// Two wires per element, `(lo, hi)`, inputs first and the claimed evaluation last.
+	pub fn deferred_wires(&self) -> Option<&[Wire]> {
+		self.deferred.as_ref().map(|d| d.wires.as_slice())
+	}
+
+	/// Discharges the wiring claim this circuit exported, reading it off the outer statement.
+	///
+	/// This is the check [`Discharge::Deferred`] skipped. **Without it the outer proof attests to
+	/// strictly less than a verification**: the inner proof's wiring constraint is simply not
+	/// checked, anywhere, by anyone.
+	///
+	/// `outer_inout` is the outer proof's public values, which is what
+	/// [`ValueVec::inout`](binius_core::constraint_system::ValueVec::inout) returns for a witness
+	/// this circuit produced. The inner statement occupies its front and the claim follows.
+	///
+	/// The cost is one native evaluation of the inner wiring multilinear. That is ordinary work
+	/// outside a circuit, and it is paid once no matter how many levels deferred to here.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error::NothingDeferred`] when the circuit checks the claim in-circuit.
+	///
+	/// Returns [`Error::StatementLength`] when `outer_inout` is not this circuit's statement.
+	///
+	/// Returns [`Error::Verifier`] when the claim does not hold.
+	pub fn check_deferred(&self, outer_inout: &[Word]) -> Result<(), Error> {
+		let Some(deferred) = &self.deferred else {
+			return Err(Error::NothingDeferred);
+		};
+
+		// The claim sits behind the inner statement, so the two lengths together fix the layout.
+		// A mismatch means the caller handed over some other circuit's statement.
+		let expected = self.statement.len() + deferred.wires.len();
+		if outer_inout.len() != expected {
+			return Err(Error::StatementLength {
+				expected,
+				actual: outer_inout.len(),
+			});
+		}
+
+		// Each element is the `(lo, hi)` pair the binding placed, in the order the wiring
+		// multilinear reads its input. The claimed evaluation is the last of them.
+		let elems = outer_inout[self.statement.len()..]
+			.chunks_exact(2)
+			.map(|pair| {
+				B128::new((u128::from(pair[1].as_u64()) << 64) | u128::from(pair[0].as_u64()))
+			})
+			.collect::<Vec<_>>();
+		let (inputs, claimed) = elems
+			.split_last()
+			.map(|(claimed, inputs)| (inputs.to_vec(), *claimed))
+			.expect("a bound claim holds at least its claimed evaluation");
+
+		let claim = DeferredWiringClaim {
+			shape: deferred.shape,
+			inputs,
+			claimed,
+		};
+		claim
+			.check(self.verifier.constraint_system())
+			.map_err(binius_verifier::Error::from)?;
+		Ok(())
+	}
+
+	/// Verifies an outer proof of this circuit, settling everything it defers.
+	///
+	/// This is the safe way to check an outer proof, and the reason it exists is that the unsafe
+	/// way is otherwise shorter. Verifying the proof alone attests to a *verification minus its
+	/// wiring constraint* whenever the claim was deferred, and nothing about the proof says so.
+	///
+	/// ```text
+	///   verify the outer proof  +  check_deferred  =  the inner statement really was proved
+	/// ```
+	///
+	/// `outer` must be a verifier for [`circuit`](Self::circuit); a different system would check a
+	/// different proof.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error::Verifier`] when the outer proof does not verify, or when the deferred
+	/// claim does not hold.
+	pub fn verify_outer(
+		&self,
+		outer: &Verifier<StdHashSuite>,
+		inout: &[Word],
+		proof: Vec<u8>,
+	) -> Result<(), Error> {
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		outer.verify(inout, &mut transcript)?;
+		transcript
+			.finalize()
+			.map_err(binius_verifier::Error::from)?;
+
+		// An in-circuit discharge already checked the claim as constraints, so there is nothing
+		// left to settle and nothing to complain about.
+		if self.deferred.is_some() {
+			self.check_deferred(inout)?;
+		}
+		Ok(())
 	}
 
 	/// The compiled circuit, and the inventory of wires a witness supplies.
@@ -251,14 +451,40 @@ impl RecursiveCircuit {
 			.create_channel(filler_channel);
 
 		let statement = channel.observe_words(inout);
-		self.verifier
+		let claim = self
+			.verifier
 			.iop_verifier()
-			.verify(&statement, &mut channel)?
-			.check_symbolic(&mut channel)
-			.map_err(binius_verifier::Error::from)?;
+			.verify(&statement, &mut channel)?;
+
+		// This channel carries values, so the same claim comes back concrete here. Under
+		// `Discharge::Deferred` those values are what the bound public wires need; the build's
+		// equality then pins them against the wires the circuit derived.
+		//
+		// `assert_zero` is a no-op on this channel, so checking in-circuit costs nothing to mirror.
+		let exported = match self.deferred {
+			None => {
+				claim
+					.check_symbolic(&mut channel)
+					.map_err(binius_verifier::Error::from)?;
+				None
+			}
+			Some(_) => Some(claim.defer()),
+		};
 
 		// Checks the replay consumed exactly the wires the build recorded, no more and no fewer.
+		// This also ends the channel's borrow of the filler, so the claim can be written below.
 		channel.finish()?.finish();
+
+		if let (Some(deferred), Some(claim)) = (&self.deferred, exported) {
+			let words = claim
+				.inputs
+				.iter()
+				.chain(iter::once(&claim.claimed))
+				.flat_map(|elem| element_words(u128::from(*elem)));
+			for (&wire, word) in iter::zip(&deferred.wires, words) {
+				filler[wire] = Word(word);
+			}
+		}
 
 		Ok(())
 	}

--- a/crates/recursion/src/circuit.rs
+++ b/crates/recursion/src/circuit.rs
@@ -23,18 +23,18 @@
 //!   Verifier(inner) -> build -> circuit_1 -> Verifier(circuit_1) -> build -> circuit_2
 //! ```
 //!
-//! How much a level costs depends on what it does with the inner wiring claim, which is what
-//! [`Discharge`] selects.
+//! What a level costs depends on how it settles the inner wiring claim.
 //!
-//! - [`Discharge::InCircuit`] evaluates the claim as constraints. That walks every inner
-//!   constraint, so a level costs about fifteen times the rows of the level it verifies, and the
-//!   tower diverges.
-//! - [`Discharge::Deferred`] puts the claim on public wires instead and leaves it unchecked. The
-//!   claim is logarithmic in the inner system, so the cost proportional to it disappears.
+//! Evaluating the claim as constraints walks every inner constraint.
+//! A level then costs about fifteen times the level below, and the tower diverges.
 //!
-//! Deferring moves work rather than removing it. Whoever holds the outer proof owes the check,
-//! and [`RecursiveCircuit::check_deferred`] is it. Nothing anywhere verifies the claim unless
-//! that runs.
+//! Putting the claim on public wires instead leaves it unchecked.
+//! The claim is logarithmic in the inner system, so the cost proportional to it disappears.
+//! A level then costs under six times the level below.
+//!
+//! Deferring moves work rather than removing it.
+//! Whoever holds the outer proof owes the check.
+//! Nothing anywhere verifies the claim unless that check runs.
 
 use std::iter;
 
@@ -83,28 +83,29 @@ pub enum Error {
 	#[error("the recorded circuit is not satisfied by the replayed witness")]
 	Unsatisfied(PopulateError),
 
-	/// [`RecursiveCircuit::check_deferred`] was called on a circuit that checks in-circuit.
+	/// A claim was asked for from a circuit that checks the claim in-circuit.
 	#[error("this circuit discharges the wiring claim in-circuit, so nothing is left to check")]
 	NothingDeferred,
 }
 
 /// What a recursive circuit does with the inner proof's wiring claim.
 ///
-/// The claim says the wiring multilinear evaluates to a stated value. Discharging it means
-/// evaluating that multilinear, which walks every constraint of the inner system.
+/// The claim says the wiring multilinear evaluates to a stated value.
+/// Discharging it means evaluating that multilinear.
+/// That walks every constraint of the inner system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Discharge {
 	/// Evaluate the claim as constraints, inside the circuit.
 	///
-	/// Self-contained: an outer proof of this circuit needs nothing checked beside it. The cost
-	/// is proportional to the inner system, so a tower of these cannot close.
+	/// Self-contained: an outer proof needs nothing checked beside it.
+	/// The cost tracks the inner system, so a tower of these cannot close.
 	#[default]
 	InCircuit,
 
 	/// Put the claim on public wires and leave it unchecked.
 	///
-	/// The claim is logarithmic in the inner system, so this is the cheap half of the trade. It
-	/// is only sound if someone settles the claim: see [`RecursiveCircuit::check_deferred`].
+	/// The claim is logarithmic in the inner system, so this is the cheap half of the trade.
+	/// It is only sound if someone settles the claim afterwards.
 	Deferred,
 }
 
@@ -132,7 +133,7 @@ pub struct RecursiveCircuit {
 
 	/// The wiring claim this circuit exported, when it exported one.
 	///
-	/// `None` under [`Discharge::InCircuit`], where the claim was checked instead.
+	/// Absent when the circuit checked the claim as constraints instead.
 	deferred: Option<Deferred>,
 }
 
@@ -140,14 +141,13 @@ pub struct RecursiveCircuit {
 struct Deferred {
 	/// How the claim's flat input splits back into its sections.
 	///
-	/// Fixed by the inner system, so it is build-time data and travels with the circuit rather
-	/// than with each proof.
+	/// Fixed by the inner system, so it travels with the circuit rather than with each proof.
 	shape: WiringEvalShape,
 
-	/// The inout wires carrying the claim: two per element, `(lo, hi)`.
+	/// The inout wires carrying the claim: two per element, low half then high half.
 	///
-	/// The claim's inputs come first, in the order the wiring multilinear reads them, and the
-	/// claimed evaluation is the last element.
+	/// The claim's inputs come first, in the order the wiring multilinear reads them.
+	/// The claimed evaluation is the last element.
 	wires: Vec<Wire>,
 }
 
@@ -171,13 +171,15 @@ impl RecursiveCircuit {
 		Self::build_with(verifier, Discharge::InCircuit)
 	}
 
-	/// Records `verifier`'s run, settling the inner wiring claim the way `discharge` says.
+	/// Records the verifier's run, settling the inner wiring claim the way the caller asks.
 	///
-	/// See [`Discharge`] for what the choice costs, and what it obliges.
+	/// The two settlements differ in cost and in what they oblige.
 	///
 	/// # Errors
 	///
-	/// As [`build`](Self::build).
+	/// Returns an error when the inner trace is not opened with FRI.
+	///
+	/// Returns an error when the shape itself is unsatisfiable.
 	pub fn build_with(
 		verifier: Verifier<StdHashSuite>,
 		discharge: Discharge,
@@ -200,8 +202,9 @@ impl RecursiveCircuit {
 		// The verifier's own arithmetic becomes constraints, down to every assertion along the way.
 		let claim = verifier.iop_verifier().verify(&statement, &mut channel)?;
 
-		// The wiring claim is the one piece whose cost tracks the inner system, so it is the one
-		// piece worth a choice.
+		// Invariant: the wiring claim is the only cost that tracks the inner system's size.
+		//
+		// So it is the only part of the replay worth a choice.
 		let exported = match discharge {
 			Discharge::InCircuit => {
 				claim
@@ -214,8 +217,11 @@ impl RecursiveCircuit {
 
 		let mut builder_channel = channel.finish()?;
 
-		// The inner statement is bound first, so it occupies the front of the outer statement and
-		// an exported claim follows it. `check_deferred` reads that layout back.
+		// The inner statement is bound first.
+		//
+		//     outer statement:  [ inner statement | exported claim ]
+		//
+		// Settling the claim later reads that layout back.
 		let statement = builder_channel.bind_public(statement);
 		let deferred = exported.map(|claim| {
 			let DeferredWiringClaim {
@@ -256,39 +262,43 @@ impl RecursiveCircuit {
 		&self.statement
 	}
 
-	/// The inout wires carrying the exported wiring claim, or `None` if it was checked in-circuit.
+	/// The inout wires carrying the exported wiring claim.
 	///
-	/// Two wires per element, `(lo, hi)`, inputs first and the claimed evaluation last.
+	/// Absent when the circuit checked the claim as constraints instead.
+	///
+	/// Two wires per element, low half then high half.
+	/// The claim's inputs come first and the claimed evaluation is last.
 	pub fn deferred_wires(&self) -> Option<&[Wire]> {
 		self.deferred.as_ref().map(|d| d.wires.as_slice())
 	}
 
-	/// Discharges the wiring claim this circuit exported, reading it off the outer statement.
+	/// Settles the wiring claim this circuit exported, reading it off the outer statement.
 	///
-	/// This is the check [`Discharge::Deferred`] skipped. **Without it the outer proof attests to
-	/// strictly less than a verification**: the inner proof's wiring constraint is simply not
-	/// checked, anywhere, by anyone.
+	/// This is the check a deferred circuit skipped.
+	/// **Without it the outer proof attests to less than a verification.**
+	/// The inner proof's wiring constraint is then checked nowhere, by nobody.
 	///
-	/// `outer_inout` is the outer proof's public values, which is what
-	/// [`ValueVec::inout`](binius_core::constraint_system::ValueVec::inout) returns for a witness
-	/// this circuit produced. The inner statement occupies its front and the claim follows.
+	/// The argument is the outer proof's public values.
+	/// The inner statement occupies its front, and the claim follows.
 	///
-	/// The cost is one native evaluation of the inner wiring multilinear. That is ordinary work
-	/// outside a circuit, and it is paid once no matter how many levels deferred to here.
+	/// The cost is one native evaluation of the inner wiring multilinear.
+	/// That is ordinary work outside a circuit.
+	/// It is paid once, however many levels deferred into it.
 	///
 	/// # Errors
 	///
-	/// Returns [`Error::NothingDeferred`] when the circuit checks the claim in-circuit.
+	/// Returns an error when the circuit checked the claim in-circuit.
 	///
-	/// Returns [`Error::StatementLength`] when `outer_inout` is not this circuit's statement.
+	/// Returns an error when the values are not this circuit's statement.
 	///
-	/// Returns [`Error::Verifier`] when the claim does not hold.
+	/// Returns an error when the claim does not hold.
 	pub fn check_deferred(&self, outer_inout: &[Word]) -> Result<(), Error> {
 		let Some(deferred) = &self.deferred else {
 			return Err(Error::NothingDeferred);
 		};
 
 		// The claim sits behind the inner statement, so the two lengths together fix the layout.
+		//
 		// A mismatch means the caller handed over some other circuit's statement.
 		let expected = self.statement.len() + deferred.wires.len();
 		if outer_inout.len() != expected {
@@ -298,8 +308,10 @@ impl RecursiveCircuit {
 			});
 		}
 
-		// Each element is the `(lo, hi)` pair the binding placed, in the order the wiring
-		// multilinear reads its input. The claimed evaluation is the last of them.
+		// Each element is the low-half, high-half pair the binding placed.
+		//
+		// They arrive in the order the wiring multilinear reads its input.
+		// The claimed evaluation is the last of them.
 		let elems = outer_inout[self.statement.len()..]
 			.chunks_exact(2)
 			.map(|pair| {
@@ -324,21 +336,24 @@ impl RecursiveCircuit {
 
 	/// Verifies an outer proof of this circuit, settling everything it defers.
 	///
-	/// This is the safe way to check an outer proof, and the reason it exists is that the unsafe
-	/// way is otherwise shorter. Verifying the proof alone attests to a *verification minus its
-	/// wiring constraint* whenever the claim was deferred, and nothing about the proof says so.
+	/// This is the safe way to check an outer proof.
+	/// It exists because the unsafe way is otherwise shorter.
+	///
+	/// A deferred claim makes the proof alone attest to less than a verification.
+	/// Nothing about the proof says so.
 	///
 	/// ```text
-	///   verify the outer proof  +  check_deferred  =  the inner statement really was proved
+	///   the outer proof verifies  +  the claim holds  =  the inner statement really was proved
 	/// ```
 	///
-	/// `outer` must be a verifier for [`circuit`](Self::circuit); a different system would check a
-	/// different proof.
+	/// The verifier passed in must be one for this circuit.
+	/// A different system would check a different proof.
 	///
 	/// # Errors
 	///
-	/// Returns [`Error::Verifier`] when the outer proof does not verify, or when the deferred
-	/// claim does not hold.
+	/// Returns an error when the outer proof does not verify.
+	///
+	/// Returns an error when the deferred claim does not hold.
 	pub fn verify_outer(
 		&self,
 		outer: &Verifier<StdHashSuite>,
@@ -351,8 +366,9 @@ impl RecursiveCircuit {
 			.finalize()
 			.map_err(binius_verifier::Error::from)?;
 
-		// An in-circuit discharge already checked the claim as constraints, so there is nothing
-		// left to settle and nothing to complain about.
+		// An in-circuit discharge already checked the claim as constraints.
+		//
+		// So there is nothing left to settle, and nothing to complain about.
 		if self.deferred.is_some() {
 			self.check_deferred(inout)?;
 		}
@@ -456,11 +472,12 @@ impl RecursiveCircuit {
 			.iop_verifier()
 			.verify(&statement, &mut channel)?;
 
-		// This channel carries values, so the same claim comes back concrete here. Under
-		// `Discharge::Deferred` those values are what the bound public wires need; the build's
-		// equality then pins them against the wires the circuit derived.
+		// This channel carries values, so the same claim comes back concrete here.
 		//
-		// `assert_zero` is a no-op on this channel, so checking in-circuit costs nothing to mirror.
+		// Those values are what the bound public wires need.
+		// The build's equality then pins them against the wires the circuit derived.
+		//
+		// Asserting is a no-op on this channel, so mirroring the in-circuit check costs nothing.
 		let exported = match self.deferred {
 			None => {
 				claim

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -67,6 +67,6 @@ mod shared;
 pub mod symbolic;
 
 pub use channel::{Binius64BuilderChannel, Commitment, Recorded};
-pub use circuit::{Error, RecursiveCircuit};
+pub use circuit::{Discharge, Error, RecursiveCircuit};
 pub use filler::WitnessFillerChannel;
 pub use symbolic::{SymbolicElem, SymbolicWord};

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -225,9 +225,11 @@ fn the_recursive_circuit_proves_and_verifies() {
 fn deferring_shrinks_a_level_by_the_cost_of_the_level_below() {
 	// Invariant: the wiring claim is the only cost that tracks the inner system's size.
 	//
-	// So the two discharges diverge at different rates, and the gap between them at depth 2 *is*
-	// the term deferral removes. One level below, that term is small; one level up it dominates,
-	// which is why the comparison has to be made here and not at depth 1.
+	// So the two settlements diverge at different rates.
+	// The gap between them at depth 2 *is* the term deferral removes.
+	//
+	// One level below, that term is small.
+	// One level up it dominates, which is why the comparison belongs here and not at depth 1.
 	//
 	//     depth 1: verifies the CRC-64 proof
 	//     depth 2: verifies depth 1's proof
@@ -273,8 +275,9 @@ fn deferring_shrinks_a_level_by_the_cost_of_the_level_below() {
 		100.0 * saved as f64 / inline2 as f64
 	);
 
-	// Both still diverge. The replay itself is sublinear but not yet below one at these sizes, so
-	// a closing tower needs the merge node's own parameters, not just this seam.
+	// Both still diverge.
+	// The replay is sublinear but not yet below one at these sizes.
+	// A closing tower needs the merge node's own parameters, not just this seam.
 	assert!(defer2 > defer1, "the replay term still grows: closure is the merge node's checkpoint");
 }
 
@@ -437,9 +440,9 @@ fn a_malformed_proof_is_rejected_rather_than_crashing() {
 fn deferring_the_wiring_claim_removes_its_cost_and_keeps_it_checkable() {
 	// Invariant: discharging the wiring claim is the one cost proportional to the inner system.
 	//
-	// Deferring it exports the claim on public wires instead. So the BMUL column drops by the
-	// evaluation's whole cost, and the statement grows only by the claim, which is logarithmic in
-	// the inner system.
+	// Deferring exports the claim on public wires instead.
+	// So the BMUL column drops by the evaluation's whole cost.
+	// The statement grows only by the claim, which is logarithmic in the inner system.
 	//
 	//     in-circuit: assert_zero(eval(inputs) - claimed)   -> constraints over every inner row
 	//     deferred:   inputs, claimed -> public wires       -> a check the holder owes
@@ -481,8 +484,8 @@ fn deferring_the_wiring_claim_removes_its_cost_and_keeps_it_checkable() {
 	assert_eq!(outer_inout.len(), deferred.statement().len() + 2 * claim_elems);
 	prove(deferred.circuit(), witness);
 
-	// The exported claim holds against the inner constraint system, which is the check the
-	// circuit skipped. This is the whole obligation deferral creates.
+	// The exported claim holds against the inner constraint system.
+	// That is the check the circuit skipped, and the whole obligation deferral creates.
 	deferred
 		.check_deferred(&outer_inout)
 		.expect("an honest proof must export a claim that holds");
@@ -507,8 +510,10 @@ fn a_tampered_deferred_claim_is_rejected() {
 		.unwrap();
 	let honest = witness.inout().to_vec();
 
-	// Every word of the claim is load-bearing: the inputs are the point it is evaluated at, and
-	// the last element is the value itself. Moving any one of them must break the equality.
+	// Every word of the claim is load-bearing.
+	// The inputs are the point it is evaluated at.
+	// The last element is the value itself.
+	// Moving any one of them must break the equality.
 	for offset in [0, 1, 2 * (deferred.deferred_wires().unwrap().len() / 2) - 1] {
 		let mut tampered = honest.clone();
 		let word = &mut tampered[deferred.statement().len() + offset];
@@ -521,9 +526,10 @@ fn a_tampered_deferred_claim_is_rejected() {
 
 #[test]
 fn an_in_circuit_discharge_leaves_nothing_deferred() {
-	// Invariant: the two discharges are exclusive, so asking one for the other's work is an error
-	// rather than a silent pass. A silent pass is how a caller ends up believing a claim was
-	// settled twice when it was settled once.
+	// Invariant: the two discharges are exclusive.
+	//
+	// So asking one for the other's work is an error rather than a silent pass.
+	// A silent pass is how a caller ends up believing a claim was settled when it was not.
 	let inner = prove_crc64();
 	let inline = RecursiveCircuit::build_with(inner.verifier, Discharge::InCircuit).unwrap();
 
@@ -540,15 +546,15 @@ fn an_in_circuit_discharge_leaves_nothing_deferred() {
 fn a_deferred_claim_that_disagrees_with_the_circuit_is_rejected() {
 	// Invariant: the exported claim is bound, not merely reported.
 	//
-	// `check_deferred` reads the claim off the outer statement, so the statement has to be the
-	// claim the circuit actually derived. The binding is what forces that, and this is the test
-	// that it is a constraint rather than a convention.
+	// Settling reads the claim off the outer statement.
+	// So the statement has to carry the claim the circuit actually derived.
+	// The binding is what forces that, and this pins it as a constraint rather than a convention.
 	//
 	//     before:  public claim word == the word the circuit derived
 	//     after:   public claim word != it, and the equality the binding emitted breaks
 	//
-	// Without this, a prover could publish a claim that holds while verifying a proof that raised
-	// a different one — and `check_deferred` would happily confirm the published one.
+	// Without it a prover could publish a claim that holds while verifying a proof that raised a
+	// different one, and the later check would confirm the published one.
 	let inner = prove_crc64();
 	let deferred =
 		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::Deferred).unwrap();
@@ -565,7 +571,8 @@ fn a_deferred_claim_that_disagrees_with_the_circuit_is_rejected() {
 		.populate_wire_witness(&mut filler)
 		.expect_err("a claim word that disagrees must leave the circuit unsatisfied");
 
-	// `..` is forced: `PopulateError` is non-exhaustive. Both of its fields are checked here.
+	// The rest pattern is forced: the error type is non-exhaustive.
+	// Both of its fields are checked here.
 	let PopulateError {
 		failures, total, ..
 	} = error;
@@ -582,9 +589,9 @@ fn a_deferred_claim_that_disagrees_with_the_circuit_is_rejected() {
 fn verify_outer_settles_the_deferred_claim() {
 	// Invariant: the one-call path checks strictly more than verifying the proof does.
 	//
-	// The outer proof verifies on its own even when the claim it exported is false, because the
-	// circuit never constrained the claim to hold — only to be reported honestly. So a statement
-	// carrying a broken claim passes `Verifier::verify` and must still fail `verify_outer`.
+	// The outer proof verifies on its own even when the claim it exported is false.
+	// The circuit never constrained the claim to hold, only to be reported honestly.
+	// So a statement carrying a broken claim passes the proof check and must still be rejected.
 	let inner = prove_crc64();
 	let deferred =
 		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::Deferred).unwrap();
@@ -598,9 +605,11 @@ fn verify_outer_settles_the_deferred_claim() {
 		.verify_outer(&outer.verifier, &honest, outer.proof.clone())
 		.expect("an honest outer proof must verify and its claim must hold");
 
-	// The same proof against a statement whose claim was moved: the transcript no longer matches
-	// the statement, so this fails at the proof. Either rejection is correct; what matters is that
-	// no path accepts it.
+	// The same proof, against a statement whose claim was moved.
+	//
+	// The transcript no longer matches the statement, so this fails at the proof.
+	// Either rejection is correct.
+	// What matters is that no path accepts it.
 	let mut tampered = honest;
 	let at = deferred.statement().len();
 	tampered[at] = Word(tampered[at].0 ^ 1);

--- a/crates/recursion/tests/recursion_end_to_end.rs
+++ b/crates/recursion/tests/recursion_end_to_end.rs
@@ -26,7 +26,7 @@ use binius_frontend::{
 };
 use binius_hash::StdHashSuite;
 use binius_prover::Prover;
-use binius_recursion::{Error, RecursiveCircuit};
+use binius_recursion::{Discharge, Error, RecursiveCircuit};
 use binius_transcript::{ProverTranscript, VerifierTranscript};
 use binius_verifier::{Verifier, config::StdChallenger};
 
@@ -221,38 +221,61 @@ fn the_recursive_circuit_proves_and_verifies() {
 }
 
 #[test]
-#[ignore = "builds a 50M-gate circuit; run explicitly to re-measure per-level growth"]
-fn one_more_level_costs_far_more_than_the_level_below() {
-	// Invariant: discharging the wiring claim in-circuit is proportional to the inner system.
+#[ignore = "builds two multi-million-row circuits; run explicitly to re-measure per-level growth"]
+fn deferring_shrinks_a_level_by_the_cost_of_the_level_below() {
+	// Invariant: the wiring claim is the only cost that tracks the inner system's size.
 	//
-	// A level's cost is dominated by a term proportional to the rows of the level beneath it, so
-	// the tower diverges: `rows(n+1) / rows(n)` sits far above one and does not fall with depth.
-	// That ratio is the whole reason the claim has to be deferred instead.
+	// So the two discharges diverge at different rates, and the gap between them at depth 2 *is*
+	// the term deferral removes. One level below, that term is small; one level up it dominates,
+	// which is why the comparison has to be made here and not at depth 1.
 	//
 	//     depth 1: verifies the CRC-64 proof
 	//     depth 2: verifies depth 1's proof
 	let inner = prove_crc64();
 
-	let depth1 = RecursiveCircuit::build(inner.verifier.clone()).unwrap();
-	let witness1 = depth1
-		.witness(inner.witness.inout(), inner.proof.clone())
+	let mut report = Vec::new();
+	for discharge in [Discharge::InCircuit, Discharge::Deferred] {
+		let depth1 = RecursiveCircuit::build_with(inner.verifier.clone(), discharge).unwrap();
+		let rows1 = rows(&CircuitStat::collect(depth1.circuit()));
+
+		// Depth 2 reads only depth 1's *shape*, so depth 1 need not be proved to measure this.
+		let verifier1 = Verifier::<StdHashSuite>::setup(
+			depth1.circuit().constraint_system().clone(),
+			LOG_INV_RATE,
+		)
 		.unwrap();
-	let rows1 = rows(&CircuitStat::collect(depth1.circuit()));
+		let depth2 = RecursiveCircuit::build_with(verifier1, discharge).unwrap();
+		let rows2 = rows(&CircuitStat::collect(depth2.circuit()));
 
-	// Depth 2 reads only depth 1's *shape*, so depth 1 need not be proved to measure this.
-	let verifier1 =
-		Verifier::<StdHashSuite>::setup(depth1.circuit().constraint_system().clone(), LOG_INV_RATE)
-			.unwrap();
-	let depth2 = RecursiveCircuit::build(verifier1).unwrap();
-	let rows2 = rows(&CircuitStat::collect(depth2.circuit()));
+		println!(
+			"{discharge:?}: depth1 {rows1} -> depth2 {rows2} = {:.2}x",
+			rows2 as f64 / rows1 as f64
+		);
+		report.push((rows1, rows2));
+	}
 
-	let growth = rows2 as f64 / rows1 as f64;
-	println!("rows: depth1 {rows1} -> depth2 {rows2} = {growth:.2}x");
+	let [(inline1, inline2), (defer1, defer2)] = report[..] else {
+		unreachable!()
+	};
 
-	// A closing tower would sit at or below one. Pinning a floor documents that it does not, and
-	// turns the day this drops into a test failure worth reading.
-	assert!(growth > 5.0, "inline discharge is expected to diverge, measured {growth:.2}x");
-	assert_eq!(witness1.inout(), inner.witness.inout());
+	// Deferring costs a little at depth 1, where the claim it exports is nearly free either way.
+	assert!(defer1 < inline1, "deferring cannot add rows");
+
+	// It pays at depth 2, where the claim it dropped was proportional to depth 1's whole size.
+	// This gap is the entire reason the seam exists.
+	assert!(
+		defer2 < inline2,
+		"deferring must remove the term proportional to the level below: {defer2} vs {inline2}"
+	);
+	let saved = inline2 - defer2;
+	println!(
+		"deferral saved {saved} rows at depth 2, {:.1}% of the inline level",
+		100.0 * saved as f64 / inline2 as f64
+	);
+
+	// Both still diverge. The replay itself is sublinear but not yet below one at these sizes, so
+	// a closing tower needs the merge node's own parameters, not just this seam.
+	assert!(defer2 > defer1, "the replay term still grows: closure is the merge node's checkpoint");
 }
 
 /// Flips one bit of the first recorded wire of `kind`, and returns why the circuit then fails.
@@ -408,4 +431,180 @@ fn a_malformed_proof_is_rejected_rather_than_crashing() {
 			"a {len}-byte tape must fail on the tape, got {error}"
 		);
 	}
+}
+
+#[test]
+fn deferring_the_wiring_claim_removes_its_cost_and_keeps_it_checkable() {
+	// Invariant: discharging the wiring claim is the one cost proportional to the inner system.
+	//
+	// Deferring it exports the claim on public wires instead. So the BMUL column drops by the
+	// evaluation's whole cost, and the statement grows only by the claim, which is logarithmic in
+	// the inner system.
+	//
+	//     in-circuit: assert_zero(eval(inputs) - claimed)   -> constraints over every inner row
+	//     deferred:   inputs, claimed -> public wires       -> a check the holder owes
+	let inner = prove_crc64();
+
+	let inline =
+		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::InCircuit).unwrap();
+	let deferred =
+		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::Deferred).unwrap();
+
+	let a = CircuitStat::collect(inline.circuit());
+	let b = CircuitStat::collect(deferred.circuit());
+	let claim_elems = deferred.deferred_wires().unwrap().len() / 2;
+	println!(
+		"in-circuit {} BMUL / {} rows  ->  deferred {} BMUL / {} rows, claim {} elements",
+		a.n_bmul_constraints,
+		rows(&a),
+		b.n_bmul_constraints,
+		rows(&b),
+		claim_elems,
+	);
+
+	// The evaluation is pure field arithmetic, so deferring can only take BMUL away.
+	assert!(
+		b.n_bmul_constraints < a.n_bmul_constraints,
+		"deferring must drop the evaluation's BMUL cost"
+	);
+	// And the claim it exports has to stay small, or deferral trades one cost for another.
+	assert!(
+		claim_elems < 512,
+		"the exported claim must be logarithmic in the inner system, got {claim_elems} elements"
+	);
+
+	// The deferred circuit still proves and verifies, and its statement carries the claim.
+	let witness = deferred
+		.witness(inner.witness.inout(), inner.proof.clone())
+		.unwrap();
+	let outer_inout = witness.inout().to_vec();
+	assert_eq!(outer_inout.len(), deferred.statement().len() + 2 * claim_elems);
+	prove(deferred.circuit(), witness);
+
+	// The exported claim holds against the inner constraint system, which is the check the
+	// circuit skipped. This is the whole obligation deferral creates.
+	deferred
+		.check_deferred(&outer_inout)
+		.expect("an honest proof must export a claim that holds");
+}
+
+#[test]
+fn a_tampered_deferred_claim_is_rejected() {
+	// Invariant: the deferred check is a real evaluation, not a formality.
+	//
+	// Fixture state: one honest proof, its exported claim read off the outer statement, with one
+	// word of that claim then flipped.
+	//
+	//     before:  eval(inputs) == claimed
+	//     after:   one coordinate moved, so the two sides disagree
+	//
+	// If this passed, deferral would be exporting an unchecked constraint and calling it checked.
+	let inner = prove_crc64();
+	let deferred =
+		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::Deferred).unwrap();
+	let witness = deferred
+		.witness(inner.witness.inout(), inner.proof.clone())
+		.unwrap();
+	let honest = witness.inout().to_vec();
+
+	// Every word of the claim is load-bearing: the inputs are the point it is evaluated at, and
+	// the last element is the value itself. Moving any one of them must break the equality.
+	for offset in [0, 1, 2 * (deferred.deferred_wires().unwrap().len() / 2) - 1] {
+		let mut tampered = honest.clone();
+		let word = &mut tampered[deferred.statement().len() + offset];
+		*word = Word(word.0 ^ 1);
+		deferred
+			.check_deferred(&tampered)
+			.expect_err("a moved claim word must fail the deferred check");
+	}
+}
+
+#[test]
+fn an_in_circuit_discharge_leaves_nothing_deferred() {
+	// Invariant: the two discharges are exclusive, so asking one for the other's work is an error
+	// rather than a silent pass. A silent pass is how a caller ends up believing a claim was
+	// settled twice when it was settled once.
+	let inner = prove_crc64();
+	let inline = RecursiveCircuit::build_with(inner.verifier, Discharge::InCircuit).unwrap();
+
+	assert!(inline.deferred_wires().is_none());
+	assert!(matches!(
+		inline
+			.check_deferred(&[])
+			.expect_err("there is no claim to check"),
+		Error::NothingDeferred
+	));
+}
+
+#[test]
+fn a_deferred_claim_that_disagrees_with_the_circuit_is_rejected() {
+	// Invariant: the exported claim is bound, not merely reported.
+	//
+	// `check_deferred` reads the claim off the outer statement, so the statement has to be the
+	// claim the circuit actually derived. The binding is what forces that, and this is the test
+	// that it is a constraint rather than a convention.
+	//
+	//     before:  public claim word == the word the circuit derived
+	//     after:   public claim word != it, and the equality the binding emitted breaks
+	//
+	// Without this, a prover could publish a claim that holds while verifying a proof that raised
+	// a different one — and `check_deferred` would happily confirm the published one.
+	let inner = prove_crc64();
+	let deferred =
+		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::Deferred).unwrap();
+	let mut filler = deferred
+		.fill(inner.witness.inout(), inner.proof.clone())
+		.unwrap();
+
+	// Mutation: flip one bit of the first claim word, leaving every derived wire alone.
+	let bound = deferred.deferred_wires().unwrap()[0];
+	filler[bound] = Word(filler[bound].0 ^ 1);
+
+	let error = deferred
+		.circuit()
+		.populate_wire_witness(&mut filler)
+		.expect_err("a claim word that disagrees must leave the circuit unsatisfied");
+
+	// `..` is forced: `PopulateError` is non-exhaustive. Both of its fields are checked here.
+	let PopulateError {
+		failures, total, ..
+	} = error;
+	assert_eq!(total, 1, "only the binding may fail");
+	assert!(
+		failures[0].path.contains("bind_public_elem"),
+		"the failure must come from the claim binding: {}",
+		failures[0].path
+	);
+	assert!(!failures[0].detail.is_empty(), "a failure must carry a diagnostic");
+}
+
+#[test]
+fn verify_outer_settles_the_deferred_claim() {
+	// Invariant: the one-call path checks strictly more than verifying the proof does.
+	//
+	// The outer proof verifies on its own even when the claim it exported is false, because the
+	// circuit never constrained the claim to hold — only to be reported honestly. So a statement
+	// carrying a broken claim passes `Verifier::verify` and must still fail `verify_outer`.
+	let inner = prove_crc64();
+	let deferred =
+		RecursiveCircuit::build_with(inner.verifier.clone(), Discharge::Deferred).unwrap();
+	let witness = deferred
+		.witness(inner.witness.inout(), inner.proof.clone())
+		.unwrap();
+	let honest = witness.inout().to_vec();
+	let outer = prove(deferred.circuit(), witness);
+
+	deferred
+		.verify_outer(&outer.verifier, &honest, outer.proof.clone())
+		.expect("an honest outer proof must verify and its claim must hold");
+
+	// The same proof against a statement whose claim was moved: the transcript no longer matches
+	// the statement, so this fails at the proof. Either rejection is correct; what matters is that
+	// no path accepts it.
+	let mut tampered = honest;
+	let at = deferred.statement().len();
+	tampered[at] = Word(tampered[at].0 ^ 1);
+	deferred
+		.verify_outer(&outer.verifier, &tampered, outer.proof)
+		.expect_err("a moved claim must not be accepted");
 }

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -48,6 +48,6 @@ mod verify;
 pub use error::Error;
 pub use shift_ind::evaluate_shift_inds;
 pub use verify::{
-	OperatorData, VerifyOutput, WiringEvalClaim, WiringEvalFn, check_eval, evaluate_words_mle,
-	verify,
+	DeferredWiringClaim, OperatorData, VerifyOutput, WiringEvalClaim, WiringEvalFn,
+	WiringEvalShape, check_eval, evaluate_words_mle, verify,
 };

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -385,17 +385,19 @@ where
 			.chain(iter::once(r_segment.clone()))
 			.collect();
 
-		let eval_fn = WiringEvalFn {
+		let eval_fn = WiringEvalFn::new(
 			constraint_system,
-			inout,
-			zero_r_x_prime_len,
-			bitand_r_x_prime_len,
-			intmul_r_x_prime_len,
-			binmul_r_x_prime_len,
-			r_s_len,
-			r_v_len,
-			r_y_len,
-		};
+			WiringEvalShape {
+				inout,
+				zero_r_x_prime_len,
+				bitand_r_x_prime_len,
+				intmul_r_x_prime_len,
+				binmul_r_x_prime_len,
+				r_s_len,
+				r_v_len,
+				r_y_len,
+			},
+		);
 		WiringEvalClaim {
 			eval_fn,
 			inputs,
@@ -455,6 +457,74 @@ impl<F: BinaryField> WiringEvalClaim<'_, F> {
 	}
 }
 
+impl<'a, E> WiringEvalClaim<'a, E> {
+	/// Exports the claim instead of discharging it.
+	///
+	/// Discharging costs one evaluation of the wiring multilinear, and that evaluation walks
+	/// every constraint of the system. Inside a circuit that is proportional to the inner
+	/// system, which is why a circuit that pays it can never verify a proof of itself.
+	///
+	/// Exporting hands the claim out whole instead, to be settled somewhere the cost is
+	/// ordinary — natively, once, at the root of an aggregation tree.
+	///
+	/// The inputs are short: [`WiringEvalShape::n_inputs`] is logarithmic in the constraint
+	/// count, since every section is a challenge vector over a padded log-sized index. That is
+	/// what makes exporting cheaper than checking.
+	///
+	/// # Correctness
+	///
+	/// Nothing is verified here, and nothing about the claim is checked later unless a holder
+	/// checks it. A dropped claim is an unchecked constraint, which is why the result is
+	/// `#[must_use]`.
+	pub fn defer(self) -> DeferredWiringClaim<E> {
+		DeferredWiringClaim {
+			shape: self.eval_fn.shape(),
+			inputs: self.inputs,
+			claimed: self.claimed,
+		}
+	}
+}
+
+/// A wiring claim that was exported rather than discharged.
+///
+/// Holding one is owing a check. [`check`](Self::check) is that check, and it needs only the
+/// constraint system the claim is about — public data — so it can run far from the verifier that
+/// raised the claim.
+///
+/// ```text
+///   verify -> claim -> defer -> travels as public values -> check, natively, at the root
+/// ```
+#[must_use = "a deferred wiring claim that nobody discharges is an unchecked constraint"]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeferredWiringClaim<E> {
+	/// How [`inputs`](Self::inputs) splits back into its sections.
+	pub shape: WiringEvalShape,
+	/// The point the wiring multilinear is claimed to be evaluated at.
+	pub inputs: Vec<E>,
+	/// The evaluation the prover claims.
+	pub claimed: E,
+}
+
+impl<F: BinaryField> DeferredWiringClaim<F> {
+	/// Discharges the claim against the constraint system it is about.
+	///
+	/// `constraint_system` must be the one the claim was raised over. A different system names a
+	/// different polynomial, so the check would be meaningless rather than merely wrong; the
+	/// caller owes that pairing.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error::VerificationFailure`] when the evaluation disagrees with the claim.
+	pub fn check(&self, constraint_system: &ConstraintSystem) -> Result<(), Error> {
+		let eval_fn = WiringEvalFn::new(constraint_system, self.shape);
+		if eval_fn.call_native(&self.inputs) == self.claimed {
+			Ok(())
+		} else {
+			Err(Error::VerificationFailure)
+		}
+	}
+}
+
 impl<E> WiringEvalClaim<'_, E> {
 	/// Discharges the claim over `channel`'s elements: evaluates the wiring multilinear there and
 	/// asserts it equals the claimed value.
@@ -498,6 +568,24 @@ impl<E> WiringEvalClaim<'_, E> {
 pub struct WiringEvalFn<'a> {
 	/// The AND, IMUL and BMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,
+	/// How the flat input splits back into its sections.
+	shape: WiringEvalShape,
+}
+
+/// How a wiring claim's flat input splits back into its sections.
+///
+/// Every length here is fixed by the constraint system and the reduction run over it.
+/// None of them is read off a prover message.
+/// So one shape describes every proof of one shape, and carrying it costs nothing per proof.
+///
+/// That is what lets a claim be discharged later, away from the run that raised it: see
+/// [`DeferredWiringClaim`].
+///
+/// The fields stay private, and the only way to obtain one is [`WiringEvalFn::shape`]. A
+/// hand-built shape could disagree with the run that produced the inputs, and the mismatch would
+/// surface as a wrong evaluation rather than an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WiringEvalShape {
 	/// Which segment holds the inout values, which fixes where the word-index tensor is cut.
 	inout: InoutSegment,
 	/// Length of the Zero operator's `r_x_prime` section.
@@ -514,6 +602,41 @@ pub struct WiringEvalFn<'a> {
 	r_v_len: usize,
 	/// Length of the `r_y` section (the column challenges).
 	r_y_len: usize,
+}
+
+impl WiringEvalShape {
+	/// The number of elements a claim of this shape reads.
+	///
+	/// Four batching coefficients, one `r_x_prime` vector per operator, both shift slots, the
+	/// column challenges, then the single `r_segment` coordinate.
+	pub const fn n_inputs(&self) -> usize {
+		4 + self.zero_r_x_prime_len
+			+ self.bitand_r_x_prime_len
+			+ self.intmul_r_x_prime_len
+			+ self.binmul_r_x_prime_len
+			+ 2 * self.r_s_len
+			+ 2 * self.r_v_len
+			+ self.r_y_len
+			+ 1
+	}
+}
+
+impl<'a> WiringEvalFn<'a> {
+	/// Rebuilds the evaluation over `constraint_system`, reading its input with `shape`.
+	///
+	/// This is how a [`DeferredWiringClaim`] is discharged: the shape travelled with the claim,
+	/// and the system it sums over is public, so no part of the original run is needed.
+	pub const fn new(constraint_system: &'a ConstraintSystem, shape: WiringEvalShape) -> Self {
+		Self {
+			constraint_system,
+			shape,
+		}
+	}
+
+	/// How this evaluation reads its flat input.
+	pub const fn shape(&self) -> WiringEvalShape {
+		self.shape
+	}
 }
 
 /// The per-operation [`OperationEvalFn`] inputs [`WiringEvalFn::operation_inputs`] splits out of
@@ -551,19 +674,19 @@ impl WiringEvalFn<'_> {
 		// accessor reports for an empty constraint set; so do the Zero and BitAnd reductions'
 		// single all-zero padding rows.
 		debug_assert_eq!(
-			self.zero_r_x_prime_len,
+			self.shape.zero_r_x_prime_len,
 			self.constraint_system.log_zero_constraints().unwrap_or(0)
 		);
 		debug_assert_eq!(
-			self.bitand_r_x_prime_len,
+			self.shape.bitand_r_x_prime_len,
 			self.constraint_system.log_and_constraints().unwrap_or(0)
 		);
 		debug_assert_eq!(
-			self.intmul_r_x_prime_len,
+			self.shape.intmul_r_x_prime_len,
 			self.constraint_system.log_imul_constraints().unwrap_or(0)
 		);
 		debug_assert_eq!(
-			self.binmul_r_x_prime_len,
+			self.shape.binmul_r_x_prime_len,
 			self.constraint_system.log_bmul_constraints().unwrap_or(0)
 		);
 
@@ -573,24 +696,24 @@ impl WiringEvalFn<'_> {
 		let intmul_lambda_v = vals[2].clone();
 		let binmul_lambda_v = vals[3].clone();
 		let mut off = 4;
-		let zero_r_x_prime_v = &vals[off..off + self.zero_r_x_prime_len];
-		off += self.zero_r_x_prime_len;
-		let bitand_r_x_prime_v = &vals[off..off + self.bitand_r_x_prime_len];
-		off += self.bitand_r_x_prime_len;
-		let intmul_r_x_prime_v = &vals[off..off + self.intmul_r_x_prime_len];
-		off += self.intmul_r_x_prime_len;
-		let binmul_r_x_prime_v = &vals[off..off + self.binmul_r_x_prime_len];
-		off += self.binmul_r_x_prime_len;
-		let r_s_inner_v = &vals[off..off + self.r_s_len];
-		off += self.r_s_len;
-		let r_v_inner_v = &vals[off..off + self.r_v_len];
-		off += self.r_v_len;
-		let r_s_outer_v = &vals[off..off + self.r_s_len];
-		off += self.r_s_len;
-		let r_v_outer_v = &vals[off..off + self.r_v_len];
-		off += self.r_v_len;
-		let r_y_v = &vals[off..off + self.r_y_len];
-		off += self.r_y_len;
+		let zero_r_x_prime_v = &vals[off..off + self.shape.zero_r_x_prime_len];
+		off += self.shape.zero_r_x_prime_len;
+		let bitand_r_x_prime_v = &vals[off..off + self.shape.bitand_r_x_prime_len];
+		off += self.shape.bitand_r_x_prime_len;
+		let intmul_r_x_prime_v = &vals[off..off + self.shape.intmul_r_x_prime_len];
+		off += self.shape.intmul_r_x_prime_len;
+		let binmul_r_x_prime_v = &vals[off..off + self.shape.binmul_r_x_prime_len];
+		off += self.shape.binmul_r_x_prime_len;
+		let r_s_inner_v = &vals[off..off + self.shape.r_s_len];
+		off += self.shape.r_s_len;
+		let r_v_inner_v = &vals[off..off + self.shape.r_v_len];
+		off += self.shape.r_v_len;
+		let r_s_outer_v = &vals[off..off + self.shape.r_s_len];
+		off += self.shape.r_s_len;
+		let r_v_outer_v = &vals[off..off + self.shape.r_v_len];
+		off += self.shape.r_v_len;
+		let r_y_v = &vals[off..off + self.shape.r_y_len];
+		off += self.shape.r_y_len;
 		// `r_segment` is the top word-index coordinate, appended after `r_y`; it selects the public
 		// (0) vs hidden (1) segment.
 		let r_segment = vals[off].clone();
@@ -607,7 +730,7 @@ impl WiringEvalFn<'_> {
 		//     over the unused `r_y` coordinates — the same `padded_public_eval` factor that
 		//     `check_eval` reconstructs the witness evaluation with.
 		let cs = &self.constraint_system;
-		let log_public_words = cs.log_public_words(self.inout);
+		let log_public_words = cs.log_public_words(self.shape.inout);
 
 		let public_scale = Hypercube::One.eq_one_var(r_segment.clone(), E::zero())
 			* Hypercube::One.eq_ind_zero(&r_y_v[log_public_words..]);
@@ -619,7 +742,7 @@ impl WiringEvalFn<'_> {
 		// private values trail the hidden one; the inout values follow whichever indicator they
 		// are placed in. The padding words between the runs are dropped, since no index can name
 		// one.
-		let r_y_tensor = match self.inout {
+		let r_y_tensor = match self.shape.inout {
 			InoutSegment::Public => [
 				&public_tensor[..cs.n_const()],
 				&public_tensor[cs.offset_inout()..cs.offset_inout() + cs.n_inout],

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -460,22 +460,22 @@ impl<F: BinaryField> WiringEvalClaim<'_, F> {
 impl<'a, E> WiringEvalClaim<'a, E> {
 	/// Exports the claim instead of discharging it.
 	///
-	/// Discharging costs one evaluation of the wiring multilinear, and that evaluation walks
-	/// every constraint of the system. Inside a circuit that is proportional to the inner
-	/// system, which is why a circuit that pays it can never verify a proof of itself.
+	/// Discharging evaluates the wiring multilinear, which walks every constraint of the system.
+	/// Inside a circuit that cost tracks the inner system.
+	/// So a circuit that pays it can never verify a proof of itself.
 	///
-	/// Exporting hands the claim out whole instead, to be settled somewhere the cost is
-	/// ordinary — natively, once, at the root of an aggregation tree.
+	/// Exporting hands the claim out whole instead.
+	/// It is settled once, natively, where the cost is ordinary.
 	///
-	/// The inputs are short: [`WiringEvalShape::n_inputs`] is logarithmic in the constraint
-	/// count, since every section is a challenge vector over a padded log-sized index. That is
-	/// what makes exporting cheaper than checking.
+	/// The claim is short.
+	/// Every section of its input is a challenge vector over a padded log-sized index.
+	/// So the input length is logarithmic in the constraint count.
 	///
 	/// # Correctness
 	///
-	/// Nothing is verified here, and nothing about the claim is checked later unless a holder
-	/// checks it. A dropped claim is an unchecked constraint, which is why the result is
-	/// `#[must_use]`.
+	/// Nothing is verified here.
+	/// Nothing is verified later either, unless a holder settles the claim.
+	/// A dropped claim is an unchecked constraint.
 	pub fn defer(self) -> DeferredWiringClaim<E> {
 		DeferredWiringClaim {
 			shape: self.eval_fn.shape(),
@@ -487,17 +487,18 @@ impl<'a, E> WiringEvalClaim<'a, E> {
 
 /// A wiring claim that was exported rather than discharged.
 ///
-/// Holding one is owing a check. [`check`](Self::check) is that check, and it needs only the
-/// constraint system the claim is about — public data — so it can run far from the verifier that
-/// raised the claim.
+/// Holding one is owing a check.
+///
+/// Settling it needs only the constraint system the claim is about, which is public data.
+/// So it can run far from the verifier that raised the claim.
 ///
 /// ```text
-///   verify -> claim -> defer -> travels as public values -> check, natively, at the root
+///   verify -> claim -> export -> travels as public values -> settled natively at the root
 /// ```
 #[must_use = "a deferred wiring claim that nobody discharges is an unchecked constraint"]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeferredWiringClaim<E> {
-	/// How [`inputs`](Self::inputs) splits back into its sections.
+	/// How the flat input below splits back into its sections.
 	pub shape: WiringEvalShape,
 	/// The point the wiring multilinear is claimed to be evaluated at.
 	pub inputs: Vec<E>,
@@ -506,15 +507,15 @@ pub struct DeferredWiringClaim<E> {
 }
 
 impl<F: BinaryField> DeferredWiringClaim<F> {
-	/// Discharges the claim against the constraint system it is about.
+	/// Settles the claim against the constraint system it is about.
 	///
-	/// `constraint_system` must be the one the claim was raised over. A different system names a
-	/// different polynomial, so the check would be meaningless rather than merely wrong; the
-	/// caller owes that pairing.
+	/// The system must be the one the claim was raised over.
+	/// A different one names a different polynomial.
+	/// The check would then be meaningless rather than wrong, so the caller owes that pairing.
 	///
 	/// # Errors
 	///
-	/// Returns [`Error::VerificationFailure`] when the evaluation disagrees with the claim.
+	/// Returns an error when the evaluation disagrees with the claim.
 	pub fn check(&self, constraint_system: &ConstraintSystem) -> Result<(), Error> {
 		let eval_fn = WiringEvalFn::new(constraint_system, self.shape);
 		if eval_fn.call_native(&self.inputs) == self.claimed {
@@ -574,16 +575,15 @@ pub struct WiringEvalFn<'a> {
 
 /// How a wiring claim's flat input splits back into its sections.
 ///
-/// Every length here is fixed by the constraint system and the reduction run over it.
-/// None of them is read off a prover message.
-/// So one shape describes every proof of one shape, and carrying it costs nothing per proof.
+/// Every length here is fixed by the constraint system and the reduction over it.
+/// None is read off a prover message.
 ///
-/// That is what lets a claim be discharged later, away from the run that raised it: see
-/// [`DeferredWiringClaim`].
+/// So one shape covers every proof of one shape, at no per-proof cost.
+/// That is what lets a claim be settled away from the run that raised it.
 ///
-/// The fields stay private, and the only way to obtain one is [`WiringEvalFn::shape`]. A
-/// hand-built shape could disagree with the run that produced the inputs, and the mismatch would
-/// surface as a wrong evaluation rather than an error.
+/// The fields are private on purpose.
+/// A hand-built shape could disagree with the inputs it reads.
+/// The mismatch would surface as a wrong evaluation, not an error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WiringEvalShape {
 	/// Which segment holds the inout values, which fixes where the word-index tensor is cut.
@@ -607,8 +607,11 @@ pub struct WiringEvalShape {
 impl WiringEvalShape {
 	/// The number of elements a claim of this shape reads.
 	///
-	/// Four batching coefficients, one `r_x_prime` vector per operator, both shift slots, the
-	/// column challenges, then the single `r_segment` coordinate.
+	/// - Four batching coefficients.
+	/// - One constraint-index challenge vector per operator.
+	/// - Both shift slots.
+	/// - The column challenges.
+	/// - One trailing word-index coordinate.
 	pub const fn n_inputs(&self) -> usize {
 		4 + self.zero_r_x_prime_len
 			+ self.bitand_r_x_prime_len
@@ -622,10 +625,12 @@ impl WiringEvalShape {
 }
 
 impl<'a> WiringEvalFn<'a> {
-	/// Rebuilds the evaluation over `constraint_system`, reading its input with `shape`.
+	/// Rebuilds the evaluation over a constraint system, reading its input with the given shape.
 	///
-	/// This is how a [`DeferredWiringClaim`] is discharged: the shape travelled with the claim,
-	/// and the system it sums over is public, so no part of the original run is needed.
+	/// This is how an exported claim is settled.
+	/// The shape travels with the claim.
+	/// The system it sums over is public.
+	/// So no part of the original run is needed.
 	pub const fn new(constraint_system: &'a ConstraintSystem, shape: WiringEvalShape) -> Self {
 		Self {
 			constraint_system,


### PR DESCRIPTION
Closes [BINIUS-555](https://linear.app/jimpo/issue/BINIUS-555).

Lets a recursive circuit put the inner proof's wiring claim on public wires instead of evaluating it as constraints. Per-level growth falls from **14.77x to 5.65x**.

### The problem

[#2352](https://github.com/binius-zk/binius64/pull/2352) measured a tower that diverges: one level costs **14.77x** the constraint rows of the level it verifies.

One term causes it. The circuit discharges the inner wiring claim — the "monster" — as constraints, and evaluating that multilinear walks every constraint of the inner system. Measured, **6.0 BMUL per inner constraint row**, stable to 1% over a 256x range.

```
R(C) = H(C) + 6.0 * C
       ^^^^   ^^^^^^^
       replay   the claim
```

A tower closes only if some `C*` has `R(C*) <= C*`. The claim term alone is `6.0 * C`, so `R(C) > 6C > C` always. **No fixed point exists** while the claim is paid inline, and the replay cannot rescue it: it is *added to*, not multiplied by, a term with slope 6.

### The idea

Don't evaluate the claim. Export it.

The claim is a point and a value — "the wiring multilinear at `inputs` equals `claimed`" — and both are elements the verifier already derived. Put them on public wires, unchecked.

That is a win because the claim is **short**. Every section of `inputs` is a challenge vector over a padded log-sized index, so its length is logarithmic in the inner system: measured, **51 elements**. Exporting 51 elements replaces a cost proportional to 878,939 rows.

The check moves rather than vanishing. Whoever holds the outer proof owes it, and it is one native evaluation against a *public* constraint system — ordinary work outside a circuit, paid once however many levels deferred into it.

Same trade `succinctlabs/flock` makes with `MatrixAssertion`, arrived at independently by `leanEthereum/leanVM-b`.

### Per level

| discharge | depth 1 | depth 2 | growth |
|---|---|---|---|
| in-circuit | 878,939 | 12,984,191 | 14.77x |
| deferred | 873,977 | 4,939,643 | **5.65x** |

**Deferral cuts depth 2 by 62%** — 8,044,548 rows.

At depth 1 the drop is 4,884 BMUL, exactly the claim's cost at that size, landing BMUL on 360,351 — the value #2352 measured with the claim removed. The depth-2 saving *exceeds* the direct `6.0 * C` term because a smaller circuit also needs smaller commitments, so the replay shrinks with it.

**The tower still does not close.** 5.65x is well above one; the replay term dominates at these sizes. Closure is the merge node's checkpoint, with its own FRI parameters, not this seam's. Stated so nobody reads 5.65x as done.

### What this does not do: claims accumulate

Exporting a claim gets it out of the circuit. It does not get it out of the *statement*.

A level reads its child's whole statement as public input, carries it forward, and appends its own claim. Measured over two levels:

| | statement | added |
|---|---:|---|
| inner | 5 words | — |
| level 1 | 107 words | claim of 51 elements |
| level 2 | 305 words | claim of 99 elements |

So a level never checks its child's claim, it only copies it along. At the root, `N` levels means `N` separate claims to settle, and each is larger than the last because a claim's length tracks the log of the system it is about.

A tree over many leaves would carry one claim per leaf, which is a to-do list rather than aggregation. Folding claims into one is the next PR, and it is what makes the statement constant-size regardless of tree width or depth.

Worth being explicit that folding needs more than this seam: claims combine only when they are about the *same* polynomial, and the claims above are about different constraint systems. That is what forces a uniform node shape later.

### A follow-up this leaves open

A deferred claim carries no identifier of which constraint system it is about; settling it takes the system as an argument and trusts the caller to pair them correctly. Documented, and sufficient while there is one claim and one obvious system.

It stops being sufficient once claims from different systems meet in one accumulator, where the requirement is that a mismatched claim is *rejected* rather than silently folded. That wants a real key on the claim, which is best added alongside the accumulator that needs it.

### The change

```
- claim.check_symbolic(&mut channel)?;                  // constraints over every inner row
+ match discharge {
+     Discharge::InCircuit => claim.check_symbolic(&mut channel)?,
+     Discharge::Deferred  => bind the claim to public wires, unchecked,
+ }
```

- `WiringEvalFn` carries a `WiringEvalShape` — the section lengths — instead of seven loose fields. `Copy`, fixed by the constraint system and the reduction, never read off a prover message. So it is build-time data travelling with the circuit, not with each proof, which is what lets a claim be read back away from the run that raised it.
- `WiringEvalClaim::defer()` returns a `#[must_use]` `DeferredWiringClaim`, settled by `check(&constraint_system)`.
- `Discharge::{InCircuit, Deferred}` picks the behaviour. `RecursiveCircuit::build` is unchanged and still discharges in-circuit.
- `RecursiveCircuit::check_deferred` settles the claim from the outer statement; `verify_outer` does proof-then-claim in one call.

### Soundness

Deferral swaps a checked constraint for an owed one, so what matters is that the claim cannot be lied about, and cannot be quietly skipped.

- **The claim is bound, not reported.** Each element keeps the wires that derived it and gains public wires constrained equal to them, so a prover cannot publish a claim the circuit did not derive. A test flips one claim word and pins the failure to `bind_public_elem`.
- **The check is a real evaluation.** A test moves the first, second, and last claim words and requires `check_deferred` to reject each. Otherwise deferral would export an unchecked constraint and call it settled.
- **The binding doubles as a cross-check.** The replay computes the claim concretely and supplies the public half, so a build-versus-replay desync fails at the binding rather than surfacing later.
- **Settling needs no secret.** The constraint system is public and the shape is build-time data.

**The obligation this creates, stated plainly.** A deferred circuit whose claim nobody checks attests to a verification *minus its wiring constraint*, and the proof does not say so. `#[must_use]` cannot reach that, because the claim lives inside the circuit. Mitigated by making the safe path the short one (`verify_outer`) and documenting the obligation at every entry point; making it structurally impossible needs a sink that consumes the claim, which is the accumulator in the next PR.

### Scope

- **changed:** `crates/verifier/src/protocols/shift/verify.rs` — the shape refactor plus `defer`/`DeferredWiringClaim`
- **changed:** `crates/recursion` — `Discharge`, `bind_public_elems`, `check_deferred`, `verify_outer`
- **untouched:** the replay itself. Hashing, Merkle and sumcheck costs are the same; this removes only the term proportional to the inner system
- **behaviour-preserving by default:** `build` still discharges in-circuit, so every existing caller is unaffected

### Verification

- `cargo clippy -p binius-recursion -p binius-verifier --all-targets --all-features -- -D warnings` — clean, CI's exact flags
- nightly `cargo fmt --all --check`, `cargo doc` on both crates — clean
- `cargo test -p binius-recursion` — 70 tests pass (12 in the end-to-end suite, 1 ignored by design)
- `cargo test -p binius-verifier` — 13 pass
- `cargo test -p binius-prover --test prove_verify` — 17 pass, which is what exercises `WiringEvalFn` natively after the shape refactor
- the ignored growth test run explicitly — reports the table above
- **Not verifiable locally:** anything `--workspace`. No C compiler here, so `alloca`'s build script fails. CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
