### PR TITLE
Rename shift::OperatorData to OperationClaim and drop its arity

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -245,8 +245,7 @@ mod tests {
 	use binius_verifier::{
 		config::{B128, StdChallenger},
 		protocols::shift::{
-			LOG_SHIFT_COUNT, OperatorData as VerifierOperatorData, SHIFT_COUNT, check_eval,
-			evaluate_words_mle, verify,
+			LOG_SHIFT_COUNT, OperationClaim, SHIFT_COUNT, check_eval, evaluate_words_mle, verify,
 		},
 	};
 	use rand::prelude::*;
@@ -396,20 +395,18 @@ mod tests {
 
 		// Verify against the single-instance shift verifier.
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verifier_zero = VerifierOperatorData::new(r_x_zero, [B128::ZERO]);
-		let verifier_bitand = VerifierOperatorData::new(r_x, bitand_evals);
-		let verifier_intmul = VerifierOperatorData::new(Vec::new(), intmul_evals);
-		let verifier_bmul = VerifierOperatorData::new(Vec::new(), [B128::ZERO; 6]);
-		let verifier_output = verify(
-			&cs,
-			InoutSegment::Hidden,
+		let verifier_zero = OperationClaim::new(r_x_zero, vec![B128::ZERO]);
+		let verifier_bitand = OperationClaim::new(r_x, bitand_evals.to_vec());
+		let verifier_intmul = OperationClaim::new(Vec::new(), intmul_evals.to_vec());
+		let verifier_bmul = OperationClaim::new(Vec::new(), vec![B128::ZERO; 6]);
+		let verifier_claims = [
 			&verifier_zero,
 			&verifier_bitand,
 			&verifier_intmul,
 			&verifier_bmul,
-			&mut verifier_transcript,
-		)
-		.unwrap();
+		];
+		let verifier_output =
+			verify(&cs, InoutSegment::Hidden, verifier_claims, &mut verifier_transcript).unwrap();
 		// The public segment over the shift's whole index space. The full reduction reads this
 		// from the prover and ties it to the constants with a ring-switch; driving the shift
 		// alone, evaluate it here.
@@ -423,12 +420,7 @@ mod tests {
 			&cs,
 			InoutSegment::Hidden,
 			public_eval,
-			[
-				&verifier_zero.r_x_prime,
-				&verifier_bitand.r_x_prime,
-				&verifier_intmul.r_x_prime,
-				&verifier_bmul.r_x_prime,
-			],
+			verifier_claims.map(|claim| claim.r_x_prime.as_slice()),
 			&domain_subspace,
 			&r_z,
 			&verifier_output,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -25,7 +25,7 @@ use binius_prover::{
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	config::StdChallenger,
-	protocols::shift::{OperatorData as VerifierOperatorData, verify},
+	protocols::shift::{OperationClaim, verify},
 };
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use sha2::{Digest, Sha256 as Sha256Hasher};
@@ -208,19 +208,23 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			b.iter(|| {
 				let mut verifier_transcript = setup_verifier_transcript.clone();
 
+				let verifier_zero_data =
+					OperationClaim::new(r_x_prime_zero.clone(), zero_evals.to_vec());
 				let verifier_bitand_data =
-					VerifierOperatorData::new(r_x_prime_bitand.clone(), bitand_evals);
+					OperationClaim::new(r_x_prime_bitand.clone(), bitand_evals.to_vec());
 				let verifier_intmul_data =
-					VerifierOperatorData::new(r_x_prime_intmul.clone(), intmul_evals);
-				let verifier_binmul_data = VerifierOperatorData::new(Vec::new(), [F::ZERO; 6]);
+					OperationClaim::new(r_x_prime_intmul.clone(), intmul_evals.to_vec());
+				let verifier_binmul_data = OperationClaim::new(Vec::new(), vec![F::ZERO; 6]);
 
 				verify(
 					&cs,
 					InoutSegment::Public,
-					&VerifierOperatorData::new(r_x_prime_zero.clone(), zero_evals),
-					&verifier_bitand_data,
-					&verifier_intmul_data,
-					&verifier_binmul_data,
+					[
+						&verifier_zero_data,
+						&verifier_bitand_data,
+						&verifier_intmul_data,
+						&verifier_binmul_data,
+					],
 					&mut verifier_transcript,
 				)
 				.unwrap();

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -28,9 +28,7 @@ use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::StdChallenger,
-	protocols::shift::{
-		OperatorData as VerifierOperatorData, check_eval, evaluate_words_mle, verify,
-	},
+	protocols::shift::{OperationClaim, check_eval, evaluate_words_mle, verify},
 };
 use itertools::Itertools;
 use rand::{SeedableRng, rngs::StdRng};
@@ -470,21 +468,19 @@ fn test_shift_prove_and_verify() {
 		// Create verifier transcript and call the verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
-		let verifier_zero_data = VerifierOperatorData::new(r_x_prime_zero, [F::ZERO]);
-		let verifier_bitand_data = VerifierOperatorData::new(r_x_prime_bitand, bitand_evals);
-		let verifier_intmul_data = VerifierOperatorData::new(r_x_prime_intmul, intmul_evals);
-		let verifier_binmul_data = VerifierOperatorData::new(r_x_prime_binmul, binmul_evals);
-
-		let verifier_output = verify(
-			&cs,
-			InoutSegment::Public,
+		let verifier_zero_data = OperationClaim::new(r_x_prime_zero, vec![F::ZERO]);
+		let verifier_bitand_data = OperationClaim::new(r_x_prime_bitand, bitand_evals.to_vec());
+		let verifier_intmul_data = OperationClaim::new(r_x_prime_intmul, intmul_evals.to_vec());
+		let verifier_binmul_data = OperationClaim::new(r_x_prime_binmul, binmul_evals.to_vec());
+		let verifier_claims = [
 			&verifier_zero_data,
 			&verifier_bitand_data,
 			&verifier_intmul_data,
 			&verifier_binmul_data,
-			&mut verifier_transcript,
-		)
-		.unwrap();
+		];
+
+		let verifier_output =
+			verify(&cs, InoutSegment::Public, verifier_claims, &mut verifier_transcript).unwrap();
 
 		// The public segment over the shift's whole index space. The full reduction reads this
 		// from the prover and ties it to the public words with a ring-switch; driving the shift
@@ -500,12 +496,7 @@ fn test_shift_prove_and_verify() {
 			&cs,
 			InoutSegment::Public,
 			public_eval,
-			[
-				&verifier_zero_data.r_x_prime,
-				&verifier_bitand_data.r_x_prime,
-				&verifier_intmul_data.r_x_prime,
-				&verifier_binmul_data.r_x_prime,
-			],
+			verifier_claims.map(|claim| claim.r_x_prime.as_slice()),
 			&subspace,
 			&r_zhat_prime,
 			&verifier_output,

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -72,6 +72,6 @@ mod verify;
 pub use error::Error;
 pub use shift_ind::evaluate_shift_inds;
 pub use verify::{
-	DeferredWiringClaim, OperatorData, VerifyOutput, WiringEvalClaim, WiringEvalFn,
+	DeferredWiringClaim, OperationClaim, VerifyOutput, WiringEvalClaim, WiringEvalFn,
 	WiringEvalShape, check_eval, evaluate_words_mle, verify,
 };

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -29,9 +29,8 @@ use getset::Getters;
 use itertools::chain;
 
 use super::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_MAX_ARITY, LOG_OPERATION_COUNT, LOG_SHIFT_COUNT,
-	OPERATION_COUNT, OperationEvalFn, SHIFT_COUNT, SHIFT_LOG_VARS, WiringWeights, ZERO_ARITY,
-	error::Error, shift_ind::evaluate_shift_inds,
+	LOG_MAX_ARITY, LOG_OPERATION_COUNT, LOG_SHIFT_COUNT, OPERATION_COUNT, OperationEvalFn,
+	SHIFT_COUNT, SHIFT_LOG_VARS, WiringWeights, error::Error, shift_ind::evaluate_shift_inds,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -65,27 +64,21 @@ where
 		.sum()
 }
 
-/// Verifier data for an operation with the specified arity.
+/// One operation's evaluation claims entering the shift reduction.
 ///
-/// Contains the challenge points and evaluation claims needed by the verifier.
-/// The verifier receives these values during the protocol and uses them to
-/// verify the monster multilinear evaluations.
-///
-/// # Fields
-///
-/// - `r_x_prime`: multilinear challenge point from the protocol
-/// - `evals`: array of evaluation claims, one per operand position
+/// The reduction takes one claim per operation and batches the four into the single claim its
+/// sumcheck runs on.
 #[derive(Debug, Clone)]
-pub struct OperatorData<F, const ARITY: usize> {
+pub struct OperationClaim<F> {
+	/// The constraint-index point the operands are claimed at.
 	pub r_x_prime: Vec<F>,
-	pub evals: [F; ARITY],
+	/// One evaluation per operand position, so as many as the operation's arity.
+	pub evals: Vec<F>,
 }
 
-impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
-	// Constructs a new operator data instance encoding
-	// evaluation claim with multilinear challenge `r_x_prime` and evaluations `evals`
-	// (one eval for each operand of the operation).
-	pub const fn new(r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
+impl<F: FieldOps> OperationClaim<F> {
+	/// The operand evaluations `evals`, claimed at the constraint-index point `r_x_prime`.
+	pub const fn new(r_x_prime: Vec<F>, evals: Vec<F>) -> Self {
 		Self { r_x_prime, evals }
 	}
 
@@ -97,9 +90,10 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 	///
 	/// ## Preconditions
 	///
-	/// * `operand_weights` has at least `ARITY` entries; the slots above the arity name no claim.
+	/// * `operand_weights` has at least one entry per eval; the slots above the arity name no
+	///   claim.
 	fn batched_eval(&self, operand_weights: &[F]) -> F {
-		assert!(operand_weights.len() >= ARITY); // precondition
+		assert!(operand_weights.len() >= self.evals.len()); // precondition
 		iter::zip(&self.evals, operand_weights)
 			.map(|(eval, weight)| eval.clone() * weight)
 			.sum()
@@ -186,10 +180,9 @@ impl<F> VerifyOutput<F> {
 /// # Parameters
 /// - `constraint_system`: The constraint system containing AND, IMUL and BMUL constraints
 /// - `inout`: Which segment holds the inout values, which fixes where the two segments split
-/// - `bitand_data`: Operator data for bit multiplication operations
-/// - `intmul_data`: Operator data for integer multiplication operations
-/// - `binmul_data`: Operator data for GHASH-field multiplication operations
-/// - `transcript`: Interactive transcript for challenge sampling and message reading
+/// - `claims`: Each operation's evaluation claims, ordered as the operators are declared: zero,
+///   bitand, intmul, binmul
+/// - `channel`: Interactive channel for challenge sampling and message reading
 ///
 /// # Returns
 /// Returns [`VerifyOutput`] containing the final challenges and witness evaluation,
@@ -202,10 +195,7 @@ impl<F> VerifyOutput<F> {
 pub fn verify<F, C>(
 	constraint_system: &ConstraintSystem,
 	inout: InoutSegment,
-	zero_data: &OperatorData<C::Elem, ZERO_ARITY>,
-	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
-	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
-	binmul_data: &OperatorData<C::Elem, BINMUL_ARITY>,
+	claims: [&OperationClaim<C::Elem>; OPERATION_COUNT],
 	channel: &mut C,
 ) -> Result<VerifyOutput<C::Elem>, Error>
 where
@@ -223,15 +213,8 @@ where
 	let operation_weights = eq_ind_partial_eval_scalars(&operation_batch_challenges);
 	let operand_weights = eq_ind_partial_eval_scalars(&operand_batch_challenges);
 
-	let eval = inner_product(
-		operation_weights,
-		[
-			zero_data.batched_eval(&operand_weights),
-			bitand_data.batched_eval(&operand_weights),
-			intmul_data.batched_eval(&operand_weights),
-			binmul_data.batched_eval(&operand_weights),
-		],
-	);
+	let eval =
+		inner_product(operation_weights, claims.map(|claim| claim.batched_eval(&operand_weights)));
 
 	// The sumcheck runs over the witness as well: the public segment in the low half-cube and
 	// the hidden segment in the high half-cube, selected by the top word-index variable. Each

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -17,7 +17,7 @@
 //! A batch of one instance still runs that sumcheck, over no rounds.
 //! It is the batched protocol either way, because its prover folds a batched witness.
 
-use std::{array, iter};
+use std::iter;
 
 use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment},
@@ -46,7 +46,7 @@ use crate::{
 		binmul::{BinMulOutput, verify as verify_binmul_reduction},
 		bitand::AndCheckOutput,
 		intmul::{IntMulOutput, verify as verify_intmul_reduction},
-		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperatorData, WiringEvalClaim},
+		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, WiringEvalClaim},
 		zero,
 	},
 	ring_switch::{self, RingSwitchVerifyOutput, eval_rs_eq},
@@ -242,7 +242,7 @@ where
 	// instance point is still zero.
 	let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
 	let zero_point = zero::reduction_point(r_x_and, log_n_zero, || channel.sample());
-	let zero = OperatorData::new(zero_point, [Channel::Elem::zero()]);
+	let zero = shift::OperationClaim::new(zero_point, vec![Channel::Elem::zero()]);
 
 	// Collapse the multiplications' per-bit operand claims to the oblong form BitAnd already has.
 	// The Lagrange weights fold them at the univariate challenge BitAnd just drew.
@@ -268,11 +268,14 @@ where
 	} else {
 		(
 			bitand_claim.r_rho,
-			OperatorData::new(bitand_claim.r_x, bitand_claim.operand_claims),
+			shift::OperationClaim::new(bitand_claim.r_x, bitand_claim.operand_claims.to_vec()),
 			absent_or_claimed(intmul_claim),
 			absent_or_claimed(binmul_claim),
 		)
 	};
+
+	// The four operations' claims, in the order the shift reduction batches them.
+	let claims = [&zero, &bitand, &intmul, &binmul];
 
 	// Reduce the operand claims to one witness evaluation.
 	let shift = {
@@ -282,7 +285,7 @@ where
 			perfetto_category = "phase"
 		)
 		.entered();
-		shift::verify::<B128, _>(cs, inout, &zero, &bitand, &intmul, &binmul, channel)?
+		shift::verify::<B128, _>(cs, inout, claims, channel)?
 	};
 
 	// Tie in the public values through the public-input consistency check.
@@ -300,12 +303,7 @@ where
 			cs,
 			inout,
 			public_eval,
-			[
-				&zero.r_x_prime,
-				&bitand.r_x_prime,
-				&intmul.r_x_prime,
-				&binmul.r_x_prime,
-			],
+			claims.map(|claim| claim.r_x_prime.as_slice()),
 			&shift_domain,
 			&z_challenge,
 			&shift,
@@ -408,20 +406,16 @@ where
 /// Its zero claim therefore contributes nothing.
 fn absent_or_claimed<F: FieldOps, const ARITY: usize>(
 	claim: Option<OperationClaim<F, ARITY>>,
-) -> OperatorData<F, ARITY> {
+) -> shift::OperationClaim<F> {
 	match claim {
-		Some(claim) => OperatorData::new(claim.r_x, claim.operand_claims),
-		None => OperatorData::new(Vec::new(), array::from_fn(|_| F::zero())),
+		Some(claim) => shift::OperationClaim::new(claim.r_x, claim.operand_claims.to_vec()),
+		None => shift::OperationClaim::new(Vec::new(), vec![F::zero(); ARITY]),
 	}
 }
 
 /// The shared instance point together with every operation's operand data at that point.
-type RerandOutput<F> = (
-	Vec<F>,
-	OperatorData<F, BITAND_ARITY>,
-	OperatorData<F, INTMUL_ARITY>,
-	OperatorData<F, BINMUL_ARITY>,
-);
+type RerandOutput<F> =
+	(Vec<F>, shift::OperationClaim<F>, shift::OperationClaim<F>, shift::OperationClaim<F>);
 
 /// One operation's oblong operand claims and the points they are claimed at.
 ///
@@ -599,14 +593,14 @@ impl<F: FieldOps> RerandomizedOperations<F> {
 		}
 		channel.assert_zero(evaluate_univariate(&expected, &batch_coeff) - eval)?;
 
-		let bitand_data = OperatorData::new(self.bitand.r_x, bitand_evals);
+		let bitand_data = shift::OperationClaim::new(self.bitand.r_x, bitand_evals.to_vec());
 		let intmul_data = match (self.intmul, intmul_evals) {
-			(Some(intmul), Some(evals)) => OperatorData::new(intmul.r_x, evals),
-			_ => OperatorData::new(Vec::new(), array::from_fn(|_| F::zero())),
+			(Some(intmul), Some(evals)) => shift::OperationClaim::new(intmul.r_x, evals.to_vec()),
+			_ => shift::OperationClaim::new(Vec::new(), vec![F::zero(); INTMUL_ARITY]),
 		};
 		let binmul_data = match (self.binmul, binmul_evals) {
-			(Some(binmul), Some(evals)) => OperatorData::new(binmul.r_x, evals),
-			_ => OperatorData::new(Vec::new(), array::from_fn(|_| F::zero())),
+			(Some(binmul), Some(evals)) => shift::OperationClaim::new(binmul.r_x, evals.to_vec()),
+			_ => shift::OperationClaim::new(Vec::new(), vec![F::zero(); BINMUL_ARITY]),
 		};
 		Ok((r_rho, bitand_data, intmul_data, binmul_data))
 	}


### PR DESCRIPTION
Follows #2386. No behavior change.

The shift reduction receives one evaluation claim per operation. The type carrying it was named
after the operator rather than the claim, and it was generic over the operation arity purely to size
`evals`, which made the four claims four distinct types.

`OperatorData<F, ARITY>` becomes `OperationClaim<F>` with `evals: Vec<F>`. Nothing needed the length
in the type: inside the reduction the evals are consumed only by `batched_eval`, whose precondition
is now that `operand_weights` has an entry per eval rather than `ARITY` entries.

With one type for all four operations, `verify` takes them as
`[&OperationClaim<C::Elem>; OPERATION_COUNT]` in the order the operators are declared, matching how
`check_eval` already takes their `r_x_prime` points. Its four `batched_eval` calls become one `map`.

Each caller now builds the array once and derives the `check_eval` argument from it:

```rust
let claims = [&zero, &bitand, &intmul, &binmul];
shift::verify::<B128, _>(cs, inout, claims, channel)?;
// ...
shift::check_eval::<B128, _>(cs, inout, public_eval, claims.map(|claim| claim.r_x_prime.as_slice()), ...)
```

so the two entry points cannot disagree on the operator order.

`reduction.rs` has its own private `OperationClaim` — the pre-rerandomization claim that also carries
`r_rho` — so it names this one `shift::OperationClaim` by path. The three test and bench call sites
drop the `OperatorData as VerifierOperatorData` alias they needed while the verifier and prover types
shared a name.

The arity constants stay: they size the operand arrays the channel reads and the absent-operation
zero claims.
