### PR TITLE
[field] Move field type definitions into a fields/ subdirectory

### DIFF
--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -2,7 +2,7 @@
 
 use std::array;
 
-use binius_field::{Field, Ghash128b, aes_field::Rijndael8b};
+use binius_field::{Field, Ghash128b, fields::rijndael::Rijndael8b};
 use criterion::{
 	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };

--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -8,9 +8,9 @@ use super::{
 	simd_arithmetic::{VmullWideMul, packed_aes_16x8b_invert_or_zero, packed_aes_16x8b_square},
 };
 use crate::{
-	aes_field::Rijndael8b,
 	arch::PackedPrimitiveType,
 	arithmetic_traits::{InvertOrZero, Square},
+	fields::rijndael::Rijndael8b,
 	underlier::WithUnderlier,
 };
 

--- a/crates/field/src/arch/aarch64/simd_arithmetic.rs
+++ b/crates/field/src/arch/aarch64/simd_arithmetic.rs
@@ -11,7 +11,8 @@ use bytemuck::TransparentWrapper;
 
 use super::m128::M128;
 use crate::{
-	aes_field::Rijndael8b, arch::portable::packed::PackedPrimitiveType, arithmetic_traits::WideMul,
+	arch::portable::packed::PackedPrimitiveType, arithmetic_traits::WideMul,
+	fields::rijndael::Rijndael8b,
 };
 
 #[inline]

