### PR TITLE
BINIUS-571: Drop the redundant Underlier bound from the GFNI Mul and WideMul impls

### DIFF
--- a/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
+++ b/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
@@ -33,7 +33,7 @@ pub(super) trait GfniType: Copy + TowerSimdType {
 #[derive(TransparentWrapper)]
 pub struct Gfni<T>(T);
 
-impl<U: GfniType + Underlier> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>> {
+impl<U: GfniType> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>> {
 	type Output = Self;
 
 	#[inline(always)]
@@ -50,7 +50,7 @@ impl<U: GfniType + Underlier> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijn
 #[derive(TransparentWrapper)]
 pub struct GfniWideMul<T>(T);
 
-impl<U: GfniType + Underlier> WideMul for GfniWideMul<PackedPrimitiveType<U, Rijndael8b>> {
+impl<U: GfniType> WideMul for GfniWideMul<PackedPrimitiveType<U, Rijndael8b>> {
 	type Output = PackedPrimitiveType<U, Rijndael8b>;
 
 	#[inline(always)]


### PR DESCRIPTION
Closes [BINIUS-571](https://linear.app/jimpo/issue/BINIUS-571).

Removes a generic bound that another bound already implies, at two impl sites.
Pure refactor — no behaviour change, no codegen change.

Follow-up to @benji-potamus's review comment on #2384.

### The problem

Two impls in the GFNI module spell out a bound `GfniType` already implies.

```rust
impl<U: GfniType + Underlier> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>>
impl<U: GfniType + Underlier> WideMul for GfniWideMul<PackedPrimitiveType<U, Rijndael8b>>
```

`GfniType` reaches `Underlier` through its own supertrait chain:

```
GfniType:      Copy + TowerSimdType
TowerSimdType: Sized + Copy + Underlier
```

So `+ Underlier` constrains nothing at either site.

An implied bound is worse than noise.
It reads as though the impl needs something extra, so a reader cannot tell which constraints are load-bearing.

### The change

Two lines in `crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs`:

```diff
-impl<U: GfniType + Underlier> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>> {
+impl<U: GfniType> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>> {

-impl<U: GfniType + Underlier> WideMul for GfniWideMul<PackedPrimitiveType<U, Rijndael8b>> {
+impl<U: GfniType> WideMul for GfniWideMul<PackedPrimitiveType<U, Rijndael8b>> {
```

The `Underlier` import stays, because the third impl in the file still names it.

### Why the third impl keeps its bound

The file has one more impl, deliberately untouched:

```rust
impl<U: GfniType + Underlier> InvertOrZero for Gfni<PackedPrimitiveType<U, Rijndael8b>>
```

#2384 rewrites that exact line to `+ Divisible<u64>`, which is a real bound rather than an implied one.

`Underlier`'s supertrait is `Divisible<U1>`, and one instantiation of a generic trait says nothing about another.
So `Divisible<u64>` does not follow from `Underlier`, and the qword broadcast in the inverse genuinely needs it named.

Editing that line here would collide with #2384 and gain nothing.

### On the review's framing, and the base

The comment reads "now that `GfniType: Underlier` is the supertrait".

The bound is in fact already redundant *before* #2384, through `TowerSimdType: Underlier`.
So this stands on its own against `main` rather than waiting for #2384 to merge, and the two-line diff touches lines #2384 never does.

The same declaration carries a second redundancy — `Copy` in `GfniType: Copy + TowerSimdType`, likewise implied by `Underlier` — which #2384 already removes, so it is left alone here.

### Soundness

Removing an implied bound cannot change which types satisfy the impl.
The set of accepted `U` is identical, because `GfniType` already entailed `Underlier`, so trait selection and the emitted code are unchanged.

Existing coverage is the right shape and was left alone: the `packed_aes.rs` proptests pin `Gfni::invert_or_zero` and the GFNI `WideMul` lane-by-lane against the scalar table oracle, including an exhaustive sweep of all $2^{16}$ AES scalar pairs.
No tests were added, because a bounds-only change has nothing new to pin.

### Scope

- **changed:** two `impl` bounds in `crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs`
- **left untouched:** the `InvertOrZero` impl and the `GfniType` declaration, both owned by #2384

### Verification

This module is `cfg`-gated on the `gfni` target feature, so only the native leg compiles it.
Confirmed present: `rustc --print cfg -Ctarget-cpu=native` reports `target_feature="gfni"`.

| check | `-Ctarget-cpu=native` | portable (no `RUSTFLAGS`) |
|---|---|---|
| `cargo test -p binius-field --release` | 273 passed, 0 failed | — |
| doctests | 2 passed, 0 failed | — |
| `cargo clippy -p binius-field --all-targets --all-features -- -D warnings` | clean | clean |

- `cargo check --workspace --all-targets` (native) — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-field --document-private-items` — clean
- `tools/check_copyright_notice.py` — 694 files, 0 missing

The portable leg's job here is to prove the non-GFNI build is unaffected, which it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
