### PR TITLE
BINIUS-560: Hold a sumcheck weight as a product of factors

### DIFF
--- a/crates/ip-prover/src/sumcheck/factored_multilinear.rs
+++ b/crates/ip-prover/src/sumcheck/factored_multilinear.rs
@@ -1,0 +1,264 @@
+// Copyright 2026 The Binius Developers
+
+//! A dense multilinear held as a product of factors over disjoint runs of variables.
+
+use binius_field::{Field, PackedField};
+use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
+
+/// A multilinear that factorizes across disjoint runs of its variables.
+///
+/// Some weights are a product of small pieces rather than one table.
+/// An equality indicator over several axes factorizes across them, for instance.
+///
+/// Storing such a weight whole costs the product of the pieces' lengths.
+/// Storing the pieces costs their sum.
+///
+/// ```text
+///     whole:   2^(n_1 + n_2 + n_3) entries
+///     factors: 2^n_1 + 2^n_2 + 2^n_3 entries
+/// ```
+///
+/// The saving is what lets a sumcheck range over a space far too large to materialize, so long as
+/// nothing ever asks for the whole table at once.
+///
+/// # Variable order
+///
+/// Factors are held lowest run first.
+///
+/// A factor over `n` variables owns the next `n` bits of the index, above the bits the factors
+/// before it own. So the last factor owns the highest variables, and is the one a fold consumes
+/// first.
+///
+/// ```text
+///     index = [ factor 0 bits | factor 1 bits | ... | last factor bits ]
+///               lowest                                       highest
+/// ```
+///
+/// # Examples
+///
+/// ```ignore
+/// // A weight over an operand axis, a shift axis, and a value axis.
+/// let mut weight = FactoredMultilinear::new(vec![operand, shift, value]);
+/// let at_index = weight.get(index);
+/// weight.fold_highest_var(challenge);
+/// ```
+#[derive(Debug, Clone)]
+pub struct FactoredMultilinear<P: PackedField> {
+	/// The factors still holding variables, lowest run first.
+	///
+	/// A factor is dropped once folding has bound every one of its variables.
+	factors: Vec<FieldBuffer<P>>,
+
+	/// The product of every factor already bound away.
+	///
+	/// A factor that runs out of variables holds one value, which multiplies in here.
+	/// Keeping it separate is what lets the factor list shrink instead of carrying empty buffers.
+	bound: P::Scalar,
+}
+
+impl<P: PackedField> FactoredMultilinear<P> {
+	/// Builds a multilinear from its factors, lowest variable run first.
+	///
+	/// A factor with no variables is folded straight into the bound product rather than kept,
+	/// since it holds a value and no axis.
+	pub fn new(factors: impl IntoIterator<Item = FieldBuffer<P>>) -> Self {
+		let mut bound = P::Scalar::ONE;
+		let factors = factors
+			.into_iter()
+			.filter(|factor| {
+				if factor.log_len() == 0 {
+					bound *= factor.get(0);
+					false
+				} else {
+					true
+				}
+			})
+			.collect();
+		Self { factors, bound }
+	}
+
+	/// The number of variables still free.
+	pub fn n_vars(&self) -> usize {
+		self.factors.iter().map(FieldBuffer::log_len).sum()
+	}
+
+	/// The value at one vertex of the hypercube over the free variables.
+	///
+	/// Each factor reads the bits it owns, and the results multiply.
+	/// So a lookup costs one multiplication per factor rather than one per variable.
+	///
+	/// # Panics
+	///
+	/// Panics if the index does not fit the free variables.
+	pub fn get(&self, index: usize) -> P::Scalar {
+		let n_vars = self.n_vars();
+		assert!(
+			n_vars >= usize::BITS as usize || index < 1 << n_vars,
+			"precondition: index {index} must fit {n_vars} variables"
+		);
+
+		let mut value = self.bound;
+		let mut rest = index;
+		for factor in &self.factors {
+			// The factor's own bits are the low ones of what is left.
+			let mask = (1 << factor.log_len()) - 1;
+			value *= factor.get(rest & mask);
+			rest >>= factor.log_len();
+		}
+		value
+	}
+
+	/// Fixes the highest free variable to a value.
+	///
+	/// The highest variable belongs to the last factor, so that is the factor this folds.
+	/// A factor whose variables are all bound holds one value, which moves into the bound product.
+	///
+	/// # Panics
+	///
+	/// Panics if no variable is free.
+	pub fn fold_highest_var(&mut self, challenge: P::Scalar) {
+		let factor = self
+			.factors
+			.last_mut()
+			.expect("precondition: at least one variable must be free");
+		fold_highest_var_inplace(factor, challenge);
+
+		// A factor down to a single value is no longer an axis, so it leaves the list.
+		if factor.log_len() == 0 {
+			self.bound *= factor.get(0);
+			self.factors.pop();
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{Ghash128b, PackedBinaryGhash1x128b, Random, arch::OptimalPackedB128};
+	use proptest::prelude::*;
+	use rand::{SeedableRng, prelude::StdRng};
+
+	use super::*;
+
+	/// The product of the factors, materialized in full, as the reference to pin against.
+	fn materialize<P: PackedField>(factors: &[FieldBuffer<P>]) -> FieldBuffer<P> {
+		let n_vars: usize = factors.iter().map(FieldBuffer::log_len).sum();
+		let values = (0..1usize << n_vars)
+			.map(|index| {
+				let mut rest = index;
+				let mut value = P::Scalar::ONE;
+				for factor in factors {
+					let mask = (1 << factor.log_len()) - 1;
+					value *= factor.get(rest & mask);
+					rest >>= factor.log_len();
+				}
+				value
+			})
+			.collect::<Vec<_>>();
+		FieldBuffer::from_values(&values)
+	}
+
+	fn random_factors<P: PackedField>(rng: &mut StdRng, shape: &[usize]) -> Vec<FieldBuffer<P>>
+	where
+		P::Scalar: Random,
+	{
+		shape
+			.iter()
+			.map(|&log_len| {
+				let values = (0..1usize << log_len)
+					.map(|_| P::Scalar::random(&mut *rng))
+					.collect::<Vec<_>>();
+				FieldBuffer::from_values(&values)
+			})
+			.collect()
+	}
+
+	#[test]
+	fn a_factor_with_no_variables_folds_into_the_product() {
+		// Invariant: a factor holding one value is a scalar, not an axis.
+		//
+		// Keeping it in the list would leave a buffer a fold could never consume, and the variable
+		// count would then disagree with what folding can bind.
+		type P = PackedBinaryGhash1x128b;
+		let mut rng = StdRng::seed_from_u64(1);
+
+		let factors = random_factors::<P>(&mut rng, &[0, 2, 0]);
+		let expected = materialize(&factors);
+
+		let factored = FactoredMultilinear::new(factors);
+
+		// Only the two-variable factor remains an axis.
+		assert_eq!(factored.n_vars(), 2);
+		for index in 0..4 {
+			assert_eq!(factored.get(index), expected.get(index));
+		}
+	}
+
+	#[test]
+	fn folding_consumes_the_factors_from_the_highest_variable_down() {
+		// Invariant: the last factor owns the highest variables.
+		//
+		// Fixture state: three factors over 1, 2 and 1 variables, so four in total.
+		//
+		//     index bits:  [ f0 : 1 | f1 : 2 | f2 : 1 ]
+		//                    low                 high
+		//
+		// Folding once must bind f2 away entirely, leaving three variables in two factors.
+		type P = PackedBinaryGhash1x128b;
+		let mut rng = StdRng::seed_from_u64(2);
+
+		let factors = random_factors::<P>(&mut rng, &[1, 2, 1]);
+		let mut factored = FactoredMultilinear::new(factors.clone());
+		let mut reference = materialize(&factors);
+		assert_eq!(factored.n_vars(), 4);
+
+		let challenge = Ghash128b::random(&mut rng);
+		factored.fold_highest_var(challenge);
+		fold_highest_var_inplace(&mut reference, challenge);
+
+		// The one-variable top factor is gone, so its value now rides the bound product.
+		assert_eq!(factored.n_vars(), 3);
+		for index in 0..8 {
+			assert_eq!(factored.get(index), reference.get(index), "index {index}");
+		}
+	}
+
+	proptest! {
+		/// Folding a factored weight tracks folding the product it stands for, at every step.
+		///
+		/// This is the whole contract: a caller may use the factors in place of the table, and the
+		/// two must agree after any sequence of challenges, not only at the start.
+		#[test]
+		fn folding_tracks_the_materialized_product(
+			shape in prop::collection::vec(0usize..=3, 1..=4),
+			seed: u64,
+		) {
+			type P = OptimalPackedB128;
+			let mut rng = StdRng::seed_from_u64(seed);
+
+			let factors = random_factors::<P>(&mut rng, &shape);
+			let mut factored = FactoredMultilinear::new(factors.clone());
+			let mut reference = materialize(&factors);
+
+			// The materialized reference is the product, so the two must start equal.
+			prop_assert_eq!(factored.n_vars(), reference.log_len());
+			for index in 0..reference.len() {
+				prop_assert_eq!(factored.get(index), reference.get(index));
+			}
+
+			// Bind every variable, comparing after each one.
+			while factored.n_vars() > 0 {
+				let challenge = Ghash128b::random(&mut rng);
+				factored.fold_highest_var(challenge);
+				fold_highest_var_inplace(&mut reference, challenge);
+
+				prop_assert_eq!(factored.n_vars(), reference.log_len());
+				for index in 0..reference.len() {
+					prop_assert_eq!(factored.get(index), reference.get(index));
+				}
+			}
+
+			// Fully bound, both are the single value the whole product folded to.
+			prop_assert_eq!(factored.get(0), reference.get(0));
+		}
+	}
+}

--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -7,6 +7,7 @@ pub mod bivariate_product_mle;
 pub mod common;
 mod drive;
 pub mod eq_tracker;
+pub mod factored_multilinear;
 pub mod mle_store;
 mod mle_to_sumcheck;
 pub mod multilinear_eval;


### PR DESCRIPTION
Closes [BINIUS-560](https://linear.app/jimpo/issue/BINIUS-560).

A sumcheck weight that factorizes across its variables, stored as the factors rather than the table. Foundation for the fold's prover — nothing uses it outside its tests yet.

### The stack

**This is the bottom of a three-PR stack** building the fold that batches deferred wiring claims. Each piece is independently reviewable; only the last one folds anything.

```
  #2369   3b-i    the weight, stored as pieces instead of one table   <- this PR
  #2370   3b-ii   teach the sparse-dense sumcheck to take one
  #2371   3b-iii  the fold itself
```

Design note, with the reduction and its soundness argument: [Folding deferred wiring claims](https://linear.app/jimpo/document/folding-deferred-wiring-claims-design-99d3c050a1d5).

Why the fold is needed at all: [#2357](https://github.com/binius-zk/binius64/pull/2357) let a recursive circuit export its wiring claim rather than discharge it, which took per-level growth from 14.77x to 5.65x. But claims then accumulate — one per level, each larger than the last — so a tree over `N` leaves carries `N` of them. Folding is what makes the statement constant-size at any width or depth.

### The problem

The fold that batches deferred wiring claims ([#2357](https://github.com/binius-zk/binius64/pull/2357), [#2361](https://github.com/binius-zk/binius64/pull/2361)) sumchecks over the wiring tensor's column axes — operand position, the two shift slots, and the value address:

```
    V = 3 + 9 + 9 + 26 = 47 column variables
```

Its weight is dense over that space, so materializing it is `2^47` field elements: **2 PiB**. The sparse side of the same sumcheck has only about `2^24.6` entries, so the weight is the sole obstacle.

But the weight is never arbitrary. It is a product of one piece per axis — batching powers on the operand axis, an equality indicator on each shift slot, another on the value address. Storing the product costs the product of the pieces' lengths; storing the pieces costs their **sum**:

```
    whole:   2^(n_1 + n_2 + n_3) entries
    factors: 2^n_1 + 2^n_2 + 2^n_3 entries
```

### The idea

Keep the pieces. A weight held as factors over disjoint runs of variables answers the only two questions a sumcheck asks of it.

- **Value at a vertex.** Each factor reads the bits it owns and the results multiply, so a lookup is one multiplication per *factor* rather than one per variable.
- **Folding the highest free variable.** That variable belongs to the last factor, so only that factor folds.

```
    index = [ factor 0 bits | factor 1 bits | ... | last factor bits ]
              lowest                                       highest
```

A factor whose variables are all bound holds a single value, which moves into a running product and leaves the list. So the list shrinks as the protocol runs, and every factor in it always holds at least one variable.

Nothing ever asks for the whole table, which is what makes the `2^47` space usable.

### Correctness

Nothing here verifies anything. The contract is arithmetic: **a caller may use the factors in place of the table they stand for.**

That is what the tests pin, and they pin it after *every* fold rather than only at the start — a representation that agreed initially and drifted under folding would be worse than useless.

- **Property test.** Random factors of random shapes; materialize their product as the reference; bind every variable one at a time and compare the full table at each step, plus the final scalar.
- **Index convention.** Three factors over 1, 2 and 1 variables — one fold must consume the top factor entirely, leaving three variables in two factors.
- **Degenerate factor.** A factor with no variables joins the running product rather than sitting in the list as an axis folding could never consume.

### Scope

- **new:** one module in `crates/ip-prover/src/sumcheck/`
- **no callers yet.** The sparse-dense product sumcheck this is meant to feed takes its dense side as a full buffer; generalizing that is the next step
- **nothing existing changed** beyond one module declaration

### Verification

- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean, CI's exact flags
- nightly `cargo fmt --all --check`, `cargo doc` — clean
- `cargo test -p binius-ip-prover` — **100 pass**, including the three new ones
- **Unrelated observation:** in `--release`, `logup_star::prove::tests::test_out_of_range_index_panics` fails, because the message it matches comes from a `debug_assert!` that release elides and a raw bounds panic surfaces instead. Pre-existing, on `main`, and untouched by this change — CI runs the test profile, where it passes. Flagging it rather than fixing it here.
- **Not verifiable locally:** anything `--workspace`. No C compiler here, so `alloca`'s build script fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

