### PR TITLE
BINIUS-582: Fill the idle 32-bit lanes in SHA-256, so every block costs 364 AND constraints

### DIFF
--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -211,13 +211,37 @@ pub fn sha256_compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16])
 		builder.assert_eq("sha256_compress.round_state", hinted, expected);
 	}
 
-	// Feed-forward, then drop the high lane.
+	// Feed-forward, two output words per gate.
 	//
-	// It carries the round-31 state the split already consumed.
-	// A caller reads one compression's output, in the low 32 bits.
+	// The rounds have consumed the split, so both lanes are free again.
+	// Pairing the words refills them, and 8 additions become 4:
+	//
+	//     low lane  <- H[2j]
+	//     high lane <- H[2j + 1]
+	//
+	// Each summand is cleared before it enters the low lane.
+	//
+	// - A state word's high half holds the round-31 state the split already spent.
+	// - A caller's high half is not required to be empty.
+	//
+	// The shift into the high lane clears its own operand, so only the low one needs it.
+	let pair =
+		|lo: Wire, hi: Wire| builder.bxor(clear_high_bits(builder, lo, 32), builder.shl(hi, 32));
+	let sums: [Wire; 4] = array::from_fn(|j| {
+		builder.iadd_32(
+			pair(state_in.0[2 * j], state_in.0[2 * j + 1]),
+			pair(state.0[2 * j], state.0[2 * j + 1]),
+		)
+	});
+
+	// A caller reads one compression's output, in the low 32 bits with the high 32 zero.
 	State(array::from_fn(|i| {
-		let sum = builder.iadd_32(state_in.0[i], state.0[i]);
-		clear_high_bits(builder, sum, 32)
+		let sum = sums[i / 2];
+		if i % 2 == 0 {
+			clear_high_bits(builder, sum, 32)
+		} else {
+			builder.shr(sum, 32)
+		}
 	}))
 }
 
@@ -676,13 +700,82 @@ fn small_sigma_1(b: &CircuitBuilder, x: Wire) -> Wire {
 #[cfg(test)]
 mod tests {
 	use binius_core::word::Word;
-	use binius_frontend::{CircuitBuilder, Hint, Wire};
+	use binius_frontend::{CircuitBuilder, CircuitStat, Hint, Wire};
 	use proptest::prelude::*;
 
 	use super::{
 		IV, Sha256Compress2x, State, compress_2x_gates, populate_message_block, ref_compress,
 		sha256_compress, sha256_compress_2x, sha256_compress_2x_seq,
 	};
+
+	/// AND constraints one 32-bit SHA-256 compression cannot go below.
+	///
+	/// XOR, rotation and shift are affine, so they cost nothing.
+	/// Only the AND of two affine forms is witnessed, and each one eliminates exactly one summand:
+	///
+	/// ```text
+	///     n-summand modular sum          n - 1
+	///     Ch, Maj                            1  each
+	/// ```
+	///
+	/// A compression's nonlinear work is therefore fixed:
+	///
+	/// ```text
+	///     schedule    48 words x 3 sums                      144
+	///     rounds      64 x (Ch + Maj + 7 sums)               576
+	///     feedforward 8 sums                                   8
+	///                                                       ----
+	///                                                        728
+	/// ```
+	///
+	/// A gate constrains both 32-bit halves of its word at once, so two lanes share that total.
+	const AND_PER_COMPRESSION: usize = 364;
+
+	/// AND constraints a circuit spends on the state `f` returns.
+	///
+	/// The output is bound to public wires, since dead code elimination would drop it otherwise.
+	/// Binding is affine, so it lands on ZERO constraints and leaves the AND count alone.
+	fn and_cost(f: impl FnOnce(&CircuitBuilder) -> State) -> usize {
+		let builder = CircuitBuilder::new();
+		let out = f(&builder);
+		for wire in out.0 {
+			let public = builder.add_inout();
+			builder.assert_eq("out", wire, public);
+		}
+		CircuitStat::collect(&builder.build()).n_and_constraints
+	}
+
+	#[test]
+	fn a_compression_spends_only_its_nonlinear_work() {
+		let inputs = |b: &CircuitBuilder| {
+			let state = State::public(b);
+			let m: [Wire; 16] = std::array::from_fn(|_| b.add_inout());
+			(state, m)
+		};
+
+		// One compression across two lanes: 32 rounds each, and paired feed-forward words.
+		let single = and_cost(|b| {
+			let (state, m) = inputs(b);
+			sha256_compress(b, state, m)
+		});
+		assert_eq!(single, AND_PER_COMPRESSION);
+
+		// Two compressions across two lanes: one lane each, all 64 rounds.
+		let paired = and_cost(|b| {
+			let (state, m) = inputs(b);
+			sha256_compress_2x(b, state, m)
+		});
+		assert_eq!(paired, 2 * AND_PER_COMPRESSION);
+
+		// Chaining the pair costs no more: the hint that breaks the dependency is affine to bind.
+		let chained = and_cost(|b| {
+			let (state, _) = inputs(b);
+			let blocks: [[Wire; 16]; 2] =
+				std::array::from_fn(|_| std::array::from_fn(|_| b.add_inout()));
+			sha256_compress_2x_seq(b, state, blocks)
+		});
+		assert_eq!(chained, 2 * AND_PER_COMPRESSION);
+	}
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
 	///

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -4,7 +4,7 @@ use std::{array, iter};
 use binius_core::word::Word;
 use binius_frontend::{ChipGadget, CircuitBuilder, Hint, Wire, WitnessFiller};
 
-use crate::util::clear_high_bits;
+use crate::util::{clear_high_bits, pack_u32_words};
 
 const IV: [u32; 8] = [
 	0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
@@ -47,18 +47,20 @@ impl State {
 		State(std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64))))
 	}
 
