### PR TITLE
Revert: make bit-reversal a standalone function again

### DIFF
--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -7,6 +7,7 @@ use binius_compute::BufferData;
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice,
+	bit_reverse::bit_reverse_packed,
 	multilinear::{MultilinearMut, hypercube::Hypercube},
 };
 use binius_utils::{
@@ -121,9 +122,9 @@ where
 			// Prepend the new variable via bit-reverse + append + bit-reverse. This does not need
 			// to be fast: it runs once per pre-switchover round on a small tensor (see
 			// BINIUS-327).
-			tensor.as_mut_view().bit_reverse();
+			bit_reverse_packed(tensor.as_mut_view());
 			let mut tensor = Hypercube::One.expand(&[challenge]).append_to(tensor);
-			tensor.as_mut_view().bit_reverse();
+			bit_reverse_packed(tensor.as_mut_view());
 			self.tensor = tensor;
 
 			if self.tensor.log_len() == self.switchover {

--- a/crates/math/benches/bit_reverse.rs
+++ b/crates/math/benches/bit_reverse.rs
@@ -4,7 +4,7 @@ use binius_field::{
 	BinaryField, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
 	PackedField,
 };
-use binius_math::test_utils::random_field_buffer;
+use binius_math::{bit_reverse::bit_reverse_packed, test_utils::random_field_buffer};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
@@ -20,9 +20,9 @@ fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
 		let throughput = Throughput::Bytes(((F::N_BITS / 8) << log_d) as u64);
 		group.throughput(throughput);
 
-		group.bench_function(BenchmarkId::new("bit_reverse", &parameter), |b| {
+		group.bench_function(BenchmarkId::new("bit_reverse_packed", &parameter), |b| {
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| data.as_mut_view().bit_reverse());
+			b.iter(|| bit_reverse_packed(data.as_mut_view()));
 		});
 	}
 

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -39,52 +39,54 @@ const CACHE_LINE_BYTES: usize = 64;
 /// - A narrower scalar keeps the capped tile rather than paying for further instances.
 const MAX_LOG_TILE_PACKED: usize = 3;
 
-impl<P: PackedField> FieldSliceMut<'_, P> {
-	/// Permutes the elements of this buffer by reversing the bits of every index, in place.
-	///
-	/// An index is reversed over the bit width that the length of the buffer takes.
-	/// Packed representations are handled, so one exchange may move lanes within a single element.
-	///
-	/// ```text
-	///     8 elements:   index 001 -> index 100
-	/// ```
-	pub fn bit_reverse(&mut self) {
-		// A buffer shorter than a square of packed elements leaves the two passes below no room.
-		let log_len = self.log_len();
-		if log_len < 2 * P::LOG_WIDTH {
-			return bit_reverse_packed_naive(self.as_mut_view());
-		}
+/// Permutes the elements of a buffer by reversing the bits of every index, in place.
+///
+/// An index is reversed over the bit width that the length of the buffer takes.
+/// Packed representations are handled, so one exchange may move lanes within a single element.
+///
+/// ```text
+///     8 elements:   index 001 -> index 100
+/// ```
+///
+/// # Arguments
+///
+/// * `buffer` - the mutable view of packed field elements to permute
+pub fn bit_reverse_packed<P: PackedField>(buffer: FieldSliceMut<'_, P>) {
+	// A buffer shorter than a square of packed elements leaves the two passes below no room.
+	let log_len = buffer.log_len();
+	if log_len < 2 * P::LOG_WIDTH {
+		return bit_reverse_packed_naive(buffer);
+	}
 
-		// Scalars covering one cache line, which is the granularity a permutation is charged at.
-		let log_scalar_bytes = size_of::<P::Scalar>().next_power_of_two().ilog2() as usize;
-		let log_line = checked_log_2(CACHE_LINE_BYTES).saturating_sub(log_scalar_bytes);
+	// Scalars covering one cache line, which is the granularity a permutation is charged at.
+	let log_scalar_bytes = size_of::<P::Scalar>().next_power_of_two().ilog2() as usize;
+	let log_line = checked_log_2(CACHE_LINE_BYTES).saturating_sub(log_scalar_bytes);
 
-		// Why: a tile under a line wastes bandwidth, and widening one costs sub-block work.
-		// Measured, that trade only wins for a packing under half a line.
-		// From half a line up the added work costs more than the bandwidth it recovers.
-		let log_tile = if P::LOG_WIDTH + 1 < log_line {
-			log_line
-		} else {
-			P::LOG_WIDTH
-		};
+	// Why: a tile under a line wastes bandwidth, and widening one costs sub-block work.
+	// Measured, that trade only wins for a packing under half a line.
+	// From half a line up the added work costs more than the bandwidth it recovers.
+	let log_tile = if P::LOG_WIDTH + 1 < log_line {
+		log_line
+	} else {
+		P::LOG_WIDTH
+	};
 
-		// A short buffer takes the widest tile its own length allows.
-		// The length check above leaves half the length at or above the packing width.
-		// So neither clamp can cut a tile below one packed element.
-		let log_tile = log_tile
-			.min(P::LOG_WIDTH + MAX_LOG_TILE_PACKED)
-			.min(log_len / 2);
+	// A short buffer takes the widest tile its own length allows.
+	// The length check above leaves half the length at or above the packing width.
+	// So neither clamp can cut a tile below one packed element.
+	let log_tile = log_tile
+		.min(P::LOG_WIDTH + MAX_LOG_TILE_PACKED)
+		.min(log_len / 2);
 
-		// Why: a constant tile bound is what keeps each pass's gather and scatter unrolled.
-		// A run-time bound lowers the moves of a one-element tile to a call.
-		// That call is most of the work at that width.
-		match log_tile - P::LOG_WIDTH {
-			0 => bit_reverse_tiled::<P, 0>(self.as_mut_view()),
-			1 => bit_reverse_tiled::<P, 1>(self.as_mut_view()),
-			2 => bit_reverse_tiled::<P, 2>(self.as_mut_view()),
-			// The clamp caps the tile at the widest instance, which answers every larger value.
-			_ => bit_reverse_tiled::<P, MAX_LOG_TILE_PACKED>(self.as_mut_view()),
-		}
+	// Why: a constant tile bound is what keeps each pass's gather and scatter unrolled.
+	// A run-time bound lowers the moves of a one-element tile to a call.
+	// That call is most of the work at that width.
+	match log_tile - P::LOG_WIDTH {
+		0 => bit_reverse_tiled::<P, 0>(buffer),
+		1 => bit_reverse_tiled::<P, 1>(buffer),
+		2 => bit_reverse_tiled::<P, 2>(buffer),
+		// The clamp caps the tile at the widest instance, which answers every larger value.
+		_ => bit_reverse_tiled::<P, MAX_LOG_TILE_PACKED>(buffer),
 	}
 }
 
@@ -386,7 +388,7 @@ mod tests {
 		let mut naive = data_orig;
 
 		// Invariant: moving whole tiles lands every element where the definition puts it.
-		blocked.as_mut_view().bit_reverse();
+		bit_reverse_packed(blocked.as_mut_view());
 		bit_reverse_packed_naive(naive.as_mut_view());
 
 		assert_eq!(blocked, naive, "mismatch at log_d={log_d}");
@@ -434,8 +436,8 @@ mod tests {
 			// Invariant: reversing the bits of an index twice is the identity.
 			// So a buffer permuted twice has to come back exactly as it went in.
 			let mut twice = orig.clone();
-			twice.as_mut_view().bit_reverse();
-			twice.as_mut_view().bit_reverse();
+			bit_reverse_packed(twice.as_mut_view());
+			bit_reverse_packed(twice.as_mut_view());
 
 			prop_assert_eq!(twice, orig);
 		}

--- a/crates/math/src/multilinear/hypercube/expansion.rs
+++ b/crates/math/src/multilinear/hypercube/expansion.rs
@@ -265,7 +265,10 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::test_utils::{B128, Packed128b, index_to_hypercube_point, random_scalars};
+	use crate::{
+		bit_reverse::bit_reverse_packed,
+		test_utils::{B128, Packed128b, index_to_hypercube_point, random_scalars},
+	};
 
 	type P = Packed128b;
 	type F = B128;
@@ -464,9 +467,9 @@ mod tests {
 
 		let mut tensor = FieldBuffer::<P>::from_values(&[F::ONE]);
 		for &r in point.iter().rev() {
-			tensor.as_mut_view().bit_reverse();
+			bit_reverse_packed(tensor.as_mut_view());
 			tensor = Hypercube::One.expand(&[r]).append_to::<P>(tensor);
-			tensor.as_mut_view().bit_reverse();
+			bit_reverse_packed(tensor.as_mut_view());
 		}
 
 		assert_eq!(tensor, Hypercube::One.expand(&point).build::<P>());

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -14,7 +14,10 @@ use getset::CopyGetters;
 use super::{
 	FieldBuffer, FieldSlice, FieldSliceMut, binary_subspace::BinarySubspace, ntt::AdditiveNTT,
 };
-use crate::ntt::{DomainContext, domain_context::GaoMateerOnTheFly};
+use crate::{
+	bit_reverse::bit_reverse_packed,
+	ntt::{DomainContext, domain_context::GaoMateerOnTheFly},
+};
 
 /// [Reed–Solomon] codes over binary fields.
 ///
@@ -142,7 +145,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		let mut output = FieldBuffer::from_view_with_capacity_in(alloc, data, log_output_len);
 
 		// Permute the message once, then repeat it, so every copy inherits the permutation.
-		output.as_mut_view().bit_reverse();
+		bit_reverse_packed(output.as_mut_view());
 		output.repeat_extend(log_output_len);
 
 		ntt.forward_transform(output.as_mut_view(), self.log_inv_rate, log_batch_size);
@@ -226,7 +229,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 
 		// The encoder permuted the message before repeating it.
 		// A bit reversal is its own transpose, so the same permutation undoes it here.
-		folded.as_mut_view().bit_reverse();
+		bit_reverse_packed(folded.as_mut_view());
 		folded
 	}
 }


### PR DESCRIPTION
Reverts #2283, which turned the bit-reversal entry point into an inherent method on the mutable buffer view.

Per [the review](https://github.com/binius-zk/binius64/pull/2283#pullrequestreview-5041002213):

> Please revert -- general guidance about cohesive struct interfaces. standalone function is better.

The buffer view's inherent interface is for operations that are part of what a buffer *is*.
A permutation helper is not one of those, even though the buffer is its only argument.

### The change

```diff
- tensor.as_mut_view().bit_reverse();
+ bit_reverse_packed(tensor.as_mut_view());
```

The declaration goes back to the free function it was:

```rust
pub fn bit_reverse_packed<P: PackedField>(buffer: FieldSliceMut<'_, P>)
```

### Scope

- `crates/math/src/bit_reverse.rs` — the inherent method becomes a free function again, under its former name.
- 10 call sites take the function-call form again.
  - 2 in the switchover prover.
  - 2 in the Reed-Solomon encoder.
  - 2 in the hypercube expansion test.
  - 3 in this module's own tests.
  - 1 in the bench.
- The bench case label quotes the restored name.
- Untouched: the permutation, the tile-width dispatch, and the private helpers.
- No test was added, removed, or changed in what it asserts.

One detail is not restored verbatim.
The original signature elided the view's lifetime, and `elided-lifetimes-in-paths` is deny since #2299.
So the parameter carries an explicit anonymous lifetime.

Call sites are written against today's `main`, not the shape they had in August.
`to_mut` is now `as_mut_view` (#2297), and the hypercube test moved into its own module.

### Verification

| Command | Result |
| --- | --- |
| `cargo build --workspace --lib --bins --tests --examples` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo test --workspace` | pass, exit 0 |
| `cargo test --doc --workspace` | pass, exit 0 |
| `cargo +nightly-2026-07-01 fmt --all --check` | clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` | clean |
| `python3 tools/check_copyright_notice.py` | 0 wrong format, 0 missing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
