### PR TITLE
BINIUS-578: Scale every GHASH lane by X with one vector sequence

### DIFF
--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -20,7 +20,7 @@ use super::super::m128::M128;
 use crate::{
 	Ghash128b as GhashB128, WideMul,
 	arch::portable::arithmetic::ghash::POLY,
-	arithmetic_traits::{GhashMulX, MulXWide, Square},
+	arithmetic_traits::{MulX, Square},
 	packed_fields::primitive::PackedPrimitiveType,
 };
 
@@ -49,10 +49,15 @@ pub fn mul_x(x: M128) -> M128 {
 	}
 }
 
-impl GhashMulX for M128 {
+/// Scaling wrapper for the GHASH packing.
+#[repr(transparent)]
+#[derive(bytemuck::TransparentWrapper)]
+pub struct GhashMulX<T>(T);
+
+impl MulX for GhashMulX<PackedPrimitiveType<M128, GhashB128>> {
 	#[inline]
-	fn ghash_mul_x(self) -> Self {
-		mul_x(self)
+	fn mul_x(self) -> Self {
+		Self::wrap(PackedPrimitiveType::wrap(mul_x(PackedPrimitiveType::peel(Self::peel(self)))))
 	}
 }
 
@@ -175,7 +180,7 @@ impl WideGhashProduct {
 	}
 }
 
-impl MulXWide for WideGhashProduct {
+impl MulX for WideGhashProduct {
 	/// Shifts the represented 256-bit polynomial `lo + mid·X^64 + hi·X^128` left by one bit.
 	///
 	/// Each 64-bit lane shifts up by one; the bit leaving the top of a lane belongs 64 bit
@@ -187,7 +192,7 @@ impl MulXWide for WideGhashProduct {
 	/// XOR-accumulating such products preserves that. Bit 127 of `hi` is therefore clear, and the
 	/// bit the rotation wraps back into the low lane is zero.
 	#[inline]
-	fn mul_x_wide(self) -> Self {
+	fn mul_x(self) -> Self {
 		let (v0, v1, v2): (uint64x2_t, uint64x2_t, uint64x2_t) =
 			(self.lo.into(), self.mid.into(), self.hi.into());
 
@@ -287,7 +292,7 @@ impl WideMul for GhashClMulWideMul<PackedPrimitiveType<M128, GhashB128>> {
 mod tests {
 	use proptest::{prelude::any, proptest};
 
-	use super::{M128, MulXWide, WideGhashProduct};
+	use super::{M128, MulX, WideGhashProduct};
 
 	proptest! {
 		// Scaling by X commutes with the reduction: scaling the unreduced product matches
@@ -295,9 +300,9 @@ mod tests {
 		#[test]
 		fn mul_x_wide_commutes_with_reduce(a in any::<u128>(), b in any::<u128>()) {
 			let wide = WideGhashProduct::wide_mul(M128::from_u128(a), M128::from_u128(b));
-			let mul_x = WideGhashProduct::wide_mul(wide.reduce(), M128::from_u128(2)).reduce();
+			let scaled = WideGhashProduct::wide_mul(wide.reduce(), M128::from_u128(2)).reduce();
 
-			assert_eq!(wide.mul_x_wide().reduce(), mul_x);
+			assert_eq!(wide.mul_x().reduce(), scaled);
 		}
 	}
 }

--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -19,12 +19,42 @@ use bytemuck::TransparentWrapper;
 use super::super::m128::M128;
 use crate::{
 	Ghash128b as GhashB128, WideMul,
-	arithmetic_traits::{MulXWide, Square},
+	arch::portable::arithmetic::ghash::POLY,
+	arithmetic_traits::{GhashMulX, MulXWide, Square},
 	packed_fields::primitive::PackedPrimitiveType,
 };
 
-// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87.
-const POLY: u128 = 0x87;
+/// Scales the single 128-bit GHASH lane by `X`.
+#[inline]
+pub fn mul_x(x: M128) -> M128 {
+	let x_u64x2: uint64x2_t = x.into();
+
+	// Safety: the module is compiled only under `target_feature = "neon"`, which every intrinsic
+	// below requires.
+	unsafe {
+		// No instruction shifts a whole 128-bit lane by one bit, so build the shift from the two
+		// 64-bit halves. The bit leaving the low half belongs at position 64, which is where
+		// moving it up a half-lane puts it. The bit leaving the high half is the coefficient of
+		// X^128 and falls off the top.
+		let shifted = M128::from(vshlq_n_u64::<1>(x_u64x2))
+			^ move_64_to_hi(vshrq_n_u64::<63>(x_u64x2).into());
+
+		// That term is what the modulus rewrites as `0x87`. Bit 127 is the sign bit of the high
+		// half, so shifting that half right by 63 as a signed value fills it with copies of the
+		// bit, and duplicating it over both halves spreads the mask across the lane.
+		let sign = vshrq_n_s64::<63>(vreinterpretq_s64_u64(x_u64x2));
+		let mask = M128::from(vreinterpretq_u64_s64(vdupq_laneq_s64::<1>(sign)));
+
+		shifted ^ (mask & M128::from_u128(POLY))
+	}
+}
+
+impl GhashMulX for M128 {
+	#[inline]
+	fn ghash_mul_x(self) -> Self {
+		mul_x(self)
+	}
+}
 
 /// Carryless multiply of two 64-bit lanes selected from the 128-bit inputs by the bytes of
 /// `IMM8`, matching the semantics of x86_64's `clmulepi64`.

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -17,3 +17,6 @@ pub type GhashSquare1x<T> = super::arithmetic::ghash::GhashClMul<T>;
 /// Invert wrapper for the `PackedGhash1x128b` packing: the shared Itoh-Tsujii inversion
 /// (there is no CLMUL inverse).
 pub type GhashInvert1x<T> = crate::arch::portable::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
+
+/// Scaling wrapper for the `PackedGhash1x128b` packing: the NEON shift sequence.
+pub type GhashMulX1x<T> = super::arithmetic::ghash::GhashMulX<T>;

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -11,9 +11,9 @@ cfg_if! {
 	if #[cfg(all(target_arch = "x86_64"))] {
 		mod x86_64;
 		pub use x86_64::{packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512, M128, M256, M512, m256_from_u128s};
-		pub use x86_64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
-		pub use x86_64::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
-		pub use x86_64::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use x86_64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x, GhashMulX1x};
+		pub use x86_64::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x, GhashMulX2x};
+		pub use x86_64::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x, GhashMulX4x};
 		pub use x86_64::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use x86_64::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use x86_64::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
@@ -21,10 +21,10 @@ cfg_if! {
 	} else if #[cfg(target_arch = "aarch64")] {
 		mod aarch64;
 		pub use aarch64::{packed_aes_128, packed_ghash_128, M128, M256, M512, m256_from_u128s};
-		pub use aarch64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
+		pub use aarch64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x, GhashMulX1x};
 		pub use portable::{packed_aes_256, packed_aes_512, packed_ghash_256, packed_ghash_512};
-		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
-		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x, GhashMulX2x};
+		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x, GhashMulX4x};
 		pub use portable::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use aarch64::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use portable::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
@@ -32,19 +32,19 @@ cfg_if! {
 	} else if #[cfg(target_arch = "wasm32")] {
 		mod wasm32;
 		pub use wasm32::{packed_ghash_128, packed_ghash_256};
-		pub use wasm32::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
+		pub use wasm32::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x, GhashMulX1x};
 		pub use portable::{M128, M256, M512, m256_from_u128s, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_512};
-		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
-		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x, GhashMulX2x};
+		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x, GhashMulX4x};
 		pub use portable::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use portable::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use portable::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
 		pub use portable::packed_aes_512::{AesWideMul64x, AesSquare64x, AesInvert64x};
 	} else {
 		pub use portable::{M128, M256, M512, m256_from_u128s, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
-		pub use portable::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
-		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
-		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use portable::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x, GhashMulX1x};
+		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x, GhashMulX2x};
+		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x, GhashMulX4x};
 		pub use portable::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use portable::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use portable::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -12,9 +12,10 @@ use bytemuck::TransparentWrapper;
 
 use super::super::univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64};
 use crate::{
-	Ghash128b as GhashB128, WideMul,
-	arithmetic_traits::{MulXWide, Square},
+	BinaryField, Divisible, Ghash128b as GhashB128, WideMul,
+	arithmetic_traits::{MulX, Square},
 	packed_fields::primitive::PackedPrimitiveType,
+	underlier::Underlier,
 };
 
 /// The reduction polynomial `X^128 + X^7 + X^2 + X + 1`, with its `X^128` term left implicit.
@@ -134,14 +135,14 @@ impl<U: Underlier128bLanes> WideGhashProduct<U> {
 	}
 }
 
