### PR TITLE
BINIUS-579: Cut the GFNI identity-matrix doc down to what the code cannot say

### DIFF
--- a/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
+++ b/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
@@ -12,29 +12,10 @@ use crate::{
 
 /// The 8x8 identity matrix over `GF(2)`, in the byte encoding `vgf2p8affineinvqb` expects.
 ///
-/// The instruction inverts each byte `b` of its input and then applies a `GF(2)`-affine map:
+/// The instruction reads its matrix bytes from the high output bit down.
+/// So the identity descends from `0x80` rather than ascending from `0x01`.
 ///
-/// ```text
-/// out.bit[i] = parity(matrix.byte[7 - i] AND inv(b)) XOR imm8.bit[i]
-/// ```
-///
-/// Here `inv` is the multiplicative inverse in `GF(2^8)` under `x^8 + x^4 + x^3 + x + 1`.
-/// That is the Rijndael polynomial, so the field is exactly [`Rijndael8b`].
-/// Passing the identity matrix with `imm8 = 0` leaves `inv(b)` untransformed.
-///
-/// The formula feeds `matrix.byte[k]` into output bit `7 - k`.
-/// Selecting one input bit means that byte holds one set bit.
-/// So the identity is `matrix.byte[k] = 1 << (7 - k)`, descending, not `0x01, 0x02, 0x04, ...`:
-///
-/// ```text
-/// byte 0 = 0b10000000  ->  out.bit[7] = inv(b).bit[7]
-/// byte 1 = 0b01000000  ->  out.bit[6] = inv(b).bit[6]
-/// ...
-/// byte 7 = 0b00000001  ->  out.bit[0] = inv(b).bit[0]
-/// ```
-///
-/// The instruction defines `inv(0) = 0`.
-/// That is exactly the [`InvertOrZero`] contract, so a zero byte needs no special case.
+/// A zero byte inverts to zero, so no special case is needed.
 #[rustfmt::skip]
 const IDENTITY_MAP: u64 = u64::from_le_bytes([
 	0b10000000,


### PR DESCRIPTION
Closes [BINIUS-579](https://linear.app/jimpo/issue/BINIUS-579).

Trims a 23-line doc comment to 4 lines. Doc lines only — no code changes.

### The problem

The identity matrix handed to the affine-inverse instruction carried 23 lines of documentation.

It re-derived the instruction's output-bit formula, restated the Rijndael polynomial, and drew an eight-line byte-by-byte diagram.

All of that is either in the instruction's own reference or visible in the constant's value on the next line.

Long docs on small items cost twice: they are read every time someone passes through, and they go stale without anyone noticing.

### The idea

Keep only what a maintainer cannot get from the code.

One fact qualifies, and it is a trap: the bytes descend from `0x80` rather than ascending from `0x01`.

Tidying the value into the more natural ascending pattern would silently compute the wrong inverse, so that earns its line.

The formula, the polynomial and the diagram are reference material rather than warnings.

### The change

Before, 23 doc lines with two fenced blocks and an eight-line diagram. After, four:

```
/// The 8x8 identity matrix over `GF(2)`, in the byte encoding `vgf2p8affineinvqb` expects.
///
/// The instruction reads its matrix bytes from the high output bit down.
/// So the identity descends from `0x80` rather than ascending from `0x01`.
///
/// A zero byte inverts to zero, so no special case is needed.
#[rustfmt::skip]
const IDENTITY_MAP: u64 = u64::from_le_bytes([
```

### Scope

- **changed:** one doc comment in the field crate's GFNI backend
- **untouched:** the constant's value and its formatting attribute — the diff is doc lines only
- two intra-doc links are dropped; both items they pointed at are still used by code, so nothing is stranded

### Verification

Checks scoped to the change, which is comments only:

| check | result |
|---|---|
| `typos` (v1.32.0, the pinned CI version) | clean |
| `cargo +nightly-2026-07-01 fmt --all --check` | clean |
| `clippy -p binius-field --all-targets --all-features -- -D warnings` (native) | clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-field --document-private-items` | clean |

The rustdoc gate is the load-bearing one: it is what proves that dropping two intra-doc link targets left no surviving link dangling.

`typos` is included because the whole diff is prose, and it is the CI step a prose-only change is most likely to trip.

Clippy passing at `-D warnings` also confirms the two imports those links referenced are still used by code, so no unused-import warning appears.

The module is gated on the `gfni` target feature, so the native leg is the only one that compiles it. A comment-only change cannot break another target, so no workspace-wide run was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
