### PR TITLE
BINIUS-576: Derive packed-field Mul from WideMul and delete the vestigial strategy layer

### DIFF
--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -1,33 +1,35 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+/// Defines a packed binary field over an underlier, with the scalar it packs and its arithmetic.
+///
+/// Squaring, inversion and the widening multiply are supplied per target as strategies.
+/// Multiplication is always the widening multiply followed by its reduction, so the two cannot
+/// disagree.
 macro_rules! define_packed_binary_field {
 	(
 		$name:ident, $scalar:path, $underlier:ident,
-		($($mul:tt)*),
 		($($square:tt)*),
 		($($invert:tt)*),
 		($($wide_mul:tt)*)
 	) => {
-		// Define packed field types
 		pub type $name = $crate::packed_fields::primitive::PackedPrimitiveType<$underlier, $scalar>;
 
-		// Serialization is provided by a single generic impl on `PackedPrimitiveType` (see
-		// `packed.rs`), so no per-type impl is needed here.
+		impl std::ops::Mul for $name {
+			type Output = Self;
 
-		// Define multiplication
-		impl_strategy!(impl_mul_with       $name, ($($mul)*));
+			#[inline]
+			fn mul(self, rhs: Self) -> Self {
+				<Self as $crate::arithmetic_traits::WideMul>::reduce(
+					<Self as $crate::arithmetic_traits::WideMul>::wide_mul(self, rhs),
+				)
+			}
+		}
 
-		// Define square
-		impl_strategy!(impl_square_with    $name, ($($square)*));
+		impl_square_with!($name @ $($square)*);
 
-		// Define invert
-		impl_strategy!(impl_invert_with    $name, ($($invert)*));
+		impl_invert_with!($name @ $($invert)*);
 
-		// Define widening multiplication. Every packed field is a `WideMul` (it's a parent trait
-		// of `PackedField`). The caller passes a wrapper struct (a `TransparentWrapper` around this
-		// packed field) that carries the actual `WideMul` impl; here we forward to it by wrapping
-		// the inputs and peeling the reduced result.
 		impl $crate::arithmetic_traits::WideMul for $name {
 			type Output =
 				<$($wide_mul)* <$name> as $crate::arithmetic_traits::WideMul>::Output;
@@ -52,26 +54,4 @@ macro_rules! define_packed_binary_field {
 
 pub(crate) use define_packed_binary_field;
 
-pub(crate) use crate::arithmetic_traits::{impl_invert_with, impl_mul_with, impl_square_with};
-
-pub(crate) mod portable_macros {
-	macro_rules! impl_strategy {
-		($impl_macro:ident $name:ident, (None)) => {};
-		// gfni condition: strategy types are in $crate::arch
-		($impl_macro:ident $name:ident, (if gfni $strategy:tt else $fallback:tt)) => {
-			cfg_if! {
-				if #[cfg(all(target_arch = "x86_64", target_feature = "sse2", target_feature = "gfni"))] {
-					$impl_macro!($name @ $crate::arch::$strategy);
-				} else {
-					$impl_macro!($name @ $crate::arch::$fallback);
-				}
-			}
-		};
-		// Path to strategy in caller's scope
-		($impl_macro:ident $name:ident, ($($strategy:tt)*)) => {
-			$impl_macro!($name @ $($strategy)*);
-		};
-	}
-
-	pub(crate) use impl_strategy;
-}
+pub(crate) use crate::arithmetic_traits::{impl_invert_with, impl_square_with};

--- a/crates/field/src/arch/strategies.rs
+++ b/crates/field/src/arch/strategies.rs
@@ -163,19 +163,3 @@ where
 		Self::wrap(PackedPrimitiveType::from_underlier(Divisible::<SubU>::from_iter(lanes)))
 	}
 }
-
-/// Wrapper that defines multiplication as `reduce(wide_mul(a, b))`, deferring to the type's own
-/// [`WideMul`] impl, making the widening multiply the single source of truth for both `Mul` and
-/// `WideMul`. Used by every GHASH and AES packing.
-#[repr(transparent)]
-#[derive(TransparentWrapper)]
-pub struct MulFromWideMul<T>(T);
-
-impl<P: WideMul> std::ops::Mul for MulFromWideMul<P> {
-	type Output = Self;
-
-	#[inline]
-	fn mul(self, rhs: Self) -> Self {
-		Self::wrap(P::reduce(P::wide_mul(Self::peel(self), Self::peel(rhs))))
-	}
-}

--- a/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
+++ b/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
@@ -53,20 +53,12 @@ pub(super) trait GfniType: Underlier {
 	fn gf2p8affineinv_epi64_epi8(x: Self, a: Self) -> Self;
 }
 
-/// GFNI multiplication wrapper for AES packings: `gf2p8mul` produces the reduced byte directly.
+/// Supplies inversion for the AES-field packings.
+///
+/// `gf2p8affineinv` inverts each byte in `GF(2^8)`, then applies a `GF(2)`-affine map.
 #[repr(transparent)]
 #[derive(TransparentWrapper)]
 pub struct Gfni<T>(T);
-
-impl<U: GfniType> std::ops::Mul for Gfni<PackedPrimitiveType<U, Rijndael8b>> {
-	type Output = Self;
-
-	#[inline(always)]
-	fn mul(self, rhs: Self) -> Self {
-		let (a, b) = (Self::peel(self), Self::peel(rhs));
-		Self::wrap(U::gf2p8mul_epi8(a.0, b.0).into())
-	}
-}
 
 /// GFNI widening multiply for AES packings: `gf2p8mul` already produces the reduced byte, so the
 /// wide product is `Self` and `reduce` is the identity. The single-instruction multiply covers

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -69,28 +69,8 @@ pub trait InvertOrZero {
 	}
 }
 
