### PR TITLE
BINIUS-573: Ask for transparent huge pages on the buffer pool's large blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ jwt-simple = { version = "0.13.0", default-features = false, features = [
 k256 = "0.14.0"
 keccak = "0.2.0"
 lazy_static = "1.5.0"
+libc = "0.2"
 num-bigint = "0.5.1"
 num-integer = "0.1.46"
 num-traits = "0.2.19"

--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -8,3 +8,8 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+
+# `madvise(MADV_HUGEPAGE)` for the pool's large blocks; Linux ships transparent huge pages in
+# `madvise` mode, so a mapping that never asks gets 4 KiB pages.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true

--- a/crates/compute/src/buffer_pool.rs
+++ b/crates/compute/src/buffer_pool.rs
@@ -103,7 +103,13 @@ impl BufferPool {
 			.get_mut(&n_chunks)
 			.and_then(Vec::pop);
 
-		let mut block = reused.unwrap_or_else(|| Vec::with_capacity(n_chunks));
+		// A fresh block is the only one whose backing pages are new.
+		// The advice applies to the mapping, so a recycled block already carries it.
+		let mut block = reused.unwrap_or_else(|| {
+			let mut fresh: Vec<AlignedChunk> = Vec::with_capacity(n_chunks);
+			advise_huge_pages(fresh.as_mut_ptr().cast::<u8>(), byte_len);
+			fresh
+		});
 		let ptr = block.as_mut_ptr().cast::<T>();
 		// The block owns the allocation; forget it so its `Drop` does not free the memory we are
 		// about to hand to the `Vec`.
@@ -125,6 +131,72 @@ impl BufferPool {
 			.push(block);
 	}
 }
+
+/// Asks the kernel to back a freshly allocated range with transparent huge pages.
+///
+/// The prover sweeps buffers of tens to hundreds of megabytes with large strides.
+///
+/// On 4 KiB pages such a sweep walks thousands of page-table entries and thrashes the TLB.
+///
+/// A 2 MiB page covers 512 times as much of the buffer per entry.
+///
+/// Linux commonly ships transparent huge pages in advisory mode.
+///
+/// A mapping then gets huge pages only if it asks, so a caller that never asks stays on 4 KiB.
+///
+/// The request changes no value the pool hands out.
+///
+/// A kernel that declines it leaves the buffer working exactly as before.
+#[cfg(target_os = "linux")]
+fn advise_huge_pages(ptr: *mut u8, len: usize) {
+	/// A transparent huge page is 2 MiB, and a smaller request can never be honoured.
+	const HUGE_PAGE_LEN: usize = 2 << 20;
+
+	// Below one huge page there is nothing the kernel could promote.
+	if len < HUGE_PAGE_LEN {
+		return;
+	}
+
+	// SAFETY: the queried name is valid and the call only reads kernel state.
+	let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+	let Ok(page) = usize::try_from(page) else {
+		return;
+	};
+	if page == 0 {
+		return;
+	}
+
+	// The kernel accepts only a page-aligned start, and a large allocation carries a small
+	// allocator header, so the range usually begins mid-page.
+	//
+	//     block:   |--h--|=================================|
+	//     advised:       |============================|
+	//                    ^ next page boundary         ^ trimmed to whole pages
+	let addr = ptr as usize;
+	let aligned = addr.next_multiple_of(page);
+	let Some(len) = len.checked_sub(aligned - addr) else {
+		return;
+	};
+	let len = len & !(page - 1);
+
+	// Trimming can drop the range below one huge page, which leaves nothing to promote.
+	if len < HUGE_PAGE_LEN {
+		return;
+	}
+
+	// SAFETY: the range lies inside the block just allocated, starts on a page boundary and
+	// spans whole pages, which is what the kernel requires.
+	//
+	// The request only changes how those pages are backed, never their contents, so a refusal
+	// needs no handling.
+	unsafe {
+		libc::madvise(aligned as *mut libc::c_void, len, libc::MADV_HUGEPAGE);
+	}
+}
+
+/// Leaves the mapping to the allocator on platforms whose page hints this does not use.
+#[cfg(not(target_os = "linux"))]
+fn advise_huge_pages(_ptr: *mut u8, _len: usize) {}
 
 impl fmt::Debug for BufferPool {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Closes [BINIUS-573](https://linear.app/jimpo/issue/BINIUS-573).

Asks the kernel to back the buffer pool's large blocks with 2 MiB pages instead of 4 KiB pages.

(Supersedes #2390, which GitHub wedged on a stale head commit and auto-closed.)

### The problem

Linux commonly ships transparent huge pages in advisory mode.

A mapping then gets huge pages only if it asks for them.

The prover never asks, so every working buffer runs on 4 KiB pages.

A 256 MiB buffer is 65,536 page-table entries, and the prover sweeps such buffers with large strides.

### The idea

When the pool allocates a *fresh* block of at least one huge page, ask for huge pages.

A 2 MiB page covers 512 times as much of the buffer per page-table entry.

Recycled blocks need no request: the advice lives on the mapping, which the pool keeps.

### The change

One helper, plus four lines in the pool's allocation path.

The request is skipped below 2 MiB, where the kernel could not honour it anyway.

The kernel accepts only a page-aligned start, and a large allocation carries a small allocator header, so the range is trimmed:

```text
    block:   |--h--|=================================|
    advised:       |============================|
                   ^ next page boundary         ^ trimmed to whole pages
```

### Soundness

The request changes no value the pool hands out — only how the kernel backs those pages.

A kernel that declines it leaves the buffer working exactly as before.

### Scope

- **new:** the page-hint helper in `binius-compute`, and `libc` as a dependency of that crate
- **changed:** four lines in the pool's allocation path
- **untouched:** blocks below 2 MiB, recycled blocks, and platforms whose page hints this does not use

`libc` is already in the lock file through several transitive users, so this adds no new build.

Only the pool's own blocks are covered. Buffers allocated outside the pool still run on 4 KiB pages; covering those would need an allocator-level hook.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-compute --all-targets --all-features -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo build -p binius-compute --target wasm32-unknown-unknown` — clean
- nightly `cargo fmt --all`, `typos`, copyright — clean
- `cargo test -p binius-compute` — 11 passed

### Benchmark

Two independent confirmations that the request takes effect, both insensitive to machine load:

| metric, 256 MiB pool buffer | before | after |
|---|---|---|
| minor page faults | 65,538 | **639** |
| anonymous huge pages mapped | 0 KiB | **258,048 KiB** |

End-to-end prove, idle 16-core Zen 5:

| BLAKE3 compressions | before | after | ratio |
|---|---|---|---|
| 4,096 | 69.42 ms | 68.94 ms | 1.007x (within drift) |
| 65,536 | 1.393 s | 1.359 s | **1.025x** |
| 65,536 | 1.557 s | 1.515 s | **1.027x** |

The win grows with problem size, which is what the page-table argument predicts — the small case has too little TLB pressure to gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)