### PR TITLE
BINIUS-35: Give each oracle one dummy wire beyond the FRI query count

### DIFF
--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -350,12 +350,35 @@ impl<F: Field> ConstraintSystem<F> {
 	}
 }
 
+/// Random padding appended to a committed segment.
+///
+/// The padding is what keeps the segment's openings independent of its real wires.
+/// Every committed segment carries the same amount, so each is padded on its own.
 #[derive(Debug, Clone, Copy)]
 pub struct BlindingInfo {
-	/// The number of random dummy wires that must be added.
+	/// The number of random dummy wires appended after the segment's real wires.
 	pub n_dummy_wires: usize,
 	/// The number of random dummy multiplication constraints that must be added.
 	pub n_dummy_constraints: usize,
+}
+
+impl BlindingInfo {
+	/// The blinding a committed segment needs when FRI opens it at `n_test_queries` positions.
+	///
+	/// Each query opens one Merkle leaf, revealing one codeword symbol of the segment.
+	/// A symbol is a fixed linear function of the segment.
+	/// So `n_test_queries` random wires make every opened symbol uniform and independent.
+	///
+	/// One further wire covers the leaves that are never opened.
+	/// Their hashes still travel in the authentication paths, and the leaves carry no salt.
+	/// The spare degree of randomness keeps an unopened leaf unguessable, as a salt would.
+	pub const fn for_fri_queries(n_test_queries: usize) -> Self {
+		Self {
+			n_dummy_wires: n_test_queries + 1,
+			// TODO: Document why these are necessary
+			n_dummy_constraints: 2,
+		}
+	}
 }
 
 #[derive(Debug, Clone)]

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -83,10 +83,7 @@ fn test_zk_wrapped_prove_verify() {
 	// === Step 4: Build outer padded constraint system ===
 	let log_inv_rate = 1;
 	let n_test_queries = fri::calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
-	let blinding_info = BlindingInfo {
-		n_dummy_wires: n_test_queries,
-		n_dummy_constraints: 2,
-	};
+	let blinding_info = BlindingInfo::for_fri_queries(n_test_queries);
 	let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
 	let outer_layout = Arc::new(outer_layout.with_blinding(*outer_cs.blinding_info()));
 

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -174,3 +174,48 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use binius_field::Ghash128b as B128;
+	use binius_spartan_frontend::{
+		circuit_builder::{CircuitBuilder, ConstraintBuilder},
+		compiler::compile,
+	};
+
+	use super::*;
+
+	#[test]
+	fn every_committed_segment_reserves_one_wire_beyond_the_fri_queries() {
+		// Each FRI query opens one Merkle leaf, revealing one codeword symbol of the segment.
+		const N_TEST_QUERIES: usize = 32;
+
+		// Any circuit will do: blinding is padding appended after whatever real wires exist.
+		let mut builder = ConstraintBuilder::<B128>::new();
+		let x = builder.alloc_inout();
+		let y = builder.alloc_inout();
+		builder.assert_eq(x, y);
+		let (cs, _layout) = compile(builder);
+
+		let n_precommit = cs.n_precommit() as usize;
+		let n_private = cs.n_private() as usize;
+
+		let info = BlindingInfo::for_fri_queries(N_TEST_QUERIES);
+		let padded = ConstraintSystemPadded::new(cs, info);
+
+		// Invariant: the dummy wires must outnumber the queries.
+		// Spending exactly one per query would leave the unopened leaves with no randomness of
+		// their own, and the leaves carry no salt.
+		assert!(info.n_dummy_wires > N_TEST_QUERIES);
+
+		// Each segment is rounded up to a power of two, so its reserved size must still cover
+		// every real wire plus the whole blinding allowance:
+		//
+		//     precommit: n_precommit + n_dummy_wires
+		//     private  : n_private   + n_dummy_wires + 3 * n_dummy_constraints
+		assert!(padded.precommit_size() >= n_precommit + info.n_dummy_wires);
+		assert!(
+			padded.private_size() >= n_private + info.n_dummy_wires + 3 * info.n_dummy_constraints
+		);
+	}
+}

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -252,11 +252,7 @@ where
 	) -> Result<Self, Error> {
 		// Modify the constraint system for zero-knowledge.
 		let n_test_queries = fri::calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
-		let blinding_info = BlindingInfo {
-			n_dummy_wires: n_test_queries,
-			// TODO: Document why these are necessary
-			n_dummy_constraints: 2,
-		};
+		let blinding_info = BlindingInfo::for_fri_queries(n_test_queries);
 		let constraint_system = ConstraintSystemPadded::new(constraint_system, blinding_info);
 
 		let iop_verifier = IOPVerifier::new(constraint_system);

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -105,10 +105,7 @@ where
 
 		// Pad the outer constraint system for zero-knowledge.
 		let n_test_queries = fri::calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
-		let blinding_info = BlindingInfo {
-			n_dummy_wires: n_test_queries,
-			n_dummy_constraints: 2,
-		};
+		let blinding_info = BlindingInfo::for_fri_queries(n_test_queries);
 		let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
 		let outer_layout = Arc::new(outer_layout.with_blinding(*outer_cs.blinding_info()));
 		let outer_iop_verifier = IronSpartanIOPVerifier::new(outer_cs);


### PR DESCRIPTION
Closes [BINIUS-35](https://linear.app/jimpo/issue/BINIUS-35).

Pads each committed segment with `q + 1` random wires instead of `q`, so the leaves nobody opens still carry randomness of their own.

### The problem

A committed segment is padded with random dummy wires so its FRI openings say nothing about the real wires.

Each of the `q` queries opens one Merkle leaf, revealing one codeword symbol of the segment.

A symbol is a fixed linear function of the segment, so `q` random wires make every opened symbol uniform.

That covers the openings exactly — and leaves nothing over.

But the verifier sees more than the leaves it opened.

Every authentication path carries the hashes of leaves that were **never** opened, and this Merkle tree salts no leaf.

So an unopened leaf is committed as a bare hash of its contents, and has to stay unguessable on its own.

With exactly `q` dummy wires the queries have spent the entire randomness budget, so an attacker who guesses the real wires can recompute an unopened leaf, hash it, and confirm the guess against the path.

### The idea

Spend one more wire than the queries can consume.

```
    before:  q     dummy wires, all q consumed by the q openings -> 0 left
    after:   q + 1 dummy wires, q consumed by the q openings     -> 1 left
```

That surviving degree of randomness keeps every unopened leaf uniform over $\mathbb{F}_{2^{128}}$, which is exactly the job a per-leaf salt would do.

At the default rate, `q = 232`, so the count goes 232 to 233.

### The change

Both setup paths spelled the padding out by hand, and they must agree or hiding breaks with no test failing.

They now share one constructor that carries the reasoning with it:

```
- BlindingInfo { n_dummy_wires: n_test_queries, n_dummy_constraints: 2 }
+ BlindingInfo::for_fri_queries(n_test_queries)          // n_test_queries + 1
```

The prover reads its blinding back off the constraint system, so nothing on that side needed touching.

The same count also feeds the mask oracle's extra degrees of freedom, so all three outer oracles pick up the extra wire from this one constant.

### Why `q + 1` and not more

Two things could have made the base count wrong, and both were checked against the code rather than assumed.

**A query does not reveal a block of symbols.** A ZK oracle commits with `log_batch_size == 1`, so its leaf is a `(message symbol, mask symbol)` pair.

The mask row is independent randomness, so only one of the two comes from the segment — `q` queries reveal `q` symbols, not `2q`.

**The mask does not already cover this.** The masking challenge is consumed as the *first FRI fold challenge*, so the raw leaf is revealed and folded afterwards.

The mask therefore hides the evaluation claim, not the query openings, and cannot stand in for the padding.

### Soundness

Nothing about the protocol, the transcript, or the challenge distribution changes.

This only widens the random padding appended to a committed segment.

### Scope

- **changed:** the two ZK setup paths, now sharing one constructor
- **changed:** the wrapper integration test, which mirrors production and so uses the same constructor
- **new:** a test pinning that the extra wire survives padding into both committed segments
- **untouched:** the prover, which derives its blinding from the constraint system

A segment rounds up to a power of two, so the extra wire is free unless the count sat exactly on a boundary.

This lands only the `+1`. [BINIUS-581](https://linear.app/jimpo/issue/BINIUS-581) needs `q + 1 + o`, and the `+o` term is not addressed here.

### Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo check --workspace --all-targets` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --document-private-items` — clean
- nightly `cargo fmt --all --check`, `typos`, copyright — clean
- `cargo test` on the five affected crates — 164 passed, including the ZK prove/verify round trips and the wrapper integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)