--- a/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
+++ b/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
@@ -25,7 +25,7 @@ use crate::{
 	BinaryField1b, Divisible, ExtensionField,
 	arch::M128,
 	arithmetic_traits::{InvertOrZero, Square},
-	ghash::Ghash128b as GhashB128,
+	fields::ghash::Ghash128b as GhashB128,
 	linear_transformation::{
 		BytewiseLookupTransformation, BytewiseLookupTransformationFactory,
 		InputWrappingTransformationFactory, LinearTransformationFactory,

--- a/crates/field/src/arch/portable/scaled_arithmetic.rs
+++ b/crates/field/src/arch/portable/scaled_arithmetic.rs
@@ -102,7 +102,7 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::{aes_field::Rijndael8b, arch::M128};
+	use crate::{arch::M128, fields::rijndael::Rijndael8b};
 
 	// A two-lane `ScaledUnderlier` AES packing whose `M128` lanes carry their own `WideMul`.
 	type Inner = PackedPrimitiveType<ScaledUnderlier<M128, 2>, Rijndael8b>;

--- a/crates/field/src/fields/ghash.rs
+++ b/crates/field/src/fields/ghash.rs
@@ -12,13 +12,11 @@ use std::{
 
 use bytemuck::{Pod, Zeroable};
 
-use super::{
-	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
-	extension::ExtensionField,
-};
 use crate::{
 	Field, Rijndael8b,
 	arch::M128,
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
+	extension::ExtensionField,
 	underlier::{U1, WithUnderlier},
 };
 

--- a/crates/field/src/fields/ghash_sq.rs
+++ b/crates/field/src/fields/ghash_sq.rs
@@ -25,13 +25,11 @@ use std::{
 
 use bytemuck::{Pod, Zeroable};
 
-use super::{
-	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
-	extension::ExtensionField,
-};
 use crate::{
 	Field, Ghash128b,
 	arch::{M128, M256, m256_from_u128s},
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
+	extension::ExtensionField,
 	underlier::U1,
 };
 

--- a/crates/field/src/fields/mod.rs
+++ b/crates/field/src/fields/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2026 The Binius Developers
+
+pub mod ghash;
+pub mod ghash_sq;
+pub mod rijndael;

--- a/crates/field/src/fields/rijndael.rs
+++ b/crates/field/src/fields/rijndael.rs
@@ -9,8 +9,11 @@ use std::{
 
 use bytemuck::{Pod, Zeroable};
 
-use super::binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension};
-use crate::{ExtensionField, Field, underlier::U1};
+use crate::{
+	ExtensionField, Field,
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
+	underlier::U1,
+};
 
 // These fields represent a tower based on AES GF(2^8) field (GF(256)/x^8+x^4+x^3+x+1)
 // that is isomorphically included into binary tower, i.e.:

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -12,15 +12,13 @@
 //!
 //! [DP23]: https://eprint.iacr.org/2023/1784
 
-pub mod aes_field;
 pub mod arch;
 pub mod arithmetic_traits;
 pub mod binary_field;
 mod divisible;
 pub mod extension;
 pub mod field;
-pub mod ghash;
-pub mod ghash_sq;
+pub mod fields;
 pub mod linear_transformation;
 mod macros;
 pub mod packed;
@@ -38,14 +36,12 @@ pub mod transpose;
 mod underlier;
 pub mod util;
 
-pub use aes_field::*;
 pub use arithmetic_traits::WideMul;
 pub use binary_field::*;
 pub use divisible::Divisible;
 pub use extension::*;
 pub use field::{Field, FieldOps};
-pub use ghash::*;
-pub use ghash_sq::*;
+pub use fields::{ghash::*, ghash_sq::*, rijndael::*};
 pub use packed::PackedField;
 pub use packed_aes::*;
 pub use packed_binary_field::*;

--- a/crates/field/src/packed_aes.rs
+++ b/crates/field/src/packed_aes.rs
@@ -2,13 +2,13 @@
 // Copyright 2026 The Binius Developers
 
 use crate::{
-	aes_field::Rijndael8b,
 	arch::{
 		AesInvert1x, AesInvert16x, AesInvert32x, AesInvert64x, AesSquare1x, AesSquare16x,
 		AesSquare32x, AesSquare64x, AesWideMul1x, AesWideMul16x, AesWideMul32x, AesWideMul64x,
 		M128, M256, M512, MulFromWideMul,
 		portable::packed_macros::{portable_macros::*, *},
 	},
+	fields::rijndael::Rijndael8b,
 };
 
 define_packed_binary_field!(


### PR DESCRIPTION
Pure mechanical reorganization of `binius-field`, no behavior change.

### What moved

- `crates/field/src/ghash.rs` → `crates/field/src/fields/ghash.rs`
- `crates/field/src/ghash_sq.rs` → `crates/field/src/fields/ghash_sq.rs`
- `crates/field/src/aes_field.rs` → `crates/field/src/fields/rijndael.rs` (module `aes_field` renamed to `rijndael`, matching the field's existing type name `Rijndael8b`)

`crates/field/src/binary_field.rs` stays at the crate root: beyond defining `BinaryField1b`, it also carries the shared `binary_field!`/`impl_field_extension!` macro infrastructure that every field module (including the three moved above) builds on.

### API surface

Unaffected. `fields/mod.rs` declares the three submodules, and `lib.rs` re-exports `fields::{ghash::*, ghash_sq::*, rijndael::*}` at the crate root, so existing call sites like `binius_field::{Ghash128b, Rijndael8b, GhashSq256b, BinaryField1b}` keep working unchanged. The new explicit path `binius_field::fields::rijndael::Rijndael8b` is also available.

### What else changed

Only the handful of places that referenced the old module paths directly rather than the re-exported names:
- `crates/field/src/packed_aes.rs`
- `crates/field/src/arch/aarch64/packed_aes_128.rs`
- `crates/field/src/arch/aarch64/simd_arithmetic.rs`
- `crates/field/src/arch/portable/scaled_arithmetic.rs`
- `crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs`
- `crates/field/benches/binary_field.rs`

### Verification

- `cargo build -p binius-field --all-features` — clean
- `cargo build --workspace --all-targets --all-features` — clean
- `cargo test -p binius-field --lib` — 253 passed, 1 ignored, 0 failed
- `prek run --all-files rustfmt` — clean
- `prek run --stage pre-push --all-files clippy` — clean
- `python3 tools/check_copyright_notice.py` — 0 wrong, 0 missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)