### PR TITLE
Restore the mutable chunk accessor

### DIFF
--- a/crates/math/src/field_buffer/chunks.rs
+++ b/crates/math/src/field_buffer/chunks.rs
@@ -74,6 +74,12 @@ impl<P: PackedField> SubWordChunk<P> {
 		self.word_index
 	}
 
+	/// Element count of the chunk, as a base-2 logarithm.
+	#[inline]
+	pub(super) const fn log_len(self) -> usize {
+		self.log_len
+	}
+
 	/// Reads the chunk's elements out of the word holding it.
 	#[inline]
 	pub(super) fn scalars(self, word: P) -> impl Iterator<Item = P::Scalar> + Send + Clone {
@@ -86,6 +92,29 @@ impl<P: PackedField> SubWordChunk<P> {
 	#[inline]
 	pub(super) fn repack(self, words: &[P]) -> P {
 		P::from_scalars(self.scalars(words[self.word_index]))
+	}
+
+	/// Copies an edited chunk back into the lanes it came from.
+	///
+	/// The inverse of copying the chunk out.
+	/// Lane `i` of the chunk lands back at the lane it was read from.
+	///
+	/// ```text
+	/// WIDTH = 4, log_len = 1, lane_offset = 2
+	///
+	/// chunk  [ y z . . ]
+	/// word   [ a b y z ]   lanes 0 and 1 keep whatever they held
+	/// ```
+	///
+	/// Lanes of the word outside the chunk are left untouched, since neighbouring chunks own them.
+	#[inline]
+	pub(super) fn merge_into(self, word: &mut P, chunk: &P) {
+		// The chunk's elements sit at lanes 0..2^log_len, so the loop walks exactly those.
+		for i in 0..1 << self.log_len {
+			// The lane offset is a multiple of the chunk length, so the bits below it are free.
+			// Setting them with an OR therefore addresses lane i of this chunk and no other.
+			word.set(self.lane_offset | i, chunk.get(i));
+		}
 	}
 }
 

--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -54,7 +54,7 @@ use chunks::SubWordChunk;
 pub use chunks::{Chunks, ChunksMut};
 pub use scalars::Scalars;
 pub use view::{FieldSlice, FieldSliceData, FieldSliceMut, FieldVec};
-pub use write_back::SplitMut;
+pub use write_back::{ChunkMut, SplitMut};
 
 /// A power-of-two-sized buffer containing field elements, stored in packed fields.
 ///
@@ -710,6 +710,55 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 
 		let chunk_count = 1 << (self.log_len - log_chunk_size);
 		ChunksMut::new(self.as_mut(), log_chunk_size, chunk_count)
+	}
+
+	/// Get a mutable aligned chunk of size `2^log_chunk_size`.
+	///
+	/// Addresses the same chunk as the shared accessor, and lends it mutably.
+	///
+	/// A chunk of at least one packed word is lent straight from the store, so edits land at once.
+	/// A smaller one shares a word with its neighbours, so it comes back behind a write-back guard.
+	/// The guard hands out a copy of the chunk's lanes and merges the edits back when it drops.
+	///
+	/// Unlike the mutable chunk iterator, this takes any chunk size up to the buffer's length.
+	/// Lending exactly one chunk is what makes a sub-word size safe.
+	/// A second live copy of the same word would merge over the first.
+	///
+	/// # Preconditions
+	///
+	/// * `log_chunk_size` must be at most `log_len`.
+	/// * `chunk_index` must be less than the chunk count.
+	#[track_caller]
+	pub fn chunk_mut(&mut self, log_chunk_size: usize, chunk_index: usize) -> ChunkMut<'_, P> {
+		assert!(
+			log_chunk_size <= self.log_len,
+			"precondition: log_chunk_size must be at most log_len"
+		);
+
+		let chunk_count = 1 << (self.log_len - log_chunk_size);
+		assert!(
+			chunk_index < chunk_count,
+			"precondition: chunk_index must be less than chunk_count"
+		);
+
+		if log_chunk_size >= P::LOG_WIDTH {
+			// Whole words: the chunk is a run of the store, so it is lent out as it lies.
+			let words_per_chunk = 1 << (log_chunk_size - P::LOG_WIDTH);
+			let chunk = &mut self.words[chunk_index * words_per_chunk..][..words_per_chunk];
+			ChunkMut::borrowed(log_chunk_size, chunk)
+		} else {
+			// Sub-word: several chunks share one word.
+			// This one is therefore copied into a word of its own, starting at lane 0.
+			//
+			//     WIDTH = 4, chunks of 2 elements
+			//     word 1 = [ chunk 2 | chunk 3 ]  ->  chunk 3 detaches to [ x y . . ]
+			let location = SubWordChunk::new(log_chunk_size, chunk_index);
+			let chunk = location.repack(&self.words);
+
+			// The guard keeps the word the copy came from, and merges the copy back on drop.
+			let parent = &mut self.words[location.word_index()];
+			ChunkMut::detached(location, chunk, parent)
+		}
 	}
 
 	/// Consumes the buffer and halves it, returning a guard that owns the store.
