### PR TITLE
BINIUS-559: Batch shift-reduction operand claims with tensor weights

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -68,7 +68,7 @@ where
 {
 	// One batching coefficient per operation, drawn from the channel.
 	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
-	let prepared = claims.prepare(|| channel.sample());
+	let prepared = claims.prepare(channel);
 
 	// Phase 1: accumulate the g rows once per key segment. The public words are constants shared
 	// by every instance, so the single-instance builder folds them directly from their bits; the
@@ -182,7 +182,7 @@ where
 /// rows[key.dense_shift_idx * Word::BITS + bit] += folded_bit * acc(key)
 /// ```
 ///
-/// where `acc(key)` is the key's lambda-weighted partial evaluation tensor.
+/// where `acc(key)` is the key's batching-weighted partial evaluation tensor.
 /// Every word carrying that key accumulates into the same row.
 ///
 /// This scalar implementation ignores the single-instance builder's packing and parallelism.
@@ -202,11 +202,11 @@ pub fn build_g_from_folded_words<F: BinaryField>(
 		for key in keys {
 			let operator_data = &prepared[key.operation];
 
-			// The lambda-weighted partial evaluation tensor for this shifted word.
+			// The batching-weighted partial evaluation tensor for this shifted word.
 			let acc = key.accumulate(
 				&segment.constraint_indices,
-				operator_data.r_x_prime_tensor.as_ref(),
-				&operator_data.lambda_powers,
+				operator_data.weighted_r_x_prime_tensor.as_ref(),
+				&prepared.operand_weights,
 			);
 
 			let base = key.dense_shift_idx as usize * Word::BITS;
@@ -527,7 +527,7 @@ mod tests {
 			intmul: OperatorData::zero_claim(r_z),
 			binmul: OperatorData::zero_claim(r_z),
 		};
-		let prepared = claims.prepare(|| B128::random(&mut rng));
+		let prepared = claims.prepare(&mut ProverTranscript::<StdChallenger>::default());
 
 		// The g rows: the public segment folds from raw constant words via the single-instance
 		// builder, the hidden segment from the instance-folded words. The h multilinear comes

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -269,8 +269,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let hidden_words = value_vec.non_public();
 	let subspace = BinarySubspace::<Rijndael8b>::with_dim(Word::LOG_BITS).isomorphic();
 
-	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
-	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
+	// Prepare the operator data. Sampling is cheap and not part of any benched phase, so a
+	// throwaway transcript stands in for the proving one and yields realistic-magnitude data.
 	// SHA256 has no BMUL constraints, so that one is a zero claim at an empty point, matching the
 	// real prover (`prove.rs` `None` branch).
 	let prepared = OperatorClaims {
@@ -291,7 +291,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 		},
 		binmul: OperatorData::zero_claim(r_zhat_prime),
 	}
-	.prepare(|| F::random(&mut rng));
+	.prepare(&mut ProverTranscript::<StdChallenger>::default());
 
 	// The phases are sequential and stateful: each one consumes the previous phase's outputs.
 	//

--- a/crates/prover/src/protocols/shift/claims.rs
+++ b/crates/prover/src/protocols/shift/claims.rs
@@ -19,7 +19,11 @@
 use std::ops::Index;
 
 use binius_field::Field;
-use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
+use binius_ip_prover::channel::IPProverChannel;
+use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
+use binius_verifier::protocols::shift::{
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_MAX_ARITY, LOG_OPERATION_COUNT, ZERO_ARITY,
+};
 
 use super::{Operation, OperatorData, PreparedOperatorData};
 
@@ -39,34 +43,50 @@ pub struct OperatorClaims<F: Field> {
 }
 
 impl<F: Field> OperatorClaims<F> {
-	/// Draws one batching coefficient per operation and folds it into that operation's claim.
+	/// Draws the two batching challenge vectors and folds their weights into the claims.
 	///
 	/// An operation holds one claim per operand, and the reduction proves them all at once.
-	/// Batching weights operand `i` by the `i`-th power of the operation's own coefficient.
+	/// The claim of operand `m` of operation `op` is weighted by the product of two equality
+	/// indicators, one per axis:
 	///
-	/// The powers start at the first, never the zeroth.
-	/// So each operation's batched value already carries a random factor of its own.
-	/// The four can then be summed directly, with no further scaling to separate them.
+	/// ```text
+	/// eq(operation_batch_challenges, op) * eq(operand_batch_challenges, m)
+	/// ```
 	///
-	/// The coefficients are drawn in the order `[Zero, BitwiseAnd, IntegerMul, BinMul]`.
-	/// The verifier draws in that same order, so this sequence is protocol, not detail.
+	/// Two operations' weights are distinct entries of one equality tensor, so their batched
+	/// values sum directly, with no further scaling to separate them.
+	///
+	/// The operand axis is shared by the four operations, and padded to a cube: an operation of
+	/// arity below `1 << LOG_MAX_ARITY` reads a prefix of the same weights, and the slots above
+	/// its arity name no claim.
+	///
+	/// The challenges are drawn operation axis first, and the operation weights are indexed in
+	/// the order `[Zero, BitwiseAnd, IntegerMul, BinMul]`. The verifier does both the same way, so
+	/// these orders are protocol, not detail.
 	///
 	/// The arities are erased on the way out, since both proving phases dispatch on a shift key.
 	///
 	/// # Arguments
 	///
-	/// - `sample`: draws the next batching coefficient from the transcript.
-	pub fn prepare(self, mut sample: impl FnMut() -> F) -> PreparedOperatorClaims<F> {
+	/// - `channel`: the transcript the batching challenges are drawn from.
+	pub fn prepare(self, channel: &mut impl IPProverChannel<F>) -> PreparedOperatorClaims<F> {
+		let operation_batch_challenges = channel.sample_many(LOG_OPERATION_COUNT);
+		let operand_batch_challenges = channel.sample_many(LOG_MAX_ARITY);
+
+		let operation_weights = eq_ind_partial_eval_scalars(&operation_batch_challenges);
+		let operand_weights = eq_ind_partial_eval_scalars(&operand_batch_challenges);
+
 		PreparedOperatorClaims {
-			zero: PreparedOperatorData::new(self.zero, sample()),
-			bitand: PreparedOperatorData::new(self.bitand, sample()),
-			intmul: PreparedOperatorData::new(self.intmul, sample()),
-			binmul: PreparedOperatorData::new(self.binmul, sample()),
+			zero: PreparedOperatorData::new(self.zero, operation_weights[0], &operand_weights),
+			bitand: PreparedOperatorData::new(self.bitand, operation_weights[1], &operand_weights),
+			intmul: PreparedOperatorData::new(self.intmul, operation_weights[2], &operand_weights),
+			binmul: PreparedOperatorData::new(self.binmul, operation_weights[3], &operand_weights),
+			operand_weights,
 		}
 	}
 }
 
-/// The claims with their batching coefficients folded in, as both proving phases read them.
+/// The claims with their batching weights folded in, as both proving phases read them.
 ///
 /// Each entry also carries the tensor expansion of its constraint point.
 /// That expansion is shared by every key of the operation, so it is built once here.
@@ -80,13 +100,18 @@ pub struct PreparedOperatorClaims<F: Field> {
 	pub intmul: PreparedOperatorData<F>,
 	/// The prepared claim for the BMUL constraints.
 	pub binmul: PreparedOperatorData<F>,
+	/// The weight of each operand position, `1 << LOG_MAX_ARITY` entries.
+	///
+	/// The operand axis is shared by the four operations, so this table is too: a key reads it at
+	/// the operand position its constraint index names, whatever operation the key belongs to.
+	pub operand_weights: Vec<F>,
 }
 
 impl<F: Field> PreparedOperatorClaims<F> {
 	/// The four operations' claims collapsed into the single value the reduction proves.
 	///
-	/// Each operation's batched evaluation already carries a random factor of its own, drawn for
-	/// it alone, so the four sum directly with no further scaling.
+	/// Each operation's batched evaluation already carries its own weight on the operation axis,
+	/// so the four sum directly with no further scaling.
 	///
 	/// This is the claim phase 1 hands its sumcheck, and it is the same value the verifier
 	/// computes from the operand evaluation claims before running its own.
@@ -113,7 +138,8 @@ impl<F: Field> Index<Operation> for PreparedOperatorClaims<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_verifier::config::B128;
+	use binius_transcript::ProverTranscript;
+	use binius_verifier::config::{B128, StdChallenger};
 
 	use super::*;
 
@@ -128,37 +154,56 @@ mod tests {
 	}
 
 	#[test]
-	fn prepare_carries_each_operations_arity_into_the_erased_form() {
-		// Invariant: erasing the arity keeps it as a length, one lambda power per operand.
+	fn prepare_shares_one_operand_axis_across_the_four_operations() {
+		// Invariant: the operand axis is a cube wide enough for every arity, and the four
+		// operations read the same one.
 		//
-		// The four arities are 1, 3, 4 and 6, all distinct.
-		// So a claim reached through the wrong index arm shows up as the wrong count.
-		let prepared = zero_claims().prepare(|| B128::ONE);
+		// The widest arity is BMUL's six, so a cube narrower than that would leave two of its
+		// operand claims unweighted.
+		let prepared = zero_claims().prepare(&mut ProverTranscript::<StdChallenger>::default());
 
-		assert_eq!(prepared[Operation::Zero].lambda_powers.len(), ZERO_ARITY);
-		assert_eq!(prepared[Operation::BitwiseAnd].lambda_powers.len(), BITAND_ARITY);
-		assert_eq!(prepared[Operation::IntegerMul].lambda_powers.len(), INTMUL_ARITY);
-		assert_eq!(prepared[Operation::BinMul].lambda_powers.len(), BINMUL_ARITY);
+		assert_eq!(prepared.operand_weights.len(), 1 << LOG_MAX_ARITY);
+		for arity in [ZERO_ARITY, BITAND_ARITY, INTMUL_ARITY, BINMUL_ARITY] {
+			assert!(arity <= prepared.operand_weights.len());
+		}
 	}
 
 	#[test]
-	fn prepare_draws_one_coefficient_per_operation_in_transcript_order() {
-		// Invariant: the coefficients are drawn in the order [Zero, AND, IMUL, BMUL].
-		// The verifier draws in that order; any other batches a claim by the wrong coefficient.
+	fn prepare_draws_the_two_axes_in_transcript_order() {
+		// Invariant: the operation axis is drawn before the operand axis, and each axis takes as
+		// many challenges as its width.
 		//
-		// This stand-in transcript hands out 1, 2, 3, 4, so a coefficient names its draw position.
-		let mut draws = 0u128;
-		let prepared = zero_claims().prepare(|| {
-			draws += 1;
-			B128::new(draws)
-		});
+		// The verifier draws in that order; any other weights the claims by a different tensor.
+		//
+		// Two transcripts from the same seed hand out the same sequence, so drawing the axes by
+		// hand from one pins what `prepare` must have drawn from the other. The axes have
+		// different widths, so drawing them in the other order splits that sequence differently
+		// and the expansions below disagree.
+		let mut expected = ProverTranscript::<StdChallenger>::default();
+		let operation_weights =
+			eq_ind_partial_eval_scalars(&expected.sample_many(LOG_OPERATION_COUNT));
+		let operand_weights = eq_ind_partial_eval_scalars(&expected.sample_many(LOG_MAX_ARITY));
 
-		assert_eq!(draws, 4, "one draw per operation");
+		let mut channel = ProverTranscript::<StdChallenger>::default();
+		let prepared = zero_claims().prepare(&mut channel);
 
-		// Powers start at the first, so a claim's leading power is the coefficient it was given.
-		assert_eq!(prepared[Operation::Zero].lambda_powers[0], B128::new(1));
-		assert_eq!(prepared[Operation::BitwiseAnd].lambda_powers[0], B128::new(2));
-		assert_eq!(prepared[Operation::IntegerMul].lambda_powers[0], B128::new(3));
-		assert_eq!(prepared[Operation::BinMul].lambda_powers[0], B128::new(4));
+		assert_eq!(prepared.operand_weights, operand_weights);
+
+		// The two stay in lockstep only if `prepare` drew exactly those five and no more.
+		assert_eq!(
+			IPProverChannel::<B128>::sample(&mut channel),
+			IPProverChannel::<B128>::sample(&mut expected)
+		);
+
+		// A claim scaled by its operation's weight reproduces that weight, since the operand
+		// claims here are all zero and the constraint point is empty.
+		for (operation, weight) in [
+			(Operation::Zero, operation_weights[0]),
+			(Operation::BitwiseAnd, operation_weights[1]),
+			(Operation::IntegerMul, operation_weights[2]),
+			(Operation::BinMul, operation_weights[3]),
+		] {
+			assert_eq!(prepared[operation].weighted_r_x_prime_tensor.as_ref(), &[weight]);
+		}
 	}
 }

--- a/crates/prover/src/protocols/shift/key_collection/collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection/collection.rs
@@ -13,18 +13,13 @@ use binius_utils::{
 	},
 	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
 };
-use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
+use binius_verifier::protocols::shift::LOG_MAX_ARITY;
 use bytes::{Buf, BufMut};
 use tracing::instrument;
 
-use super::{
-	builder, dense_shift_encoding::DenseShiftEncoding, key_segment::KeySegment,
-	operation::Operation,
-};
+use super::{builder, dense_shift_encoding::DenseShiftEncoding, key_segment::KeySegment};
 use crate::protocols::shift::{
-	claims::PreparedOperatorClaims,
-	monster::{OuterSlotWeights, ScalarTables},
-	shift_ind::ShiftChallenge,
+	claims::PreparedOperatorClaims, monster::OuterSlotWeights, shift_ind::ShiftChallenge,
 };
 
 /// The prover's complete view of a constraint system's shift keys, split by value-vector segment.
@@ -72,7 +67,7 @@ impl KeyCollection {
 	///
 	/// For each witness word, this sums every one of its keys' contributions.
 	/// A key's contribution is its constraint-index accumulation, scaled by a scalar that
-	/// folds together the batching power, the bit-index evaluation, and the two
+	/// folds together the operand batching weight, the bit-index evaluation, and the two
 	/// equality-indicator weights of the shift sequence the key names.
 	///
 	/// # Returns
@@ -105,58 +100,46 @@ impl KeyCollection {
 		// `SHIFT_COUNT^2`.
 		let outer_weights = OuterSlotWeights::<F>::new(outer);
 
-		// The scalars of one operation, laid out with the operand index innermost, so a
+		// The scalars of one key segment, laid out with the operand index innermost, so a
 		// key's weights form one contiguous chunk its wide accumulation can index by
 		// operand.
 		//
+		// The operand axis is shared by the four operations, so this is one table at the
+		// padded stride rather than one per operation at that operation's arity.
+		//
 		// A key's sequence selects itself through an equality indicator over both slots.
-		// The h evaluation is one factor shared by every key of the operation.
-		let build_scalars = |arity: usize,
-		                     lambda_powers: &[F],
-		                     dense_shift_enc: &DenseShiftEncoding| {
-			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
-			for (dense_shift_idx, [inner_shift, outer_shift]) in dense_shift_enc.iter().enumerate()
-			{
-				let shift_scalar = h_eval
-					* r_v_tensor.as_ref()[inner_shift.variant as usize]
-					* r_s_tensor.as_ref()[inner_shift.amount as usize]
-					* outer_weights.weight(outer_shift);
-				for operand_idx in 0..arity {
-					scalars[dense_shift_idx * arity + operand_idx] =
-						lambda_powers[operand_idx] * shift_scalar;
-				}
-			}
-			scalars
-		};
-
-		// Each segment has its own dense shift encoding, so it has its own scalar tables.
-		let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
-			zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, dense_shift_enc),
-			bitand: build_scalars(BITAND_ARITY, &prepared.bitand.lambda_powers, dense_shift_enc),
-			intmul: build_scalars(INTMUL_ARITY, &prepared.intmul.lambda_powers, dense_shift_enc),
-			binmul: build_scalars(BINMUL_ARITY, &prepared.binmul.lambda_powers, dense_shift_enc),
+		// The h evaluation is one factor shared by every key.
+		let build_scalars = |dense_shift_enc: &DenseShiftEncoding| {
+			dense_shift_enc
+				.iter()
+				.flat_map(|[inner_shift, outer_shift]| {
+					let shift_scalar = h_eval
+						* r_v_tensor.as_ref()[inner_shift.variant as usize]
+						* r_s_tensor.as_ref()[inner_shift.amount as usize]
+						* outer_weights.weight(outer_shift);
+					prepared
+						.operand_weights
+						.iter()
+						.map(move |operand_weight| *operand_weight * shift_scalar)
+				})
+				.collect::<Vec<_>>()
 		};
 
 		// The scalar for one word of a segment: the accumulated contribution of all its
 		// keys, summed unreduced and reduced once at the end.
-		let word_scalar = |segment: &KeySegment, tables: &ScalarTables<F>, index: usize| {
+		let word_scalar = |segment: &KeySegment, scalars: &[F], index: usize| {
 			let wide = segment
 				.word_keys(index)
 				.iter()
 				.map(|key| {
-					// The scalar table is per operation, and its stride is that
-					// operation's arity.
-					let (scalars, arity) = match key.operation {
-						Operation::Zero => (&tables.zero, ZERO_ARITY),
-						Operation::BitwiseAnd => (&tables.bitand, BITAND_ARITY),
-						Operation::IntegerMul => (&tables.intmul, INTMUL_ARITY),
-						Operation::BinMul => (&tables.binmul, BINMUL_ARITY),
-					};
-					let base = key.dense_shift_idx as usize * arity;
+					// One chunk per shift sequence, at the padded stride. A key reads the
+					// whole chunk whatever its operation's arity is; the slots above that
+					// arity name no operand and are never indexed.
+					let base = (key.dense_shift_idx as usize) << LOG_MAX_ARITY;
 					key.accumulate_wide(
 						&segment.constraint_indices,
-						prepared[key.operation].r_x_prime_tensor.as_ref(),
-						&scalars[base..base + arity],
+						prepared[key.operation].weighted_r_x_prime_tensor.as_ref(),
+						&scalars[base..base + (1 << LOG_MAX_ARITY)],
 					)
 				})
 				.sum::<<F as WideMul>::Output>();
@@ -167,7 +150,8 @@ impl KeyCollection {
 		// power-of-two length exactly, the hidden piece is zero-padded up to the hidden
 		// segment length.
 		let build_segment = |segment: &KeySegment, log_len: usize| {
-			let tables = build_scalar_tables(&segment.dense_shift_enc);
+			// Each segment has its own dense shift encoding, so it has its own scalar table.
+			let scalars = build_scalars(&segment.dense_shift_enc);
 			let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 			let n_words = segment.n_words();
 			// Full packed elements: each maps exactly `P::WIDTH` words, so `from_scalars`
@@ -184,7 +168,7 @@ impl KeyCollection {
 				.for_each(|(chunk_index, slot)| {
 					let start = chunk_index * P::WIDTH;
 					slot.write(P::from_scalars(
-						(0..P::WIDTH).map(|i| word_scalar(segment, &tables, start + i)),
+						(0..P::WIDTH).map(|i| word_scalar(segment, &scalars, start + i)),
 					));
 				});
 			// Safety: the parallel loop above initialized every one of the `n_full`
@@ -193,7 +177,7 @@ impl KeyCollection {
 			if !n_words.is_multiple_of(P::WIDTH) {
 				let start = n_full * P::WIDTH;
 				values.push(P::from_scalars(
-					(start..n_words).map(|word_index| word_scalar(segment, &tables, word_index)),
+					(start..n_words).map(|word_index| word_scalar(segment, &scalars, word_index)),
 				));
 			}
 			values.resize(capacity, P::default());

--- a/crates/prover/src/protocols/shift/key_collection/key.rs
+++ b/crates/prover/src/protocols/shift/key_collection/key.rs
@@ -178,10 +178,8 @@ mod tests {
 	use std::{iter, mem};
 
 	use binius_field::Ghash128b;
-	use binius_math::FieldBuffer;
 
 	use super::*;
-	use crate::protocols::shift::PreparedOperatorData;
 
 	type F = Ghash128b;
 
@@ -231,7 +229,7 @@ mod tests {
 	fn accumulate_by_operand<'a>(
 		key: &'a Key,
 		constraint_indices: &'a [ConstraintIndex],
-		operator_data: &'a PreparedOperatorData<F>,
+		r_x_prime_tensor: &'a [F],
 	) -> impl Iterator<Item = (usize, F)> + 'a {
 		let Range { start, end } = key.range;
 
@@ -241,14 +239,14 @@ mod tests {
 		iter::from_fn(move || {
 			let current = maybe_current?;
 
-			acc += operator_data.r_x_prime_tensor.as_ref()[current.constraint_index as usize];
+			acc += r_x_prime_tensor[current.constraint_index as usize];
 			for next in &mut iter {
 				maybe_current = Some(next);
 				if next.operand_index != current.operand_index {
 					let ret = mem::take(&mut acc);
 					return Some((current.operand_index as usize, ret));
 				}
-				acc += operator_data.r_x_prime_tensor.as_ref()[next.constraint_index as usize];
+				acc += r_x_prime_tensor[next.constraint_index as usize];
 			}
 
 			maybe_current = None;
@@ -285,32 +283,17 @@ mod tests {
 			dense_shift_idx: 0,
 			range: 0..constraint_indices.len() as u32,
 		};
-		let operator_data = PreparedOperatorData {
-			batched_eval: F::ZERO,
-			r_zhat_prime: F::ZERO,
-			r_x_prime_tensor: FieldBuffer::from_values(&[
-				f(2),
-				f(3),
-				f(5),
-				f(7),
-				f(11),
-				f(13),
-				f(17),
-				f(19),
-			]),
-			lambda_powers: vec![f(23), f(29), f(31)],
-		};
+		let r_x_prime_tensor = [f(2), f(3), f(5), f(7), f(11), f(13), f(17), f(19)];
+		// The operand axis is padded to a cube, so it holds more weights than the arity of the
+		// operation the key names. Only the leading ones are ever read.
+		let operand_weights = [f(23), f(29), f(31), f(37), f(41), f(43), f(47), f(53)];
 
-		let expected = accumulate_by_operand(&key, &constraint_indices, &operator_data)
-			.map(|(operand_index, acc)| acc * operator_data.lambda_powers[operand_index])
+		let expected = accumulate_by_operand(&key, &constraint_indices, &r_x_prime_tensor)
+			.map(|(operand_index, acc)| acc * operand_weights[operand_index])
 			.sum::<F>();
 
 		assert_eq!(
-			key.accumulate(
-				&constraint_indices,
-				operator_data.r_x_prime_tensor.as_ref(),
-				&operator_data.lambda_powers
-			),
+			key.accumulate(&constraint_indices, &r_x_prime_tensor, &operand_weights),
 			expected
 		);
 
@@ -344,16 +327,16 @@ mod tests {
 		let non_contiguous_expected = accumulate_by_operand(
 			&non_contiguous_key,
 			&non_contiguous_constraint_indices,
-			&operator_data,
+			&r_x_prime_tensor,
 		)
-		.map(|(operand_index, acc)| acc * operator_data.lambda_powers[operand_index])
+		.map(|(operand_index, acc)| acc * operand_weights[operand_index])
 		.sum::<F>();
 
 		assert_eq!(
 			non_contiguous_key.accumulate(
 				&non_contiguous_constraint_indices,
-				operator_data.r_x_prime_tensor.as_ref(),
-				&operator_data.lambda_powers
+				&r_x_prime_tensor,
+				&operand_weights
 			),
 			non_contiguous_expected
 		);
@@ -364,11 +347,7 @@ mod tests {
 			range: 0..0,
 		};
 		assert_eq!(
-			empty_key.accumulate(
-				&constraint_indices,
-				operator_data.r_x_prime_tensor.as_ref(),
-				&operator_data.lambda_powers
-			),
+			empty_key.accumulate(&constraint_indices, &r_x_prime_tensor, &operand_weights),
 			F::ZERO
 		);
 	}

--- a/crates/prover/src/protocols/shift/key_collection/key_segment.rs
+++ b/crates/prover/src/protocols/shift/key_collection/key_segment.rs
@@ -104,12 +104,13 @@ impl KeySegment {
 					for key in keys {
 						let operator_data = &prepared[key.operation];
 
-						// Fold this key's accumulator value: the constraint-index tensor
-						// weighted by the batching powers for this operand position.
+						// Fold this key's accumulator value: the constraint-index tensor,
+						// already carrying the operation's weight, against the operand
+						// weight of each position the key names.
 						let acc = key.accumulate(
 							&self.constraint_indices,
-							operator_data.r_x_prime_tensor.as_ref(),
-							&operator_data.lambda_powers,
+							operator_data.weighted_r_x_prime_tensor.as_ref(),
+							&prepared.operand_weights,
 						);
 						let acc_packed = P::broadcast(acc);
 

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -14,17 +14,6 @@ use super::{phase_1::SHIFT_OPERATOR_LOG_LEN, shift_ind::ShiftChallenge};
 /// The width the half-word (`*32`) shift variants act over.
 const HALF_WORD_BITS: usize = 32;
 
-/// The phase-2 scalar weights of one key segment, one table per operation.
-///
-/// A table holds the `arity` weights of each shift sequence the segment uses, in dense shift index
-/// order, so a key's weights are the chunk at `key.dense_shift_idx * arity`.
-pub(super) struct ScalarTables<F> {
-	pub(super) zero: Vec<F>,
-	pub(super) bitand: Vec<F>,
-	pub(super) intmul: Vec<F>,
-	pub(super) binmul: Vec<F>,
-}
-
 /// The equality-indicator weights of a shift sequence's outer slot.
 ///
 /// The sequence weight factorizes across its two slots, so each slot carries its own two tensors:

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -3,11 +3,11 @@
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, PackedField, util::powers};
+use binius_field::{BinaryField, Field, PackedField};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product,
-	multilinear::eq::eq_ind_partial_eval, univariate::EvaluationDomain,
+	multilinear::eq::scaled_eq_ind_partial_eval, univariate::EvaluationDomain,
 };
 
 use super::{
@@ -60,57 +60,61 @@ impl<F: Field, const ARITY: usize> OperatorData<F, ARITY> {
 	}
 }
 
-/// One operation's claims, with the expansions every proving phase needs precomputed.
+/// One operation's claims, with the expansion every proving phase needs precomputed.
 ///
-/// Every shift key of the operation reads the same two expansions, built once here:
-///
-/// - the constraint point, expanded into its equality-indicator tensor;
-/// - the batching coefficient, expanded into its powers, one per operand.
+/// Every shift key of the operation reads the same constraint-point expansion, built once here.
+/// The operation's own batching weight is folded into it: that weight reaches every term of the
+/// operation, and the expansion's seed is where it costs nothing to carry.
 ///
 /// The arity is erased, since every phase picks an operation at run time and all four have to
 /// share one type.
 /// Only the batched combination survives that erasure, as a single scalar.
 #[derive(Debug, Clone)]
 pub struct PreparedOperatorData<F: Field> {
-	/// The operand claims collapsed into one value by the batching coefficient, starting at
-	/// the first power:
+	/// The operand claims collapsed into one value by the batching weights:
 	///
 	/// ```text
-	/// batched_eval = sum_i evals[i] * lambda^(i + 1)
+	/// batched_eval = operation_weight * sum_i evals[i] * operand_weights[i]
 	/// ```
 	///
-	/// Two operations' batched values can be summed directly, with no further scaling.
+	/// Two operations' batched values can be summed directly, with no further scaling, since
+	/// their operation weights are distinct entries of one equality tensor.
 	pub batched_eval: F,
 	/// The univariate challenge folding the bit axis, shared by every operation.
 	pub r_zhat_prime: F,
-	/// The equality-indicator tensor of the constraint point, one weight per constraint.
-	pub r_x_prime_tensor: FieldBuffer<F>,
-	/// The batching coefficient's powers, one per operand, starting at the first power.
-	///
-	/// Indexable at run time by the operand a shift key names.
-	pub lambda_powers: Vec<F>,
+	/// The equality-indicator tensor of the constraint point, one weight per constraint, scaled by
+	/// this operation's own batching weight.
+	pub weighted_r_x_prime_tensor: FieldBuffer<F>,
 }
 
 impl<F: Field> PreparedOperatorData<F> {
-	/// Expands one operation's claims against the batching coefficient drawn for it.
+	/// Expands one operation's claims against the batching weights drawn for it.
 	///
 	/// # Arguments
 	///
 	/// - `operator_data`: the operand claims, and the point they are claimed at.
-	/// - `lambda`: the batching coefficient for this operation.
-	pub fn new<const ARITY: usize>(operator_data: OperatorData<F, ARITY>, lambda: F) -> Self {
+	/// - `operation_weight`: this operation's entry in the operation-axis equality tensor.
+	/// - `operand_weights`: the operand-axis equality tensor, shared by the four operations. Only
+	///   its leading `ARITY` entries name a claim of this operation.
+	pub fn new<const ARITY: usize>(
+		operator_data: OperatorData<F, ARITY>,
+		operation_weight: F,
+		operand_weights: &[F],
+	) -> Self {
 		let OperatorData {
 			evals,
 			r_zhat_prime,
 			r_x_prime,
 		} = operator_data;
-		let r_x_prime_tensor = eq_ind_partial_eval::<F>(&r_x_prime);
-		let lambda_powers: Vec<F> = powers(lambda).skip(1).take(ARITY).collect();
+		let weighted_r_x_prime_tensor =
+			scaled_eq_ind_partial_eval::<F>(&r_x_prime, operation_weight);
 		Self {
-			batched_eval: inner_product(evals, lambda_powers.iter().copied()),
+			// Only the leading `ARITY` weights name a claim; `inner_product` pairs the two
+			// sequences exactly, so the shared tail is cut here.
+			batched_eval: operation_weight
+				* inner_product(evals, operand_weights[..ARITY].iter().copied()),
 			r_zhat_prime,
-			r_x_prime_tensor,
-			lambda_powers,
+			weighted_r_x_prime_tensor,
 		}
 	}
 }
@@ -167,7 +171,7 @@ where
 	// SOUNDNESS: this must draw in the same order the verifier draws in.
 	let prepared = {
 		let _scope = tracing::debug_span!("Expand tensor queries").entered();
-		claims.prepare(|| channel.sample())
+		claims.prepare(channel)
 	};
 
 	// The weights the reduction's first factor carries, one per bit position.

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -38,6 +38,30 @@ pub const BITAND_ARITY: usize = 3;
 pub const INTMUL_ARITY: usize = 4;
 pub const BINMUL_ARITY: usize = 6;
 
+/// The number of operations the shift reduction batches: ZERO, AND, IMUL and BMUL.
+pub const OPERATION_COUNT: usize = 4;
+
+/// The base-2 logarithm of the operation axis the reduction batches over.
+///
+/// An operation's claims are weighted by the equality indicator of this many challenges, evaluated
+/// at the operation's own index in the order above.
+pub const LOG_OPERATION_COUNT: usize = 2;
+
+/// The base-2 logarithm of the operand axis the reduction batches over.
+///
+/// An operand's claim is weighted by the equality indicator of this many challenges, evaluated at
+/// the operand's position. The four operations share one such axis, padded to a cube: an operation
+/// of lower arity reads a prefix of the same weights, and the slots above its arity name no claim
+/// and contribute nothing.
+pub const LOG_MAX_ARITY: usize = 3;
+
+// The two axes above are cubes, so each has to cover what it indexes.
+const _: () = assert!(OPERATION_COUNT <= 1 << LOG_OPERATION_COUNT);
+const _: () = assert!(ZERO_ARITY <= 1 << LOG_MAX_ARITY);
+const _: () = assert!(BITAND_ARITY <= 1 << LOG_MAX_ARITY);
+const _: () = assert!(INTMUL_ARITY <= 1 << LOG_MAX_ARITY);
+const _: () = assert!(BINMUL_ARITY <= 1 << LOG_MAX_ARITY);
+
 mod monster;
 mod shift_ind;
 

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -4,22 +4,15 @@
 use std::iter;
 
 use binius_core::constraint_system::{Operand, ValueIndex};
-use binius_field::{
-	BinaryField, FieldOps, WideMul,
-	util::{FieldFn, powers},
-};
-use binius_math::multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars};
-use binius_utils::{
-	checked_arithmetics::log2_ceil_usize,
-	rayon::{
-		prelude::*,
-		task_size::{IndexedParallelIteratorExt, WorkPerItem},
-	},
+use binius_field::{BinaryField, FieldOps, WideMul, util::powers};
+use binius_utils::rayon::{
+	prelude::*,
+	task_size::{IndexedParallelIteratorExt, WorkPerItem},
 };
 
 use super::SHIFT_COUNT;
 
-/// A [`FieldFn`] evaluating one operation's monster multilinear polynomial.
+/// The evaluation of one operation's monster multilinear polynomial.
 ///
 /// The monster multilinear encodes all `ARITY`-operand constraints of a single operation (BitAnd,
 /// IntMul or BinMul) into one polynomial:
@@ -34,81 +27,20 @@ use super::SHIFT_COUNT;
 /// variants, `h_op` is the shift selector polynomial, and `M_{m,op}` is the multilinear extension
 /// of the operand values.
 ///
-/// The `FieldFn` input is the flat slice built by [`encode_operation_input`]: the constraint
-/// challenge `r_x'`, then the batching coefficient `lambda`, then the shared shift scalars, then
-/// the word-index tensor `r_y`. [`FieldFn::call`] evaluates generically over any `E`;
-/// [`FieldFn::call_native`] takes the `WideMul`-accelerated base-field path.
+/// Both evaluations read one borrowed weight table per axis, bundled as [`WiringWeights`]. The
+/// tables the four operations share are then built once by the caller and lent to all four, rather
+/// than copied into a per-operation buffer. [`Self::call`] evaluates generically over any `E`;
+/// [`Self::call_native`] takes the `WideMul`-accelerated base-field path.
 pub struct OperationEvalFn<'a, C, const ARITY: usize> {
 	/// The operation's constraints, each exposing its `ARITY` operands as an array in storage
 	/// order.
 	constraints: &'a [C],
-	/// The number of constants the constraints may name.
-	n_constants: usize,
-	/// The number of inout values the constraints may name.
-	n_inout: usize,
-	/// The number of private values the constraints may name.
-	n_hidden: usize,
 }
 
 impl<'a, C, const ARITY: usize> OperationEvalFn<'a, C, ARITY> {
 	/// Wraps an operation's constraints for monster-multilinear evaluation.
-	///
-	/// The three counts are the segment lengths of the system holding the constraints. They are
-	/// what the word-index tensor is cut along when the input is split back apart, so
-	/// [`encode_operation_input`] must be given runs of matching lengths.
-	pub const fn new(
-		constraints: &'a [C],
-		n_constants: usize,
-		n_inout: usize,
-		n_hidden: usize,
-	) -> Self {
-		Self {
-			constraints,
-			n_constants,
-			n_inout,
-			n_hidden,
-		}
-	}
-
-	/// Splits the flat [`FieldFn`] input into its sections.
-	///
-	/// The `r_x'` section has `ceil(log2(constraints.len()))` entries — the reductions run over the
-	/// constraint count rounded up to a power of two — so the split needs no state beyond the
-	/// constraints.
-	///
-	/// Two shift-scalar tables follow, one per slot of a term's shift sequence.
-	/// Each is [`SHIFT_COUNT`] entries wide; see [`ShiftScalars`] for why the weight splits that
-	/// way.
-	///
-	/// The word-index tensor arrives as one run per value segment, in
-	/// [`ValueSegment`](binius_core::constraint_system::ValueSegment) order, and
-	/// comes back as an array indexed by that segment. An operand term is then read at
-	/// `r_y_tensor[segment][index]`, which is the term's own `(segment, index)` pair — no address
-	/// arithmetic in between. The runs hold only the words a constraint can name, so the padding
-	/// between sections never reaches the input.
-	fn split_input<'i, E>(
-		&self,
-		input: &'i [E],
-	) -> (&'i [E], &'i E, ShiftScalars<'i, E>, [&'i [E]; 3]) {
-		let n_vars = log2_ceil_usize(self.constraints.len());
-		let (r_x_prime, rest) = input.split_at(n_vars);
-		let (lambda, rest) = rest.split_first().expect("input encodes lambda");
-		let (inner, rest) = rest.split_at(SHIFT_COUNT);
-		let (outer, rest) = rest.split_at(SHIFT_COUNT);
-		let shift_scalars = ShiftScalars {
-			inner: inner
-				.try_into()
-				.expect("input encodes the inner shift scalars"),
-			outer: outer
-				.try_into()
-				.expect("input encodes the outer shift scalars"),
-		};
-
-		let (constants, rest) = rest.split_at(self.n_constants);
-		let (inout, rest) = rest.split_at(self.n_inout);
-		let (hidden, _) = rest.split_at(self.n_hidden);
-
-		(r_x_prime, lambda, shift_scalars, [constants, inout, hidden])
+	pub const fn new(constraints: &'a [C]) -> Self {
+		Self { constraints }
 	}
 }
 
@@ -158,39 +90,6 @@ impl<E> Clone for WiringWeights<'_, E> {
 }
 
 impl<E> Copy for WiringWeights<'_, E> {}
-
-/// The shift-sequence weight tables, one per slot of the sequence.
-///
-/// A term's sequence weight factorizes across its two slots:
-///
-/// ```text
-/// eq(r_v1, v_1) * eq(r_s1, s_1)  *  eq(r_v2, v_2) * eq(r_s2, s_2)
-/// \_______ inner table _______/     \_______ outer table ______/
-/// ```
-///
-/// One table per slot holds the weights at `2 * SHIFT_COUNT` = 1,024 entries.
-/// Keying a single table on the whole sequence would need `SHIFT_COUNT^2` = 262,144.
-/// Fanning that out over the operand batching coefficients reaches roughly 1.5M multiplications at
-/// BMUL's arity of six.
-///
-/// The cost of the split is one extra multiply per term.
-pub struct ShiftScalars<'a, E> {
-	/// The weight of each spelling the inner shift slot can take, with the operand batching
-	/// coefficients yet to be fanned in.
-	pub inner: &'a [E; SHIFT_COUNT],
-	/// The weight of each spelling the outer shift slot can take.
-	pub outer: &'a [E; SHIFT_COUNT],
-}
-
-// Two shared slices copy freely whatever `E` is. Deriving these would demand `E: Copy`, which the
-// generic evaluation path does not have.
-impl<E> Clone for ShiftScalars<'_, E> {
-	fn clone(&self) -> Self {
-		*self
-	}
-}
-
-impl<E> Copy for ShiftScalars<'_, E> {}
 
 impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARITY> {
 	/// Every nonzero of the wiring tensor, in constraint order.
@@ -252,41 +151,31 @@ impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARIT
 		}
 		acc
 	}
-}
 
-impl<F, C, const ARITY: usize> FieldFn<F> for OperationEvalFn<'_, C, ARITY>
-where
-	F: BinaryField,
-	C: AsRef<[Operand; ARITY]> + Sync,
-{
-	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, input: &[E]) -> E {
-		let (r_x_prime, lambda, shift_scalars, r_y_tensor) = self.split_input(input);
-
-		let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
-		// The batching coefficients fan into the inner table only, holding it to
-		// `SHIFT_COUNT * arity`; the outer weight multiplies in per term.
-		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, lambda, ARITY);
-
-		// One contribution per constraint.
-		// Each term is weighted by its two slots' shift scalars and its word-index tensor entry.
-		// The running sum then scales by the constraint-index tensor entry.
-		//
-		// The tensor covers the padded constraint count, so the zip stops at the last real
-		// constraint; padding rows carry no operand terms and contribute nothing.
+	/// Evaluates the monster multilinear against one weight table per axis.
+	///
+	/// This is [`contract`](Self::contract)'s sum, grouped by constraint: a constraint's weight
+	/// multiplies in once for the whole constraint rather than once per term. Grouping is exact,
+	/// so the two agree; it is the cheaper path, and the one a circuit runs.
+	///
+	/// The constraint table covers the padded constraint count, so the walk stops at the last real
+	/// constraint; padding rows carry no operand terms and contribute nothing.
+	pub fn call<E: FieldOps>(&self, weights: WiringWeights<'_, E>) -> E {
 		let mut eval = E::zero();
-		for (constraint, r_x_prime_entry) in iter::zip(self.constraints, &r_x_prime_tensor) {
+		for (constraint, constraint_weight) in iter::zip(self.constraints, weights.constraint) {
 			let mut constraint_eval = E::zero();
 			for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 				for svi in operand {
-					let inner = svi.inner().index() * ARITY + operand_id;
-					let outer = svi.outer().index();
-					constraint_eval += operand_shift_scalars[inner].clone()
-						* &shift_scalars.outer[outer]
-						* &r_y_tensor[svi.value_index.segment() as usize]
+					// Two axes share one table: the inner slot's spelling with the operand
+					// innermost.
+					let inner_operand = svi.inner().index() * ARITY + operand_id;
+					constraint_eval += weights.inner_operand[inner_operand].clone()
+						* &weights.outer[svi.outer().index()]
+						* &weights.value[svi.value_index.segment() as usize]
 							[svi.value_index.index() as usize];
 				}
 			}
-			eval += constraint_eval * r_x_prime_entry;
+			eval += constraint_eval * constraint_weight;
 		}
 
 		eval
@@ -297,76 +186,41 @@ where
 	/// Produces the identical result, but defers the `GF(2^128)` reductions: the per-constraint
 	/// contributions accumulate into a single *unreduced* wide element, reduced exactly once at the
 	/// end (reduction is `F`-linear, so this equals reducing each per-constraint product and
-	/// summing). The generic [`call`](FieldFn::call) can't do this because `E: FieldOps` does not
+	/// summing). The generic [`call`](Self::call) can't do this because `E: FieldOps` does not
 	/// imply `WideMul`.
-	fn call_native(&self, input: &[F]) -> F {
-		let (r_x_prime, lambda, shift_scalars, r_y_tensor) = self.split_input(input);
-
-		// The packed expansion threads the tensor's multiplications.
-		// It applies over the base field, which is its own single-element packing.
-		let r_x_prime_tensor = eq_ind_partial_eval::<F>(r_x_prime);
-		let operand_shift_scalars = operand_shift_scalar_table(shift_scalars.inner, lambda, ARITY);
-
+	pub fn call_native<F: BinaryField>(&self, weights: WiringWeights<'_, F>) -> F
+	where
+		C: Sync,
+	{
 		// One unreduced wide product per constraint. The constraints partition cleanly across
 		// rayon: each produces a single wide element and they are summed, so there is no large
-		// per-task accumulator. The single final reduction is `F`-linear. The tensor covers the
-		// padded constraint count, so the zip stops at the last real constraint; the padding rows
-		// have no operand terms and contribute nothing.
+		// per-task accumulator. The single final reduction is `F`-linear. The constraint table
+		// covers the padded constraint count, so the zip stops at the last real constraint; the
+		// padding rows have no operand terms and contribute nothing.
 		//
 		// A constraint names only a handful of terms.
 		// So a minimum task size keeps each task above rayon's own handoff cost.
 		let eval = self
 			.constraints
 			.par_iter()
-			.zip(r_x_prime_tensor.as_ref().par_iter())
+			.zip(weights.constraint.par_iter())
 			.with_min_task(WorkPerItem::FieldMuls)
-			.map(|(constraint, &r_x_prime_entry)| {
+			.map(|(constraint, &constraint_weight)| {
 				let mut constraint_eval = F::ZERO;
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
-						let inner = svi.inner().index() * ARITY + operand_id;
-						let outer = svi.outer().index();
-						constraint_eval += operand_shift_scalars[inner]
-							* shift_scalars.outer[outer]
-							* r_y_tensor[svi.value_index.segment() as usize]
+						let inner_operand = svi.inner().index() * ARITY + operand_id;
+						constraint_eval += weights.inner_operand[inner_operand]
+							* weights.outer[svi.outer().index()]
+							* weights.value[svi.value_index.segment() as usize]
 								[svi.value_index.index() as usize];
 					}
 				}
-				F::wide_mul(constraint_eval, r_x_prime_entry)
+				F::wide_mul(constraint_eval, constraint_weight)
 			})
 			.sum::<<F as WideMul>::Output>();
 		F::reduce(eval)
 	}
-}
-
-/// Builds the flat [`FieldFn`] input consumed by [`OperationEvalFn`].
-///
-/// Concatenates `r_x_prime ++ [lambda] ++ inner_shift_scalars ++ outer_shift_scalars ++
-/// r_y_tensor`. `OperationEvalFn::split_input` is the inverse; it recovers the `r_x'` length from
-/// the constraint count, so only `lambda` and the two fixed-length shift-scalar tables need a known
-/// position.
-pub fn encode_operation_input<E: Clone>(
-	r_x_prime: &[E],
-	lambda: E,
-	shift_scalars: ShiftScalars<'_, E>,
-	r_y_tensor: [&[E]; 3],
-) -> Vec<E> {
-	let n_words = r_y_tensor
-		.iter()
-		.map(|segment| segment.len())
-		.sum::<usize>();
-	let mut input = Vec::with_capacity(r_x_prime.len() + 1 + 2 * SHIFT_COUNT + n_words);
-	input.extend_from_slice(r_x_prime);
-	input.push(lambda);
-	// The inner table leads the outer one, which is the order `split_input` cuts them back apart.
-	input.extend_from_slice(shift_scalars.inner);
-	input.extend_from_slice(shift_scalars.outer);
-	// One run per value segment, in `ValueSegment` order, which is how `split_input` cuts them
-	// back apart.
-	for segment in r_y_tensor {
-		input.extend_from_slice(segment);
-	}
-	input
 }
 
 /// Folds the operand batching coefficients (λ powers) into the inner slot's shift scalars,
@@ -376,7 +230,7 @@ pub fn encode_operation_input<E: Clone>(
 /// The fan-out stays on this one table.
 /// A term's outer-slot weight multiplies in where the term is read.
 /// So the table is `SHIFT_COUNT * arity` entries rather than `SHIFT_COUNT^2 * arity`.
-fn operand_shift_scalar_table<E: FieldOps>(
+pub fn operand_shift_scalar_table<E: FieldOps>(
 	shift_scalars: &[E; SHIFT_COUNT],
 	lambda: &E,
 	arity: usize,
@@ -403,6 +257,7 @@ mod tests {
 	};
 	use binius_field::{Field, Ghash128b, Random};
 	use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, test_utils::random_scalars};
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use rand::prelude::*;
 
 	use super::{super::SHIFT_VARIANT_COUNT, *};
@@ -457,6 +312,21 @@ mod tests {
 			.collect()
 	}
 
+	/// The weight tables a run's own reduction reads, one per axis of the wiring tensor.
+	fn run_weights<'a, F: BinaryField>(
+		r_x_prime_tensor: &'a [F],
+		inner_operand: &'a [F],
+		outer: &'a [F; SHIFT_COUNT],
+		value: [&'a [F]; 3],
+	) -> WiringWeights<'a, F> {
+		WiringWeights {
+			constraint: r_x_prime_tensor,
+			inner_operand,
+			outer,
+			value,
+		}
+	}
+
 	#[test]
 	fn evaluate_monster_scales_by_the_outer_slot_weight() {
 		// Invariant: the outer slot's weight reaches every term, and reaches it as a factor.
@@ -476,14 +346,13 @@ mod tests {
 		let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 		let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
-		let eval_fn = OperationEvalFn::new(&constraints, 0, 0, n_words);
+		let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
+		let inner_operand =
+			operand_shift_scalar_table(&inner, &lambda, constraints[0].as_ref().len());
+
+		let eval_fn = OperationEvalFn::new(&constraints);
 		let eval_with_outer = |outer: &[F; SHIFT_COUNT]| {
-			let shift_scalars = ShiftScalars {
-				inner: &inner,
-				outer,
-			};
-			let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
-			eval_fn.call_native(&input)
+			eval_fn.call_native(run_weights(&r_x_prime_tensor, &inner_operand, outer, r_y_tensor))
 		};
 
 		let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
@@ -514,30 +383,15 @@ mod tests {
 				}))
 			})
 			.collect::<Vec<_>>();
-		let shift_scalars = ShiftScalars {
-			inner: &inner,
-			outer: &identity_selecting,
-		};
-		let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
 		assert_eq!(
 			eval_with_outer(&identity_selecting),
-			OperationEvalFn::new(&singly_shifted_only, 0, 0, n_words).call_native(&input)
+			OperationEvalFn::new(&singly_shifted_only).call_native(run_weights(
+				&r_x_prime_tensor,
+				&inner_operand,
+				&identity_selecting,
+				r_y_tensor
+			))
 		);
-	}
-
-	/// The weight tables a run's own reduction reads, matching the flat input it encodes.
-	fn run_weights<'a, F: BinaryField>(
-		r_x_prime_tensor: &'a [F],
-		inner_operand: &'a [F],
-		outer: &'a [F; SHIFT_COUNT],
-		value: [&'a [F]; 3],
-	) -> WiringWeights<'a, F> {
-		WiringWeights {
-			constraint: r_x_prime_tensor,
-			inner_operand,
-			outer,
-			value,
-		}
 	}
 
 	#[test]
@@ -565,25 +419,15 @@ mod tests {
 			let hidden = random_scalars::<F>(&mut rng, n_words);
 			let value = [&[][..], &[][..], &hidden[..]];
 
-			let eval_fn = OperationEvalFn::new(&constraints, 0, 0, n_words);
+			let eval_fn = OperationEvalFn::new(&constraints);
 
-			// The grouped path reads one flat input.
-			let input = encode_operation_input(
-				&r_x_prime,
-				lambda,
-				ShiftScalars {
-					inner: &inner,
-					outer: &outer,
-				},
-				value,
-			);
-			let batched = eval_fn.call::<F>(&input);
-
-			// The flat path reads the same weights, one table per axis.
+			// Both paths read the same weights, one table per axis.
 			let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
 			let inner_operand = operand_shift_scalar_table(&inner, &lambda, arity);
-			let contracted =
-				eval_fn.contract(run_weights(&r_x_prime_tensor, &inner_operand, &outer, value));
+			let weights = run_weights(&r_x_prime_tensor, &inner_operand, &outer, value);
+
+			let batched = eval_fn.call::<F>(weights);
+			let contracted = eval_fn.contract(weights);
 
 			// A vacuous agreement on zero would prove nothing about which nonzeros were read.
 			assert_ne!(batched, F::ZERO, "the fixture must evaluate to something");
@@ -608,7 +452,7 @@ mod tests {
 		let n_constraints = 16usize;
 		let constraints = random_and_constraints(&mut rng, n_constraints, n_words);
 		let arity = constraints[0].as_ref().len();
-		let eval_fn = OperationEvalFn::new(&constraints, 0, 0, n_words);
+		let eval_fn = OperationEvalFn::new(&constraints);
 
 		// Every occupied position, plus one deliberately empty one to show the test can fail.
 		let occupied = eval_fn.entries().collect::<Vec<_>>();
@@ -676,7 +520,7 @@ mod tests {
 			vec![ShiftedValueIndex::new(v1, [s_a, s_b])],
 			vec![],
 		])];
-		let eval_fn = OperationEvalFn::new(&constraints, 0, 0, 2);
+		let eval_fn = OperationEvalFn::new(&constraints);
 
 		// The enumeration reports the repeat as two entries: cancellation is the field's doing.
 		let entries = eval_fn.entries().collect::<Vec<_>>();
@@ -719,17 +563,17 @@ mod tests {
 			// it from the inner table, would disagree with the other.
 			let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 			let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
-			let shift_scalars = ShiftScalars {
-				inner: &inner,
-				outer: &outer,
-			};
 			let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 			let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
-			let eval_fn = OperationEvalFn::new(&constraints, 0, 0, n_words);
-			let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
-			let generic = eval_fn.call::<F>(&input);
-			let native = eval_fn.call_native(&input);
+			let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
+			let inner_operand =
+				operand_shift_scalar_table(&inner, &lambda, constraints[0].as_ref().len());
+			let weights = run_weights(&r_x_prime_tensor, &inner_operand, &outer, r_y_tensor);
+
+			let eval_fn = OperationEvalFn::new(&constraints);
+			let generic = eval_fn.call::<F>(weights);
+			let native = eval_fn.call_native(weights);
 			assert_eq!(generic, native, "n_constraints = {n_constraints}");
 		}
 	}
@@ -738,8 +582,8 @@ mod tests {
 	/// has no operand terms, so it contributes nothing. This is what lets the constraint system
 	/// keep its true count while the reductions run over the padded one.
 	///
-	/// [`FieldFn::call`] and [`FieldFn::call_native`] walk the constraints over independent zips,
-	/// so both are checked.
+	/// [`OperationEvalFn::call`] and [`OperationEvalFn::call_native`] walk the constraints over
+	/// independent zips, so both are checked.
 	#[test]
 	fn evaluate_monster_ignores_zero_padding_constraints() {
 		type F = Ghash128b;
@@ -761,21 +605,21 @@ mod tests {
 		let lambda = F::random(&mut rng);
 		let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 		let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
-		let shift_scalars = ShiftScalars {
-			inner: &inner,
-			outer: &outer,
-		};
 		let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 		let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
-		let input = encode_operation_input(&r_x_prime, lambda, shift_scalars, r_y_tensor);
+		let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
+		let inner_operand =
+			operand_shift_scalar_table(&inner, &lambda, constraints[0].as_ref().len());
+		let weights = run_weights(&r_x_prime_tensor, &inner_operand, &outer, r_y_tensor);
+
 		assert_eq!(
-			OperationEvalFn::new(&constraints, 0, 0, n_words).call::<F>(&input),
-			OperationEvalFn::new(&padded, 0, 0, n_words).call::<F>(&input)
+			OperationEvalFn::new(&constraints).call::<F>(weights),
+			OperationEvalFn::new(&padded).call::<F>(weights)
 		);
 		assert_eq!(
-			OperationEvalFn::new(&constraints, 0, 0, n_words).call_native(&input),
-			OperationEvalFn::new(&padded, 0, 0, n_words).call_native(&input)
+			OperationEvalFn::new(&constraints).call_native(weights),
+			OperationEvalFn::new(&padded).call_native(weights)
 		);
 	}
 }

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -4,28 +4,29 @@
 use std::iter;
 
 use binius_core::constraint_system::{Operand, ValueIndex};
-use binius_field::{BinaryField, FieldOps, WideMul, util::powers};
+use binius_field::{BinaryField, FieldOps, WideMul};
 use binius_utils::rayon::{
 	prelude::*,
 	task_size::{IndexedParallelIteratorExt, WorkPerItem},
 };
 
-use super::SHIFT_COUNT;
+use super::LOG_MAX_ARITY;
 
 /// The evaluation of one operation's monster multilinear polynomial.
 ///
-/// The monster multilinear encodes all `ARITY`-operand constraints of a single operation (BitAnd,
-/// IntMul or BinMul) into one polynomial:
+/// The monster multilinear encodes all `ARITY`-operand constraints of a single operation (Zero,
+/// BitAnd, IntMul or BinMul) into one polynomial:
 ///
 /// $$
 /// \sum_{\text{m_idx} \in \text{enumerate(operands)}}
-///     \lambda^{\text{m_idx}+1}
+///     \text{eq}(r_m, \text{m_idx})
 ///     \sum_{\text{op}} h_{\text{op}}(r_j, r_s) \cdot M_{\text{m}, \text{op}}(r_x', r_y, r_s)
 /// $$
 ///
 /// where `m_idx` indexes the operand position (0 to `ARITY - 1`), `op` ranges over the shift
 /// variants, `h_op` is the shift selector polynomial, and `M_{m,op}` is the multilinear extension
-/// of the operand values.
+/// of the operand values. The operand batching weight is the equality indicator of the operand
+/// axis, which the four operations share.
 ///
 /// Both evaluations read one borrowed weight table per axis, bundled as [`WiringWeights`]. The
 /// tables the four operations share are then built once by the caller and lent to all four, rather
@@ -73,10 +74,14 @@ pub struct WiringEntry {
 pub struct WiringWeights<'a, E> {
 	/// One entry per constraint index, covering the padded constraint count.
 	pub constraint: &'a [E],
-	/// One entry per inner slot spelling paired with an operand position, the operand innermost.
+	/// One entry per inner slot spelling paired with an operand position, the operand innermost:
+	/// `(inner_shift << LOG_MAX_ARITY) | operand`.
+	///
+	/// The operand axis is padded to a cube so that the table is a plain tensor expansion, which
+	/// is why its stride is `1 << LOG_MAX_ARITY` rather than the operation's own arity.
 	pub inner_operand: &'a [E],
-	/// One entry per outer slot spelling.
-	pub outer: &'a [E; SHIFT_COUNT],
+	/// One entry per outer slot spelling, `SHIFT_COUNT` of them.
+	pub outer: &'a [E],
 	/// One entry per value address, in three runs: constants, then inout, then private.
 	pub value: [&'a [E]; 3],
 }
@@ -125,7 +130,8 @@ impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARIT
 	///
 	/// ```text
 	///     sum over nonzeros of
-	///         constraint[i] * inner_operand[inner * ARITY + a] * outer[o] * value[seg][idx]
+	///         constraint[i] * inner_operand[(inner << LOG_MAX_ARITY) | a] * outer[o]
+	///             * value[seg][idx]
 	/// ```
 	///
 	/// Contract with equality indicators and the result is the tensor's multilinear extension.
@@ -143,7 +149,7 @@ impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARIT
 		let mut acc = E::zero();
 		for entry in self.entries() {
 			// Two axes share one table: the inner slot's spelling with the operand innermost.
-			let inner_operand = entry.inner_shift * ARITY + entry.operand;
+			let inner_operand = (entry.inner_shift << LOG_MAX_ARITY) | entry.operand;
 			acc += weights.constraint[entry.constraint].clone()
 				* &weights.inner_operand[inner_operand]
 				* &weights.outer[entry.outer_shift]
@@ -168,7 +174,7 @@ impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARIT
 				for svi in operand {
 					// Two axes share one table: the inner slot's spelling with the operand
 					// innermost.
-					let inner_operand = svi.inner().index() * ARITY + operand_id;
+					let inner_operand = (svi.inner().index() << LOG_MAX_ARITY) | operand_id;
 					constraint_eval += weights.inner_operand[inner_operand].clone()
 						* &weights.outer[svi.outer().index()]
 						* &weights.value[svi.value_index.segment() as usize]
@@ -209,7 +215,7 @@ impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARIT
 				let mut constraint_eval = F::ZERO;
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
-						let inner_operand = svi.inner().index() * ARITY + operand_id;
+						let inner_operand = (svi.inner().index() << LOG_MAX_ARITY) | operand_id;
 						constraint_eval += weights.inner_operand[inner_operand]
 							* weights.outer[svi.outer().index()]
 							* weights.value[svi.value_index.segment() as usize]
@@ -221,31 +227,6 @@ impl<C: AsRef<[Operand; ARITY]>, const ARITY: usize> OperationEvalFn<'_, C, ARIT
 			.sum::<<F as WideMul>::Output>();
 		F::reduce(eval)
 	}
-}
-
-/// Folds the operand batching coefficients (λ powers) into the inner slot's shift scalars,
-/// producing a table indexed by `(variant, amount, operand_id)` whose entry is
-/// `inner[variant * Word::BITS + amount] · λ^{operand_id + 1}`.
-///
-/// The fan-out stays on this one table.
-/// A term's outer-slot weight multiplies in where the term is read.
-/// So the table is `SHIFT_COUNT * arity` entries rather than `SHIFT_COUNT^2 * arity`.
-pub fn operand_shift_scalar_table<E: FieldOps>(
-	shift_scalars: &[E; SHIFT_COUNT],
-	lambda: &E,
-	arity: usize,
-) -> Vec<E> {
-	let lambda_powers = powers(lambda.clone())
-		.skip(1)
-		.take(arity)
-		.collect::<Vec<_>>();
-	let mut table = Vec::with_capacity(shift_scalars.len() * arity);
-	for shift_scalar in shift_scalars {
-		for lambda_power in &lambda_powers {
-			table.push(shift_scalar.clone() * lambda_power);
-		}
-	}
-	table
 }
 
 #[cfg(test)]
@@ -260,7 +241,10 @@ mod tests {
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use rand::prelude::*;
 
-	use super::{super::SHIFT_VARIANT_COUNT, *};
+	use super::{
+		super::{SHIFT_COUNT, SHIFT_VARIANT_COUNT},
+		*,
+	};
 
 	/// Builds `n_constraints` random arity-3 constraints (like `AndConstraint`), constraint-major:
 	/// one array of operands per constraint.
@@ -312,6 +296,9 @@ mod tests {
 			.collect()
 	}
 
+	/// The width of the inner table, which spans the operand axis as well as the shift axis.
+	const OPERAND_SHIFT_COUNT: usize = SHIFT_COUNT << LOG_MAX_ARITY;
+
 	/// The weight tables a run's own reduction reads, one per axis of the wiring tensor.
 	fn run_weights<'a, F: BinaryField>(
 		r_x_prime_tensor: &'a [F],
@@ -341,14 +328,11 @@ mod tests {
 		let n_words = 40usize;
 		let constraints = random_and_constraints(&mut rng, 32, n_words);
 		let r_x_prime = random_scalars::<F>(&mut rng, 5);
-		let lambda = F::random(&mut rng);
-		let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 		let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 		let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
 		let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
-		let inner_operand =
-			operand_shift_scalar_table(&inner, &lambda, constraints[0].as_ref().len());
+		let inner_operand = random_scalars::<F>(&mut rng, OPERAND_SHIFT_COUNT);
 
 		let eval_fn = OperationEvalFn::new(&constraints);
 		let eval_with_outer = |outer: &[F; SHIFT_COUNT]| {
@@ -410,11 +394,8 @@ mod tests {
 		// A power-of-two count, and one whose weight tensor runs past the last constraint.
 		for n_constraints in [64usize, 37] {
 			let constraints = random_and_constraints(&mut rng, n_constraints, n_words);
-			let arity = constraints[0].as_ref().len();
 
 			let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
-			let lambda = F::random(&mut rng);
-			let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 			let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 			let hidden = random_scalars::<F>(&mut rng, n_words);
 			let value = [&[][..], &[][..], &hidden[..]];
@@ -423,7 +404,7 @@ mod tests {
 
 			// Both paths read the same weights, one table per axis.
 			let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
-			let inner_operand = operand_shift_scalar_table(&inner, &lambda, arity);
+			let inner_operand = random_scalars::<F>(&mut rng, OPERAND_SHIFT_COUNT);
 			let weights = run_weights(&r_x_prime_tensor, &inner_operand, &outer, value);
 
 			let batched = eval_fn.call::<F>(weights);
@@ -469,8 +450,8 @@ mod tests {
 			// One indicator per axis: one at the target's index, zero everywhere else.
 			let mut constraint = vec![F::ZERO; n_constraints];
 			constraint[target.constraint] = F::ONE;
-			let mut inner_operand = vec![F::ZERO; SHIFT_COUNT * arity];
-			inner_operand[target.inner_shift * arity + target.operand] = F::ONE;
+			let mut inner_operand = vec![F::ZERO; OPERAND_SHIFT_COUNT];
+			inner_operand[(target.inner_shift << LOG_MAX_ARITY) | target.operand] = F::ONE;
 			let mut outer = [F::ZERO; SHIFT_COUNT];
 			outer[target.outer_shift] = F::ONE;
 			let mut hidden = vec![F::ZERO; n_words];
@@ -533,7 +514,7 @@ mod tests {
 		assert_eq!(entries[0], entries[1], "the repeat sits at one position");
 
 		// Weights of one everywhere: the sum is then the nonzero count mod two, which is one.
-		let ones_inner = vec![F::ONE; SHIFT_COUNT * 3];
+		let ones_inner = vec![F::ONE; OPERAND_SHIFT_COUNT];
 		let ones_outer = [F::ONE; SHIFT_COUNT];
 		let ones_value = [F::ONE; 2];
 		let got = eval_fn.contract(run_weights(
@@ -558,17 +539,14 @@ mod tests {
 			let constraints = random_and_constraints(&mut rng, n_constraints, n_words);
 
 			let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
-			let lambda = F::random(&mut rng);
 			// Both slots draw random weights, so a path that dropped the outer factor, or read
 			// it from the inner table, would disagree with the other.
-			let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 			let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 			let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 			let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
 			let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
-			let inner_operand =
-				operand_shift_scalar_table(&inner, &lambda, constraints[0].as_ref().len());
+			let inner_operand = random_scalars::<F>(&mut rng, OPERAND_SHIFT_COUNT);
 			let weights = run_weights(&r_x_prime_tensor, &inner_operand, &outer, r_y_tensor);
 
 			let eval_fn = OperationEvalFn::new(&constraints);
@@ -602,15 +580,12 @@ mod tests {
 			.collect::<Vec<_>>();
 
 		let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
-		let lambda = F::random(&mut rng);
-		let inner: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 		let outer: [F; SHIFT_COUNT] = std::array::from_fn(|_| F::random(&mut rng));
 		let hidden_tensor = random_scalars::<F>(&mut rng, n_words);
 		let r_y_tensor = [&[][..], &[][..], &hidden_tensor[..]];
 
 		let r_x_prime_tensor = eq_ind_partial_eval_scalars(&r_x_prime);
-		let inner_operand =
-			operand_shift_scalar_table(&inner, &lambda, constraints[0].as_ref().len());
+		let inner_operand = random_scalars::<F>(&mut rng, OPERAND_SHIFT_COUNT);
 		let weights = run_weights(&r_x_prime_tensor, &inner_operand, &outer, r_y_tensor);
 
 		assert_eq!(

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -28,7 +28,7 @@ use getset::Getters;
 
 use super::{
 	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_COUNT, OperationEvalFn, SHIFT_COUNT,
-	SHIFT_LOG_VARS, ShiftScalars, ZERO_ARITY, encode_operation_input, error::Error,
+	SHIFT_LOG_VARS, WiringWeights, ZERO_ARITY, error::Error, operand_shift_scalar_table,
 	shift_ind::evaluate_shift_inds,
 };
 
@@ -651,37 +651,93 @@ impl<'a> WiringEvalFn<'a> {
 	}
 }
 
-/// The per-operation [`OperationEvalFn`] inputs [`WiringEvalFn::operation_inputs`] splits out of
-/// its flat input slice. A `None` marks an operation with no constraints, whose reduction is
-/// skipped.
-struct OperationInputs<E> {
-	zero: Vec<E>,
-	bitand: Vec<E>,
-	intmul: Option<Vec<E>>,
-	binmul: Option<Vec<E>>,
+/// One operation's own weight tables, as [`WiringEvalFn::wiring_weights`] builds them.
+///
+/// The tables the four operations share live on [`WiringInputs`] beside these.
+struct OperationWeights<E> {
+	/// The equality indicator of the operation's constraint challenge, one weight per constraint.
+	constraint: Vec<E>,
+	/// The inner shift slot's weights with the operation's batching coefficients fanned in, at
+	/// `inner_shift * ARITY + operand`.
+	inner_operand: Vec<E>,
+}
+
+/// The weight tables [`WiringEvalFn::wiring_weights`] builds from its flat input slice.
+///
+/// The outer-slot and word-index tables are shared, so each is built once and lent to all four
+/// operations rather than copied per operation.
+struct WiringInputs<E> {
+	/// The Zero operation's own tables.
+	zero: OperationWeights<E>,
+	/// The BitAnd operation's own tables.
+	bitand: OperationWeights<E>,
+	/// The IntMul operation's own tables.
+	intmul: OperationWeights<E>,
+	/// The BinMul operation's own tables.
+	binmul: OperationWeights<E>,
+	/// The weight of each spelling the outer shift slot can take.
+	outer_shift_scalars: Box<[E; SHIFT_COUNT]>,
+	/// The word-index indicator over the public half of the value vector.
+	public_tensor: Vec<E>,
+	/// The word-index indicator over the hidden half of the value vector.
+	hidden_tensor: Vec<E>,
+}
+
+/// Bundles one operation's own tables with the two every operation shares.
+fn operation_weights<'a, E>(
+	operation: &'a OperationWeights<E>,
+	outer: &'a [E; SHIFT_COUNT],
+	value: [&'a [E]; 3],
+) -> WiringWeights<'a, E> {
+	WiringWeights {
+		constraint: &operation.constraint,
+		inner_operand: &operation.inner_operand,
+		outer,
+		value,
+	}
+}
+
+impl<E> WiringInputs<E> {
+	/// The word-index tensor cut into one run per value segment, which is what an operand term's
+	/// `(segment, index)` pair reads against.
+	///
+	/// The constants lead the public indicator and the private values trail the hidden one; the
+	/// inout values follow whichever indicator they are placed in. The padding words between the
+	/// runs are dropped, since no index can name one.
+	fn value_tensor(&self, cs: &ConstraintSystem, inout: InoutSegment) -> [&[E]; 3] {
+		match inout {
+			InoutSegment::Public => [
+				&self.public_tensor[..cs.n_const()],
+				&self.public_tensor[cs.offset_inout()..cs.offset_inout() + cs.n_inout],
+				&self.hidden_tensor[..cs.n_private],
+			],
+			InoutSegment::Hidden => [
+				&self.public_tensor[..cs.n_const()],
+				&self.hidden_tensor[..cs.n_inout],
+				&self.hidden_tensor[cs.n_inout..cs.n_inout + cs.n_private],
+			],
+		}
+	}
 }
 
 impl WiringEvalFn<'_> {
 	/// Shared setup for [`FieldFn::call`] and [`FieldFn::call_native`]: splits the flat `vals`
-	/// slice, builds the shared shift-scalar and word-index tensors, and re-encodes them (with each
-	/// operation's `r_x'` and `lambda`) into the per-operation [`OperationEvalFn`] input via
-	/// [`encode_operation_input`].
+	/// slice and builds one weight table per axis of each operation's wiring tensor.
 	///
-	/// The Zero and BitAnd inputs are always present; the IntMul and BinMul inputs are `None` when
-	/// that operation has no constraints and is skipped.
+	/// The expansion is supplied by the caller:
 	///
-	/// The scaled word-index expansion is supplied by the caller:
-	///
-	/// - That axis spans the whole trace, so it is the expansion worth threading.
+	/// - The word-index axis spans the whole trace, so it is the expansion worth threading.
 	/// - Only a concrete field element can cross threads, so the generic path stays serial.
-	fn operation_inputs<E: FieldOps>(
+	///
+	/// It is handed a scale as well as a point, since the two word-index tables carry one; the
+	/// constraint-index tables ask for a scale of one, which is the identity.
+	fn wiring_weights<E: FieldOps>(
 		&self,
 		vals: &[E],
 		scaled_expand: impl Fn(&[E], E) -> Vec<E>,
-	) -> OperationInputs<E> {
-		// Each operation's `r_x'` section is as long as its reduction has constraint variables, and
-		// [`OperationEvalFn::split_input`] re-derives that length from the constraint count alone.
-		// The two derivations must agree or both sides mis-split the same input. An absent IntMul
+	) -> WiringInputs<E> {
+		// Each operation's `r_x'` section is as long as its reduction has constraint variables, so
+		// its expansion covers the padded constraint count the evaluation walks. An absent IntMul
 		// (resp. BinMul) reduction contributes an empty point, which matches the `None` the
 		// accessor reports for an empty constraint set; so do the Zero and BitAnd reductions'
 		// single all-zero padding rows.
@@ -749,30 +805,13 @@ impl WiringEvalFn<'_> {
 		let public_tensor = scaled_expand(&r_y_v[..log_public_words], public_scale);
 		let hidden_tensor = scaled_expand(r_y_v, r_segment);
 
-		// Cut the two indicators into one run per value segment, which is what an operand term's
-		// `(segment, index)` pair reads against. The constants lead the public indicator and the
-		// private values trail the hidden one; the inout values follow whichever indicator they
-		// are placed in. The padding words between the runs are dropped, since no index can name
-		// one.
-		let r_y_tensor = match self.shape.inout {
-			InoutSegment::Public => [
-				&public_tensor[..cs.n_const()],
-				&public_tensor[cs.offset_inout()..cs.offset_inout() + cs.n_inout],
-				&hidden_tensor[..cs.n_private],
-			],
-			InoutSegment::Hidden => [
-				&public_tensor[..cs.n_const()],
-				&hidden_tensor[..cs.n_inout],
-				&hidden_tensor[cs.n_inout..cs.n_inout + cs.n_private],
-			],
-		};
 		// A term's sequence selects itself through an equality indicator over both slots' axes.
 		// The weight factorizes, so this is one table per slot rather than one over the whole
-		// sequence space — see the two-table split on the scalars type.
+		// sequence space.
 		//
-		// Both are built once, so the Zero, BitAnd, IntMul and BinMul monster evaluations share
-		// them. Each is indexed by `variant * Word::BITS + amount`. The bit-index factors scaling
-		// all of them are left for `check_eval` to multiply in.
+		// The outer table is built once, so the Zero, BitAnd, IntMul and BinMul evaluations share
+		// it. It is indexed by `variant * Word::BITS + amount`. The bit-index factors scaling it
+		// are left for `check_eval` to multiply in.
 		let slot_scalars = |r_s: &[E], r_v: &[E]| {
 			let eq_r_v = eq_ind_partial_eval_scalars(r_v);
 			let eq_r_s = eq_ind_partial_eval_scalars(r_s);
@@ -782,57 +821,68 @@ impl WiringEvalFn<'_> {
 		};
 		let inner_shift_scalars = slot_scalars(r_s_inner_v, r_v_inner_v);
 		let outer_shift_scalars = slot_scalars(r_s_outer_v, r_v_outer_v);
-		let shift_scalars = ShiftScalars {
-			inner: &inner_shift_scalars,
-			outer: &outer_shift_scalars,
+
+		// The inner table carries the operand batching coefficients, which differ per operation,
+		// so it is the one table each operation builds for itself. An operation with no
+		// constraints sums no terms, so it is handed empty tables and evaluates to zero.
+		let operation_weights = |r_x_prime: &[E], lambda: E, arity: usize, n_constraints: usize| {
+			if n_constraints == 0 {
+				return OperationWeights {
+					constraint: Vec::new(),
+					inner_operand: Vec::new(),
+				};
+			}
+			OperationWeights {
+				constraint: scaled_expand(r_x_prime, E::one()),
+				inner_operand: operand_shift_scalar_table(&inner_shift_scalars, &lambda, arity),
+			}
 		};
 
-		// Re-encode the shared tensors with each operation's `r_x'` and `lambda`. IntMul and BinMul
-		// are skipped (no input built) when they have no constraints.
-		let zero_input =
-			encode_operation_input(zero_r_x_prime_v, zero_lambda_v, shift_scalars, r_y_tensor);
-		let bitand_input =
-			encode_operation_input(bitand_r_x_prime_v, bitand_lambda_v, shift_scalars, r_y_tensor);
-		let intmul_input = (!self.constraint_system.imul_constraints.is_empty()).then(|| {
-			encode_operation_input(intmul_r_x_prime_v, intmul_lambda_v, shift_scalars, r_y_tensor)
-		});
-		let binmul_input = (!self.constraint_system.bmul_constraints.is_empty()).then(|| {
-			encode_operation_input(binmul_r_x_prime_v, binmul_lambda_v, shift_scalars, r_y_tensor)
-		});
-
-		OperationInputs {
-			zero: zero_input,
-			bitand: bitand_input,
-			intmul: intmul_input,
-			binmul: binmul_input,
+		WiringInputs {
+			zero: operation_weights(
+				zero_r_x_prime_v,
+				zero_lambda_v,
+				ZERO_ARITY,
+				cs.zero_constraints.len(),
+			),
+			bitand: operation_weights(
+				bitand_r_x_prime_v,
+				bitand_lambda_v,
+				BITAND_ARITY,
+				cs.and_constraints.len(),
+			),
+			intmul: operation_weights(
+				intmul_r_x_prime_v,
+				intmul_lambda_v,
+				INTMUL_ARITY,
+				cs.imul_constraints.len(),
+			),
+			binmul: operation_weights(
+				binmul_r_x_prime_v,
+				binmul_lambda_v,
+				BINMUL_ARITY,
+				cs.bmul_constraints.len(),
+			),
+			outer_shift_scalars,
+			public_tensor,
+			hidden_tensor,
 		}
 	}
 }
 
 impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
-		let OperationInputs {
-			zero: zero_input,
-			bitand: bitand_input,
-			intmul: intmul_input,
-			binmul: binmul_input,
-		} = self.operation_inputs(vals, scaled_eq_ind_partial_eval_scalars);
+		let inputs = self.wiring_weights(vals, scaled_eq_ind_partial_eval_scalars);
 		let cs = &self.constraint_system;
+		let value = inputs.value_tensor(cs, self.shape.inout);
+		let outer = &inputs.outer_shift_scalars;
+		// The outer and word-index tables are lent to all four; only the first two differ.
+		let weights = |operation| operation_weights(operation, outer, value);
 
-		let zero =
-			OperationEvalFn::new(&cs.zero_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call::<E>(&zero_input);
-		let bitand =
-			OperationEvalFn::new(&cs.and_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call::<E>(&bitand_input);
-		let intmul = intmul_input.map_or_else(E::zero, |input| {
-			OperationEvalFn::new(&cs.imul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call::<E>(&input)
-		});
-		let binmul = binmul_input.map_or_else(E::zero, |input| {
-			OperationEvalFn::new(&cs.bmul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call::<E>(&input)
-		});
+		let zero = OperationEvalFn::new(&cs.zero_constraints).call(weights(&inputs.zero));
+		let bitand = OperationEvalFn::new(&cs.and_constraints).call(weights(&inputs.bitand));
+		let intmul = OperationEvalFn::new(&cs.imul_constraints).call(weights(&inputs.intmul));
+		let binmul = OperationEvalFn::new(&cs.bmul_constraints).call(weights(&inputs.binmul));
 
 		zero + bitand + intmul + binmul
 	}
@@ -840,32 +890,22 @@ impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 	/// Native fast path: each operation's evaluation defers `WideMul` reductions (see
 	/// [`OperationEvalFn`]'s `call_native`).
 	fn call_native(&self, vals: &[F]) -> F {
-		let OperationInputs {
-			zero: zero_input,
-			bitand: bitand_input,
-			intmul: intmul_input,
-			binmul: binmul_input,
-		} = self.operation_inputs(vals, |point, scale| {
+		let inputs = self.wiring_weights(vals, |point, scale| {
 			// The packed expansion threads the tensor's multiplications.
 			// It applies over the base field, which is its own single-element packing.
 			scaled_eq_ind_partial_eval::<F>(point, scale).into_inner()
 		});
 		let cs = &self.constraint_system;
+		let value = inputs.value_tensor(cs, self.shape.inout);
+		let outer = &inputs.outer_shift_scalars;
+		let weights = |operation| operation_weights(operation, outer, value);
 
-		let zero =
-			OperationEvalFn::new(&cs.zero_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call_native(&zero_input);
-		let bitand =
-			OperationEvalFn::new(&cs.and_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call_native(&bitand_input);
-		let intmul = intmul_input.map_or(F::ZERO, |input| {
-			OperationEvalFn::new(&cs.imul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call_native(&input)
-		});
-		let binmul = binmul_input.map_or(F::ZERO, |input| {
-			OperationEvalFn::new(&cs.bmul_constraints, cs.n_const(), cs.n_inout, cs.n_private)
-				.call_native(&input)
-		});
+		let zero = OperationEvalFn::new(&cs.zero_constraints).call_native(weights(&inputs.zero));
+		let bitand = OperationEvalFn::new(&cs.and_constraints).call_native(weights(&inputs.bitand));
+		let intmul =
+			OperationEvalFn::new(&cs.imul_constraints).call_native(weights(&inputs.intmul));
+		let binmul =
+			OperationEvalFn::new(&cs.bmul_constraints).call_native(weights(&inputs.binmul));
 
 		zero + bitand + intmul + binmul
 	}

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, iter};
+use std::iter;
 
 use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
@@ -14,6 +14,7 @@ use binius_ip::{
 };
 use binius_math::{
 	BinarySubspace,
+	inner_product::inner_product,
 	line::extrapolate_line,
 	multilinear::{
 		eq::{
@@ -22,13 +23,14 @@ use binius_math::{
 		},
 		evaluate::evaluate_inplace_scalars,
 	},
-	univariate::{EvaluationDomain, evaluate_univariate},
+	univariate::EvaluationDomain,
 };
 use getset::Getters;
+use itertools::chain;
 
 use super::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_COUNT, OperationEvalFn, SHIFT_COUNT,
-	SHIFT_LOG_VARS, WiringWeights, ZERO_ARITY, error::Error, operand_shift_scalar_table,
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_MAX_ARITY, LOG_OPERATION_COUNT, LOG_SHIFT_COUNT,
+	OperationEvalFn, SHIFT_COUNT, SHIFT_LOG_VARS, WiringWeights, ZERO_ARITY, error::Error,
 	shift_ind::evaluate_shift_inds,
 };
 
@@ -87,12 +89,20 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 		Self { r_x_prime, evals }
 	}
 
-	// Batching is scaled by random lambda and therefore this batched
-	// evaluation claim can be added to other batched evaluation claims
-	// without further random scaling.
-	fn batched_eval(&self, lambda: F) -> F {
-		let eval = evaluate_univariate(&self.evals, &lambda);
-		lambda * eval
+	/// The operand claims collapsed into one value by the operand-axis equality tensor.
+	///
+	/// Operand `m` is weighted by `operand_weights[m]`. Combining the four operations is the
+	/// caller's step: their weights are distinct entries of the operation-axis tensor, so the
+	/// four values this returns pair with it as an inner product.
+	///
+	/// ## Preconditions
+	///
+	/// * `operand_weights` has at least `ARITY` entries; the slots above the arity name no claim.
+	fn batched_eval(&self, operand_weights: &[F]) -> F {
+		assert!(operand_weights.len() >= ARITY); // precondition
+		iter::zip(&self.evals, operand_weights)
+			.map(|(eval, weight)| eval.clone() * weight)
+			.sum()
 	}
 }
 
@@ -103,14 +113,12 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 /// verification steps including PCS verification.
 #[derive(Debug, Getters)]
 pub struct VerifyOutput<F> {
-	/// Random coefficient for batching ZERO constraint evaluations.
-	zero_lambda: F,
-	/// Random coefficient for batching AND constraint evaluations.
-	bitand_lambda: F,
-	/// Random coefficient for batching IMUL constraint evaluations.
-	intmul_lambda: F,
-	/// Random coefficient for batching BMUL constraint evaluations.
-	binmul_lambda: F,
+	/// The challenges whose equality indicator weights each operation in the batch (length
+	/// [`LOG_OPERATION_COUNT`]).
+	operation_batch_challenges: Vec<F>,
+	/// The challenges whose equality indicator weights each operand position, shared by the four
+	/// operations (length [`LOG_MAX_ARITY`]).
+	operand_batch_challenges: Vec<F>,
 	/// Challenge point for the witness bit index (length `Word::LOG_BITS`).
 	pub r_j: Vec<F>,
 	/// Challenge point for the inner shift's amount variables (length `Word::LOG_BITS`).
@@ -161,8 +169,8 @@ impl<F> VerifyOutput<F> {
 /// Verifies the shift protocol with a single sumcheck.
 ///
 /// # Protocol Overview
-/// 1. **Sampling Phase**: Samples random lambda coefficients for batching bitand, intmul and binmul
-///    evaluation claims across operands.
+/// 1. **Sampling Phase**: Samples the two challenge vectors whose equality indicators batch the
+///    four operations' evaluation claims across operands.
 /// 2. **Sumcheck**: Verifies the batched evaluation claim over all `SHIFT_LOG_VARS +
 ///    log_word_count` variables of the claim, degree 2 in each. A shifted value index names two
 ///    shifts applied in sequence, and the rounds peel them from the output end inward: the outer
@@ -204,15 +212,26 @@ where
 	F: BinaryField,
 	C: IPVerifierChannel<F>,
 {
-	let zero_lambda = channel.sample();
-	let bitand_lambda = channel.sample();
-	let intmul_lambda = channel.sample();
-	let binmul_lambda = channel.sample();
+	// SOUNDNESS: the prover draws these in the same order.
+	let operation_batch_challenges = channel.sample_many(LOG_OPERATION_COUNT);
+	let operand_batch_challenges = channel.sample_many(LOG_MAX_ARITY);
 
-	let eval = zero_data.batched_eval(zero_lambda.clone())
-		+ bitand_data.batched_eval(bitand_lambda.clone())
-		+ intmul_data.batched_eval(intmul_lambda.clone())
-		+ binmul_data.batched_eval(binmul_lambda.clone());
+	// A claim's batching weight is the product of the two axes' equality indicators, so the two
+	// expansions factor it: the operand tensor batches one operation's own claims, and the
+	// operation tensor combines the four. The operation weights are indexed in the order the four
+	// operator arguments are declared.
+	let operation_weights = eq_ind_partial_eval_scalars(&operation_batch_challenges);
+	let operand_weights = eq_ind_partial_eval_scalars(&operand_batch_challenges);
+
+	let eval = inner_product(
+		operation_weights,
+		[
+			zero_data.batched_eval(&operand_weights),
+			bitand_data.batched_eval(&operand_weights),
+			intmul_data.batched_eval(&operand_weights),
+			binmul_data.batched_eval(&operand_weights),
+		],
+	);
 
 	// The sumcheck runs over the witness as well: the public segment in the low half-cube and
 	// the hidden segment in the high half-cube, selected by the top word-index variable. Each
@@ -249,10 +268,8 @@ where
 	let witness_eval = channel.recv_one()?;
 
 	Ok(VerifyOutput {
-		zero_lambda,
-		bitand_lambda,
-		intmul_lambda,
-		binmul_lambda,
+		operation_batch_challenges,
+		operand_batch_challenges,
 		r_j,
 		r_y,
 		r_segment,
@@ -324,10 +341,8 @@ where
 	C::Elem: FieldOps<Scalar = F> + From<F>,
 {
 	let VerifyOutput {
-		zero_lambda,
-		bitand_lambda,
-		intmul_lambda,
-		binmul_lambda,
+		operation_batch_challenges,
+		operand_batch_challenges,
 		eval,
 		r_j,
 		r_s_inner,
@@ -364,7 +379,7 @@ where
 	let monster_eval = l_tilde_eval * shift_ind_eval * wiring_eval.clone();
 
 	// The function the caller checks the claim with, and the flat input it reads. Every entry is a
-	// public-channel-derived element (`bitand_lambda`, `intmul_lambda`, the operator data's
+	// public-channel-derived element (the two batching challenge vectors, the operator data's
 	// `r_x_prime` vectors, both shift slots' challenges, `r_y`, and `r_segment` last); the
 	// constraint system it sums over is fixed.
 	let claim = {
@@ -376,21 +391,22 @@ where
 		let r_v_len = r_v_inner.len();
 		let r_y_len = r_y.len();
 
-		let inputs: Vec<C::Elem> = iter::once(zero_lambda.clone())
-			.chain(iter::once(bitand_lambda.clone()))
-			.chain(iter::once(intmul_lambda.clone()))
-			.chain(iter::once(binmul_lambda.clone()))
-			.chain(zero_data.r_x_prime.iter().cloned())
-			.chain(bitand_data.r_x_prime.iter().cloned())
-			.chain(intmul_data.r_x_prime.iter().cloned())
-			.chain(binmul_data.r_x_prime.iter().cloned())
-			.chain(r_s_inner.iter().cloned())
-			.chain(r_v_inner.iter().cloned())
-			.chain(r_s_outer.iter().cloned())
-			.chain(r_v_outer.iter().cloned())
-			.chain(r_y.iter().cloned())
-			.chain(iter::once(r_segment.clone()))
-			.collect();
+		let inputs: Vec<C::Elem> = chain!(
+			operation_batch_challenges,
+			operand_batch_challenges,
+			&zero_data.r_x_prime,
+			&bitand_data.r_x_prime,
+			&intmul_data.r_x_prime,
+			&binmul_data.r_x_prime,
+			r_s_inner,
+			r_v_inner,
+			r_s_outer,
+			r_v_outer,
+			r_y,
+			iter::once(r_segment),
+		)
+		.cloned()
+		.collect();
 
 		let eval_fn = WiringEvalFn::new(
 			constraint_system,
@@ -562,7 +578,7 @@ impl<E> WiringEvalClaim<'_, E> {
 /// The inputs are the flat concatenation of these sections, in order:
 ///
 /// ```text
-/// zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_s_inner.. | r_v_inner.. | r_s_outer.. | r_v_outer.. | r_y.. | r_segment
+/// operation_batch_challenges.. | operand_batch_challenges.. | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_s_inner.. | r_v_inner.. | r_s_outer.. | r_v_outer.. | r_y.. | r_segment
 /// ```
 ///
 /// The stored lengths recover each variable-length section from that flat slice. Both shift slots
@@ -614,13 +630,15 @@ pub struct WiringEvalShape {
 impl WiringEvalShape {
 	/// The number of elements a claim of this shape reads.
 	///
-	/// - Four batching coefficients.
+	/// - The operation and operand batching challenges, both of fixed length.
 	/// - One constraint-index challenge vector per operator.
 	/// - Both shift slots.
 	/// - The column challenges.
 	/// - One trailing word-index coordinate.
 	pub const fn n_inputs(&self) -> usize {
-		4 + self.zero_r_x_prime_len
+		LOG_OPERATION_COUNT
+			+ LOG_MAX_ARITY
+			+ self.zero_r_x_prime_len
 			+ self.bitand_r_x_prime_len
 			+ self.intmul_r_x_prime_len
 			+ self.binmul_r_x_prime_len
@@ -651,48 +669,46 @@ impl<'a> WiringEvalFn<'a> {
 	}
 }
 
-/// One operation's own weight tables, as [`WiringEvalFn::wiring_weights`] builds them.
-///
-/// The tables the four operations share live on [`WiringInputs`] beside these.
-struct OperationWeights<E> {
-	/// The equality indicator of the operation's constraint challenge, one weight per constraint.
-	constraint: Vec<E>,
-	/// The inner shift slot's weights with the operation's batching coefficients fanned in, at
-	/// `inner_shift * ARITY + operand`.
-	inner_operand: Vec<E>,
-}
-
 /// The weight tables [`WiringEvalFn::wiring_weights`] builds from its flat input slice.
 ///
-/// The outer-slot and word-index tables are shared, so each is built once and lent to all four
-/// operations rather than copied per operation.
+/// Only the constraint-index table differs between operations. The other three are built once and
+/// lent to all four, rather than copied per operation.
+///
+/// Each constraint table is the equality indicator of its operation's constraint challenge, scaled
+/// by that operation's own weight on the operation axis. That is where the operation weight rides
+/// for free: it reaches every term of the operation, and seeding the expansion with it costs
+/// nothing beyond the expansion itself. An operation with no constraints sums no terms, so its
+/// table is left empty.
 struct WiringInputs<E> {
-	/// The Zero operation's own tables.
-	zero: OperationWeights<E>,
-	/// The BitAnd operation's own tables.
-	bitand: OperationWeights<E>,
-	/// The IntMul operation's own tables.
-	intmul: OperationWeights<E>,
-	/// The BinMul operation's own tables.
-	binmul: OperationWeights<E>,
+	/// The Zero operation's constraint-index table.
+	zero_constraint: Vec<E>,
+	/// The BitAnd operation's constraint-index table.
+	bitand_constraint: Vec<E>,
+	/// The IntMul operation's constraint-index table.
+	intmul_constraint: Vec<E>,
+	/// The BinMul operation's constraint-index table.
+	binmul_constraint: Vec<E>,
+	/// The weight of each `(inner shift, operand position)` pair, at
+	/// `(inner_shift << LOG_MAX_ARITY) | operand`.
+	operand_inner_shift_scalars: Vec<E>,
 	/// The weight of each spelling the outer shift slot can take.
-	outer_shift_scalars: Box<[E; SHIFT_COUNT]>,
+	outer_shift_scalars: Vec<E>,
 	/// The word-index indicator over the public half of the value vector.
 	public_tensor: Vec<E>,
 	/// The word-index indicator over the hidden half of the value vector.
 	hidden_tensor: Vec<E>,
 }
 
-/// Bundles one operation's own tables with the two every operation shares.
+/// Bundles one operation's constraint table with the three every operation shares.
 fn operation_weights<'a, E>(
-	operation: &'a OperationWeights<E>,
-	outer: &'a [E; SHIFT_COUNT],
+	constraint: &'a [E],
+	inputs: &'a WiringInputs<E>,
 	value: [&'a [E]; 3],
 ) -> WiringWeights<'a, E> {
 	WiringWeights {
-		constraint: &operation.constraint,
-		inner_operand: &operation.inner_operand,
-		outer,
+		constraint,
+		inner_operand: &inputs.operand_inner_shift_scalars,
+		outer: &inputs.outer_shift_scalars,
 		value,
 	}
 }
@@ -759,11 +775,10 @@ impl WiringEvalFn<'_> {
 		);
 
 		// Split the flat input back into its sections, in the order they were concatenated.
-		let zero_lambda_v = vals[0].clone();
-		let bitand_lambda_v = vals[1].clone();
-		let intmul_lambda_v = vals[2].clone();
-		let binmul_lambda_v = vals[3].clone();
-		let mut off = 4;
+		let operation_batch_v = &vals[..LOG_OPERATION_COUNT];
+		let mut off = LOG_OPERATION_COUNT;
+		let operand_batch_v = &vals[off..off + LOG_MAX_ARITY];
+		off += LOG_MAX_ARITY;
 		let zero_r_x_prime_v = &vals[off..off + self.shape.zero_r_x_prime_len];
 		off += self.shape.zero_r_x_prime_len;
 		let bitand_r_x_prime_v = &vals[off..off + self.shape.bitand_r_x_prime_len];
@@ -809,60 +824,52 @@ impl WiringEvalFn<'_> {
 		// The weight factorizes, so this is one table per slot rather than one over the whole
 		// sequence space.
 		//
-		// The outer table is built once, so the Zero, BitAnd, IntMul and BinMul evaluations share
-		// it. It is indexed by `variant * Word::BITS + amount`. The bit-index factors scaling it
-		// are left for `check_eval` to multiply in.
-		let slot_scalars = |r_s: &[E], r_v: &[E]| {
-			let eq_r_v = eq_ind_partial_eval_scalars(r_v);
-			let eq_r_s = eq_ind_partial_eval_scalars(r_s);
-			Box::new(array::from_fn::<_, SHIFT_COUNT, _>(|i| {
-				eq_r_v[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
-			}))
-		};
-		let inner_shift_scalars = slot_scalars(r_s_inner_v, r_v_inner_v);
-		let outer_shift_scalars = slot_scalars(r_s_outer_v, r_v_outer_v);
+		// A shift is indexed `variant * Word::BITS + amount`, the amount below the variant, so a
+		// slot's table is the expansion of the amount challenges followed by the variant ones.
+		// The operand batching weight rides below the shift in the inner table, since the
+		// expansion puts the first segment of a point in the low index bits.
+		//
+		// Both are built once, so the Zero, BitAnd, IntMul and BinMul evaluations share them. The
+		// bit-index factors scaling them are left for `check_eval` to multiply in.
+		let operand_inner_shift_scalars =
+			eq_ind_partial_eval_scalars(&[operand_batch_v, r_s_inner_v, r_v_inner_v].concat());
+		let outer_shift_scalars = eq_ind_partial_eval_scalars(&[r_s_outer_v, r_v_outer_v].concat());
+		debug_assert_eq!(outer_shift_scalars.len(), SHIFT_COUNT);
 
-		// The inner table carries the operand batching coefficients, which differ per operation,
-		// so it is the one table each operation builds for itself. An operation with no
-		// constraints sums no terms, so it is handed empty tables and evaluates to zero.
-		let operation_weights = |r_x_prime: &[E], lambda: E, arity: usize, n_constraints: usize| {
+		// One weight per operation, indexed in the order the operator arguments are declared,
+		// which is the order `verify` batches its four claims in. It seeds the operation's own
+		// constraint expansion, which is the one table left that differs between operations.
+		let operation_weights = eq_ind_partial_eval_scalars(operation_batch_v);
+		let constraint_table = |r_x_prime: &[E], weight: &E, n_constraints: usize| {
 			if n_constraints == 0 {
-				return OperationWeights {
-					constraint: Vec::new(),
-					inner_operand: Vec::new(),
-				};
-			}
-			OperationWeights {
-				constraint: scaled_expand(r_x_prime, E::one()),
-				inner_operand: operand_shift_scalar_table(&inner_shift_scalars, &lambda, arity),
+				Vec::new()
+			} else {
+				scaled_expand(r_x_prime, weight.clone())
 			}
 		};
 
 		WiringInputs {
-			zero: operation_weights(
+			zero_constraint: constraint_table(
 				zero_r_x_prime_v,
-				zero_lambda_v,
-				ZERO_ARITY,
+				&operation_weights[0],
 				cs.zero_constraints.len(),
 			),
-			bitand: operation_weights(
+			bitand_constraint: constraint_table(
 				bitand_r_x_prime_v,
-				bitand_lambda_v,
-				BITAND_ARITY,
+				&operation_weights[1],
 				cs.and_constraints.len(),
 			),
-			intmul: operation_weights(
+			intmul_constraint: constraint_table(
 				intmul_r_x_prime_v,
-				intmul_lambda_v,
-				INTMUL_ARITY,
+				&operation_weights[2],
 				cs.imul_constraints.len(),
 			),
-			binmul: operation_weights(
+			binmul_constraint: constraint_table(
 				binmul_r_x_prime_v,
-				binmul_lambda_v,
-				BINMUL_ARITY,
+				&operation_weights[3],
 				cs.bmul_constraints.len(),
 			),
+			operand_inner_shift_scalars,
 			outer_shift_scalars,
 			public_tensor,
 			hidden_tensor,
@@ -875,14 +882,18 @@ impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 		let inputs = self.wiring_weights(vals, scaled_eq_ind_partial_eval_scalars);
 		let cs = &self.constraint_system;
 		let value = inputs.value_tensor(cs, self.shape.inout);
-		let outer = &inputs.outer_shift_scalars;
-		// The outer and word-index tables are lent to all four; only the first two differ.
-		let weights = |operation| operation_weights(operation, outer, value);
+		// Three of the four tables are lent to all four operations; only the constraint one
+		// differs, and it is what carries the operation's own batching weight.
+		let weights = |constraint| operation_weights(constraint, &inputs, value);
 
-		let zero = OperationEvalFn::new(&cs.zero_constraints).call(weights(&inputs.zero));
-		let bitand = OperationEvalFn::new(&cs.and_constraints).call(weights(&inputs.bitand));
-		let intmul = OperationEvalFn::new(&cs.imul_constraints).call(weights(&inputs.intmul));
-		let binmul = OperationEvalFn::new(&cs.bmul_constraints).call(weights(&inputs.binmul));
+		let zero =
+			OperationEvalFn::new(&cs.zero_constraints).call(weights(&inputs.zero_constraint));
+		let bitand =
+			OperationEvalFn::new(&cs.and_constraints).call(weights(&inputs.bitand_constraint));
+		let intmul =
+			OperationEvalFn::new(&cs.imul_constraints).call(weights(&inputs.intmul_constraint));
+		let binmul =
+			OperationEvalFn::new(&cs.bmul_constraints).call(weights(&inputs.binmul_constraint));
 
 		zero + bitand + intmul + binmul
 	}
@@ -897,15 +908,16 @@ impl<F: BinaryField> FieldFn<F> for WiringEvalFn<'_> {
 		});
 		let cs = &self.constraint_system;
 		let value = inputs.value_tensor(cs, self.shape.inout);
-		let outer = &inputs.outer_shift_scalars;
-		let weights = |operation| operation_weights(operation, outer, value);
+		let weights = |constraint| operation_weights(constraint, &inputs, value);
 
-		let zero = OperationEvalFn::new(&cs.zero_constraints).call_native(weights(&inputs.zero));
-		let bitand = OperationEvalFn::new(&cs.and_constraints).call_native(weights(&inputs.bitand));
-		let intmul =
-			OperationEvalFn::new(&cs.imul_constraints).call_native(weights(&inputs.intmul));
-		let binmul =
-			OperationEvalFn::new(&cs.bmul_constraints).call_native(weights(&inputs.binmul));
+		let zero = OperationEvalFn::new(&cs.zero_constraints)
+			.call_native(weights(&inputs.zero_constraint));
+		let bitand = OperationEvalFn::new(&cs.and_constraints)
+			.call_native(weights(&inputs.bitand_constraint));
+		let intmul = OperationEvalFn::new(&cs.imul_constraints)
+			.call_native(weights(&inputs.intmul_constraint));
+		let binmul = OperationEvalFn::new(&cs.bmul_constraints)
+			.call_native(weights(&inputs.binmul_constraint));
 
 		zero + bitand + intmul + binmul
 	}


### PR DESCRIPTION
Closes [BINIUS-559](https://linear.app/jimpo/issue/BINIUS-559/batch-shift-reduction-operand-claims-with-tensor-weights-instead-of).

Replaces the shift reduction's four per-operation lambdas with two challenge vectors, and makes a
claim's batching weight the product of their equality indicators:

```
batched_eval = sum_op sum_{m < arity(op)}  eq(operation_batch_challenges, op)
                                         * eq(operand_batch_challenges, m) * e_{op,m}
```

The operand weights then no longer differ between operations, so the table that fans them into the
shift scalars is built **once** instead of four times, and becomes a plain tensor expansion rather
than a bespoke fan-out. The operation weight is a single scalar, which rides for free in the
constraint-index expansion's seed.

**Transcript change**: 4 samples become 5 (2 for the operation axis, then 3 for the operand axis),
so recorded proofs need regenerating. Soundness is unchanged in practice — the old scheme is a
degree-≤6 polynomial in four challenges (error ≤ 6/|F|), the new one a multilinear in five
(error ≤ 5/|F|).

### Commits

**1. `Hand the shift-scalar tables to the monster evaluation by reference`**

`OperationEvalFn`'s two evaluations now read [`WiringWeights`] — the borrowed per-axis bundle
#2361 introduced for `contract` — instead of a flat `FieldFn` input they had to be copied into.
`ShiftScalars`, `encode_operation_input`, `split_input` and the three segment-length fields all
delete; `call` and `contract` end up reading the same four tables, which is what lets the shared
ones be built once and lent to all four operations. Net −360/+250 lines, no behaviour change.

*This is the one design call worth a look.* The issue proposed a new borrowed field on
`OperationEvalFn` alongside a shrunken flat input; routing through `WiringWeights` instead converges
with #2361 rather than standing up a second bundle beside it. Happy to split this back out into its
own PR if you'd rather review it separately from the protocol change.

**2. `Batch shift-reduction operand claims with tensor weights`**

The protocol change itself, verifier and prover in lockstep (the transcript order is shared, so the
two cannot land apart).

- `mod.rs` — `OPERATION_COUNT`, `LOG_OPERATION_COUNT`, `LOG_MAX_ARITY`, hardcoded with `const _`
  asserts against the four arities.
- `verify.rs` — samples the two vectors in place of four scalars; `OperatorData::batched_eval`
  becomes an inner product against the operand tensor prefix, scaled by the operation weight; the
  wiring claim's input header goes from four lambdas to the five challenges, so `n_inputs` is the
  only shape change.
- `monster.rs` — `operand_shift_scalar_table` deletes; the inner table is indexed
  `(shift_index << LOG_MAX_ARITY) | operand_id`, which is one expansion of one concatenated point.
- prover `claims.rs` / `prove.rs` — `prepare` samples the two vectors in the verifier's order;
  `PreparedOperatorClaims` gains the shared `operand_weights`; `PreparedOperatorData` loses
  `lambda_powers` and folds its operation weight into the constraint tensor, which is renamed
  `weighted_r_x_prime_tensor` so the name doesn't hide the scaling (that was the issue's open
  question — folding it in is where it's free, and the rename is what keeps it honest).
- prover `key_collection/` — `build_scalars` collapses from four loops at strides 1/3/4/6 to one at
  stride 8, `ScalarTables` collapses to a single `Vec<F>`, and the per-key `match key.operation` for
  arity goes away with it.

### Expected impact

|  | now | after |
| -- | -- | -- |
| Verifier weight-table setup, muls / eval | ~8,350 | ~4,600 (−45%) |
| Prover `build_scalars` muls / key segment | ~30·D | ~12·D (−60%) |
| `ScalarTables` size / key segment | 14·D elems | 8·D elems |
| Transcript samples | 4 | 5 |

The table's stride is the padded `1 << LOG_MAX_ARITY = 8` rather than the true max arity of 6:
stride 6 would save ~1k multiplications but is not a tensor expansion, so it would mean keeping the
hand-rolled helper.

### Verification

`cargo nextest run --workspace` — 2075 passed, 15 skipped. Doc tests, `cargo doc
--document-private-items`, and `cargo clippy --workspace --all-targets -- -D warnings` all clean.
Each commit is independently green. The recursion end-to-end tests cover the deferred-claim round
trip through the changed `WiringEvalShape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)