### PR TITLE
BINIUS-583: Stop zero-padding from leaking a field buffer's dead lanes

### DIFF
--- a/crates/math/src/field_buffer/mod.rs
+++ b/crates/math/src/field_buffer/mod.rs
@@ -358,12 +358,17 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 		// The target starts fully zeroed, so only the occupied words need writing.
 		let mut extended = Self::zeros_in(alloc, log_len);
 
-		// Whole packed words move across untouched.
-		//
-		// Invariant: lanes past the logical length are zero.
-		// So a trailing partial word already carries zeros in its high lanes.
-		// Those are exactly the zeros the padding would otherwise write.
-		extended.as_mut()[..self.as_ref().len()].copy_from_slice(self.as_ref());
+		if self.log_len < P::LOG_WIDTH {
+			// The source's single word also spans lanes that the padding covers.
+			// Nothing sitting there is an element of it, so only the live scalars carry over.
+			//
+			//     source   [ s_0, s_1, x, y ]
+			//     result   [ s_0, s_1, 0, 0 ] [ 0, 0, 0, 0 ]
+			extended.as_mut()[0] = P::from_scalars(self.iter_scalars());
+		} else {
+			// Every lane of every source word is live, so whole words move across untouched.
+			extended.as_mut()[..self.as_ref().len()].copy_from_slice(self.as_ref());
+		}
 
 		extended
 	}
@@ -515,8 +520,6 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// The mutable counterpart of the shared word iterator, covering the same run of words.
 	/// A final word below the packing width is lent out whole, dead lanes included.
-	/// Padding the buffer out to a wider length turns those lanes live.
-	/// Zeros there are what make that padding zero.
 	#[inline]
 	pub fn iter_packed_mut(&mut self) -> slice::IterMut<'_, P> {
 		self.as_mut().iter_mut()