@@ -1454,6 +1503,111 @@ mod tests {
 	}
 
 	#[test]
+	fn chunk_mut() {
+		// A packed word holds 4 lanes, so log_len 4 fills exactly 4 words.
+		// The sweep below therefore straddles the word boundary:
+		//
+		//     log_chunk_size 0  ->  1 element    ->  4 chunks share one word
+		//     log_chunk_size 1  ->  2 elements   ->  2 chunks share one word
+		//     log_chunk_size 2  ->  4 elements   ->  one whole word each
+		//     log_chunk_size 3  ->  8 elements   ->  two whole words each
+		//     log_chunk_size 4  ->  16 elements  ->  the whole 4-word store
+		let log_len = 4;
+		let values: Vec<F> = (0..1u128 << log_len).map(F::new).collect();
+
+		for log_chunk_size in 0..=log_len {
+			let mut buffer = FieldBuffer::<P>::from_values(&values);
+			let chunk_count = 1 << (log_len - log_chunk_size);
+
+			// Rewrite every element through its own chunk, one guard at a time.
+			// Each guard merges before the next detaches, so chunks sharing a word chain safely.
+			for chunk_index in 0..chunk_count {
+				let mut guard = buffer.chunk_mut(log_chunk_size, chunk_index);
+				let mut chunk = guard.chunk();
+
+				// The view is the chunk alone, so its indices run from 0 whatever the shape.
+				assert_eq!(chunk.len(), 1 << log_chunk_size);
+				for i in 0..1 << log_chunk_size {
+					let old = u128::from(chunk.get(i).val());
+					chunk.set(i, F::new(old * 10));
+				}
+			}
+
+			// Every element comes back scaled, including those sharing a word with a neighbour.
+			for index in 0..1 << log_len {
+				assert_eq!(
+					buffer.get(index),
+					F::new(index as u128 * 10),
+					"log_chunk_size={log_chunk_size}, index={index}"
+				);
+			}
+		}
+
+		// A sub-word guard must write back its own lanes and leave the rest of the word alone.
+		//
+		//     word 0 = [ 0 1 2 3 ], chunks of 2 elements
+		//     chunk 1 = elements 2..4, so lanes 0..2 must survive untouched
+		let mut buffer = FieldBuffer::<P>::from_values(&values);
+		{
+			let mut guard = buffer.chunk_mut(1, 1);
+			let mut chunk = guard.chunk();
+			chunk.set(0, F::new(70));
+			chunk.set(1, F::new(80));
+		}
+		assert_eq!(buffer.get(0), F::new(0));
+		assert_eq!(buffer.get(1), F::new(1));
+		assert_eq!(buffer.get(2), F::new(70));
+		assert_eq!(buffer.get(3), F::new(80));
+
+		// The words past the edited one are untouched as well.
+		for index in 4..16 {
+			assert_eq!(buffer.get(index), F::new(index as u128));
+		}
+
+		// A buffer shorter than one packed word still splits into sub-word chunks.
+		// 2 elements live in a 4-lane word, so the 2 dead lanes must not become elements.
+		let mut small = FieldBuffer::<P>::from_values(&[F::new(10), F::new(20)]);
+		{
+			let mut guard = small.chunk_mut(0, 1);
+			guard.chunk().set(0, F::new(21));
+		}
+		assert_eq!(small.len(), 2);
+		assert_eq!(small.iter_scalars().collect::<Vec<_>>(), vec![F::new(10), F::new(21)]);
+
+		// A whole-word guard writes into the store directly, and touches no neighbouring word.
+		let mut buffer = FieldBuffer::<P>::from_values(&values);
+		{
+			let mut guard = buffer.chunk_mut(3, 1); // elements 8..16, words 2 and 3
+			let mut chunk = guard.chunk();
+			for i in 0..8 {
+				chunk.set(i, F::new(100 + i as u128));
+			}
+		}
+		for index in 0..8 {
+			assert_eq!(buffer.get(index), F::new(index as u128));
+		}
+		for index in 8..16 {
+			assert_eq!(buffer.get(index), F::new(100 + (index - 8) as u128));
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition")]
+	fn chunk_mut_invalid_size() {
+		let mut buffer = FieldBuffer::<P>::zeros(4);
+		// 5 > 4: no chunk that size exists in a 16-element buffer.
+		let _ = buffer.chunk_mut(5, 0);
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition")]
+	fn chunk_mut_invalid_index() {
+		let mut buffer = FieldBuffer::<P>::zeros(4);
+		// 16 elements in chunks of 4 gives 4 chunks, indexed 0..4.
+		let _ = buffer.chunk_mut(2, 4);
+	}
+
+	#[test]
 	fn chunks() {
 		let values: Vec<F> = (0..16).map(F::new).collect();
 		let buffer = FieldBuffer::<P>::from_values(&values);
@@ -1824,6 +1978,48 @@ mod tests {
 
 			// Concatenating the chunks reproduces the buffer, in order and without gaps.
 			prop_assert_eq!(chunks.concat(), values);
+		}
+
+		#[test]
+		fn chunk_mut_merges_like_direct_writes(
+			(log_len, log_chunk_size, chunk_index) in (0usize..=6)
+				.prop_flat_map(|log_len| (Just(log_len), 0usize..=log_len))
+				.prop_flat_map(|(log_len, log_chunk_size)| {
+					(Just(log_len), Just(log_chunk_size), 0usize..1 << (log_len - log_chunk_size))
+				}),
+			seed in any::<u64>(),
+		) {
+			// Invariant: a chunk edited through its guard equals the same scalars written by index.
+			//
+			// A packed word holds 4 lanes, so the sweep covers chunk sizes on both sides of it.
+			// Exactly one chunk is edited here.
+			// The elements left alone then pin that the merge stays inside the chunk's lanes.
+			let mut rng = StdRng::seed_from_u64(seed);
+			let original = random_field_buffer::<P>(&mut rng, log_len);
+
+			// Fresh scalars, one per element of the chosen chunk, distinct from a random fill.
+			let replacements: Vec<F> = (0..1u128 << log_chunk_size)
+				.map(|i| F::new(i * 7 + 1))
+				.collect();
+
+			// Path under test: one guard over one chunk, merged when it drops.
+			let mut guarded = original.clone();
+			{
+				let mut guard = guarded.chunk_mut(log_chunk_size, chunk_index);
+				let mut chunk = guard.chunk();
+				for (i, &value) in replacements.iter().enumerate() {
+					chunk.set(i, value);
+				}
+			}
+
+			// Reference path: the same scalars written straight in, at the indices the chunk spans.
+			let mut direct = original;
+			for (i, &value) in replacements.iter().enumerate() {
+				direct.set(chunk_index << log_chunk_size | i, value);
+			}
+
+			// Equality compares every live scalar, so this covers the edited and untouched alike.
+			prop_assert_eq!(guarded, direct);
 		}
 
 		#[test]

--- a/crates/math/src/field_buffer/write_back.rs
+++ b/crates/math/src/field_buffer/write_back.rs
@@ -1,22 +1,27 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-//! Guard for writing through halves of a field buffer narrower than one packed word.
+//! Guards for writing through a region of a field buffer narrower than one packed word.
 //!
-//! Two such halves share a single word, so neither can be lent out as a mutable slice of words.
-//! The guard therefore works in three steps:
+//! Such a region cannot be lent out as a mutable slice of packed words.
+//! The two halves of a split share a word, and a small chunk occupies only some of a word's lanes.
+//!
+//! Each guard therefore works in three steps:
 //!
 //! ```text
-//! detach   copy each half out into a word of its own
+//! detach   copy the region out into owned words
 //! lend     hand out mutable views over those owned words
-//! merge    interleave the words back into the parent word when the guard drops
+//! merge    fold the words back into the parent word when the guard drops
 //! ```
+//!
+//! A region that already spans whole words needs none of that.
+//! Both guards then lend the store out directly, and their merge step does nothing.
 
 use std::{ops::DerefMut, slice};
 
 use binius_field::PackedField;
 
-use super::{FieldBuffer, FieldSliceMut};
+use super::{FieldBuffer, FieldSliceMut, chunks::SubWordChunk};
 
 /// Guards the two halves of a buffer that was split along its highest variable.
 ///
@@ -70,4 +75,114 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> Drop for SplitMut<P, Data> {
 			(self.data[0], _) = lo_half.interleave(hi_half, self.log_len);
 		}
 	}
+}
+
+/// Guards one mutably borrowed chunk of a buffer.
+///
+/// The chunk size against the packing width decides which of two shapes the guard takes:
+///
+/// ```text
+/// chunk >= one packed word  ->  a run of whole words, lent straight from the store
+/// chunk <  one packed word  ->  the chunk's lanes copied into a word of their own
+/// ```
+///
+/// The first shape edits the store itself.
+/// Every edit is therefore already in place, and dropping the guard does nothing.
+///
+/// The second shape edits a copy taken when the guard is built.
+/// That copy holds the chunk's lanes shifted down to start at lane 0.
+/// Dropping the guard writes them back to the lanes they came from, and nothing else.
+///
+/// ```text
+/// WIDTH = 4, chunks of 2 elements, chunk 1 of word 0
+///
+/// word before   [ a b c d ]
+/// detached      [ c d . . ]   lanes 2..4 copied down to lanes 0..2
+/// after edits   [ y z . . ]
+/// word on drop  [ a b y z ]   lanes 0..2 written back to lanes 2..4
+/// ```
+///
+/// So an edit to a sub-word chunk reaches the buffer when the guard drops, and not before.
+/// Neighbouring chunks sharing the word keep their elements, since the merge skips their lanes.
+///
+/// Only one such guard can exist at a time, since it borrows the buffer mutably.
+/// Two live guards over chunks of one word would each merge a stale copy.
+/// The later merge would then undo the earlier one.
+#[derive(Debug)]
+pub struct ChunkMut<'a, P: PackedField>(ChunkMutInner<'a, P>);
+
+impl<'a, P: PackedField> ChunkMut<'a, P> {
+	/// Guards a chunk narrower than a packed word, already copied out of the word holding it.
+	pub(super) const fn detached(location: SubWordChunk<P>, chunk: P, parent: &'a mut P) -> Self {
+		Self(ChunkMutInner::Detached {
+			location,
+			chunk,
+			parent,
+		})
+	}
+
+	/// Guards a chunk of whole words, lent straight from the store.
+	pub(super) const fn borrowed(log_len: usize, chunk: &'a mut [P]) -> Self {
+		Self(ChunkMutInner::Borrowed { log_len, chunk })
+	}
+
+	/// Lends the chunk out as a mutable view, its first element at index 0.
+	///
+	/// A chunk of whole words is a view straight onto the store, so edits land at once.
+	/// A narrower chunk is a view onto the detached copy, so edits land when this guard drops.
+	pub const fn chunk(&mut self) -> FieldSliceMut<'_, P> {
+		match &mut self.0 {
+			// The copy is one word wide.
+			// So the view is that single word, cut down to the chunk's element count.
+			ChunkMutInner::Detached {
+				location,
+				chunk,
+				parent: _,
+			} => FieldBuffer {
+				log_len: location.log_len(),
+				words: slice::from_mut(chunk),
+			},
+			// The run of words is already the chunk, so the view spans all of it.
+			ChunkMutInner::Borrowed { log_len, chunk } => FieldBuffer {
+				log_len: *log_len,
+				words: chunk,
+			},
+		}
+	}
+}
+
+impl<P: PackedField> Drop for ChunkMut<'_, P> {
+	fn drop(&mut self) {
+		match &mut self.0 {
+			// A detached copy is the only shape with anything to write back.
+			ChunkMutInner::Detached {
+				location,
+				chunk,
+				parent,
+			} => location.merge_into(parent, chunk),
+			// A chunk lent from the store was edited in place, so there is nothing to merge.
+			ChunkMutInner::Borrowed { .. } => {}
+		}
+	}
+}
+
+/// The two shapes a mutably borrowed chunk takes, decided by its size against the packing width.
+#[derive(Debug)]
+enum ChunkMutInner<'a, P: PackedField> {
+	/// A chunk below one packed word, lifted out of the lanes it shares with its neighbours.
+	Detached {
+		/// Which lanes of the parent word the chunk occupies.
+		location: SubWordChunk<P>,
+		/// The detached copy the caller edits.
+		chunk: P,
+		/// The word the copy is merged back into.
+		parent: &'a mut P,
+	},
+	/// A chunk of one or more whole words, borrowed from the store and edited there.
+	Borrowed {
+		/// Element count of the chunk, as a base-2 logarithm.
+		log_len: usize,
+		/// The run of words the chunk occupies.
+		chunk: &'a mut [P],
+	},
 }