-	/// Packs the state into 4 x 64-bit words.
+	/// Packs the state into 4 x 64-bit big-endian words.
+	///
+	/// The lower-numbered word of each pair is the more significant, so it takes the high half.
+	///
+	/// # Preconditions
+	///
+	/// - Every state word holds its value in the low 32 bits, with the high 32 empty.
+	///   - The word lifted into the high half has its own high bits discarded by the shift.
+	///   - The word entering the low half is passed through unmasked.
+	///
+	/// Masking it here would commit one redundant intermediate per word.
+	/// Every caller already clears before packing.
 	pub fn pack_4x64b(&self, builder: &CircuitBuilder) -> [Wire; 4] {
-		fn pack_pair(b: &CircuitBuilder, hi: Wire, lo: Wire) -> Wire {
-			b.bxor(lo, b.shl(hi, 32))
-		}
-
-		[
-			pack_pair(builder, self.0[0], self.0[1]),
-			pack_pair(builder, self.0[2], self.0[3]),
-			pack_pair(builder, self.0[4], self.0[5]),
-			pack_pair(builder, self.0[6], self.0[7]),
-		]
+		array::from_fn(|j| builder.bxor(self.0[2 * j + 1], builder.shl(self.0[2 * j], 32)))
 	}
 }
 
@@ -219,18 +221,14 @@ pub fn sha256_compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16])
 	//     low lane  <- H[2j]
 	//     high lane <- H[2j + 1]
 	//
-	// Each summand is cleared before it enters the low lane.
+	// Neither operand arrives zero-extended, so the packing masks the one entering the low lane:
 	//
 	// - A state word's high half holds the round-31 state the split already spent.
 	// - A caller's high half is not required to be empty.
-	//
-	// The shift into the high lane clears its own operand, so only the low one needs it.
-	let pair =
-		|lo: Wire, hi: Wire| builder.bxor(clear_high_bits(builder, lo, 32), builder.shl(hi, 32));
 	let sums: [Wire; 4] = array::from_fn(|j| {
 		builder.iadd_32(
-			pair(state_in.0[2 * j], state_in.0[2 * j + 1]),
-			pair(state.0[2 * j], state.0[2 * j + 1]),
+			pack_u32_words(builder, state_in.0[2 * j], state_in.0[2 * j + 1]),
+			pack_u32_words(builder, state.0[2 * j], state.0[2 * j + 1]),
 		)
 	});
 