@@ -768,7 +771,24 @@ mod tests {
 		assert_eq!(cloned.as_view(), src.as_view());
 
 		// Copying a source shorter than one packed word keeps the two live lanes, not four.
-		let small = FieldBuffer::<P>::from_values(&scalars[..2]);
+		//
+		// Invariant: a lane past the logical length is not an element, whatever it holds.
+		//
+		// Fixture state: two live scalars, and two dead lanes carrying unrelated values.
+		//
+		//     word   [ 0, 1 | 0xdead, 0xbeef ]
+		//              ^^^^  live prefix
+		//
+		// Packing from scalars would zero those lanes, so the word is supplied whole instead.
+		let small = FieldBuffer::<P>::new(
+			1,
+			vec![P::from_scalars([
+				scalars[0],
+				scalars[1],
+				F::new(0xdead),
+				F::new(0xbeef),
+			])],
+		);
 		let cloned_small: FieldVec<P, A> = FieldBuffer::from_view_in(alloc, small.as_view());
 		assert_eq!(cloned_small.log_len(), 1);
 		assert_eq!(cloned_small.as_view(), small.as_view());


### PR DESCRIPTION
Closes [BINIUS-583](https://linear.app/jimpo/issue/BINIUS-583).

Zero-padding a field buffer copied lanes that were never elements of the source into the padding it is supposed to zero.

### The problem

A buffer shorter than one packed word still occupies a whole word.
The lanes at and past its logical length are not elements of it:

```
WIDTH = 4, log_len = 1

word:  [ s_0, s_1, dead, dead ]
         ^^^^^^^^  live prefix
```

The type is explicit that only truncation zeros them, and that every other constructor may leave whatever the caller's store held there.

Zero-padding contradicted that.
It copied whole packed words and reasoned that the trailing partial word "already carries zeros in its high lanes".
Nothing establishes that, so the dead lanes survived the copy and became live elements:

```
source (log_len 1)   [ 1, 2 | 0xdead, 0xbeef ]
padded (log_len 3)   [ 1, 2 | 0xdead, 0xbeef ] [ 0, 0, 0, 0 ]
                             ^^^^^^^^^^^^^^  should be zero
```

### It fires today

**Update:** this is not latent. A separate inspection of `binius-iop-prover` reproduced an honest
WHIR proof being *rejected* because of it, and I re-ran that reproduction against this branch.

An oracle shorter than one packed word is committed with junk in its padding, but the message the
ladder later folds writes real zeros there (`combined_message.rs:68-74` handles the narrow branch
explicitly). The two disagree and the query round catches it — so the prover produces a proof its
own verifier rejects.

It only shows up at a packing width above 1:

| ladder shape | on `main` | on this branch |
|---|---|---|
| `1x128b`, lengths `[7, 6, 5, 3]` | verifies | verifies |
| `1x128b`, lengths `[7, 1]` | verifies | verifies |
| **`4x128b`, lengths `[7, 1]`** | **rejected** | **verifies** |
| `4x128b`, lengths `[7, 1]`, source lanes pre-zeroed | verifies | verifies |

`4x128b` is what `OptimalPackedB128` resolves to on any AVX-512 machine, which is what
`binius-prover` uses. The crate's own test for that path runs at `FieldBuffer<B128>`, where
`P::WIDTH == 1` and the padding branch is vacuous — which is why nobody had seen it.

The last row is the control: rebuilding the source so its dead lanes are zero makes the same proof
verify on `main` too, which pins the cause to the padding and nothing else. The reproduction also
confirms the source buffer's four lanes are all non-zero, so this branch is not passing by accident.

Reachable wherever a caller commits an oracle of one or two scalars — `logup_star::prove` commits
one pushforward per table, and a table's size is the caller's. Not reachable in the sha256 or
`binius-prover` paths today, whose oracles are 2^22 elements.

### Where it can fire

The WHIR prover pads an oracle message shorter than one column block before committing it.
It gets there by copying a borrowed buffer — which copies dead lanes verbatim, by design and by documentation — and then padding that copy.
An oracle whose padding is not zero is a wrong commitment.

### The idea

The invariant the padding wanted cannot be enforced.
A buffer can be built over a borrowed slice the type never gets to write to, so there is no constructor that could establish it for every shape.

So the padding stops assuming it, and splits on the only case where dead lanes exist at all:

```
- extended.as_mut()[..self.as_ref().len()].copy_from_slice(self.as_ref());
+ if self.log_len < P::LOG_WIDTH {
+     extended.as_mut()[0] = P::from_scalars(self.iter_scalars());
+ } else {
+     extended.as_mut()[..self.as_ref().len()].copy_from_slice(self.as_ref());
+ }
```

Packing from the live scalars zero-fills every lane above them, which is exactly what the padding owes.

### Soundness

The fix only ever zeros positions that were never elements of the source.
A source spanning one packed word or more has no dead lanes and takes the identical code path it took before, so nothing about it changes.

I read every other routine in the crate that touches a whole trailing word, to check whether any of them makes the same assumption. None do:

- equality and the halving routines compare or interleave the live prefix only
- the inner products multiply whole words and then take the live scalars
- repeat-extend rebuilds a sub-word buffer from its live scalars
- the bit reversal's tiled path only runs once every lane is live
- the binary fold bounds its lane loop by the live count

### The test that already existed

The assertion for this exact property was already there:

```
// The two dead lanes become live, so they read back as zeros, not stale scalars.
assert!((2..8).all(|i| widened.get(i) == F::ZERO));
```

Its fixture was built from a scalar slice, and packing from scalars zero-fills — so it could never produce a dirty lane to catch.
The fixture now supplies the packed word whole, with two dead lanes carrying unrelated values.

Reverting the fix with the new fixture in place fails, as it should:

```
thread 'field_buffer::tests::alloc_constructors_global' panicked at crates/math/src/field_buffer/mod.rs:827:9:
assertion failed: (2..8).all(|i| widened.get(i) == F::ZERO)
```

### Scope

- **changed:** the sub-packing-width branch of zero-padding, one file
- **changed:** the shared fixture for the allocator-constructor tests, which both the global and pooled variants run
- **removed:** two doc lines that described the padding as depending on what a caller left in the dead lanes
- no API change, no signature change, nothing else touched

### Verification

- `cargo test -p binius-math --release` — 175 passed, 0 failed
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-math --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `cargo check --workspace --all-targets` — clean
- `typos`, `tools/check_copyright_notice.py` — clean

No benchmark: the changed branch handles a single packed word, and the branch every large buffer takes is byte-for-byte the code that was there before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