-impl<U: Underlier128bLanes> MulXWide for WideGhashProduct<U> {
+impl<U: Underlier128bLanes> MulX for WideGhashProduct<U> {
 	/// Shifts the 256-bit schoolbook product left by one bit, carrying between the four 64-bit
 	/// limbs.
 	///
 	/// The product of two 128-bit polynomials has degree at most 254, and XOR-accumulating such
 	/// products preserves that, so the top bit of `v3` is always clear and nothing is shifted out.
 	#[inline]
-	fn mul_x_wide(self) -> Self {
+	fn mul_x(self) -> Self {
 		Self {
 			v0: self.v0.shl_64(1),
 			v1: self.v1.shl_64(1) ^ self.v0.shr_64(63),
@@ -237,6 +238,23 @@ impl<U: Underlier128bLanes> WideMul for GhashWideMul<PackedPrimitiveType<U, Ghas
 /// Shared by the portable and wasm32 packings and used by the x86_64 packing when CLMUL is
 /// unavailable. Squares via the bit-spread [`ghash_square`], which interleaves the input bits with
 /// zeroes and reduces — no carryless multiply required.
+/// Scaling wrapper for the GHASH packings with no vector shift for their width.
+///
+/// Walks the 128-bit lanes and applies the scalar shift to each, so it serves every width.
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashMulX<T>(T);
+
+impl<U: Underlier + Divisible<u128>, F: BinaryField> MulX for GhashMulX<PackedPrimitiveType<U, F>> {
+	#[inline]
+	fn mul_x(self) -> Self {
+		let lanes = Divisible::<u128>::value_iter(PackedPrimitiveType::peel(Self::peel(self)))
+			.map(ghash_mul_x);
+
+		Self::wrap(PackedPrimitiveType::wrap(Divisible::<u128>::from_iter(lanes)))
+	}
+}
+
 #[repr(transparent)]
 #[derive(TransparentWrapper)]
 pub struct GhashSoftMul<T>(T);
@@ -254,7 +272,7 @@ impl<U: Underlier128bLanes> Square for GhashSoftMul<PackedPrimitiveType<U, Ghash
 mod tests {
 	use proptest::{prelude::any, proptest};
 
-	use super::{super::super::m128::M128, MulXWide, ghash_mul, ghash_wide_mul};
+	use super::{super::super::m128::M128, MulX, ghash_mul, ghash_wide_mul};
 
 	// Exercises the deferred wide-mul building blocks (`ghash_wide_mul` + `WideGhashProduct`) that
 	// `GhashWideMul` wraps, directly on the portable `M128`. This runs on every host, whereas the
@@ -286,7 +304,7 @@ mod tests {
 		fn mul_x_wide_commutes_with_reduce(a in any::<u128>(), b in any::<u128>()) {
 			let (a, b) = (M128::from(a), M128::from(b));
 			let wide = ghash_wide_mul(a, b);
-			assert_eq!(wide.mul_x_wide().reduce(), ghash_mul(wide.reduce(), M128::from(2u128)));
+			assert_eq!(wide.mul_x().reduce(), ghash_mul(wide.reduce(), M128::from(2u128)));
 		}
 	}
 }

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -17,6 +17,20 @@ use crate::{
 	packed_fields::primitive::PackedPrimitiveType,
 };
 
+/// The reduction polynomial `X^128 + X^7 + X^2 + X + 1`, with its `X^128` term left implicit.
+pub const POLY: u128 = 0x87;
+
+/// Scales one GHASH element by `X`, over `u128`. The scalar reference.
+#[inline]
+pub const fn ghash_mul_x(x: u128) -> u128 {
+	// Why: shifting up one degree can push a term to X^128, which the modulus rewrites. Negating
+	// bit 127, read as 0 or 1, gives a mask of all zeros or all ones, so one exclusive or covers
+	// both cases.
+	let mask = (x >> 127).wrapping_neg();
+
+	(x << 1) ^ (POLY & mask)
+}
+
 /// Multiply two GHASH field elements using software implementation.
 ///
 /// Method described at:

--- a/crates/field/src/arch/portable/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash_sq.rs
@@ -6,14 +6,14 @@
 //! the Karatsuba diagonal into a two-lane packed GHASH multiply buys nothing — that packed multiply
 //! decomposes back into two independent 128-bit multiplies, each with its own reduction. Keeping
 //! the three Karatsuba products separate instead lets the multiply-by-`X` of the irreducible
-//! polynomial be applied to an *unreduced* product ([`MulXWide`]), which folds it into a reduction
+//! polynomial be applied to an *unreduced* product, which folds it into a reduction
 //! that has to happen anyway: two GHASH reductions per GHASH² product rather than three.
 
 use bytemuck::TransparentWrapper;
 
 use crate::{
 	Ghash128b, PackedGhashSq1x256b, SlicedGhashSqWide, WideMul,
-	arithmetic_traits::MulXWide,
+	arithmetic_traits::MulX,
 	packed_fields::ghash_sq::{ghash_sq_coords, ghash_sq_from_coords},
 };
 
@@ -49,7 +49,7 @@ impl WideMul for GhashSqSlicedWideMul<PackedGhashSq1x256b> {
 	/// accumulated wide product, so the two coordinates cost two reductions in total.
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
-		let z0 = Ghash128b::reduce(wide.t0 + wide.t2.mul_x_wide());
+		let z0 = Ghash128b::reduce(wide.t0 + wide.t2.mul_x());
 		let z1 = z0 + Ghash128b::reduce(wide.t1 + wide.t2);
 
 		Self::wrap(ghash_sq_from_coords([z0, z1]))

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -16,8 +16,6 @@ use rand::{
 
 use crate::{
 	BinaryField,
-	arch::portable::arithmetic::ghash::ghash_mul_x,
-	arithmetic_traits::GhashMulX,
 	divisible::{Divisible, impl_divisible_memcast, impl_divisible_self},
 	packed_fields::primitive::PackedPrimitiveType,
 	underlier::{SmallU, Underlier, impl_divisible_bitmask},
@@ -212,14 +210,6 @@ impl Underlier for M128 {
 	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
 		let (a, b) = self.0.interleave(other.0, log_block_len);
 		(Self(a), Self(b))
-	}
-}
-
-impl GhashMulX for M128 {
-	/// The single lane is a `u128`, so this is the scalar reference itself.
-	#[inline]
-	fn ghash_mul_x(self) -> Self {
-		Self(ghash_mul_x(self.0))
 	}
 }
 

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -16,6 +16,8 @@ use rand::{
 
 use crate::{
 	BinaryField,
+	arch::portable::arithmetic::ghash::ghash_mul_x,
+	arithmetic_traits::GhashMulX,
 	divisible::{Divisible, impl_divisible_memcast, impl_divisible_self},
 	packed_fields::primitive::PackedPrimitiveType,
 	underlier::{SmallU, Underlier, impl_divisible_bitmask},
@@ -210,6 +212,14 @@ impl Underlier for M128 {
 	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
 		let (a, b) = self.0.interleave(other.0, log_block_len);
 		(Self(a), Self(b))
+	}
+}
+
+impl GhashMulX for M128 {
+	/// The single lane is a `u128`, so this is the scalar reference itself.
+	#[inline]
+	fn ghash_mul_x(self) -> Self {
+		Self(ghash_mul_x(self.0))
 	}
 }
 

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -17,6 +17,9 @@ pub type GhashSquare1x<T> = super::arithmetic::ghash::GhashSoftMul<T>;
 /// Invert wrapper for the `PackedGhash1x128b` packing: the shared Itoh-Tsujii inversion.
 pub type GhashInvert1x<T> = super::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
 
+/// Scaling wrapper for the `PackedGhash1x128b` packing: the shared lane walk.
+pub type GhashMulX1x<T> = super::arithmetic::ghash::GhashMulX<T>;
+
 // `M128` packs its GHASH 64-bit lanes the same way `u128` does — delegate through `u128`.
 impl Underlier128bLanes for M128 {
 	type U64 = u64;

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -13,3 +13,6 @@ pub type GhashSquare2x<T> = Scaled<T>;
 
 /// Invert wrapper for the `PackedGhash2x128b` packing.
 pub type GhashInvert2x<T> = Scaled<T>;
+
+/// Scaling wrapper for the `PackedGhash2x128b` packing: the shared lane walk.
+pub type GhashMulX2x<T> = super::arithmetic::ghash::GhashMulX<T>;

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -13,3 +13,6 @@ pub type GhashSquare4x<T> = Scaled<T>;
 
 /// Invert wrapper for the `PackedGhash4x128b` packing.
 pub type GhashInvert4x<T> = Scaled<T>;
+
+/// Scaling wrapper for the `PackedGhash4x128b` packing: the shared lane walk.
+pub type GhashMulX4x<T> = super::arithmetic::ghash::GhashMulX<T>;

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -24,6 +24,9 @@ pub type GhashSquare1x<T> = crate::arch::portable::arithmetic::ghash::GhashSoftM
 /// Invert wrapper for the `PackedGhash1x128b` packing: the shared Itoh-Tsujii inversion.
 pub type GhashInvert1x<T> = crate::arch::portable::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
 
+/// Scaling wrapper for the `PackedGhash1x128b` packing: the shared lane walk.
+pub type GhashMulX1x<T> = crate::arch::portable::arithmetic::ghash::GhashMulX<T>;
+
 impl Underlier128bLanes for M128 {
 	type U64 = u64;
 

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -16,7 +16,7 @@ use bytemuck::TransparentWrapper;
 use crate::{
 	Divisible, Ghash128b as GhashB128, WideMul,
 	arch::portable::arithmetic::ghash::POLY,
-	arithmetic_traits::{MulXWide, Square},
+	arithmetic_traits::{MulX, Square},
 	packed_fields::primitive::PackedPrimitiveType,
 	underlier::Underlier,
 };
@@ -51,6 +51,20 @@ pub trait ClMulUnderlier: GhashLanes {
 	/// Performs CLMUL operation on two 64-bit values that are selected from 128-bit lanes
 	/// by the bytes of the IMM8 parameter.
 	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self;
+}
+
+/// Scaling wrapper for the GHASH packings whose width has a vector shift.
+///
+/// One implementation covers every register width, since the sequence needs no carry-less multiply.
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashMulX<T>(T);
+
+impl<U: GhashLanes> MulX for GhashMulX<PackedPrimitiveType<U, GhashB128>> {
+	#[inline]
+	fn mul_x(self) -> Self {
+		Self::wrap(PackedPrimitiveType::wrap(mul_x(PackedPrimitiveType::peel(Self::peel(self)))))
+	}
 }
 
 /// Scales every 128-bit GHASH lane by `X`.
@@ -166,7 +180,7 @@ impl<U: ClMulUnderlier> WideGhashProduct<U> {
 	}
 }
 
-impl<U: ClMulUnderlier> MulXWide for WideGhashProduct<U> {
+impl<U: ClMulUnderlier> MulX for WideGhashProduct<U> {
 	/// Shifts the represented 256-bit polynomial `lo + mid·X^64 + hi·X^128` left by one bit.
 	///
 	/// Each 64-bit lane shifts up by one; the bit leaving the top of a lane belongs 64 bit
@@ -178,7 +192,7 @@ impl<U: ClMulUnderlier> MulXWide for WideGhashProduct<U> {
 	/// XOR-accumulating such products preserves that. Bit 127 of `hi` is therefore clear and
 	/// nothing is shifted out of the top.
 	#[inline]
-	fn mul_x_wide(self) -> Self {
+	fn mul_x(self) -> Self {
 		let (shl_lo, shl_mid, shl_hi) =
 			(U::shl_1_epi64(self.lo), U::shl_1_epi64(self.mid), U::shl_1_epi64(self.hi));
 		let (carry_lo, carry_mid, carry_hi) =
@@ -271,7 +285,7 @@ mod tests {
 	use crate::{
 		Divisible, Random, WideMul,
 		arch::{OptimalPackedB128, portable::arithmetic::ghash::ghash_mul_x},
-		arithmetic_traits::MulXWide,
+		arithmetic_traits::MulX,
 	};
 
 	/// Scaling by X commutes with the reduction: scaling the unreduced product matches multiplying
@@ -284,13 +298,13 @@ mod tests {
 			let wide = WideGhashProduct::wide_mul(U::random(&mut rng), U::random(&mut rng));
 
 			assert_eq!(
-				wide.mul_x_wide().reduce(),
+				wide.mul_x().reduce(),
 				WideGhashProduct::wide_mul(wide.reduce(), x).reduce()
 			);
 		}
 	}
 
-	// Covers every CLMUL underlier width the target supports, since the `MulXWide` impl is shared
+	// Covers every CLMUL underlier width the target supports, since the scaling impl is shared
 	// but its per-lane shift is not.
 	#[cfg(target_feature = "pclmulqdq")]
 	#[test]

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -15,21 +15,18 @@ use bytemuck::TransparentWrapper;
 
 use crate::{
 	Divisible, Ghash128b as GhashB128, WideMul,
+	arch::portable::arithmetic::ghash::POLY,
 	arithmetic_traits::{MulXWide, Square},
 	packed_fields::primitive::PackedPrimitiveType,
 	underlier::Underlier,
 };
 
-/// Trait for underliers that support CLMUL operations which are needed for the
-/// GHASH multiplication algorithm.
+/// Trait for underliers whose 128-bit lanes each hold a GHASH element, carrying the per-lane bit
+/// operations the GHASH arithmetic needs.
 ///
-/// On x86_64 this abstracts over the `M128`/`M256`/`M512` wrappers for `__m128i`/`__m256i`/
-/// `__m512i`, so the same algorithm code drives PCLMULQDQ and VPCLMULQDQ.
-pub trait ClMulUnderlier: Underlier + Divisible<u128> {
-	/// Performs CLMUL operation on two 64-bit values that are selected from 128-bit lanes
-	/// by the bytes of the IMM8 parameter.
-	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self;
-
+/// None of these is a multiply, so an implementation needs only the base SIMD instruction set for
+/// its width.
+pub trait GhashLanes: Underlier + Divisible<u128> {
 	/// For each 128-bit lane, shifts the lower 64 bits to the upper 64 bits and zeroes the lower
 	/// 64-bit.
 	fn move_64_to_hi(a: Self) -> Self;
@@ -40,6 +37,35 @@ pub trait ClMulUnderlier: Underlier + Divisible<u128> {
 	/// For each 64-bit lane, shifts the value right by 63 bits, leaving the lane's top bit as its
 	/// low bit.
 	fn shr_63_epi64(a: Self) -> Self;
+
+	/// For each 128-bit lane, returns all ones when bit 127 is set and all zeros otherwise.
+	fn broadcast_bit_127(a: Self) -> Self;
+}
+
+/// Trait for underliers that support CLMUL operations which are needed for the
+/// GHASH multiplication algorithm.
+///
+/// On x86_64 this abstracts over the `M128`/`M256`/`M512` wrappers for `__m128i`/`__m256i`/
+/// `__m512i`, so the same algorithm code drives PCLMULQDQ and VPCLMULQDQ.
+pub trait ClMulUnderlier: GhashLanes {
+	/// Performs CLMUL operation on two 64-bit values that are selected from 128-bit lanes
+	/// by the bytes of the IMM8 parameter.
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self;
+}
+
+/// Scales every 128-bit GHASH lane by `X`.
+#[inline]
+pub fn mul_x<U: GhashLanes>(x: U) -> U {
+	// No instruction shifts a whole 128-bit lane by one bit, so build the shift from the two
+	// 64-bit halves. The bit leaving the low half belongs at position 64, which is where moving it
+	// up a half-lane puts it. The bit leaving the high half is the coefficient of X^128 and falls
+	// off the top.
+	let shifted = U::shl_1_epi64(x) ^ U::move_64_to_hi(U::shr_63_epi64(x));
+
+	// That is the term the modulus rewrites: X^128 = 0x87, folded back in where bit 127 was set.
+	let overflow = U::broadcast_bit_127(x) & <U as Divisible<u128>>::broadcast(POLY);
+
+	shifted ^ overflow
 }
 
 /// The version of the multiplication for optimized suqare operation.
@@ -76,9 +102,6 @@ impl<U: ClMulUnderlier> Square for GhashClMul<PackedPrimitiveType<U, GhashB128>>
 		)))
 	}
 }
-
-// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87
-const POLY: u128 = 0x87;
 
 /// Performs reduction step: returns t0 + x^64 * t1
 #[inline]
@@ -244,8 +267,12 @@ impl<U: ClMulUnderlier> WideMul for GhashClMulWideMul<PackedPrimitiveType<U, Gha
 mod tests {
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
-	use super::{ClMulUnderlier, WideGhashProduct};
-	use crate::{Random, WideMul, arch::OptimalPackedB128, arithmetic_traits::MulXWide};
+	use super::{ClMulUnderlier, GhashLanes, POLY, WideGhashProduct, mul_x};
+	use crate::{
+		Divisible, Random, WideMul,
+		arch::{OptimalPackedB128, portable::arithmetic::ghash::ghash_mul_x},
+		arithmetic_traits::MulXWide,
+	};
 
 	/// Scaling by X commutes with the reduction: scaling the unreduced product matches multiplying
 	/// the reduced product by X (the field element 2) in every 128-bit lane.
@@ -275,6 +302,55 @@ mod tests {
 		check_mul_x_wide::<crate::arch::x86_64::m256::M256>(&mut rng);
 		#[cfg(all(target_feature = "avx512f", target_feature = "vpclmulqdq"))]
 		check_mul_x_wide::<crate::arch::x86_64::m512::M512>(&mut rng);
+	}
+
+	/// The vector sequence agrees with the scalar reference in every 128-bit lane.
+	#[allow(dead_code)]
+	fn check_mul_x<U: GhashLanes>(mut rng: impl Rng) {
+		// Values that exercise the carry between the 64-bit halves and the fold of the modulus.
+		const BOUNDARY: [u128; 8] = [
+			0,
+			1,
+			2,
+			POLY,
+			1 << 127,
+			(1 << 127) | 1,
+			(1 << 127) | (1 << 63),
+			u128::MAX,
+		];
+
+		// Give neighbouring lanes different boundary values, so a sequence that let one lane's
+		// carry leak into the next would fail here and not only on random input.
+		let mut cases = (0..BOUNDARY.len())
+			.map(|i| Divisible::<u128>::from_iter(BOUNDARY.iter().copied().cycle().skip(i)))
+			.collect::<Vec<U>>();
+		cases.extend((0..64).map(|_| U::random(&mut rng)));
+
+		for u in cases {
+			let scaled = mul_x(u);
+			let expected = Divisible::<u128>::value_iter(u).map(ghash_mul_x);
+
+			for (i, (lane, want)) in Divisible::<u128>::value_iter(scaled)
+				.zip(expected)
+				.enumerate()
+			{
+				assert_eq!(lane, want, "lane {i} of {u:?}");
+			}
+		}
+	}
+
+	// Covers every width whose lane operations the target provides, since the algorithm is shared
+	// but the shifts and the bit-127 mask underneath it are written per width.
+	#[cfg(target_feature = "sse2")]
+	#[test]
+	fn mul_x_matches_the_scalar_reference() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		check_mul_x::<crate::arch::x86_64::m128::M128>(&mut rng);
+		#[cfg(target_feature = "avx2")]
+		check_mul_x::<crate::arch::x86_64::m256::M256>(&mut rng);
+		#[cfg(target_feature = "avx512f")]
+		check_mul_x::<crate::arch::x86_64::m512::M512>(&mut rng);
 	}
 
 	/// Stress-test accumulation of many widening products. Correctness / linearity for each

--- a/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
@@ -14,8 +14,8 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	Divisible, Ghash128b, PackedGhash2x128b, PackedGhashSq1x256b, WideMul, packed_extension,
-	packed_fields::ghash_sq::ghash_sq_from_coords,
+	Divisible, Ghash128b, PackedGhash2x128b, PackedGhashSq1x256b, WideMul, arithmetic_traits::MulX,
+	packed_extension, packed_fields::ghash_sq::ghash_sq_from_coords,
 };
 
 /// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -10,10 +10,7 @@
 use super::m128::M128;
 #[cfg(not(target_feature = "pclmulqdq"))]
 use crate::arch::portable::univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64};
-use crate::{
-	arch::x86_64::arithmetic::ghash::{self, GhashLanes},
-	arithmetic_traits::GhashMulX,
-};
+use crate::arch::x86_64::arithmetic::ghash::{self, GhashLanes};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
 /// `GhashClMulWideMul` when PCLMULQDQ is available, otherwise the portable `GhashWideMul` which
@@ -94,12 +91,9 @@ impl GhashLanes for M128 {
 	}
 }
 
-impl GhashMulX for M128 {
-	#[inline]
-	fn ghash_mul_x(self) -> Self {
-		ghash::mul_x(self)
-	}
-}
+/// Scaling wrapper for the `PackedGhash1x128b` packing: the vector sequence, which needs
+/// only SSE2.
+pub type GhashMulX1x<T> = ghash::GhashMulX<T>;
 
 #[cfg(target_feature = "pclmulqdq")]
 impl ghash::ClMulUnderlier for M128 {

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -10,10 +10,10 @@
 use super::m128::M128;
 #[cfg(not(target_feature = "pclmulqdq"))]
 use crate::arch::portable::univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64};
-// Used by the CLMUL-accelerated `ClMulUnderlier` impl and the `GhashWideMul1x`/`GhashSquare1x`
-// aliases below.
-#[cfg(target_feature = "pclmulqdq")]
-use crate::arch::x86_64::arithmetic::ghash;
+use crate::{
+	arch::x86_64::arithmetic::ghash::{self, GhashLanes},
+	arithmetic_traits::GhashMulX,
+};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
 /// `GhashClMulWideMul` when PCLMULQDQ is available, otherwise the portable `GhashWideMul` which
@@ -65,13 +65,7 @@ impl Underlier128bLanes for M128 {
 	}
 }
 
-#[cfg(target_feature = "pclmulqdq")]
-impl ghash::ClMulUnderlier for M128 {
-	#[inline]
-	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-		unsafe { std::arch::x86_64::_mm_clmulepi64_si128::<IMM8>(a.into(), b.into()) }.into()
-	}
-
+impl GhashLanes for M128 {
 	#[inline]
 	fn move_64_to_hi(a: Self) -> Self {
 		unsafe { std::arch::x86_64::_mm_slli_si128::<8>(a.into()) }.into()
@@ -85,5 +79,33 @@ impl ghash::ClMulUnderlier for M128 {
 	#[inline]
 	fn shr_63_epi64(a: Self) -> Self {
 		unsafe { std::arch::x86_64::_mm_srli_epi64::<63>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn broadcast_bit_127(a: Self) -> Self {
+		// Bit 127 is the sign bit of the lane's top 32-bit word.
+		// Copying that word over the whole lane, then shifting each word right by 31 as a signed
+		// value, leaves every bit equal to it.
+		unsafe {
+			let top_word = std::arch::x86_64::_mm_shuffle_epi32::<0xff>(a.into());
+			std::arch::x86_64::_mm_srai_epi32::<31>(top_word)
+		}
+		.into()
+	}
+}
+
+impl GhashMulX for M128 {
+	#[inline]
+	fn ghash_mul_x(self) -> Self {
+		ghash::mul_x(self)
+	}
+}
+
+#[cfg(target_feature = "pclmulqdq")]
+impl ghash::ClMulUnderlier for M128 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		// Safety: the `pclmulqdq` gate on this impl is exactly what the intrinsic requires.
+		unsafe { std::arch::x86_64::_mm_clmulepi64_si128::<IMM8>(a.into(), b.into()) }.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -6,10 +6,19 @@
 //! This module provides optimized GHASH multiplication using the VPCLMULQDQ instruction
 //! available on modern x86_64 processors with AVX2 support. The implementation follows
 //! the algorithm described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
+//!
+//! Every lane operation below acts within a 128-bit lane, so one body serves both GHASH lanes.
 
 // Used by the `GhashWideMul2x` and `GhashSquare2x` fallbacks when VPCLMULQDQ is unavailable.
 #[cfg(not(target_feature = "vpclmulqdq"))]
 use crate::arch::{Divide, x86_64::m128::M128};
+use crate::{
+	arch::x86_64::{
+		arithmetic::ghash::{self, GhashLanes},
+		m256::M256,
+	},
+	arithmetic_traits::GhashMulX,
+};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
 /// `GhashClMulWideMul` when VPCLMULQDQ is available, otherwise divide into two `M128` lanes and
@@ -33,30 +42,47 @@ pub type GhashSquare2x<T> = Divide<M128, T, 2>;
 /// applied across the full 256-bit vector.
 pub type GhashInvert2x<T> = crate::arch::portable::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
 
+impl GhashLanes for M256 {
+	#[inline]
+	fn move_64_to_hi(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm256_slli_si256::<8>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn shl_1_epi64(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm256_slli_epi64::<1>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn shr_63_epi64(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm256_srli_epi64::<63>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn broadcast_bit_127(a: Self) -> Self {
+		// Bit 127 is the sign bit of each lane's top 32-bit word.
+		// Copying that word over the lane, then shifting each word right by 31 as a signed value,
+		// leaves every bit of the lane equal to it.
+		unsafe {
+			let top_word = std::arch::x86_64::_mm256_shuffle_epi32::<0xff>(a.into());
+			std::arch::x86_64::_mm256_srai_epi32::<31>(top_word)
+		}
+		.into()
+	}
+}
+
+impl GhashMulX for M256 {
+	#[inline]
+	fn ghash_mul_x(self) -> Self {
+		ghash::mul_x(self)
+	}
+}
+
 #[cfg(target_feature = "vpclmulqdq")]
-mod vpclmulqdq {
-	use crate::arch::x86_64::{arithmetic::ghash::ClMulUnderlier, m256::M256};
-
-	impl ClMulUnderlier for M256 {
-		#[inline]
-		fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-			unsafe { std::arch::x86_64::_mm256_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }
-				.into()
-		}
-
-		#[inline]
-		fn move_64_to_hi(a: Self) -> Self {
-			unsafe { std::arch::x86_64::_mm256_slli_si256::<8>(a.into()) }.into()
-		}
-
-		#[inline]
-		fn shl_1_epi64(a: Self) -> Self {
-			unsafe { std::arch::x86_64::_mm256_slli_epi64::<1>(a.into()) }.into()
-		}
-
-		#[inline]
-		fn shr_63_epi64(a: Self) -> Self {
-			unsafe { std::arch::x86_64::_mm256_srli_epi64::<63>(a.into()) }.into()
-		}
+impl ghash::ClMulUnderlier for M256 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		// Safety: the `vpclmulqdq` gate on this impl is exactly what the intrinsic requires.
+		unsafe { std::arch::x86_64::_mm256_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -10,15 +10,12 @@
 //! Every lane operation below acts within a 128-bit lane, so one body serves both GHASH lanes.
 
 // Used by the `GhashWideMul2x` and `GhashSquare2x` fallbacks when VPCLMULQDQ is unavailable.
+use crate::arch::x86_64::{
+	arithmetic::ghash::{self, GhashLanes},
+	m256::M256,
+};
 #[cfg(not(target_feature = "vpclmulqdq"))]
 use crate::arch::{Divide, x86_64::m128::M128};
-use crate::{
-	arch::x86_64::{
-		arithmetic::ghash::{self, GhashLanes},
-		m256::M256,
-	},
-	arithmetic_traits::GhashMulX,
-};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
 /// `GhashClMulWideMul` when VPCLMULQDQ is available, otherwise divide into two `M128` lanes and
@@ -71,12 +68,9 @@ impl GhashLanes for M256 {
 	}
 }
 
-impl GhashMulX for M256 {
-	#[inline]
-	fn ghash_mul_x(self) -> Self {
-		ghash::mul_x(self)
-	}
-}
+/// Scaling wrapper for the `PackedGhash2x128b` packing: the vector sequence, which needs
+/// only AVX2.
+pub type GhashMulX2x<T> = ghash::GhashMulX<T>;
 
 #[cfg(target_feature = "vpclmulqdq")]
 impl ghash::ClMulUnderlier for M256 {

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -10,13 +10,10 @@
 //! Every lane operation below acts within a 128-bit lane, so one body serves all four GHASH lanes.
 
 use super::m512::M512;
+use crate::arch::x86_64::arithmetic::ghash::{self, GhashLanes};
 // Used by the `GhashWideMul4x` and `GhashSquare4x` fallbacks when VPCLMULQDQ is unavailable.
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
 use crate::arch::{Divide, x86_64::m128::M128};
-use crate::{
-	arch::x86_64::arithmetic::ghash::{self, GhashLanes},
-	arithmetic_traits::GhashMulX,
-};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
 /// [`GhashClMulWideMul`](ghash::GhashClMulWideMul) when VPCLMULQDQ + AVX-512 are available,
@@ -76,12 +73,9 @@ impl GhashLanes for M512 {
 	}
 }
 
-impl GhashMulX for M512 {
-	#[inline]
-	fn ghash_mul_x(self) -> Self {
-		ghash::mul_x(self)
-	}
-}
+/// Scaling wrapper for the `PackedGhash4x128b` packing: the vector sequence, which needs
+/// only AVX-512F.
+pub type GhashMulX4x<T> = ghash::GhashMulX<T>;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -6,16 +6,17 @@
 //! This module provides optimized GHASH multiplication using the VPCLMULQDQ instruction
 //! available on modern x86_64 processors with AVX-512 support. The implementation follows
 //! the algorithm described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
+//!
+//! Every lane operation below acts within a 128-bit lane, so one body serves all four GHASH lanes.
 
-// Used by the CLMUL-accelerated `ClMulUnderlier` impl, the `GhashClMulWideMul`, and the
-// `GhashClMul` square aliases below.
-#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 use super::m512::M512;
-#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-use crate::arch::x86_64::arithmetic::ghash;
 // Used by the `GhashWideMul4x` and `GhashSquare4x` fallbacks when VPCLMULQDQ is unavailable.
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
 use crate::arch::{Divide, x86_64::m128::M128};
+use crate::{
+	arch::x86_64::arithmetic::ghash::{self, GhashLanes},
+	arithmetic_traits::GhashMulX,
+};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
 /// [`GhashClMulWideMul`](ghash::GhashClMulWideMul) when VPCLMULQDQ + AVX-512 are available,
@@ -38,15 +39,11 @@ pub type GhashSquare4x<T> = Divide<M128, T, 4>;
 /// applied across the full 512-bit vector.
 pub type GhashInvert4x<T> = crate::arch::portable::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
 
-#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-impl ghash::ClMulUnderlier for M512 {
-	#[inline]
-	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-		unsafe { std::arch::x86_64::_mm512_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }.into()
-	}
-
+impl GhashLanes for M512 {
 	#[inline]
 	fn move_64_to_hi(a: Self) -> Self {
+		// Interleaving the low halves of zero and `a` puts each lane's low half in its high half.
+		// Shifting a whole 128-bit lane by 8 bytes would need AVX512BW, which this does not.
 		unsafe {
 			std::arch::x86_64::_mm512_unpacklo_epi64(
 				std::arch::x86_64::_mm512_setzero_si512(),
@@ -64,5 +61,33 @@ impl ghash::ClMulUnderlier for M512 {
 	#[inline]
 	fn shr_63_epi64(a: Self) -> Self {
 		unsafe { std::arch::x86_64::_mm512_srli_epi64::<63>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn broadcast_bit_127(a: Self) -> Self {
+		// Bit 127 is the sign bit of each lane's top 32-bit word.
+		// Copying that word over the lane, then shifting each word right by 31 as a signed value,
+		// leaves every bit of the lane equal to it.
+		unsafe {
+			let top_word = std::arch::x86_64::_mm512_shuffle_epi32::<0xff>(a.into());
+			std::arch::x86_64::_mm512_srai_epi32::<31>(top_word)
+		}
+		.into()
+	}
+}
+
+impl GhashMulX for M512 {
+	#[inline]
+	fn ghash_mul_x(self) -> Self {
+		ghash::mul_x(self)
+	}
+}
+
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
+impl ghash::ClMulUnderlier for M512 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		// Safety: the `vpclmulqdq` + `avx512f` gate on this impl is what the intrinsic requires.
+		unsafe { std::arch::x86_64::_mm512_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }.into()
 	}
 }

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -6,10 +6,31 @@ use std::{
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+use crate::underlier::Underlier;
+
 /// Value that can be multiplied by itself
 pub trait Square {
 	/// Returns the value multiplied by itself
 	fn square(self) -> Self;
+}
+
+/// Scales a field element by `X`, the generator of its polynomial basis.
+///
+/// A one-bit shift plus a masked exclusive or, not a field multiply.
+/// The scaling is `GF(2)`-linear, so it applies equally to an unreduced product.
+pub trait MulX {
+	/// Returns the element scaled by `X`.
+	#[must_use]
+	fn mul_x(self) -> Self;
+}
+
+/// An underlier whose 128-bit lanes each hold a GHASH element that can be scaled by `X`.
+///
+/// The per-architecture dispatch point behind [`MulX`] for GHASH.
+pub trait GhashMulX: Underlier {
+	/// Returns the value with every 128-bit lane scaled by `X`.
+	#[must_use]
+	fn ghash_mul_x(self) -> Self;
 }
 
 /// A field type that supports widening (unreduced) multiplication.

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -6,31 +6,29 @@ use std::{
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-use crate::underlier::Underlier;
-
 /// Value that can be multiplied by itself
 pub trait Square {
 	/// Returns the value multiplied by itself
 	fn square(self) -> Self;
 }
 
-/// Scales a field element by `X`, the generator of its polynomial basis.
+/// Scales a value by `X`, the generator of the field's polynomial basis.
 ///
 /// A one-bit shift plus a masked exclusive or, not a field multiply.
-/// The scaling is `GF(2)`-linear, so it applies equally to an unreduced product.
+///
+/// The scaling is `GF(2)`-linear, so it commutes with the modular reduction.
+/// That is what lets one trait serve both a reduced element and an unreduced product:
+///
+/// ```text
+///     reduce(mul_x(wide)) == mul_x(reduce(wide))
+/// ```
+///
+/// Scaling an unreduced product folds the `X` of an irreducible polynomial into a reduction the
+/// caller is going to pay for anyway.
 pub trait MulX {
-	/// Returns the element scaled by `X`.
+	/// Returns the value scaled by `X`.
 	#[must_use]
 	fn mul_x(self) -> Self;
-}
-
-/// An underlier whose 128-bit lanes each hold a GHASH element that can be scaled by `X`.
-///
-/// The per-architecture dispatch point behind [`MulX`] for GHASH.
-pub trait GhashMulX: Underlier {
-	/// Returns the value with every 128-bit lane scaled by `X`.
-	#[must_use]
-	fn ghash_mul_x(self) -> Self;
 }
 
 /// A field type that supports widening (unreduced) multiplication.
@@ -58,18 +56,6 @@ pub trait WideMul: Sized {
 
 	fn wide_mul(a: Self, b: Self) -> Self::Output;
 	fn reduce(wide: Self::Output) -> Self;
-}
-
-/// An unreduced widening product (a [`WideMul::Output`]) that can be scaled by the field element
-/// `X` while still unreduced.
-///
-/// Scaling by `X` and the modular reduction are both `GF(2)`-linear, and they commute:
-/// `reduce(wide.mul_x_wide()) == reduce(wide).mul_x()`. Doing the scaling on the unreduced product
-/// lets an extension-field multiply fold the `X` of its irreducible polynomial into a product it is
-/// going to reduce anyway, saving a reduction over scaling the reduced coordinate.
-pub trait MulXWide {
-	/// Returns the unreduced product scaled by `X`.
-	fn mul_x_wide(self) -> Self;
 }
 
 /// Value that can be inverted
@@ -108,6 +94,23 @@ macro_rules! impl_square_with {
 }
 
 pub(crate) use impl_square_with;
+
+macro_rules! impl_mul_x_with {
+	($name:ident @ $($strategy:tt)*) => {
+		impl $crate::arithmetic_traits::MulX for $name {
+			#[inline]
+			fn mul_x(self) -> Self {
+				<$($strategy)* <$name> as ::bytemuck::TransparentWrapper<$name>>::peel(
+					$crate::arithmetic_traits::MulX::mul_x(
+						<$($strategy)* <$name> as ::bytemuck::TransparentWrapper<$name>>::wrap(self),
+					),
+				)
+			}
+		}
+	};
+}
+
+pub(crate) use impl_mul_x_with;
 
 macro_rules! impl_invert_with {
 	($name:ident @ $($strategy:tt)*) => {

--- a/crates/field/src/fields/ghash.rs
+++ b/crates/field/src/fields/ghash.rs
@@ -15,6 +15,7 @@ use bytemuck::{Pod, Zeroable};
 use crate::{
 	Field, Rijndael8b,
 	arch::M128,
+	arithmetic_traits::{GhashMulX, MulX},
 	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	field::ExtensionField,
 	underlier::{U1, UnderlierView},
@@ -52,21 +53,6 @@ impl Ghash128b {
 	}
 
 	#[inline]
-	pub fn mul_x(self) -> Self {
-		// These scalar bit manipulations are simplest over `u128`; the underlier is `M128`.
-		let val: u128 = self.to_underlier().into();
-		let shifted = val << 1;
-
-		// GHASH irreducible polynomial: x^128 + x^7 + x^2 + x + 1
-		// When the high bit is set, we need to XOR with the reduction polynomial 0x87
-		// All 1s if the top bit is set, all 0s otherwise
-		let mask = (val >> 127).wrapping_neg();
-		let result = shifted ^ (0x87 & mask);
-
-		Self::new(result)
-	}
-
-	#[inline]
 	pub fn mul_inv_x(self) -> Self {
 		// These scalar bit manipulations are simplest over `u128`; the underlier is `M128`.
 		let val: u128 = self.to_underlier().into();
@@ -81,6 +67,13 @@ impl Ghash128b {
 		let result = shifted ^ (((1u128 << 127) | 0x43) & mask);
 
 		Self::new(result)
+	}
+}
+
+impl MulX for Ghash128b {
+	#[inline]
+	fn mul_x(self) -> Self {
+		Self::from_underlier(self.to_underlier().ghash_mul_x())
 	}
 }
 

--- a/crates/field/src/fields/ghash.rs
+++ b/crates/field/src/fields/ghash.rs
@@ -13,9 +13,9 @@ use std::{
 use bytemuck::{Pod, Zeroable};
 
 use crate::{
-	Field, Rijndael8b,
+	Field, PackedGhash1x128b, Rijndael8b,
 	arch::M128,
-	arithmetic_traits::{GhashMulX, MulX},
+	arithmetic_traits::MulX,
 	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	field::ExtensionField,
 	underlier::{U1, UnderlierView},
@@ -73,7 +73,12 @@ impl Ghash128b {
 impl MulX for Ghash128b {
 	#[inline]
 	fn mul_x(self) -> Self {
-		Self::from_underlier(self.to_underlier().ghash_mul_x())
+		// The width-one packing is this field with one element, so it holds the same scaling.
+		Self::from_underlier(
+			PackedGhash1x128b::from_underlier(self.to_underlier())
+				.mul_x()
+				.to_underlier(),
+		)
 	}
 }
 

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -30,7 +30,7 @@ pub mod transpose;
 mod underlier;
 pub mod util;
 
-pub use arithmetic_traits::WideMul;
+pub use arithmetic_traits::{MulX, WideMul};
 pub use binary_field::*;
 pub use divisible::Divisible;
 pub use field::{ExtensionField, Field, FieldOps};

--- a/crates/field/src/packed_fields/ghash.rs
+++ b/crates/field/src/packed_fields/ghash.rs
@@ -8,7 +8,17 @@ use crate::{
 		GhashWideMul1x, GhashWideMul2x, GhashWideMul4x, M128, M256, M512,
 		portable::packed_macros::*,
 	},
+	arithmetic_traits::{GhashMulX, MulX},
+	packed_fields::primitive::PackedPrimitiveType,
 };
+
+impl<U: GhashMulX> MulX for PackedPrimitiveType<U, Ghash128b> {
+	/// One vector sequence covers every lane, whatever the packing width.
+	#[inline]
+	fn mul_x(self) -> Self {
+		Self::from_underlier(self.to_underlier().ghash_mul_x())
+	}
+}
 
 define_packed_binary_field!(
 	PackedGhash1x128b,
@@ -59,6 +69,23 @@ mod tests {
 		}
 	}
 
+	/// Scaling by `X` must agree with multiplying by the field element `X` in every lane.
+	///
+	/// The multiply is an independent oracle: it runs the product and the modular reduction, none
+	/// of which the scaling touches.
+	fn check_mul_x<P>(underlier: P::Underlier)
+	where
+		P: PackedField<Scalar = Ghash128b> + UnderlierView + MulX,
+	{
+		let packed = P::from_underlier(underlier);
+		let scaled = packed.mul_x();
+		let x = Ghash128b::new(2);
+
+		for i in 0..P::WIDTH {
+			assert_eq!(scaled.get(i), packed.get(i) * x, "lane {i}");
+		}
+	}
+
 	proptest! {
 		#[test]
 		fn test_get_set_256(a in any::<[u128; 2]>(), b in any::<[u128; 2]>()) {
@@ -68,6 +95,22 @@ mod tests {
 		#[test]
 		fn test_get_set_512(a in any::<[u128; 4]>(), b in any::<[u128; 4]>()) {
 			check_get_set::<4, PackedGhash4x128b>(a, b);
+		}
+
+		#[test]
+		#[allow(clippy::useless_conversion)] // the conversion depends on the target platform
+		fn mul_x_is_multiplication_by_x_1x(a in any::<u128>()) {
+			check_mul_x::<PackedGhash1x128b>(a.into());
+		}
+
+		#[test]
+		fn mul_x_is_multiplication_by_x_2x(a in any::<[u128; 2]>()) {
+			check_mul_x::<PackedGhash2x128b>(a.into());
+		}
+
+		#[test]
+		fn mul_x_is_multiplication_by_x_4x(a in any::<[u128; 4]>()) {
+			check_mul_x::<PackedGhash4x128b>(a.into());
 		}
 	}
 

--- a/crates/field/src/packed_fields/ghash.rs
+++ b/crates/field/src/packed_fields/ghash.rs
@@ -4,21 +4,12 @@
 use crate::{
 	Ghash128b,
 	arch::{
-		GhashInvert1x, GhashInvert2x, GhashInvert4x, GhashSquare1x, GhashSquare2x, GhashSquare4x,
-		GhashWideMul1x, GhashWideMul2x, GhashWideMul4x, M128, M256, M512,
-		portable::packed_macros::*,
+		GhashInvert1x, GhashInvert2x, GhashInvert4x, GhashMulX1x, GhashMulX2x, GhashMulX4x,
+		GhashSquare1x, GhashSquare2x, GhashSquare4x, GhashWideMul1x, GhashWideMul2x,
+		GhashWideMul4x, M128, M256, M512, portable::packed_macros::*,
 	},
-	arithmetic_traits::{GhashMulX, MulX},
-	packed_fields::primitive::PackedPrimitiveType,
+	arithmetic_traits::impl_mul_x_with,
 };
-
-impl<U: GhashMulX> MulX for PackedPrimitiveType<U, Ghash128b> {
-	/// One vector sequence covers every lane, whatever the packing width.
-	#[inline]
-	fn mul_x(self) -> Self {
-		Self::from_underlier(self.to_underlier().ghash_mul_x())
-	}
-}
 
 define_packed_binary_field!(
 	PackedGhash1x128b,
@@ -47,13 +38,19 @@ define_packed_binary_field!(
 	(GhashWideMul4x)
 );
 
+// Scaling by `X` is not a multiply, so it wires through its own strategy rather than a slot of the
+// packing definition -- only the GHASH packings have one.
+impl_mul_x_with!(PackedGhash1x128b @ GhashMulX1x);
+impl_mul_x_with!(PackedGhash2x128b @ GhashMulX2x);
+impl_mul_x_with!(PackedGhash4x128b @ GhashMulX4x);
+
 #[cfg(test)]
 mod tests {
 	use proptest::{arbitrary::any, proptest};
 
 	use super::*;
 	use crate::{
-		Ghash128b, PackedField, packed_fields::test_utils::packed_field_tests,
+		Ghash128b, MulX, PackedField, packed_fields::test_utils::packed_field_tests,
 		underlier::UnderlierView,
 	};
 

--- a/crates/field/src/packed_fields/ghash_sq.rs
+++ b/crates/field/src/packed_fields/ghash_sq.rs
@@ -18,7 +18,7 @@
 //!   packing divides into two width-one lanes.
 //!
 //! In both, the coordinate register is a [`PackedPrimitiveType`], so the multiply-by-`X` in the
-//! reduction is a per-lane bit shift rather than a full field multiply.
+//! reduction is a bit shift over the register rather than a full field multiply.
 //!
 //! The width-one packing's widening multiply is architecture-specific — see [`GhashSqWideMul1x`],
 //! which selects between batching the Karatsuba diagonal into one 256-bit carry-less multiply and
@@ -34,10 +34,10 @@ use bytemuck::TransparentWrapper;
 use crate::{
 	Divisible, Ghash128b, GhashSq256b, PackedField, PackedGhash2x128b, WideMul,
 	arch::{Divide, GhashSqWideMul1x, M128, M256, M512, portable::packed_macros::*},
-	arithmetic_traits::{InvertOrZero, Square},
+	arithmetic_traits::{InvertOrZero, MulX, Square},
 	packed_extension,
 	packed_fields::{primitive::PackedPrimitiveType, sliced::SlicedPackedField},
-	underlier::{Underlier, UnderlierView},
+	underlier::Underlier,
 };
 
 /// The packed GHASH coordinate register backing a `SlicedGhashSq256b<U>`.
@@ -54,26 +54,6 @@ pub type SlicedGhashSq4x256b = SlicedGhashSq256b<M512>;
 
 /// The unreduced widening product of the coordinate GHASH multiply.
 type GhashWide<U> = <Ghash<U> as WideMul>::Output;
-
-/// Multiplies every 128-bit GHASH lane of an underlier by `X`.
-///
-/// `X` scaling is `GF(2)`-linear — a per-lane bit shift with a fixed compensation, not a field
-/// multiply — so this is far cheaper than a CLMUL. It reuses the scalar
-/// [`Ghash128b::mul_x`] on each 128-bit lane, which every supported underlier divides
-/// into.
-#[inline]
-fn ghash_mul_x<U: Divisible<M128>>(u: U) -> U {
-	U::from_iter(
-		Divisible::<M128>::value_iter(u)
-			.map(|lane| Ghash128b::from_underlier(lane).mul_x().to_underlier()),
-	)
-}
-
-/// Multiplies every GHASH lane of a packed coordinate by `X`.
-#[inline]
-fn mul_x<U: Underlier + Divisible<M128>>(coord: Ghash<U>) -> Ghash<U> {
-	Ghash::<U>::from_underlier(ghash_mul_x(coord.to_underlier()))
-}
 
 /// The unreduced product of two GHASH² elements, as three separate GHASH products.
 ///
@@ -144,8 +124,8 @@ impl<W: Default + Add<Output = W>> Sum for SlicedGhashSqWide<W> {
 
 impl<U> WideMul for SlicedGhashSq256b<U>
 where
-	U: Underlier + Divisible<M128>,
-	Ghash<U>: PackedField<Scalar = Ghash128b> + WideMul,
+	U: Underlier,
+	Ghash<U>: PackedField<Scalar = Ghash128b> + WideMul + MulX,
 {
 	type Output = SlicedGhashSqWide<GhashWide<U>>;
 
@@ -170,15 +150,15 @@ where
 		let t2 = <Ghash<U> as WideMul>::reduce(wide.t2);
 		let t1 = <Ghash<U> as WideMul>::reduce(wide.t1);
 
-		let z0 = t0 + mul_x(t2);
+		let z0 = t0 + t2.mul_x();
 		Self::from_coords([z0, z0 + t1 + t2])
 	}
 }
 
 impl<U> Square for SlicedGhashSq256b<U>
 where
-	U: Underlier + Divisible<M128>,
-	Ghash<U>: PackedField<Scalar = Ghash128b>,
+	U: Underlier,
+	Ghash<U>: PackedField<Scalar = Ghash128b> + MulX,
 {
 	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two, and
 	/// `Y² = X·Y + X`.
@@ -189,15 +169,15 @@ where
 		let t0 = Square::square(a);
 		let t2 = Square::square(b);
 
-		let x_t2 = mul_x(t2);
+		let x_t2 = t2.mul_x();
 		Self::from_coords([t0 + x_t2, x_t2])
 	}
 }
 
 impl<U> InvertOrZero for SlicedGhashSq256b<U>
 where
-	U: Underlier + Divisible<M128>,
-	Ghash<U>: PackedField<Scalar = Ghash128b>,
+	U: Underlier,
+	Ghash<U>: PackedField<Scalar = Ghash128b> + MulX,
 {
 	/// Inverts through the norm of the degree-two extension. The conjugate of `u = a + b·Y` sends
 	/// `Y` to the other root of `Y² + X·Y + X` (the roots sum to `X` and multiply to `X`), giving
@@ -207,10 +187,10 @@ where
 	fn invert_or_zero(self) -> Self {
 		let [a, b] = self.to_coords();
 
-		let norm = Square::square(a) + mul_x(a * b + Square::square(b));
+		let norm = Square::square(a) + (a * b + Square::square(b)).mul_x();
 		let norm_inv = norm.invert_or_zero();
 
-		Self::from_coords([(a + mul_x(b)) * norm_inv, b * norm_inv])
+		Self::from_coords([(a + b.mul_x()) * norm_inv, b * norm_inv])
 	}
 }
 

--- a/crates/field/src/packed_fields/sliced.rs
+++ b/crates/field/src/packed_fields/sliced.rs
@@ -488,8 +488,13 @@ where
 		// Transpose the `degree × degree` matrix of `FSub` coordinates independently in each lane.
 		// Reading a whole column before writing keeps the in-place update free of read-after-write
 		// hazards within the lane.
+		//
+		// The buffer holds one lane's column and is reused across lanes, so the whole transpose
+		// allocates once rather than once per lane.
+		let mut column = Vec::with_capacity(degree);
 		for lane in 0..PSub::WIDTH {
-			let column = (0..degree).map(|j| elems[j].get(lane)).collect::<Vec<F>>();
+			column.clear();
+			column.extend((0..degree).map(|j| elems[j].get(lane)));
 			for (i, elem) in elems.iter_mut().enumerate() {
 				let transposed = <F as ExtensionField<FSub>>::from_bases(
 					(0..degree).map(|j| F::get_base(&column[j], i)),

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -22,7 +22,6 @@ use rand::{
 use super::{U1, Underlier};
 use crate::{
 	Random,
-	arithmetic_traits::GhashMulX,
 	divisible::{Divisible, mapget},
 };
 
@@ -154,13 +153,6 @@ impl<U: Underlier + Pod, const N: usize> Underlier for ScaledUnderlier<U, N> {
 
 			(Self(a), Self(b))
 		}
-	}
-}
-
-impl<U: GhashMulX + Pod, const N: usize> GhashMulX for ScaledUnderlier<U, N> {
-	#[inline]
-	fn ghash_mul_x(self) -> Self {
-		Self(self.0.map(U::ghash_mul_x))
 	}
 }
 

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -22,6 +22,7 @@ use rand::{
 use super::{U1, Underlier};
 use crate::{
 	Random,
+	arithmetic_traits::GhashMulX,
 	divisible::{Divisible, mapget},
 };
 
@@ -153,6 +154,13 @@ impl<U: Underlier + Pod, const N: usize> Underlier for ScaledUnderlier<U, N> {
 
 			(Self(a), Self(b))
 		}
+	}
+}
+
+impl<U: GhashMulX + Pod, const N: usize> GhashMulX for ScaledUnderlier<U, N> {
+	#[inline]
+	fn ghash_mul_x(self) -> Self {
+		Self(self.0.map(U::ghash_mul_x))
 	}
 }
 


### PR DESCRIPTION
Closes [BINIUS-578](https://linear.app/jimpo/issue/BINIUS-578).

Scales a GHASH element by $X$ with one vector sequence instead of one scalar step per 128-bit lane. Same values out — the identity is pinned by proptest against the field multiply.

### The problem

Multiplying a GHASH element by $X$ is not a multiplication.

GHASH is $\mathbb{F}_2[X]$ modulo $X^{128} + X^7 + X^2 + X + 1$.
An element is a polynomial whose 128 binary coefficients sit in 128 bits.
Scaling by $X$ raises every coefficient one degree, which is a one-bit left shift.
The one complication is the coefficient that lands on $X^{128}$, off the top of the register.
The modulus rewrites it: $X^{128} = X^7 + X^2 + X + 1$, the constant `0x87`.

```
x * X = (x << 1)              when bit 127 of x is clear
      = (x << 1) + 0x87       when bit 127 of x is set
```

A shift and one masked exclusive or. No carry-less multiply, no reduction loop.

The crate had this right at the scalar level and wrong everywhere above it.
`Ghash128b::mul_x` did the shift over a `u128`, and on x86 the GHASH underlier is a vector register — so that is a round trip out to general-purpose registers and back.
`packed_ghash_sq` then called it once per 128-bit lane through `Divisible`, so scaling the four lanes of an `M512` coordinate register paid four such round trips.

### The idea

Do the shift and the fold with vector instructions, on the whole underlier at once.

Eight instructions serve any width, plus two loop-invariant constants:

```
shifted  = shl_1_epi64(x) ^ move_64_to_hi(shr_63_epi64(x))   // the 128-bit shift, bit 127 falls off
overflow = broadcast_bit_127(x) & POLY                       // the X^128 term, folded back
result   = shifted ^ overflow
```

No instruction shifts a whole 128-bit lane by one bit, which is why the shift is built from the two 64-bit halves.
The bit leaving the low half belongs at position 64, which is where moving it up a half-lane puts it.
The bit leaving the high half is the $X^{128}$ term, and it is the one the mask folds back in.

### The change

- `MulX` — a new trait beside `MulXWide` in `arithmetic_traits`, carrying the identity `mul_x(x) == x * X`.
- `GhashMulX` — the per-architecture dispatch point underneath it; one blanket impl covers every GHASH packing width.
- `ClMulUnderlier` splits in two. Scaling by $X$ needs no carry-less multiply, so `move_64_to_hi`, `shl_1_epi64` and `shr_63_epi64` move into a new `GhashLanes` supertrait along with the bit-127 mask, and `ClMulUnderlier: GhashLanes` keeps only `clmulepi64`.

```
- fn ghash_mul_x<U: Divisible<M128>>(u: U) -> U {           // one scalar step per lane
-     U::from_iter(Divisible::<M128>::value_iter(u)
-         .map(|lane| Ghash128b::from_underlier(lane).mul_x().to_underlier()))
- }
+ impl<U: GhashMulX> MulX for PackedPrimitiveType<U, Ghash128b> {   // one sequence, all lanes
+     fn mul_x(self) -> Self { Self::from_underlier(self.to_underlier().ghash_mul_x()) }
+ }
```

Two things came along with it:

- `POLY` had three definitions, one per architecture backend. It is a cryptographic constant, so it now has one, in the portable module the other two import from.
- `SlicedPackedField::square_transpose` allocated a `Vec` inside its per-lane loop — `PSub::WIDTH` allocations per call, column length up to 256. The buffer is allocated once and reused.

### Soundness

No protocol surface changes; this is an arithmetic implementation swap.
`mul_x(x) == x * X` is pinned against the field multiply, an oracle that runs the CLMUL product and the modular reduction and touches none of the new code.
Every specialized path is additionally pinned against the `u128` scalar reference at every vector width.

### Scope

- **new:** `MulX`, `GhashMulX`, `GhashLanes`, the vector `mul_x` for x86 (SSE2 / AVX2 / AVX-512) and NEON, the `u128` reference.
- **changed:** `SlicedGhashSq*::{reduce, square, invert_or_zero}`, `GhashSqSquare`, `GhashSqInvert`, `GhashSqHybridWideMul::reduce`, plus the two items above.
- **untouched:** `Ghash128b::mul_inv_x` — it has no caller inside the field crate, so it keeps its scalar form rather than growing an unused vector path.
- **untouched:** both GHASH² packing layouts. Neither has a consumer outside `crates/field` yet and both call `mul_x`, so this helps whichever one survives; picking between them is separate work.

### Benchmark

Zen 5 (9950X3D), `-Ctarget-cpu=native`, minimum of 60 rounds per measurement, otherwise-idle machine.
Old and new run in the same binary back to back on the same inputs, after asserting they agree. Nanoseconds per operation.

The primitive itself:

| | old | new | speedup |
|---|---|---|---|
| `mul_x` on `M256` | 1.08 | 0.59 | **1.8×** |
| `mul_x` on `M512` | 3.38 | 0.52 | **6.5×** |

The composite GHASH² operations move much less, and I would rather say so than quote the primitive's ratio and let it stand for the whole:

| | old | new | speedup |
|---|---|---|---|
| `SlicedGhashSq4x256b` square | 0.98 | 0.75 | **1.30×** |
| `SlicedGhashSq4x256b` mul | 1.76 | 1.68 | 1.05× |
| `SlicedGhashSq4x256b` invert | 40.9 | 39.8 | 1.03× |
| `SlicedGhashSq2x256b` square | 1.50 | 1.46 | 1.03× |
| `SlicedGhashSq2x256b` mul | 3.27 | 3.27 | 1.00× |
| `SlicedGhashSq2x256b` invert | 61.0 | 59.8 | 1.02× |

`mul_x` is one step among several CLMUL products in `mul`, and among a whole Itoh-Tsujii inversion in `invert_or_zero`.
On an idle core the out-of-order engine hides most of the old path's extra work behind that latency, so only `square` — where `mul_x` is a large share of a short dependency chain — shows a clear gain.

Under CPU contention the gap is much wider: measuring the same harness on a saturated machine, the composites showed 1.3×-2.3× and `mul_x` on `M512` up to 7×, because the old path's extra instructions and its register-file round trips compete for issue slots that are no longer free. A prover saturating every core looks more like that than like the table above, but the idle numbers are the honest baseline.

Plain GHASH is untouched and does not regress: mul 2.30 / 1.22 / 0.60, square 1.55 / 0.82 / 0.39, inner product 1.56 / 0.82 / 0.41 ns per scalar at widths 1 / 2 / 4.

### Verification

Field-crate scoped, both feature legs, since `MulX` has a CLMUL path and a portable one:

- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-field --release` — 277 passed, 0 failed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-field --all-targets --all-features -- -D warnings` — clean
- `cargo test -p binius-field --release` (portable leg) — 260 passed, 0 failed
- `cargo +nightly-2026-07-01 fmt --all --check` — clean

Extra configurations checked because this PR changes which target features gate what:

- `-Ctarget-feature=+avx2,+avx512f` with no CLMUL feature at all — 276 passed, including all six `mul_x` tests. This is the configuration the `GhashLanes` split unlocks.
- `cargo check -p binius-field --lib --target aarch64-unknown-linux-gnu` with `+neon,+aes` — clean.
- `cargo check -p binius-field --lib --target wasm32-unknown-unknown`, with and without `+simd128` — clean.

The aarch64 NEON `mul_x` is compile-checked but not executed — no emulator on this host — so its correctness rests on the argument in the body comment plus CI's aarch64 leg.

New tests:

- `mul_x_matches_the_scalar_reference` pins each vector width against the `u128` reference. Boundary values (`0`, `1`, `X`, `0x87`, `1 << 127`, `(1 << 127) | 1`, `(1 << 127) | (1 << 63)`, `u128::MAX`) are laid out so neighbouring lanes differ, which is what would catch a sequence letting one lane's carry leak into the next; random input follows.
- `mul_x_is_multiplication_by_x_{1x,2x,4x}` pin every packing against the field multiply.
- The existing GHASH² proptests already check `square`, `invert_or_zero`, `Mul` and deferred `wide_mul` against the scalar reference, so the rewiring is covered end to end without new tests.

### Context

Worth recording: `arith-bench/src/ghash/clmul.rs` has had this exact branch-free sequence all along.
The benchmark crate and the field crate carry two independent abstraction layers over the same instructions — `OpsClmul` with `[U; 3]` limbs against `ClMulUnderlier` with `WideGhashProduct`, each with its own `mul_x_wide`.
This closes one gap between them; unifying them is a separate conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
