### PR TITLE
BINIUS-580: Give each PackedField scalar-iteration method one definition

### DIFF
--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -271,21 +271,6 @@ macro_rules! binary_field {
 		}
 
 		impl $crate::PackedField for $name {
-			#[inline]
-			fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-				std::iter::once(*self)
-			}
-
-			#[inline]
-			fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Send + Clone {
-				std::iter::once(self)
-			}
-
-			#[inline]
-			fn iter_slice(slice: &[Self]) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-				slice.iter().copied()
-			}
-
 			fn interleave(self, _other: Self, _log_block_len: usize) -> (Self, Self) {
 				panic!("cannot interleave when WIDTH = 1");
 			}

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -11,7 +11,6 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
-use binius_utils::iter::IterExtensions;
 use bytemuck::Zeroable;
 
 use super::{Random, arithmetic_traits::Square};
@@ -59,31 +58,23 @@ pub trait PackedField:
 	/// WIDTH is guaranteed to equal 2^LOG_WIDTH.
 	const WIDTH: usize = 1 << Self::LOG_WIDTH;
 
+	/// Yields one scalar per lane, from the lowest lane to the highest.
 	#[inline]
-	fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Send + Clone {
-		(0..Self::WIDTH).map_skippable(move |i|
-			// Safety: `i` is always less than `WIDTH`
-			unsafe { self.get_unchecked(i) })
+	fn into_iter(self) -> impl ExactSizeIterator<Item = Self::Scalar> + Send + Clone {
+		Divisible::value_iter(self)
 	}
 
+	/// Yields one scalar per lane, from the lowest lane to the highest.
 	#[inline]
-	fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-		(0..Self::WIDTH).map_skippable(move |i|
-			// Safety: `i` is always less than `WIDTH`
-			unsafe { self.get_unchecked(i) })
+	fn iter(&self) -> impl ExactSizeIterator<Item = Self::Scalar> + Send + Clone + '_ {
+		Divisible::ref_iter(self)
 	}
 
+	/// Yields every scalar of the whole slice: element by element, each element's lanes in order.
 	#[inline]