@@ -426,14 +424,12 @@ pub fn sha256_compress_2x_seq(
 	let merged_vec = builder.call_hint(Sha256CompressHint, &[], &hint_inputs);
 	let merged: [Wire; 8] = array::from_fn(|i| merged_vec[i]);
 
-	// Pack two lanes into one wire: low 32 bits = lane 0 (S2), high 32 bits = lane 1 (S1).
-	// `shl` already clears the high operand's upper bits.
-	// The low operand is cleared explicitly, since inputs are not guaranteed zero-extended.
-	let pack = |lo: Wire, hi: Wire| builder.bxor(lo, builder.shl(hi, 32));
-	let clear = |w: Wire| clear_high_bits(builder, w, 32);
-
-	// Merged block: low lane = second block, high lane = first block.
-	let merged_block: [Wire; 16] = array::from_fn(|i| pack(clear(blocks[1][i]), blocks[0][i]));
+	// Merged block, one wire per block word:
+	//
+	//     low lane  <- the second block's word
+	//     high lane <- the first block's word
+	let merged_block: [Wire; 16] =
+		array::from_fn(|i| pack_u32_words(builder, blocks[1][i], blocks[0][i]));
 
 	let out = sha256_compress_2x(builder, State::new(merged), merged_block);
 

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -147,6 +147,8 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		// The trailing odd block has no partner, so the paired core would idle a whole lane on
 		// it. The single-lane core fills that lane from the block itself, splitting its own 64
 		// rounds across the two halves, and costs half as much.
+		//
+		// It takes a pair's leftover high halves, since it reads an input state's low half only.
 		let sub = builder.subcircuit(format!("sha256_fixed_compress[{block_idx}]"));
 		state = sha256_compress(&sub, state, blocks[block_idx]);
 	}

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -144,29 +144,21 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		block_idx += 2;
 	}
 	if block_idx < n_blocks {
+		// The trailing odd block has no partner, so the paired core would idle a whole lane on
+		// it. The single-lane core fills that lane from the block itself, splitting its own 64
+		// rounds across the two halves, and costs half as much.
 		let sub = builder.subcircuit(format!("sha256_fixed_compress[{block_idx}]"));
-		state = if block_idx > 0 {
-			// The trailing odd block has no partner, but it still runs through the paired core
-			// with the second lane dead, so a registered chip serves it instead of leaving one
-			// compression behind in main. The dead lane chews on the leftover high halves and
-			// its output lands in the high halves, which the digest clearing below discards.
-			// In gates the two cores emit the same circuit, so nothing changes without a chip.
-			sha256_compress_2x(&sub, state, blocks[block_idx])
-		} else {
-			// A single-block message keeps the single-lane core: its empty high halves are what
-			// lets the digest skip the clearing below.
-			sha256_compress(&sub, state, blocks[block_idx])
-		};
+		state = sha256_compress(&sub, state, blocks[block_idx]);
 	}
 
 	// The escaping digest is the one place a clean high half is required.
 	// So clear the high half once here rather than after every pair, since a caller compares all
 	// 64 bits.
 	//