### PR DESCRIPTION
Restores the field buffer's single-chunk mutable accessor and its write-back guard, deleted in #2281.

Asked for in [this review comment](https://github.com/binius-zk/binius64/pull/2281#issuecomment-5439407065):

> I think we should restore this. Is has come up for me repeatedly before and it's a tricky thing to get right.

That is the whole case for the change.
The deletion was justified only by "nothing calls it", and a tricky operation with one tested implementation beats the same operation rewritten ad hoc at each call site.

### What comes back

- `field_buffer/mod.rs` — the accessor taking a chunk size and a chunk index and lending that chunk mutably, plus its crate-root re-export.
- `field_buffer/write_back.rs` — the guard, its two constructors, its accessor, its `Drop`, and the private inner enum. The module doc describes two guards again.
- `field_buffer/chunks.rs` — the two helpers on the sub-word chunk location that lost their only callers with the guard: the element-count accessor and the lane merge.

Two names differ from what was deleted, because the buffer's naming settled in the meantime.

| Deleted in #2281 | Restored as | Reason |
| --- | --- | --- |
| `FieldBufferChunkMut` | `ChunkMut` | #2297 renamed `FieldBufferSplitMut` to `SplitMut`; the prefix restates the module |
| `.get()` on the guard | `.chunk()` | matches `.halves()` on the sibling split guard, and does not read as the buffer's scalar `get(index)` |

The inner enum's variants are `Detached` and `Borrowed`, matching the constructor names.

### How the write-back guard works

The chunk size against the packing width picks one of two paths, once, when the guard is built.

**At or above one packed word.**
The chunk is a run of the backing store.
It is lent out as a mutable slice of those words, so every edit is already in place and dropping the guard does nothing.

**Below one packed word.**
Several chunks share a single word, so the chunk is not a slice of words and cannot be lent as one.
The guard copies the chunk's lanes down into a word of its own, starting at lane 0.
The caller edits that copy.
On drop, each of the copy's leading lanes is written back to the lane it was read from — and nothing else in the word is touched.

```text
WIDTH = 4 lanes per word, chunks of 2 elements, chunk 1 of word 0

word before    [ a b c d ]
detached copy  [ c d . . ]   lanes 2..4 copied down to lanes 0..2
after edits    [ y z . . ]
word on drop   [ a b y z ]   lanes 0..2 written back to lanes 2..4
                 ^^^         chunk 0 keeps its elements
```

Two consequences worth stating plainly, since they are what makes this easy to get wrong:

- An edit to a sub-word chunk reaches the buffer when the guard drops, not when it is written.
- Only one guard can be live at a time, because it borrows the buffer mutably. Two live copies of one word would each merge a stale word, and the later merge would undo the earlier one.

This is also why the mutable chunk *iterator* refuses sub-word sizes: it lends every chunk at once, so the copies would collide. Its doc already points at this accessor for those sizes — a reference that had nothing to point at until now.

### Tests

A packed word in the test field holds 4 lanes, so `log_chunk_size` 0 and 1 exercise the merge path and 2 and above exercise the borrow path.

- `chunk_mut` sweeps `log_chunk_size` 0 through 4 on a 16-element buffer, rewriting every element through its own chunk and checking all 16 come back scaled.
- The same test pins that a sub-word merge leaves the rest of its word alone: chunk 1 of word 0 is rewritten, and elements 0 and 1 must still read 0 and 1.
- It covers a buffer shorter than one word — 2 live elements in a 4-lane word — so the 2 dead lanes cannot become elements.
- `chunk_mut_invalid_size` and `chunk_mut_invalid_index` cover the two preconditions.
- `chunk_mut_merges_like_direct_writes` is a new proptest. It edits **one** random chunk of a random buffer through the guard, writes the same scalars into a copy by absolute index, and requires the two buffers equal. Editing one chunk rather than all of them is the point: the elements left alone are what pin the merge to the chunk's own lanes.

Both the deterministic test and the proptest were checked against two deliberate mutations of the merge, each caught:

| Mutation | Caught |
| --- | --- |
| write back to lane `i` instead of lane `lane_offset \| i` | yes, both tests |
| merge all `WIDTH` lanes instead of the chunk's `2^log_len` | yes, both tests |

### Verification

Full workspace, run from a clean worktree.

| Command | Result |
| --- | --- |
| `cargo build --workspace --lib --bins --tests --examples` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace` | pass, 67 test binaries, 0 failures |
| `cargo test --doc --workspace` | pass |
| `cargo +nightly-2026-07-01 fmt --all --check` | pass |
| `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` | pass |
| `python3 tools/check_copyright_notice.py` | pass, 0 wrong format, 0 missing |

Clippy caught one thing on the way: `redundant_clone` on the proptest's reference buffer, since the random original has no use after the two copies are made. Fixed by moving instead of cloning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