-	fn iter_slice(slice: &[Self]) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-		slice.iter().flat_map(Self::iter)
-	}
-
-	/// Initialize zero position with `scalar`, set other elements to zero.
-	#[inline(always)]
-	fn set_single(scalar: Self::Scalar) -> Self {
-		let mut result = Self::default();
-		result.set(0, scalar);
-		result
+	fn iter_slice(slice: &[Self]) -> impl ExactSizeIterator<Item = Self::Scalar> + Send + Clone + '_
+	{
+		Divisible::slice_iter(slice)
 	}
 
 	/// Construct a packed field element from a function that returns scalar values by index.
@@ -96,11 +87,7 @@ pub trait PackedField:
 	/// ignored.
 	#[inline]
 	fn from_scalars(values: impl IntoIterator<Item = Self::Scalar>) -> Self {
-		let mut result = Self::default();
-		for (i, val) in values.into_iter().take(Self::WIDTH).enumerate() {
-			result.set(i, val);
-		}
-		result
+		Divisible::from_iter(values.into_iter())
 	}
 
 	/// Returns the value to the power `exp`.
@@ -217,8 +204,6 @@ pub fn get_packed_slice<P: PackedField>(packed: &[P], i: usize) -> P::Scalar {
 /// The caller must ensure that `i` is less than `P::WIDTH * packed.len()`.
 #[inline(always)]
 pub unsafe fn get_packed_slice_unchecked<P: PackedField>(packed: &[P], i: usize) -> P::Scalar {
-	// TODO: Consider putting a get_in_slice method on Divisible
-
 	// Safety:
 	// - `i / P::WIDTH` is within the bounds of `packed` if `i` is less than `P::WIDTH *
 	//   packed.len()`
@@ -239,8 +224,6 @@ pub unsafe fn set_packed_slice_unchecked<P: PackedField>(
 	i: usize,
 	scalar: P::Scalar,
 ) {
-	// TODO: Consider putting a set_in_slice method on Divisible
-
 	// Safety: if `i` is less than `P::WIDTH * packed.len()`, then
 	// - `i / P::WIDTH` is within the bounds of `packed`
 	// - `i % P::WIDTH` is always less than `P::WIDTH
@@ -258,6 +241,8 @@ impl<PT> PackedBinaryField for PT where PT: PackedField<Scalar: BinaryField> {}
 
 #[cfg(test)]
 mod tests {
+	use std::iter::repeat_with;
+
 	use rand::prelude::*;
 
 	use crate::{
@@ -326,6 +311,68 @@ mod tests {
 		assert!(iter.next().is_none());
 	}
 
+	fn check_exact_size<P: PackedField>(mut rng: impl Rng) {
+		let packed = P::random(&mut rng);
+
+		// A reported length has to match what iteration actually produces.
+		assert_eq!(packed.iter().len(), P::WIDTH);
+		assert_eq!(packed.iter().count(), P::WIDTH);
+		assert_eq!(packed.iter().size_hint(), (P::WIDTH, Some(P::WIDTH)));
+
+		assert_eq!(packed.into_iter().len(), P::WIDTH);
+		assert_eq!(packed.into_iter().count(), P::WIDTH);
+		assert_eq!(packed.into_iter().size_hint(), (P::WIDTH, Some(P::WIDTH)));
+
+		// Over a slice the length is the slice length times the width, so the empty slice is the
+		// one case that can disagree without any single scalar being wrong.
+		for len in [0, 1, 3] {
+			let slice = repeat_with(|| P::random(&mut rng))
+				.take(len)
+				.collect::<Vec<_>>();
+			let expected = len * P::WIDTH;
+
+			assert_eq!(P::iter_slice(&slice).len(), expected);
+			assert_eq!(P::iter_slice(&slice).count(), expected);
+			assert_eq!(P::iter_slice(&slice).size_hint(), (expected, Some(expected)));
+		}
+	}
+
+	fn check_iter_slice_matches_flat_map<P: PackedField>(mut rng: impl Rng) {
+		// The empty slice included, since a zero-length run is where the two sides can disagree
+		// without any single scalar being wrong.
+		for len in [0, 1, 2, 5] {
+			let slice = repeat_with(|| P::random(&mut rng))
+				.take(len)
+				.collect::<Vec<_>>();
+
+			// Reading the whole slice equals reading each element's lanes in turn.
+			let expected = slice.iter().flat_map(P::iter).collect::<Vec<_>>();
+			assert_eq!(P::iter_slice(&slice).collect::<Vec<_>>(), expected);
+		}
+	}
+
+	fn check_skipping<P: PackedField>(mut rng: impl Rng) {
+		let packed = P::random(&mut rng);
+		let scalars = packed.iter().collect::<Vec<_>>();
+
+		// Jumping ahead lands on the same scalar as reading forward to it, and the tail after a
+		// skip is the rest of the sequence.
+		for skip in 0..P::WIDTH {
+			assert_eq!(packed.iter().nth(skip), Some(scalars[skip]));
+			assert!(packed.iter().skip(skip).eq(scalars[skip..].iter().copied()));
+		}
+		assert_eq!(packed.iter().nth(P::WIDTH), None);
+
+		// Across an element boundary, so the slice iterator's index arithmetic is exercised too.
+		// The oracle reads each element in turn, so a skip is compared against independent
+		// iteration rather than against itself.
+		let slice = [packed, P::random(&mut rng)];
+		let expected = slice.iter().flat_map(P::iter).collect::<Vec<_>>();
+		for skip in [0, P::WIDTH - 1, P::WIDTH, 2 * P::WIDTH - 1] {
+			assert_eq!(P::iter_slice(&slice).nth(skip), Some(expected[skip]));
+		}
+	}
+
 	struct PackedFieldIterationTest;
 
 	impl PackedFieldTest for PackedFieldIterationTest {
@@ -334,6 +381,9 @@ mod tests {
 
 			check_value_iteration::<P>(&mut rng);
 			check_ref_iteration::<P>(&mut rng);
+			check_exact_size::<P>(&mut rng);
+			check_iter_slice_matches_flat_map::<P>(&mut rng);
+			check_skipping::<P>(&mut rng);
 		}
 	}
 

--- a/crates/field/src/packed_fields/mod.rs
+++ b/crates/field/src/packed_fields/mod.rs
@@ -446,18 +446,6 @@ mod tests {
 		test_mul_packed_random::<PackedBinaryGhash2x128b>();
 	}
 
-	#[test]
-	fn test_iter_size_hint() {
-		assert_valid_iterator_with_exact_size_hint::<PackedBinaryField128x1b>();
-	}
-
-	fn assert_valid_iterator_with_exact_size_hint<P: PackedField>() {
-		assert_eq!(P::default().iter().size_hint(), (P::WIDTH, Some(P::WIDTH)));
-		assert_eq!(P::default().into_iter().size_hint(), (P::WIDTH, Some(P::WIDTH)));
-		assert_eq!(P::default().iter().count(), P::WIDTH);
-		assert_eq!(P::default().into_iter().count(), P::WIDTH);
-	}
-
 	packed_field_tests!(packed_8x1b, PackedBinaryField8x1b);
 	packed_field_tests!(packed_16x1b, PackedBinaryField16x1b);
 	packed_field_tests!(packed_32x1b, PackedBinaryField32x1b);

--- a/crates/field/src/packed_fields/primitive.rs
+++ b/crates/field/src/packed_fields/primitive.rs
@@ -455,20 +455,21 @@ where
 {
 	const LOG_N: usize = (U::BITS / Scalar::N_BITS).ilog2() as usize;
 
+	// Skipping ahead must not convert the lanes it jumps over.
 	#[inline]
 	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = Scalar> + Send + Clone {
-		Divisible::<Scalar::Underlier>::value_iter(value.0).map(Scalar::from_underlier)
+		Divisible::<Scalar::Underlier>::value_iter(value.0).map_skippable(Scalar::from_underlier)
 	}
 
 	#[inline]
 	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = Scalar> + Send + Clone + '_ {
-		Divisible::<Scalar::Underlier>::ref_iter(&value.0).map(Scalar::from_underlier)
+		Divisible::<Scalar::Underlier>::ref_iter(&value.0).map_skippable(Scalar::from_underlier)
 	}
 
 	#[inline]
 	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = Scalar> + Send + Clone + '_ {
 		Divisible::<Scalar::Underlier>::slice_iter(Self::to_underliers_ref(slice))
-			.map(Scalar::from_underlier)
+			.map_skippable(Scalar::from_underlier)
 	}
 
 	#[inline]
@@ -528,29 +529,6 @@ where
 	U: Underlier + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {
-	// LOG_WIDTH defaults to `Self::LOG_N`, the same `(U::BITS /
-	// Scalar::N_BITS).ilog2()` count. Scalar element access (`get_unchecked`/`set_unchecked`) is
-	// provided by the `Divisible<Scalar>` impl, which routes through `U:
-	// Divisible<Scalar::Underlier>`.
-
-	#[inline]
-	fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-		Divisible::<Scalar::Underlier>::ref_iter(&self.0)
-			.map(|underlier| Scalar::from_underlier(underlier))
-	}
-
-	#[inline]
-	fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Send + Clone {
-		Divisible::<Scalar::Underlier>::value_iter(self.0)
-			.map(|underlier| Scalar::from_underlier(underlier))
-	}
-
-	#[inline]
-	fn iter_slice(slice: &[Self]) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-		Divisible::<Scalar::Underlier>::slice_iter(Self::to_underliers_ref(slice))
-			.map_skippable(|underlier| Scalar::from_underlier(underlier))
-	}
-
 	#[inline]
 	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
 		assert!(log_block_len < Self::LOG_WIDTH);

--- a/crates/field/src/packed_fields/sliced.rs
+++ b/crates/field/src/packed_fields/sliced.rs
@@ -52,6 +52,7 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
+use binius_utils::iter::IterExtensions;
 use bytemuck::Zeroable;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -378,23 +379,28 @@ where
 	// One extension scalar per subfield lane: the packing width is `PSub::WIDTH`.
 	const LOG_N: usize = PSub::LOG_WIDTH;
 
+	// A lane's scalar is assembled from the coordinate registers, so iteration walks lane indices
+	// and skipping ahead must not assemble the lanes it jumps over.
 	#[inline]
 	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = F> + Send + Clone {
-		(0..Self::N).map(move |i| unsafe { value.get_unchecked(i) })
+		// Safety: `i` ranges over `0..Self::N`.
+		(0..Self::N).map_skippable(move |i| unsafe { value.get_unchecked(i) })
 	}
 
 	#[inline]
 	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = F> + Send + Clone + '_ {
 		let value = *value;
-		(0..Self::N).map(move |i| unsafe { value.get_unchecked(i) })
+		// Safety: `i` ranges over `0..Self::N`.
+		(0..Self::N).map_skippable(move |i| unsafe { value.get_unchecked(i) })
 	}
 
 	#[inline]
 	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = F> + Send + Clone + '_ {
-		(0..slice.len() * Self::N).map(move |global| {
-			let (elem, lane) = (global / Self::N, global % Self::N);
-			// SAFETY: `lane < Self::N` by construction.
-			unsafe { slice[elem].get_unchecked(lane) }
+		(0..slice.len() * Self::N).map_skippable(move |global| {
+			let (elem, lane) = (global >> Self::LOG_N, global & (Self::N - 1));
+			// Safety: `global` ranges over `0..slice.len() * Self::N`, so `elem < slice.len()`
+			// and `lane < Self::N`.
+			unsafe { slice.get_unchecked(elem).get_unchecked(lane) }
 		})
 	}
 


### PR DESCRIPTION
Closes [BINIUS-580](https://linear.app/jimpo/issue/BINIUS-580).

Collapses `PackedField`'s duplicated scalar-iteration surface onto the `Divisible` supertrait it already has, so each method has exactly one body. Pure refactor — no behaviour change, and no packing gets slower.

### The problem

`PackedField` has `Divisible<Self::Scalar>` as a supertrait, and that supertrait already provides scalar access and three scalar iterators.

`PackedField` kept its own `iter`, `into_iter`, `iter_slice`, `from_scalars` and `set_single` beside them.

So each iterator had **three** definitions: the trait default, an override on `PackedPrimitiveType`, and another on the width-one field packing from `binary_field!`.

Three definitions let a packing be fast on one method and slow on another, with nothing keeping them in step.

That already happened. The trait default for slice iteration was a flat map of per-element iterators; `PackedPrimitiveType` overrode it with the subdivision walk. `SlicedPackedField` inherited whichever the default happened to be.

Separately, `from_scalars` was a `set` loop, so it never reached a packing's own bulk constructor — and `set_single` had no callers anywhere in the workspace.

### The idea

Keep the names, delete the overrides, give each method one forwarding body.

```
iter        -> Divisible::ref_iter
into_iter   -> Divisible::value_iter
iter_slice  -> Divisible::slice_iter
from_scalars-> Divisible::from_iter
```

The return types tighten from `Iterator` to `ExactSizeIterator`, which the subdivision iterators already guarantee — previously that was incidental and asserted by hand for a single type.

### Per method

| method | definitions before | after |
|---|---|---|
| `iter` | 3 | 1 |
| `into_iter` | 3 | 1 |
| `iter_slice` | 3 | 1 |
| `from_scalars` | 1 (a `set` loop) | 1 (forwards) |
| `set_single` | 1 | deleted — 0 callers |

### The change

```diff
 fn iter_slice(slice: &[Self]) -> impl ExactSizeIterator<Item = Self::Scalar> + Send + Clone + '_ {
-    slice.iter().flat_map(Self::iter)          // trait default, overridden twice below
+    Divisible::slice_iter(slice)               // one definition, for every packing
 }
```

`from_scalars` is where the collapse pays immediately: the `set` loop wrote one lane at a time through an insert intrinsic selected by a runtime `match` on the index, while `Divisible::from_iter` fills the underlier directly.

### Soundness

No protocol surface is touched — this is scalar iteration and construction over an existing packing.

`from_scalars` and `Divisible::from_iter` were checked to agree exactly before forwarding: both consume at most `WIDTH` items, zero-fill a short iterator, ignore the excess, and start from an all-zero value. Every `from_iter` impl in the crate is bounded, so `from_scalars(iter.cycle())` — a real call site in `binius-math` — still terminates.

The load-bearing equality is that slice iteration still yields what reading each element in turn yields:

```
P::iter_slice(slice) == slice.iter().flat_map(P::iter)
```

That is now asserted for every packing in the crate. It was verified to have teeth: inverting the element/lane split in the sliced walk makes it fail.

### Scope

- **changed:** `packed.rs` (four forwarding bodies, `set_single` removed, the two `get`/`set_packed_slice_unchecked` TODOs resolved by keeping them free functions), `primitive.rs` and `binary_field.rs` (overrides removed), `sliced.rs` (skipping kept cheap, slice indexing drops a bounds check)
- **tests:** a hand-rolled size-hint check for one type is replaced by three checks that run for every packing — exact length, slice-equals-per-element, and skipping in agreement with forward reading
- **left untouched:** `divisible.rs` and the arch underlier files, which belong to #2392

### How this relates to #2392

#2392 makes `Divisible` fast on the SIMD underliers by reinterpreting memory instead of extracting lanes. This PR is what makes that speedup arrive uniformly: with one definition per method, no packing can inherit it unevenly. The two touch disjoint files.

### Verification

Native leg is `-Ctarget-cpu=native` on Zen 5 (AVX-512, GFNI, VPCLMULQDQ); portable leg is empty `RUSTFLAGS`.

- `cargo test -p binius-field --release` — 272 pass native, 255 pass portable
- `cargo clippy -p binius-field --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `typos` — clean
- `cargo build -p binius-field --target wasm32-unknown-unknown` with `-D warnings` — clean
- `cargo check --workspace --all-targets` — clean, the guard for the tightened public return types

### Benchmark

Per packed element, measured against the implementation each packing actually had before, old and new in the same binary.

| packing | operation | before | after | ratio |
|---|---|---|---|---|
| `PackedAESBinaryField64x8b` | `from_scalars` | 64.06 ns | 0.29 ns | **222×** |
| `PackedBinaryGhash4x128b` | `from_scalars` | 0.428 ns | 0.347 ns | 1.23× |
| `SlicedGhashSq4x256b` | `iter_slice` | 1.130 ns | 0.998 ns | 1.13× |
| `SlicedGhashSq4x256b` | `from_scalars` | 0.846 ns | 0.823 ns | 1.03× |

The 222× is the point of the collapse rather than a new optimization: a 64-lane packing was writing 64 scalars through a 64-arm insert jump table because the trait default never reached its bulk constructor.

`PackedPrimitiveType` slice iteration is absent from the table because its override and the forwarding body are the same expression — identical code, so there is nothing to measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)