-	// Why a single-block message skips it:
-	// - Such a message never enters the paired core.
-	// - The one-lane core maps an empty high half to an empty high half.
-	if n_blocks < 2 {
+	// Why an odd block count skips it:
+	// - Such a message ends on the one-lane core.
+	// - That core empties the high half of every word it returns.
+	if n_blocks % 2 == 1 {
 		return state.0;
 	}
 	std::array::from_fn(|i| clear_high_bits(builder, state.0[i], 32))
@@ -362,7 +354,7 @@ mod tests {
 	use std::array;
 
 	use binius_core::Word;
-	use binius_frontend::{CircuitBuilder, Wire};
+	use binius_frontend::{CircuitBuilder, CircuitStat, Wire};
 	use hex_literal::hex;
 	use sha2::Digest;
 
@@ -574,6 +566,30 @@ mod tests {
 
 			// Test with our circuit
 			test_sha256_fixed_with_input(&message, expected_bytes);
+		}
+	}
+
+	#[test]
+	fn every_block_costs_the_same() {
+		// AND constraints one compression spends, as `compress`'s own bound pins it.
+		const AND_PER_BLOCK: usize = 364;
+
+		// Lengths chosen to end on a word, so no boundary mask joins the count.
+		for (len_bytes, n_blocks) in [(32, 1), (64, 2), (128, 3), (192, 4), (256, 5)] {
+			let b = CircuitBuilder::new();
+			let message: Vec<Wire> = (0..len_bytes / 4).map(|_| b.add_inout()).collect();
+
+			// Bind the digest, or dead code elimination drops the last compression's tail.
+			for wire in sha256_fixed(&b, &message, len_bytes) {
+				let public = b.add_inout();
+				b.assert_eq("digest", wire, public);
+			}
+
+			// The paired core carries two blocks and the single-lane core carries one.
+			// Both spend the two 32-bit halves of every gate, so an odd count costs no more
+			// per block than an even one.
+			let stat = CircuitStat::collect(&b.build());
+			assert_eq!(stat.n_and_constraints, n_blocks * AND_PER_BLOCK, "{len_bytes} bytes");
 		}
 	}
 

--- a/crates/circuits/src/util.rs
+++ b/crates/circuits/src/util.rs
@@ -26,6 +26,21 @@ pub fn clear_high_bits(builder: &CircuitBuilder, w: Wire, n: u32) -> Wire {
 	builder.shr(builder.shl(w, n), n)
 }
 
+/// Pack two 32-bit values into the two halves of one 64-bit wire.
+///
+/// The first argument lands in the low half, the second in the high half.
+///
+/// ```text
+///     bits 32..64  <-  second argument, shifted up
+///     bits  0..32  <-  first argument, masked down
+/// ```
+///
+/// Neither operand has to arrive zero-extended.
+/// The shift that lifts one discards its high bits, and the other is masked explicitly.
+pub(crate) fn pack_u32_words(builder: &CircuitBuilder, lo: Wire, hi: Wire) -> Wire {
+	builder.bxor(clear_high_bits(builder, lo, 32), builder.shl(hi, 32))
+}
+
 /// Splits each 64-bit wire into two little-endian 32-bit word wires (low half, then high half).
 ///
 /// Returns exactly `num_words` words, zero-padding when `data` runs out.

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -1,30 +1,30 @@
 bitcoin_headers circuit
 --
 Gates & Instructions
-├─ Number of gates: 38,658
-└─ Number of evaluation instructions: 38,778
+├─ Number of gates: 38,898
+└─ Number of evaluation instructions: 39,018
 
 Constraints
-├─ ZERO constraints: 3,432 used (83.8% of 2^12)
-│  [▓▓▓▓▓▓▓▓░░] spare: 664
-├─ AND constraints: 11,810 used (72.1% of 2^14)
-│  [▓▓▓▓▓▓▓░░░] spare: 4,574
+├─ ZERO constraints: 3,412 used (83.3% of 2^12)
+│  [▓▓▓▓▓▓▓▓░░] spare: 684
+├─ AND constraints: 11,770 used (71.8% of 2^14)
+│  [▓▓▓▓▓▓▓░░░] spare: 4,614
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 110 used (85.9% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 18
-└─ Distinct value indices: 37,981
-   ├─ Distinct shifted value indices: 22,464
-   └─ Distinct unshifted value indices: 15,517
+└─ Distinct value indices: 37,867
+   ├─ Distinct shifted value indices: 22,418
+   └─ Distinct unshifted value indices: 15,449
 
 Value Vector
 ├─ Public Section: 115 (not committed)
 │  ├─ Constants: 115
 │  └─ Inout: 0
-├─ Private Section: 15,406
+├─ Private Section: 15,346
 │  ├─ Witness: 104
-│  └─ Internal: 15,302
-├─ Committed Trace: 15,406 used (94.0% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 978
-└─ Scratch (uncommitted): 38 (peak live: 38)
+│  └─ Internal: 15,242
+├─ Committed Trace: 15,346 used (93.7% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,038
+└─ Scratch (uncommitted): 46 (peak live: 46)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,30 +1,30 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 150,119
-└─ Number of evaluation instructions: 175,937
+├─ Number of gates: 150,143
+└─ Number of evaluation instructions: 175,961
 
 Constraints
-├─ ZERO constraints: 16,090 used (98.2% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 294
-├─ AND constraints: 83,896 used (64.0% of 2^17)
-│  [▓▓▓▓▓▓░░░░] spare: 47,176
+├─ ZERO constraints: 16,088 used (98.2% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 296
+├─ AND constraints: 83,892 used (64.0% of 2^17)
+│  [▓▓▓▓▓▓░░░░] spare: 47,180
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 3,718
-└─ Distinct value indices: 274,449
-   ├─ Distinct shifted value indices: 139,441
-   └─ Distinct unshifted value indices: 135,008
+└─ Distinct value indices: 274,434
+   ├─ Distinct shifted value indices: 139,440
+   └─ Distinct unshifted value indices: 134,994
 
 Value Vector
 ├─ Public Section: 93 (not committed)
 │  ├─ Constants: 93
 │  └─ Inout: 0
-├─ Private Section: 134,923
+├─ Private Section: 134,917
 │  ├─ Witness: 9
-│  └─ Internal: 134,914
-├─ Committed Trace: 134,923 used (51.5% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 127,221
+│  └─ Internal: 134,908
+├─ Committed Trace: 134,917 used (51.5% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 127,227
 └─ Scratch (uncommitted): 109 (peak live: 109)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,30 +1,30 @@
 sha256 circuit
 --
 Gates & Instructions
-├─ Number of gates: 20,312
-└─ Number of evaluation instructions: 20,312
+├─ Number of gates: 19,465
+└─ Number of evaluation instructions: 19,465
 
 Constraints
-├─ ZERO constraints: 1,759 used (85.9% of 2^11)
-│  [▓▓▓▓▓▓▓▓░░] spare: 289
-├─ AND constraints: 6,503 used (79.4% of 2^13)
-│  [▓▓▓▓▓▓▓░░░] spare: 1,689
+├─ ZERO constraints: 1,695 used (82.8% of 2^11)
+│  [▓▓▓▓▓▓▓▓░░] spare: 353
+├─ AND constraints: 6,188 used (75.5% of 2^13)
+│  [▓▓▓▓▓▓▓░░░] spare: 2,004
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 20,957
-   ├─ Distinct shifted value indices: 12,629
-   └─ Distinct unshifted value indices: 8,328
+└─ Distinct value indices: 20,179
+   ├─ Distinct shifted value indices: 12,200
+   └─ Distinct unshifted value indices: 7,979
 
 Value Vector
-├─ Public Section: 340 (not committed)
-│  ├─ Constants: 76
+├─ Public Section: 372 (not committed)
+│  ├─ Constants: 108
 │  └─ Inout: 264
-├─ Private Section: 8,254
+├─ Private Section: 7,875
 │  ├─ Witness: 0
-│  └─ Internal: 8,254
-├─ Committed Trace: 8,254 used (50.4% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 8,130
+│  └─ Internal: 7,875
+├─ Committed Trace: 7,875 used (96.1% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 317
 └─ Scratch (uncommitted): 30 (peak live: 30)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,30 +1,30 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 388,463
-└─ Number of evaluation instructions: 456,550
+├─ Number of gates: 388,535
+└─ Number of evaluation instructions: 456,622
 
 Constraints
-├─ ZERO constraints: 33,489 used (51.1% of 2^16)
-│  [▓▓▓▓▓░░░░░] spare: 32,047
-├─ AND constraints: 186,832 used (71.3% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 75,312
+├─ ZERO constraints: 33,513 used (51.1% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 32,023
+├─ AND constraints: 186,820 used (71.3% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 75,324
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 31,716 used (96.8% of 2^15)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,052
-└─ Distinct value indices: 534,925
-   ├─ Distinct shifted value indices: 280,301
-   └─ Distinct unshifted value indices: 254,624
+└─ Distinct value indices: 534,934
+   ├─ Distinct shifted value indices: 280,298
+   └─ Distinct unshifted value indices: 254,636
 
 Value Vector
 ├─ Public Section: 999 (not committed)
 │  ├─ Constants: 697
 │  └─ Inout: 302
-├─ Private Section: 253,635
+├─ Private Section: 253,647
 │  ├─ Witness: 1,381
-│  └─ Internal: 252,254
-├─ Committed Trace: 253,635 used (96.8% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 8,509
+│  └─ Internal: 252,266
+├─ Committed Trace: 253,647 used (96.8% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 8,497
 └─ Scratch (uncommitted): 1,547 (peak live: 1,547)
 

--- a/crates/recursion/src/challenger.rs
+++ b/crates/recursion/src/challenger.rs
@@ -77,7 +77,7 @@
 //! | item | AND constraints |
 //! |---|---|
 //! | one compression core, covering two chained blocks | 728 |
-//! | one observed 64-byte block, amortized | 396 |
+//! | one observed 64-byte block, amortized | 395 |
 //! | one observed word, for the byte reversal | 4 |
 //! | one 128-bit challenge, refills excluded | 12 |
 //! | one bit sample, refills excluded | 4 |
@@ -88,11 +88,12 @@
 //! Consecutive blocks of an epoch chain, so they compress in pairs.
 //! One two-lane core runs both, one per 32-bit lane of a 64-bit datapath.
 //!
-//! A lone compression already splits itself across those two lanes, at 368 constraints.
-//! So pairing saves only that split's own overhead, 8 constraints per pair.
+//! A lone compression also splits itself across those two lanes, at 364 constraints.
+//! So a pair costs exactly what its two blocks cost apart, and chaining buys gates, not
+//! constraints.
 //!
 //! An epoch that observes nothing is a single block.
-//! So 32 bytes of sampler output cost about 380 constraints, however they are cut into values.
+//! So 32 bytes of sampler output cost about 374 constraints, however they are cut into values.
 
 use std::{array, mem};
 
@@ -724,7 +725,7 @@ mod tests {
 	}
 
 	/// AND constraints one observed 64-byte block adds, hashing and byte reversal together.
-	const OBSERVED_BLOCK_AND: usize = 396;
+	const OBSERVED_BLOCK_AND: usize = 395;
 
 	/// Builds a circuit that observes some words then samples one challenge, and reports its cost.
 	///
@@ -761,7 +762,7 @@ mod tests {
 		let single = cost(0).n_and_constraints;
 
 		// A core already fills both 32-bit lanes with the two halves of its own compression.
-		// So pairing consecutive blocks saves that split's overhead, not half the work.
+		// So pairing consecutive blocks saves the work around them, never half the work.
 		assert!(
 			marginal < single + single / 8,
 			"one observed block costs {marginal} AND constraints against {single} for one core"

--- a/crates/recursion/src/merkle.rs
+++ b/crates/recursion/src/merkle.rs
@@ -55,11 +55,14 @@
 //! Its break-even therefore lands within rounding of the AND column's, and picks the same depth.
 //! These ratios are measured rather than pinned, unlike every figure in the table.
 //!
-//! One block compression is 368 AND constraints.
+//! One block compression is 364 AND constraints.
 //!
 //! A gate costs one constraint whatever its width.
 //! A compression already spends both 32-bit lanes of every gate, on its own two halves.
-//! So a second compression sharing that core saves only what the split costs, a few percent.
+//! So a second compression sharing that core costs exactly what it would cost alone.
+//!
+//! What sharing still saves is the work around the compression, paid once instead of twice.
+//! That is why a bare node costs the same either way, while a leaf and a climbed level do not.
 //!
 //! Every place that hashes independent values still takes this route:
 //!
@@ -73,13 +76,13 @@
 //!
 //! | what is measured                        | AND           | BMUL          |
 //! | --------------------------------------- | ------------- | ------------- |
-//! | a one-element leaf digest               | 376           | 0             |
-//! | a sixteen-element leaf digest           | 2263          | 0             |
+//! | a one-element leaf digest               | 372           | 0             |
+//! | a sixteen-element leaf digest           | 1948          | 0             |
 //! | two one-element leaves sharing a core   | 707 per pair  | 0             |
-//! | one inner node on its own core          | 384           | 0             |
+//! | one inner node on its own core          | 380           | 0             |
 //! | one inner node sharing a core           | 380 per node  | 0             |
 //! | one node of a verified layer's fold     | 380 per node  | 0             |
-//! | one climbed level of a lone opening     | 384           | 8             |
+//! | one climbed level of a lone opening     | 380           | 8             |
 //! | one climbed level of a paired opening   | 377 per query | 8 per query   |
 //! | picking the layer entry of an opening   | 0             | 4 * (2^L - 1) |
 //!

--- a/crates/recursion/src/merkle/tests.rs
+++ b/crates/recursion/src/merkle/tests.rs
@@ -851,13 +851,13 @@ proptest! {
 ///
 /// The module docs derive the layer-depth trade-off from this number, so a change here means the
 /// trade-off needs re-deriving.
-const LEVEL_AND: usize = 384;
+const LEVEL_AND: usize = 380;
 
 /// AND constraints one climbed level costs each query, when two openings share cores.
 const PAIRED_LEVEL_AND: usize = 377;
 
 /// AND constraints one inner node costs on its own core.
-const NODE_AND: usize = 384;
+const NODE_AND: usize = 380;
 
 /// AND constraints one inner node costs when it shares a core with a second node.
 const PAIRED_NODE_AND: usize = 380;
@@ -989,12 +989,14 @@ fn verify_opening_2x_follows_the_documented_cost_model() {
 }
 
 #[test]
-fn a_shared_core_barely_beats_two_lone_nodes() {
-	// Invariant: a lone node already spends both 32-bit lanes on its own split halves.
-	// So a second node sharing the core saves the split's overhead, not half the work.
+fn a_shared_core_costs_what_two_lone_nodes_cost() {
+	// Invariant: both cores spend every lane they have, so a node costs the same either way.
 	//
-	//     one node  on its own core :  both lanes work, one half of one node each
+	//     one node  on its own core :  both lanes work, one half of that node each
 	//     two nodes on a shared core:  both lanes work, one whole node each
+	//
+	// Sharing a core therefore buys gate count and chip reuse, never AND constraints.
+	// A leaf or a climbed level still gains, but from the work around the compression.
 	let (single, _) = cost(|builder| {
 		// Two children in, one node digest out, pinned to a public claim.
 		let inputs = digest_wires(builder, 2);


### PR DESCRIPTION
Closes [BINIUS-582](https://linear.app/jimpo/issue/BINIUS-582).

Fills two 32-bit lanes the SHA-256 hasher was leaving idle. No behavior change — same digests, same gadget contracts, fewer gates.

### The problem

An AND constraint covers both 32-bit halves of a 64-bit word at once.
So a gate that drives only one half costs the same as one that drives two, and wastes half of what it bought.

The hasher is built around that fact — the schedule and the rounds both pack two lanes.
Two places still leave a lane idle.

### The idea

Count what one compression cannot avoid, then check the circuit against it.

XOR, rotation and shift are affine, so they cost nothing.
Only the AND of two affine forms is witnessed, and each one eliminates exactly one summand:

```
n-summand modular sum      n - 1 AND constraints
Ch, Maj                    1 AND constraint each
```

That fixes a compression's nonlinear work:

```
schedule      48 words x 3 sums                144
rounds        64 x (Ch + Maj + 7 sums)         576
feed-forward  8 sums                             8
                                              ----
one compression, one lane                      728
both 32-bit lanes carry it                     364
```

So 364 is the floor. Two paths sat above it.

### Where the lanes idle

**1. The feed-forward in `sha256_compress`.**

That gadget splits one compression across the two lanes: rounds 0..32 above, 32..64 below.
By the time the feed-forward runs the split is spent and both lanes are free again — but the eight final additions were issued one word per gate.

→ 368 constraints instead of 364.

**2. The trailing odd block in `sha256_fixed`.**

Blocks are compressed in pairs through the two-lane core.
An odd block count leaves one block over, and it went through that same paired core with the second lane dead.

→ 728 constraints for one compression instead of 364.

The comment there claimed the two cores emit the same circuit without a chip. They do not: 728 against 364.

### The change

Pair the feed-forward words, so four gates do the work of eight:

```
- for i in 0..8:  iadd_32(state_in[i], state[i])           // 8 gates, high lane idle
+ for j in 0..4:  iadd_32(pair(in[2j], in[2j+1]),          // 4 gates, both lanes busy
+                         pair(st[2j], st[2j+1]))
```

Send the trailing odd block to the single-lane core, which fills the second lane from the block itself:

```
- sha256_compress_2x(sub, state, block)    // 728, second lane dead
+ sha256_compress(sub, state, block)       // 364, splits its own 64 rounds across both lanes
```

The variable-length hasher already routed its trailing block this way, so it picks up the feed-forward saving only.

### What this is not

This does not change the decomposition of SHA-256, and it is not the kind of win circuit-golf scoreboards chase.

Those exploit a ripple-carry adder that costs one row per bit, where carry-save trees, vanishing low-bit carries and the trailing zeros of `K[t]` all buy rows.
Here a 32-bit addition is one constraint, so an $n$-summand sum costs $n-1$ however it is grouped, and none of those tricks apply.

Lane utilization is the only lever this cost model leaves, and this PR takes it.

### Scope

- **changed:** the feed-forward in `sha256_compress`, and the trailing-block branch in `sha256_fixed`.
- **new:** `a_compression_spends_only_its_nonlinear_work` and `every_block_costs_the_same`, which pin the bound with its derivation.
- **re-blessed:** the four example snapshots that move — `sha256`, `bitcoin_headers`, `bitcoin_p2pkh`, `zklogin`. The other eleven are unchanged.
- **re-derived:** the two recursion cost models this moves, in `merkle.rs` and `challenger.rs`.
- **untouched:** the round function, the message schedule, `sha256_varlen`'s compression chain, and the chip path.

### Soundness

Neither change touches what is constrained, only how many gates carry it.

- The paired feed-forward clears each summand before it enters the low lane, and the shift into the high lane clears its own operand. Carries never cross bit 32, so the two sums stay independent.
- The single-lane core accepts an input state whose high halves are dirty, which is exactly what a pair leaves behind, and it returns clean ones. So the digest clearing now runs on even block counts only.
- The chip path is unaffected: paired compressions still reach a registered `Sha256Compress2x`, and one fewer call is cheaper there too, since instances pad to a power of two.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-circuits -p binius-examples --all-targets --all-features -- -D warnings` — clean.
- `cargo +nightly-2026-07-01 fmt --all --check` — clean.
- `cargo test -p binius-circuits --release` — 409 + 3 + 2 pass, including the RFC KATs, the chip tests and the two new bounds.
- `cargo test -p binius-recursion --release` — 34 + 9 + 2 + 1 + 12 + 13 pass.
- `check-snapshot` on all fifteen examples — matches.

### Benchmark

Circuit cost, from `cargo run --release --example sha256 -- stat --message-len N`:

| message | blocks | AND before | AND after | AND per block | committed trace |
|---|---|---|---|---|---|
| 128 B | 3 | 1,407 | **1,092** | 469 → **364** | 1,786 → 1,407 (both $2^{11}$) |
| 192 B | 4 | 1,456 | 1,456 | 364 → 364 | unchanged |
| 1024 B | 17 | 6,503 | **6,188** | 382.5 → **364** | 8,254 of $2^{14}$ → 7,875 of $2^{13}$ |

Prover, from `HASH_MAX_BYTES=N cargo bench -p binius-examples --bench sha256` (Basefold, `log_inv_rate` 1, same machine and session):

| message | witness gen | proof gen | verify | proof size |
|---|---|---|---|---|
| 128 B | 8.59 → **7.26 µs** (−15.5%) | 7.79 → **6.02 ms** (−22.7%) | 1.393 → **1.216 ms** (−12.7%) | 45.42 → 45.45 KiB |
| 1024 B | 39.78 → **38.55 µs** (−3.1%) | 16.35 → **12.00 ms** (−26.6%) | 5.389 → **4.970 ms** (−7.8%) | 98.78 → **75.45 KiB** |

Even block counts are the control and do not move.
The outsized 1024-byte win is the committed trace crossing a power-of-two boundary — a windfall of where that boundary happens to sit, not a general 26%.
The durable result is the "AND per block" column: **every fixed-length SHA-256 now costs exactly 364 AND constraints per block, for any message length**, where an odd block count previously paid up to 469.

### Effect on the other SHA-256 examples

The two changes land differently across the tree, so here is each one measured on its own.

| example | trailing block | feed-forward | net AND | net committed |
|---|---|---|---|---|
| `sha256` (1024 B) | −311 AND, −369 committed | −4 AND, −10 committed | **−315** | **−379** |
| `bitcoin_headers` | none | −40 AND, −60 committed | **−40** | **−60** |
| `bitcoin_p2pkh` | none | −4 AND, −6 committed | **−4** | **−6** |
| `zklogin` | none | −12 AND, +12 committed | **−12** | **+12** |

Only `sha256` has an odd trailing block to reclaim, so it takes the whole of that win — including the trace crossing $2^{14}$ down to $2^{13}$.

`zklogin` is the one place the feed-forward pairing is not a free win.
Packing two words into one gate needs the low operand masked, which is two shifts, and a lowered term carries at most two.
Where the input state is already shift-deep, that pushes a linear definition over the budget and it gets committed instead of inlined — here 12 AND constraints traded for 12 committed values and 24 ZERO constraints.

That is 0.005% of a 253,647-word trace and moves no table across a power of two, against a clean win in the other three, so the pairing stays.

### The recursion cost models

`binius-recursion` pins SHA-256 costs in two module-level tables and asserts them in tests, so this
change moves them. One consequence is worth stating rather than renumbering past.

A lone compression used to cost 368 against 364 per block on a shared core, so pairing bought four
constraints. Both are 364 now, so **a shared core and two lone cores cost the same per compression**.

| what is measured | before | after |
|---|---|---|
| a one-element leaf digest | 376 | **372** |
| a sixteen-element leaf digest | 2,263 | **1,948** |
| one inner node on its own core | 384 | **380** |
| one inner node sharing a core | 380 per node | 380 per node |
| one climbed level of a lone opening | 384 | **380** |
| one climbed level of a paired opening | 377 per query | 377 per query |
| one observed 64-byte block, amortized | 396 | **395** |

The sixteen-element leaf is the one large move: 256 bytes is five blocks, so it had an odd trailing
block to reclaim.

Every paired figure is unchanged, so the layer-depth analysis stands as written — its break-even
`2^L = 0.99 * n_q` comes from `377 / 380`, and neither number moved.

What did need rewriting is the claim that sharing a core saves the split's overhead. It no longer
saves anything on the compression; a leaf and a climbed level still gain, but from the work around
the compression being paid once instead of twice. `a_shared_core_barely_beats_two_lone_nodes` is
renamed to `a_shared_core_costs_what_two_lone_nodes_cost` and its invariant restated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