-// The `@ strategy` arm wires `$name`'s `Mul` to a strategy wrapper: a `TransparentWrapper` struct
-// (e.g. `Gfni`, `MulFromWideMul`) that carries the actual algorithm. We wrap the inputs, run
-// the wrapper's `Mul`, and peel the result. `$strategy` is captured as raw token-trees (not
-// `:ty`/`:path`) because a matched type fragment is opaque and can't have `<$name>` appended to it.
-macro_rules! impl_mul_with {
-	($name:ident @ $($strategy:tt)*) => {
-		impl std::ops::Mul for $name {
-			type Output = Self;
-
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				<$($strategy)* <$name> as ::bytemuck::TransparentWrapper<$name>>::peel(
-					<$($strategy)* <$name> as ::bytemuck::TransparentWrapper<$name>>::wrap(self)
-						* <$($strategy)* <$name> as ::bytemuck::TransparentWrapper<$name>>::wrap(rhs),
-				)
-			}
-		}
-	};
-}
-
-pub(crate) use impl_mul_with;
-
+// A strategy is captured as raw token-trees rather than a type fragment.
+// A matched type fragment is opaque, so it cannot take the packed type as a generic argument.
 macro_rules! impl_square_with {
 	($name:ident @ $($strategy:tt)*) => {
 		impl $crate::arithmetic_traits::Square for $name {

--- a/crates/field/src/packed_aes.rs
+++ b/crates/field/src/packed_aes.rs
@@ -5,8 +5,7 @@ use crate::{
 	arch::{
 		AesInvert1x, AesInvert16x, AesInvert32x, AesInvert64x, AesSquare1x, AesSquare16x,
 		AesSquare32x, AesSquare64x, AesWideMul1x, AesWideMul16x, AesWideMul32x, AesWideMul64x,
-		M128, M256, M512, MulFromWideMul,
-		portable::packed_macros::{portable_macros::*, *},
+		M128, M256, M512, portable::packed_macros::*,
 	},
 	fields::rijndael::Rijndael8b,
 };
@@ -15,7 +14,6 @@ define_packed_binary_field!(
 	PackedAESBinaryField1x8b,
 	Rijndael8b,
 	u8,
-	(MulFromWideMul),
 	(AesSquare1x),
 	(AesInvert1x),
 	(AesWideMul1x)
@@ -24,7 +22,6 @@ define_packed_binary_field!(
 	PackedAESBinaryField16x8b,
 	Rijndael8b,
 	M128,
-	(MulFromWideMul),
 	(AesSquare16x),
 	(AesInvert16x),
 	(AesWideMul16x)
@@ -33,7 +30,6 @@ define_packed_binary_field!(
 	PackedAESBinaryField32x8b,
 	Rijndael8b,
 	M256,
-	(MulFromWideMul),
 	(AesSquare32x),
 	(AesInvert32x),
 	(AesWideMul32x)
@@ -42,7 +38,6 @@ define_packed_binary_field!(
 	PackedAESBinaryField64x8b,
 	Rijndael8b,
 	M512,
-	(MulFromWideMul),
 	(AesSquare64x),
 	(AesInvert64x),
 	(AesWideMul64x)

--- a/crates/field/src/packed_ghash.rs
+++ b/crates/field/src/packed_ghash.rs
@@ -5,8 +5,8 @@ use crate::{
 	Ghash128b,
 	arch::{
 		GhashInvert1x, GhashInvert2x, GhashInvert4x, GhashSquare1x, GhashSquare2x, GhashSquare4x,
-		GhashWideMul1x, GhashWideMul2x, GhashWideMul4x, M128, M256, M512, MulFromWideMul,
-		portable::packed_macros::{portable_macros::*, *},
+		GhashWideMul1x, GhashWideMul2x, GhashWideMul4x, M128, M256, M512,
+		portable::packed_macros::*,
 	},
 };
 
@@ -14,7 +14,6 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	Ghash128b,
 	M128,
-	(MulFromWideMul),
 	(GhashSquare1x),
 	(GhashInvert1x),
 	(GhashWideMul1x)
@@ -24,7 +23,6 @@ define_packed_binary_field!(
 	PackedBinaryGhash2x128b,
 	Ghash128b,
 	M256,
-	(MulFromWideMul),
 	(GhashSquare2x),
 	(GhashInvert2x),
 	(GhashWideMul2x)
@@ -34,7 +32,6 @@ define_packed_binary_field!(
 	PackedBinaryGhash4x128b,
 	Ghash128b,
 	M512,
-	(MulFromWideMul),
 	(GhashSquare4x),
 	(GhashInvert4x),
 	(GhashWideMul4x)

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -33,10 +33,7 @@ use bytemuck::TransparentWrapper;
 
 use crate::{
 	Divisible, Ghash128b, GhashSq256b, PackedBinaryGhash2x128b, PackedField, WideMul,
-	arch::{
-		Divide, GhashSqWideMul1x, M128, M256, M512, MulFromWideMul,
-		portable::packed_macros::{portable_macros::*, *},
-	},
+	arch::{Divide, GhashSqWideMul1x, M128, M256, M512, portable::packed_macros::*},
 	arithmetic_traits::{InvertOrZero, Square},
 	packed_extension,
 	packed_fields::{primitive::PackedPrimitiveType, sliced::SlicedPackedField},
@@ -288,7 +285,6 @@ define_packed_binary_field!(
 	PackedGhashSq1x256b,
 	GhashSq256b,
 	M256,
-	(MulFromWideMul),
 	(GhashSqSquare),
 	(GhashSqInvert),
 	(GhashSqWideMul1x)
@@ -298,7 +294,6 @@ define_packed_binary_field!(
 	PackedGhashSq2x256b,
 	GhashSq256b,
 	M512,
-	(MulFromWideMul),
 	(GhashSqDivide2x),
 	(GhashSqDivide2x),
 	(GhashSqDivide2x)


### PR DESCRIPTION
Closes [BINIUS-576](https://linear.app/jimpo/issue/BINIUS-576).

Removes an algorithm slot from `define_packed_binary_field!` that had exactly one possible argument, plus the three pieces of the strategy layer that became unreachable with it. Pure refactor — no behavior change.

### The problem

`define_packed_binary_field!` takes four algorithm slots: mul, square, invert, wide_mul.

All **nine** packings pass the same value in the mul slot: `(MulFromWideMul)`.
So the slot selects nothing — it is a parameter with exactly one possible argument.

It also leaves room for a bug it cannot catch.
A packing could name a mul strategy unrelated to its own widening multiply, and `Mul` and `WideMul` would silently disagree.

### The idea

Make the widening multiply the single source of truth for multiplication.

```
Mul::mul(a, b) = WideMul::reduce(WideMul::wide_mul(a, b))
```

That is exactly what `MulFromWideMul` computed, so runtime behavior is unchanged.
The difference is that it is now the definition rather than a per-packing choice, so the two operations cannot drift apart.

A packing that needs no deferred reduction still says so — in its `$wide_mul` strategy, by setting `WideMul::Output = Self` and making `reduce` the identity.
`GfniWideMul` and `AesLookupWideMul` already do exactly that.

### What that makes dead

Three pieces, each re-verified by grep over the workspace before deletion:

- **`impl_strategy!`'s `(None)` arm** — no call site passes `(None)`.
- **`impl_strategy!`'s `(if gfni … else …)` arm** — no call site passes it, and it could not have compiled if one did: it expands `cfg_if!`, which none of the three call sites import.
- **`impl Mul for Gfni<…>`** — AES reaches GFNI through `GfniWideMul` for `wide_mul`, and through `Gfni` only for `InvertOrZero`. Its header doc is corrected to describe what it actually is.

With the mul slot gone, `impl_strategy!` has one live arm left — `$impl_macro!($name @ $strategy)` — which adds nothing over calling `impl_square_with!` / `impl_invert_with!` directly, so the macro and its `portable_macros` wrapper module go too.
`impl_mul_with!` and `MulFromWideMul` then have no callers.

Four macro layers become two:

```
- define_packed_binary_field! -> impl_strategy! -> impl_mul_with! -> wrap/peel
+ define_packed_binary_field! -> impl_square_with! / impl_invert_with!
```

### The change

```diff
 define_packed_binary_field!(
 	PackedBinaryGhash4x128b,
 	Ghash128b,
 	M512,
-	(MulFromWideMul),
 	(GhashSquare4x),
 	(GhashInvert4x),
 	(GhashWideMul4x)
 );
```

The explanation of the emitted impls moves onto the macro's own doc comment, where a reader of the macro finds it.

### Soundness

Nothing about the field arithmetic changes.
This only alters how the trait impls are generated, so every algebraic identity is preserved by construction.

### Scope

- **changed:** `arch/portable/packed_macros.rs`, `arithmetic_traits.rs`, `arch/strategies.rs`, `arch/x86_64/gfni/gfni_arithmetics.rs`, and the nine invocations in `packed_ghash.rs` / `packed_aes.rs` / `packed_ghash_sq.rs`
- **removed:** `MulFromWideMul`, `impl_mul_with!`, `impl_strategy!`, the `portable_macros` module, `impl Mul for Gfni`
- **untouched:** every strategy wrapper that actually selects an algorithm — `GhashClMul`, `GhashWideMul`, `GfniWideMul`, `Divide`, `Scaled`, `BytewiseLookup`, `ReuseMultiply`, `GhashItohTsujii`
- **untouched:** the `B1` packings and `SlicedPackedField`, which define `Mul` through their own blanket impls and never used this macro

Net −64 lines.

### Verification

Codegen equality is measured, not assumed. One probe binary exercising GHASH mul / `wide_mul` inner product / square at widths 1, 2, 4 and AES mul / invert at 16×, 32×, 64× was built against this branch and against `main`, same compiler and flags:

| leg | result |
|---|---|
| `-Ctarget-cpu=native` (AVX-512, GFNI, VPCLMULQDQ) | instruction streams **byte-identical** |
| default target (portable `Divide` / `Scaled` fallbacks) | **identical mnemonic histogram**, 78251 instructions, every mnemonic at the same count |

On the portable leg the two binaries differ only in symbol names and code layout: removing an impl renumbers the sibling-impl disambiguators in mangled names, and LLVM inlines the macro's one-line `wide_mul` forwarder so the call lands on the strategy's function directly — one fewer out-of-line hop, never more work.

Commands run, all clean:

- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-field --release` — 273 passed, 0 failed
- `cargo test -p binius-field --release` (portable) — 256 passed, 0 failed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — both legs
- `cargo build --workspace --lib --bins --tests --examples` — both legs
- `cargo test --workspace` — both legs, 70 test binaries green each
- `cargo test --doc --workspace` — 25 green
- `cargo +nightly-2026-07-01 fmt --all --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps`
- `tools/check_copyright_notice.py`

### Note for review

BINIUS-569 also edits `gfni_arithmetics.rs`, in `invert_or_zero` and the `GfniType` bound.
This PR removes the `impl Mul` above them and rewrites the `Gfni` header doc, so the two edits are adjacent but disjoint; whichever lands second may need a one-hunk rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
