### PR TITLE
BINIUS-585: Give the packed NTT engine all three of its transforms

### DIFF
--- a/crates/math/src/ntt/mod.rs
+++ b/crates/math/src/ntt/mod.rs
@@ -116,44 +116,15 @@ pub trait AdditiveNTT {
 	/// Building that column by column costs one generator row per nonzero of `a`.
 	/// One transposed pass costs `O(2^log_len * log_len)` however many nonzeros there are.
 	///
-	/// The default body mirrors the reference forward transform and is correspondingly slow.
-	/// An implementation with a fast forward transform should override it.
-	///
 	/// ## Preconditions
 	///
 	/// - same as [`Self::forward_transform`]
 	fn transpose_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<'_, P>,
+		data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
-	) {
-		let log_d = data.log_len();
-		let domain_context = self.domain_context();
-		reference::input_check(domain_context, log_d, skip_early, skip_late);
-
-		// Transposing a composition reverses it, so the layers run backwards and each keeps the
-		// twiddle it used going forward.
-		for layer in (skip_early..(log_d - skip_late)).rev() {
-			let num_blocks = 1 << layer;
-			let block_size_half = 1 << (log_d - layer - 1);
-			for block in 0..num_blocks {
-				let twiddle = domain_context.twiddle(layer, block);
-				let block_start = block << (log_d - layer);
-				for idx0 in block_start..(block_start + block_size_half) {
-					let idx1 = block_size_half | idx0;
-					// The transposed butterfly, which is the forward one with its two steps
-					// swapped: `u'' = u + v` and then `v'' = v + t * u''`.
-					let mut u = data.get(idx0);
-					let mut v = data.get(idx1);
-					u += v;
-					v += u * twiddle;
-					data.set(idx0, u);
-					data.set(idx1, v);
-				}
-			}
-		}
-	}
+	);
 
 	/// The associated [`DomainContext`].
 	fn domain_context(&self) -> &impl DomainContext<Field = Self::Field>;

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -25,6 +25,151 @@ use crate::field_buffer::FieldSliceMut;
 // Empirically it performs well and is small enough for the buffer to fit comfortably in L1 cache.
 const DEFAULT_LOG_BASE_LEN: usize = 10;
 
+/// One of the three linear maps the butterfly network computes.
+///
+/// All three run the same network over the same twiddles, and cost the same.
+/// They differ in the order the layers run and in what one butterfly does:
+///
+/// ```text
+///     forward     layers ascending     u += v * t;  v += u
+///     inverse     layers descending    v += u;      u += v * t
+///     transpose   layers descending    u += v;      v += u * t
+/// ```
+///
+/// Everything below is written once against this, so all three get the same engine.
+trait Butterfly {
+	/// Whether the layers run from the earliest to the latest.
+	const ASCENDING: bool;
+
+	/// Applies one butterfly under a twiddle.
+	fn apply<P: PackedField>(u: &mut P, v: &mut P, twiddle: P);
+
+	/// Applies one butterfly where the twiddle is zero.
+	///
+	/// One of the two values then keeps what it held, so its cache lines stay clean.
+	fn apply_zero<P: PackedField>(u: &mut P, v: &mut P);
+
+	/// Runs the same map through the scalar reference implementation.
+	fn reference<P: PackedField>(
+		domain_context: &impl DomainContext<Field = P::Scalar>,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	);
+}
+
+/// The transformation the additive NTT is named for.
+struct Forward;
+
+impl Butterfly for Forward {
+	const ASCENDING: bool = true;
+
+	#[inline(always)]
+	fn apply<P: PackedField>(u: &mut P, v: &mut P, twiddle: P) {
+		*u += *v * twiddle;
+		*v += *u;
+	}
+
+	#[inline(always)]
+	fn apply_zero<P: PackedField>(u: &mut P, v: &mut P) {
+		*v += *u;
+	}
+
+	fn reference<P: PackedField>(
+		domain_context: &impl DomainContext<Field = P::Scalar>,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		NeighborsLastReference { domain_context }.forward_transform(data, skip_early, skip_late);
+	}
+}
+
+/// The inverse of the forward transformation.
+struct Inverse;
+
+impl Butterfly for Inverse {
+	const ASCENDING: bool = false;
+
+	#[inline(always)]
+	fn apply<P: PackedField>(u: &mut P, v: &mut P, twiddle: P) {
+		*v += *u;
+		*u += *v * twiddle;
+	}
+
+	#[inline(always)]
+	fn apply_zero<P: PackedField>(u: &mut P, v: &mut P) {
+		*v += *u;
+	}
+
+	fn reference<P: PackedField>(
+		domain_context: &impl DomainContext<Field = P::Scalar>,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		NeighborsLastReference { domain_context }.inverse_transform(data, skip_early, skip_late);
+	}
+}
+
+/// The adjoint of the forward transformation.
+///
+/// The forward butterfly has determinant one, so its inverse and its transpose agree only where
+/// the twiddle vanishes.
+struct Transpose;
+
+impl Butterfly for Transpose {
+	const ASCENDING: bool = false;
+
+	#[inline(always)]
+	fn apply<P: PackedField>(u: &mut P, v: &mut P, twiddle: P) {
+		*u += *v;
+		*v += *u * twiddle;
+	}
+
+	#[inline(always)]
+	fn apply_zero<P: PackedField>(u: &mut P, v: &mut P) {
+		*u += *v;
+	}
+
+	fn reference<P: PackedField>(
+		domain_context: &impl DomainContext<Field = P::Scalar>,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		NeighborsLastReference { domain_context }.transpose_transform(data, skip_early, skip_late);
+	}
+}
+
+/// Applies one layer to the block a recursion level owns.
+///
+/// ## Preconditions
+///
+/// - `2 * block_size_half == data.len()`
+#[inline]
+fn one_block<B: Butterfly, P: PackedField>(
+	domain_context: &impl DomainContext<Field = P::Scalar>,
+	data: &mut [P],
+	block_size_half: usize,
+	layer: usize,
+	block: usize,
+) {
+	let (block0, block1) = data.split_at_mut(block_size_half);
+	if block == 0 {
+		// `domain_context.twiddle(layer, 0)` is always zero (see `DomainContext::twiddle`).
+		// So the butterfly collapses to a single addition.
+		for (u, v) in iter::zip(block0, block1) {
+			B::apply_zero(u, v);
+		}
+	} else {
+		let packed_twiddle = P::broadcast(domain_context.twiddle(layer, block));
+		for (u, v) in iter::zip(block0, block1) {
+			B::apply(u, v, packed_twiddle);
+		}
+	}
+}
+
 /// Runs a **part** of an NTT butterfly network, in depth-first order.
 ///
 /// Concretely, it processes a specific memory block in the butterfly network, which is given by
@@ -46,6 +191,9 @@ const DEFAULT_LOG_BASE_LEN: usize = 10;
 /// (Just in a different order. We listed breadth-first order, we would process them in
 /// depth-first order.)
 ///
+/// A descending map visits the same blocks, and applies a level's own layer after recursing rather
+/// than before.
+///
 /// The argument `log_base_len` determines for which `log_d` we call the breadth-first
 /// implementation as a base case.
 ///
@@ -55,13 +203,13 @@ const DEFAULT_LOG_BASE_LEN: usize = 10;
 /// - `data.len() >= 2`
 /// - `domain_context` holds all the twiddles up to `layer_range.end` (exclusive)
 /// - `layer <= layer_range.start`
-fn forward_depth_first<P: PackedField>(
+fn depth_first<B: Butterfly, P: PackedField>(
 	domain_context: &impl DomainContext<Field = P::Scalar>,
 	data: &mut [P],
 	log_d: usize,
 	layer: usize,
 	block: usize,
-	mut layer_range: Range<usize>,
+	layer_range: Range<usize>,
 	log_base_len: usize,
 ) {
 	// check preconditions
@@ -80,55 +228,151 @@ fn forward_depth_first<P: PackedField>(
 
 	// if the problem size is small, we just do breadth_first (to get rid of the stack overhead)
 	if log_d <= log_base_len {
-		forward_breadth_first(domain_context, data, log_d, layer, block, layer_range);
+		breadth_first::<B, P>(domain_context, data, log_d, layer, block, layer_range);
 		return;
 	}
 
 	let block_size_half = 1 << (log_d - 1 - P::LOG_WIDTH);
-	if layer >= layer_range.start {
-		// process only one layer of this block
-		let (block0, block1) = data.split_at_mut(block_size_half);
-		if block == 0 {
-			// `domain_context.twiddle(layer, 0)` is always zero (see `DomainContext::twiddle`).
-			// So the butterfly collapses to `v += u`, with `u` left unchanged.
-			for (u, v) in iter::zip(block0, block1) {
-				*v += *u;
-			}
-		} else {
-			let twiddle = domain_context.twiddle(layer, block);
-			let packed_twiddle = P::broadcast(twiddle);
-			for (u, v) in iter::zip(block0, block1) {
-				// perform butterfly
-				*u += *v * packed_twiddle;
-				*v += *u;
-			}
-		}
+	// Every layer this level's descendants own is above its own, so its own is in range whenever
+	// the range has started.
+	let owns_layer = layer >= layer_range.start;
 
-		layer_range.start += 1;
+	// A descendant owns only layers above this one, so the window it is handed starts no lower
+	// than the next layer. That is what keeps the precondition above true all the way down.
+	let descendant_range = layer_range.start.max(layer + 1)..layer_range.end;
+
+	if B::ASCENDING && owns_layer {
+		one_block::<B, P>(domain_context, data, block_size_half, layer, block);
 	}
 
 	// then recurse
-	forward_depth_first(
+	depth_first::<B, P>(
 		domain_context,
 		&mut data[..block_size_half],
 		log_d - 1,
 		layer + 1,
 		block << 1,
-		layer_range.clone(),
+		descendant_range.clone(),
 		log_base_len,
 	);
-	forward_depth_first(
+	depth_first::<B, P>(
 		domain_context,
 		&mut data[block_size_half..],
 		log_d - 1,
 		layer + 1,
 		(block << 1) + 1,
-		layer_range,
+		descendant_range,
 		log_base_len,
 	);
+
+	if !B::ASCENDING && owns_layer {
+		one_block::<B, P>(domain_context, data, block_size_half, layer, block);
+	}
 }
 
-/// Same as [`forward_depth_first`], but runs in breadth-first order.
+/// Applies one layer whose blocks span whole packed elements.
+///
+/// All butterflies are between values in separate packed elements, and all butterflies within a
+/// block share the same twiddle factor.
+fn word_layer<B: Butterfly, P: PackedField>(
+	domain_context: &impl DomainContext<Field = P::Scalar>,
+	data: &mut [P],
+	log_n: usize,
+	base_layer: usize,
+	base_block: usize,
+	layer: usize,
+) {
+	// log_block_size is log2 the number of packed elements forming one block.
+	let log_block_size = log_n - P::LOG_WIDTH - layer;
+	let log_half_block_size = log_block_size - 1;
+
+	// log2 the number of blocks to process in this layer
+	let log_blocks = layer - base_layer;
+	let mut layer_twiddles = domain_context
+		.iter_twiddles(layer, 0)
+		.skip(base_block << log_blocks)
+		.take(1 << log_blocks);
+	let mut blocks = data.chunks_exact_mut(1 << log_block_size);
+
+	// `domain_context.twiddle(layer, 0)` is always zero (see `DomainContext::twiddle`).
+	// `base_block == 0` is the only case where this call's first block is the domain's block 0.
+	// Peel it off once per layer instead of branching per element.
+	if base_block == 0 {
+		layer_twiddles.next();
+		if let Some(block) = blocks.next() {
+			let (block0, block1) = block.split_at_mut(1 << log_half_block_size);
+			for (u, v) in iter::zip(block0, block1) {
+				B::apply_zero(u, v);
+			}
+		}
+	}
+
+	for (block, twiddle) in iter::zip(blocks, layer_twiddles) {
+		let packed_twiddle = P::broadcast(twiddle);
+		let (block0, block1) = block.split_at_mut(1 << log_half_block_size);
+		for (u, v) in iter::zip(block0, block1) {
+			B::apply(u, v, packed_twiddle);
+		}
+	}
+}
+
+/// Applies one layer whose blocks sit inside a packed element.
+///
+/// The butterflies operate on elements within packed field elements.
+/// We solve this problem by interleaving the packed elements with each other.
+fn lane_layer<B: Butterfly, P: PackedField>(
+	domain_context: &impl DomainContext<Field = P::Scalar>,
+	data: &mut [P],
+	log_n: usize,
+	log_d: usize,
+	base_block: usize,
+	layer: usize,
+) {
+	// log_block_size is log2 the number of single elements forming one block.
+	let log_block_size = log_n - layer;
+	let log_half_block_size = log_block_size - 1;
+	let log_blocks_per_packed = P::LOG_WIDTH - log_block_size;
+	let log_half_blocks_per_packed = log_blocks_per_packed + 1;
+
+	// calculate packed_twiddle_offset
+	let mut packed_twiddle_offset = P::zero();
+	for block in 0..1 << log_blocks_per_packed {
+		let twiddle0 = domain_context.twiddle(layer, block);
+		let twiddle1 = domain_context.twiddle(layer, (1 << log_blocks_per_packed) | block);
+
+		let block_start = block << log_block_size;
+		for j in 0..1 << log_half_block_size {
+			packed_twiddle_offset.set(block_start | j, twiddle0);
+			packed_twiddle_offset.set(block_start | j | (1 << log_half_block_size), twiddle1);
+		}
+	}
+
+	// log2 the number of packed element pairs to process in this layer.
+	// This call's data is `2^(log_d - P::LOG_WIDTH)` packed elements, hence half that in pairs.
+	let log_packed_pairs = log_d - P::LOG_WIDTH - 1;
+	let layer_twiddles = domain_context
+		.iter_twiddles(layer, log_half_blocks_per_packed)
+		.skip(base_block << log_packed_pairs)
+		.take(1 << log_packed_pairs);
+
+	let (data_pairs, rest) = data.as_chunks_mut::<2>();
+	debug_assert!(
+		rest.is_empty(),
+		"data_packed length is a power of two; \
+			data_packed length is greater than 1 (checked at beginning of method)"
+	);
+	debug_assert_eq!(data_pairs.len(), 1 << log_packed_pairs);
+
+	for ([packed0, packed1], first_twiddle) in iter::zip(data_pairs, layer_twiddles) {
+		let packed_twiddle = P::broadcast(first_twiddle) + packed_twiddle_offset;
+
+		let (mut u, mut v) = (*packed0).interleave(*packed1, log_half_block_size);
+		B::apply(&mut u, &mut v, packed_twiddle);
+		(*packed0, *packed1) = u.interleave(v, log_half_block_size);
+	}
+}
+
+/// Same as the depth-first recursion above, but runs in breadth-first order.
 ///
 /// ## Preconditions
 ///
@@ -137,7 +381,7 @@ fn forward_depth_first<P: PackedField>(
 /// - `data.len() >= 2`
 /// - `domain_context` holds all the twiddles up to `layer_bound` (exclusive)
 /// - `layer <= layer_range.start`
-fn forward_breadth_first<P: PackedField>(
+fn breadth_first<B: Butterfly, P: PackedField>(
 	domain_context: &impl DomainContext<Field = P::Scalar>,
 	data: &mut [P],
 	log_d: usize,
@@ -154,93 +398,23 @@ fn forward_breadth_first<P: PackedField>(
 	let log_n = log_d + base_layer;
 	debug_assert!(layer_range.end <= log_n);
 
+	// Layers below the cutoff have blocks of whole packed elements, and layers at or above it have
+	// blocks inside one. The two shapes are contiguous, so each direction runs one then the other.
 	let packed_cutoff = (log_n - P::LOG_WIDTH).clamp(layer_range.start, layer_range.end);
 
-	// In these rounds, layer <= log_n - P::LOG_WIDTH. All butterflies are between values in
-	// separate packed elements, and all butterflies within a block share the same twiddle factor.
-	for layer in layer_range.start..packed_cutoff {
-		// log_block_size is log2 the number of packed elements forming one block.
-		let log_block_size = log_n - P::LOG_WIDTH - layer;
-		let log_half_block_size = log_block_size - 1;
-
-		// log2 the number of blocks to process in this layer
-		let log_blocks = layer - base_layer;
-		let mut layer_twiddles = domain_context
-			.iter_twiddles(layer, 0)
-			.skip(base_block << log_blocks)
-			.take(1 << log_blocks);
-		let mut blocks = data.chunks_exact_mut(1 << log_block_size);
-
-		// `domain_context.twiddle(layer, 0)` is always zero (see `DomainContext::twiddle`).
-		// `base_block == 0` is the only case where this call's first block is the domain's block 0.
-		// Peel it off once per layer instead of branching per element.
-		if base_block == 0 {
-			layer_twiddles.next();
-			if let Some(block) = blocks.next() {
-				let (block0, block1) = block.split_at_mut(1 << log_half_block_size);
-				for (u, v) in iter::zip(block0, block1) {
-					*v += *u;
-				}
-			}
+	if B::ASCENDING {
+		for layer in layer_range.start..packed_cutoff {
+			word_layer::<B, P>(domain_context, data, log_n, base_layer, base_block, layer);
 		}
-
-		for (block, twiddle) in iter::zip(blocks, layer_twiddles) {
-			let packed_twiddle = P::broadcast(twiddle);
-			let (block0, block1) = block.split_at_mut(1 << log_half_block_size);
-			for (u, v) in iter::zip(block0, block1) {
-				// perform butterfly
-				*u += *v * packed_twiddle;
-				*v += *u;
-			}
+		for layer in packed_cutoff..layer_range.end {
+			lane_layer::<B, P>(domain_context, data, log_n, log_d, base_block, layer);
 		}
-	}
-
-	// In these rounds, layer > log_n - P::LOG_WIDTH. The butterflies operate on elements within
-	// packed field elements. We solve this problem by interleaving the packed elements with each
-	// other.
-	for layer in packed_cutoff..layer_range.end {
-		// log_block_size is log2 the number of single elements forming one block.
-		let log_block_size = log_n - layer;
-		let log_half_block_size = log_block_size - 1;
-		let log_blocks_per_packed = P::LOG_WIDTH - log_block_size;
-		let log_half_blocks_per_packed = log_blocks_per_packed + 1;
-
-		// calculate packed_twiddle_offset
-		let mut packed_twiddle_offset = P::zero();
-		for block in 0..1 << log_blocks_per_packed {
-			let twiddle0 = domain_context.twiddle(layer, block);
-			let twiddle1 = domain_context.twiddle(layer, (1 << log_blocks_per_packed) | block);
-
-			let block_start = block << log_block_size;
-			for j in 0..1 << log_half_block_size {
-				packed_twiddle_offset.set(block_start | j, twiddle0);
-				packed_twiddle_offset.set(block_start | j | (1 << log_half_block_size), twiddle1);
-			}
+	} else {
+		for layer in (packed_cutoff..layer_range.end).rev() {
+			lane_layer::<B, P>(domain_context, data, log_n, log_d, base_block, layer);
 		}
-
-		// log2 the number of packed element pairs to process in this layer.
-		// This call's data is `2^(log_d - P::LOG_WIDTH)` packed elements, hence half that in pairs.
-		let log_packed_pairs = log_d - P::LOG_WIDTH - 1;
-		let layer_twiddles = domain_context
-			.iter_twiddles(layer, log_half_blocks_per_packed)
-			.skip(base_block << log_packed_pairs)
-			.take(1 << log_packed_pairs);
-
-		let (data_pairs, rest) = data.as_chunks_mut::<2>();
-		debug_assert!(
-			rest.is_empty(),
-			"data_packed length is a power of two; \
-				data_packed length is greater than 1 (checked at beginning of method)"
-		);
-		debug_assert_eq!(data_pairs.len(), 1 << log_packed_pairs);
-
-		for ([packed0, packed1], first_twiddle) in iter::zip(data_pairs, layer_twiddles) {
-			let packed_twiddle = P::broadcast(first_twiddle) + packed_twiddle_offset;
-
-			let (mut u, mut v) = (*packed0).interleave(*packed1, log_half_block_size);
-			u += v * packed_twiddle;
-			v += u;
-			(*packed0, *packed1) = u.interleave(v, log_half_block_size);
+		for layer in (layer_range.start..packed_cutoff).rev() {
+			word_layer::<B, P>(domain_context, data, log_n, base_layer, base_block, layer);
 		}
 	}
 }
@@ -250,13 +424,13 @@ fn forward_breadth_first<P: PackedField>(
 ///
 /// (The latter is the whole purpose of this function. If the number of shares is small enough (and
 /// the number of blocks is big enough) so that we don't need to split up blocks, we could just run
-/// [`forward_depth_first`] on disjoint chunks.)
+/// the depth-first recursion on disjoint chunks.)
 ///
 /// - `2^(log_d) == data.len() * packing_width`
 /// - **Important:** `2^log_num_shares * 2 <= data.len()` (every share is working with whole packed
 ///   elements, so every share needs at least 2 packed elements)
 /// - `domain_context` holds the twiddles of `layer`
-fn forward_shared_layer<P: PackedField>(
+fn shared_layer<B: Butterfly, P: PackedField>(
 	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
 	data: &mut [P],
 	log_d: usize,
@@ -278,6 +452,18 @@ fn forward_shared_layer<P: PackedField>(
 			let block = chunk0 >> (log_num_chunks - layer);
 			assert!(P::LOG_WIDTH <= log_d_chunk);
 			let log_chunk_len = log_d_chunk - P::LOG_WIDTH;
+			// SAFETY: the two chunks this task lends out are disjoint from every other task's.
+			//
+			// Inserting one bit at a fixed position is injective, and the inserted bit is what
+			// tells the pair apart. So as `k` runs over its whole range the pairs enumerate every
+			// chunk index exactly once:
+			//
+			//     log_num_shares = 2, shift = 1
+			//     k = 0 -> (000, 010)   k = 2 -> (100, 110)
+			//     k = 1 -> (001, 011)   k = 3 -> (101, 111)
+			//
+			// Every index is in range, since the widest is one below the chunk count, and the
+			// buffer outlives the loop below.
 			let chunk0 = unsafe {
 				from_raw_parts_mut(data_ptr.add(chunk0 << log_chunk_len), 1 << log_chunk_len)
 			};
@@ -296,22 +482,15 @@ fn forward_shared_layer<P: PackedField>(
 		.for_each(|(chunk0, chunk1, twiddle)| match twiddle {
 			Some(twiddle) => {
 				for (u, v) in iter::zip(chunk0, chunk1) {
-					butterfly(u, v, twiddle);
+					B::apply(u, v, twiddle);
 				}
 			}
 			None => {
 				for (u, v) in iter::zip(chunk0, chunk1) {
-					*v += *u;
+					B::apply_zero(u, v);
 				}
 			}
 		});
-}
-
-/// Applies one butterfly of the network: `u += v * twiddle`, then `v += u`.
-#[inline(always)]
-fn butterfly<P: PackedField>(u: &mut P, v: &mut P, twiddle: P) {
-	*u += *v * twiddle;
-	*v += *u;
 }
 
 /// Applies two consecutive butterfly layers to four planes held in registers.
@@ -321,7 +500,9 @@ fn butterfly<P: PackedField>(u: &mut P, v: &mut P, twiddle: P) {
 /// `twiddle_1_even` and `twiddle_1_odd` belong to the second, which pairs `(0, 1)` and `(2, 3)`.
 ///
 /// Each element is loaded once, takes part in both layers, and is stored once.
-fn fused_pair<P: PackedField>(
+///
+/// A descending map runs the second layer's pairs first.
+fn fused_pair<B: Butterfly, P: PackedField>(
 	planes: [&mut [P]; 4],
 	twiddle_0: P,
 	twiddle_1_even: P,
@@ -330,26 +511,40 @@ fn fused_pair<P: PackedField>(
 	let [plane_0, plane_1, plane_2, plane_3] = planes;
 
 	for (x_0, x_1, x_2, x_3) in izip!(plane_0, plane_1, plane_2, plane_3) {
-		butterfly(x_0, x_2, twiddle_0);
-		butterfly(x_1, x_3, twiddle_0);
-		butterfly(x_0, x_1, twiddle_1_even);
-		butterfly(x_2, x_3, twiddle_1_odd);
+		if B::ASCENDING {
+			B::apply(x_0, x_2, twiddle_0);
+			B::apply(x_1, x_3, twiddle_0);
+			B::apply(x_0, x_1, twiddle_1_even);
+			B::apply(x_2, x_3, twiddle_1_odd);
+		} else {
+			B::apply(x_0, x_1, twiddle_1_even);
+			B::apply(x_2, x_3, twiddle_1_odd);
+			B::apply(x_0, x_2, twiddle_0);
+			B::apply(x_1, x_3, twiddle_0);
+		}
 	}
 }
 
-/// Same as [`fused_pair`], for the super-block whose index is zero.
+/// Same as the fused pair above, for the super-block whose index is zero.
 ///
 /// There `twiddle_0` and `twiddle_1_even` are both the layer's block-0 twiddle, which is zero.
-/// Each of their butterflies collapses to `v += u`, leaving `u` untouched.
-/// So plane 0 is never written, and its cache lines stay clean.
-fn fused_pair_zero_block<P: PackedField>(planes: [&mut [P]; 4], twiddle_1_odd: P) {
+/// Each of their butterflies collapses to a single addition, leaving one plane untouched.
+/// So that plane is never written, and its cache lines stay clean.
+fn fused_pair_zero_block<B: Butterfly, P: PackedField>(planes: [&mut [P]; 4], twiddle_1_odd: P) {
 	let [plane_0, plane_1, plane_2, plane_3] = planes;
 
 	for (x_0, x_1, x_2, x_3) in izip!(plane_0, plane_1, plane_2, plane_3) {
-		*x_2 += *x_0;
-		*x_3 += *x_1;
-		*x_1 += *x_0;
-		butterfly(x_2, x_3, twiddle_1_odd);
+		if B::ASCENDING {
+			B::apply_zero(x_0, x_2);
+			B::apply_zero(x_1, x_3);
+			B::apply_zero(x_0, x_1);
+			B::apply(x_2, x_3, twiddle_1_odd);
+		} else {
+			B::apply_zero(x_0, x_1);
+			B::apply(x_2, x_3, twiddle_1_odd);
+			B::apply_zero(x_0, x_2);
+			B::apply_zero(x_1, x_3);
+		}
 	}
 }
 
@@ -383,7 +578,7 @@ fn fused_pair_zero_block<P: PackedField>(planes: [&mut [P]; 4], twiddle_1_odd: P
 /// - `first_layer + 2 <= log_num_shares`
 /// - `first_layer + 2 + P::LOG_WIDTH < log_d`
 /// - `domain_context` holds the twiddles of layers `first_layer` and `first_layer + 1`
-fn forward_shared_layer_pair<P: PackedField>(
+fn shared_layer_pair<B: Butterfly, P: PackedField>(
 	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
 	data: &mut [P],
 	log_d: usize,
@@ -436,9 +631,9 @@ fn forward_shared_layer_pair<P: PackedField>(
 			// `domain_context.twiddle(layer, 0)` is always zero (see `DomainContext::twiddle`).
 			// Only super-block 0 reads block 0, and it does so in both of its layers.
 			if h == 0 {
-				fused_pair_zero_block(planes, twiddle_1_odd);
+				fused_pair_zero_block::<B, P>(planes, twiddle_1_odd);
 			} else {
-				fused_pair(planes, twiddle_0, twiddle_1_even, twiddle_1_odd);
+				fused_pair::<B, P>(planes, twiddle_0, twiddle_1_even, twiddle_1_odd);
 			}
 		});
 }
@@ -453,7 +648,7 @@ fn forward_shared_layer_pair<P: PackedField>(
 ///
 /// - same as the routines this dispatches to
 /// - `layers.end <= log_num_shares`
-fn forward_shared_layers<P: PackedField>(
+fn shared_layers<B: Butterfly, P: PackedField>(
 	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
 	data: &mut [P],
 	log_d: usize,
@@ -462,15 +657,30 @@ fn forward_shared_layers<P: PackedField>(
 ) {
 	debug_assert!(layers.end <= log_num_shares);
 
-	let mut layer = layers.start;
-	while layer < layers.end {
-		// A pair needs one more layer to pair with, and planes of at least one packed element.
-		if layers.end - layer >= 2 && layer + 2 + P::LOG_WIDTH < log_d {
-			forward_shared_layer_pair(domain_context, data, log_d, layer, log_num_shares);
-			layer += 2;
-		} else {
-			forward_shared_layer(domain_context, data, log_d, layer, log_num_shares);
-			layer += 1;
+	// A pair needs one more layer to pair with, and planes of at least one packed element.
+	// Each direction walks the window from its own end, so a pair is always the two layers a
+	// single pass over the buffer is about to visit.
+	if B::ASCENDING {
+		let mut layer = layers.start;
+		while layer < layers.end {
+			if layers.end - layer >= 2 && layer + 2 + P::LOG_WIDTH < log_d {
+				shared_layer_pair::<B, P>(domain_context, data, log_d, layer, log_num_shares);
+				layer += 2;
+			} else {
+				shared_layer::<B, P>(domain_context, data, log_d, layer, log_num_shares);
+				layer += 1;
+			}
+		}
+	} else {
+		let mut layer = layers.end;
+		while layer > layers.start {
+			if layer - layers.start >= 2 && layer + P::LOG_WIDTH < log_d {
+				shared_layer_pair::<B, P>(domain_context, data, log_d, layer - 2, log_num_shares);
+				layer -= 2;
+			} else {
+				shared_layer::<B, P>(domain_context, data, log_d, layer - 1, log_num_shares);
+				layer -= 1;
+			}
 		}
 	}
 }
@@ -511,41 +721,60 @@ where
 
 	fn forward_transform<P: PackedField<Scalar = F>>(
 		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Forward, P>(data, skip_early, skip_late);
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Inverse, P>(data, skip_early, skip_late);
+	}
+
+	fn transpose_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Transpose, P>(data, skip_early, skip_late);
+	}
+
+	fn domain_context(&self) -> &impl DomainContext<Field = F> {
+		&self.domain_context
+	}
+}
+
+impl<DC: DomainContext> NeighborsLastBreadthFirst<DC> {
+	/// Runs one of the three maps over the whole buffer.
+	fn run<B: Butterfly, P: PackedField<Scalar = DC::Field>>(
+		&self,
 		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
 		let log_d = data.log_len();
+		// A buffer of at most one packed element has no pair of words to walk.
 		if log_d <= P::LOG_WIDTH {
-			let fallback_ntt = NeighborsLastReference {
-				domain_context: &self.domain_context,
-			};
-			return fallback_ntt.forward_transform(data, skip_early, skip_late);
+			return B::reference(&self.domain_context, data, skip_early, skip_late);
 		}
 
 		input_check(&self.domain_context, log_d, skip_early, skip_late);
 
-		forward_breadth_first(
-			self.domain_context(),
+		breadth_first::<B, P>(
+			&self.domain_context,
 			data.as_mut(),
 			log_d,
 			0,
 			0,
 			skip_early..(log_d - skip_late),
 		);
-	}
-
-	fn inverse_transform<P: PackedField<Scalar = F>>(
-		&self,
-		_data: FieldSliceMut<'_, P>,
-		_skip_early: usize,
-		_skip_late: usize,
-	) {
-		todo!()
-	}
-
-	fn domain_context(&self) -> &impl DomainContext<Field = F> {
-		&self.domain_context
 	}
 }
 
@@ -582,21 +811,53 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastSingleThread<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Forward, P>(data, skip_early, skip_late);
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
+		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Inverse, P>(data, skip_early, skip_late);
+	}
+
+	fn transpose_transform<P: PackedField<Scalar = Self::Field>>(
+		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Transpose, P>(data, skip_early, skip_late);
+	}
+
+	fn domain_context(&self) -> &impl DomainContext<Field = DC::Field> {
+		&self.domain_context
+	}
+}
+
+impl<DC: DomainContext> NeighborsLastSingleThread<DC> {
+	/// Runs one of the three maps over the whole buffer.
+	fn run<B: Butterfly, P: PackedField<Scalar = DC::Field>>(
+		&self,
 		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
 		let log_d = data.log_len();
+		// A buffer of at most one packed element has no pair of words to walk.
 		if log_d <= P::LOG_WIDTH {
-			let fallback_ntt = NeighborsLastReference {
-				domain_context: &self.domain_context,
-			};
-			return fallback_ntt.forward_transform(data, skip_early, skip_late);
+			return B::reference(&self.domain_context, data, skip_early, skip_late);
 		}
 
 		input_check(&self.domain_context, log_d, skip_early, skip_late);
 
-		forward_depth_first(
+		depth_first::<B, P>(
 			&self.domain_context,
 			data.as_mut(),
 			log_d,
@@ -606,19 +867,6 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastSingleThread<DC> {
 			// Ensures that log_base_len satisfies precondition
 			self.log_base_len.max(P::LOG_WIDTH + 1),
 		);
-	}
-
-	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
-		&self,
-		_data_orig: FieldSliceMut<'_, P>,
-		_skip_early: usize,
-		_skip_late: usize,
-	) {
-		unimplemented!()
-	}
-
-	fn domain_context(&self) -> &impl DomainContext<Field = DC::Field> {
-		&self.domain_context
 	}
 }
 
@@ -660,16 +908,48 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Forward, P>(data, skip_early, skip_late);
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
+		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Inverse, P>(data, skip_early, skip_late);
+	}
+
+	fn transpose_transform<P: PackedField<Scalar = Self::Field>>(
+		&self,
+		data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		self.run::<Transpose, P>(data, skip_early, skip_late);
+	}
+
+	fn domain_context(&self) -> &impl DomainContext<Field = DC::Field> {
+		&self.domain_context
+	}
+}
+
+impl<DC: DomainContext + Sync> NeighborsLastMultiThread<DC> {
+	/// Runs one of the three maps over the whole buffer.
+	fn run<B: Butterfly, P: PackedField<Scalar = DC::Field>>(
+		&self,
 		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
 		let log_d = data.log_len();
+		// A buffer of at most one packed element has no pair of words to walk.
 		if log_d <= P::LOG_WIDTH {
-			let fallback_ntt = NeighborsLastReference {
-				domain_context: &self.domain_context,
-			};
-			return fallback_ntt.forward_transform(data, skip_early, skip_late);
+			return B::reference(&self.domain_context, data, skip_early, skip_late);
 		}
 
 		input_check(&self.domain_context, log_d, skip_early, skip_late);
@@ -679,58 +959,59 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 		// in order to make sure that `2^log_num_shares * 2 <= data.len()`. This serves two
 		// purposes:
 		// - when we do the shared rounds, each thread should have at least 2 packed elements to
-		//   work with, see the precondition of [`forward_shared_layer`]
+		//   work with, see the precondition of the shared-layer pass
 		// - when we do the independent rounds, again each share should have `chunk.len() >= 2`
-		//   because this is required by [`forward_depth_first`]
+		//   because this is required by the depth-first recursion
 		let maximum_log_num_shares = log_d - P::LOG_WIDTH - 1;
 		let actual_log_num_shares = min(self.log_num_shares, maximum_log_num_shares);
 		let first_independent_layer = actual_log_num_shares;
 
 		let last_layer = log_d - skip_late;
-		let shared_layers = skip_early..min(first_independent_layer, last_layer);
-		let independent_layers = max(first_independent_layer, skip_early)..last_layer;
+		let shared = skip_early..min(first_independent_layer, last_layer);
+		let independent = max(first_independent_layer, skip_early)..last_layer;
 
-		forward_shared_layers(
-			&self.domain_context,
-			data.as_mut(),
-			log_d,
-			shared_layers,
-			actual_log_num_shares,
-		);
+		// The early layers hold blocks too wide for one worker, so they are split across all of
+		// them; the late layers hold blocks a worker owns outright. Which of the two runs first
+		// is the direction the layers run in.
+		let run_shared = |data: &mut [P]| {
+			shared_layers::<B, P>(
+				&self.domain_context,
+				data,
+				log_d,
+				shared.clone(),
+				actual_log_num_shares,
+			);
+		};
 
-		// One might think that we could just call `forward_depth_first` with
-		// `layer=independent_layers.start`. However, this would mean that the chunk size (that we
+		// One might think that we could just call `depth_first` with
+		// `layer=independent.start`. However, this would mean that the chunk size (that we
 		// split into using `par_chunks_mut`) could be just one packed element, or even less than
 		// one packed element.
-		let layer = min(independent_layers.start, maximum_log_num_shares);
-		let log_d_chunk = log_d - layer;
-		data.as_mut()
-			.par_chunks_exact_mut(1 << (log_d_chunk - P::LOG_WIDTH))
-			.enumerate()
-			.for_each(|(block, chunk)| {
-				forward_depth_first(
-					&self.domain_context,
-					chunk,
-					log_d_chunk,
-					layer,
-					block,
-					independent_layers.clone(),
-					self.log_base_len,
-				);
-			});
-	}
+		let run_independent = |data: &mut [P]| {
+			let layer = min(independent.start, maximum_log_num_shares);
+			let log_d_chunk = log_d - layer;
+			data.par_chunks_exact_mut(1 << (log_d_chunk - P::LOG_WIDTH))
+				.enumerate()
+				.for_each(|(block, chunk)| {
+					depth_first::<B, P>(
+						&self.domain_context,
+						chunk,
+						log_d_chunk,
+						layer,
+						block,
+						independent.clone(),
+						self.log_base_len,
+					);
+				});
+		};
 
-	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
-		&self,
-		_data_orig: FieldSliceMut<'_, P>,
-		_skip_early: usize,
-		_skip_late: usize,
-	) {
-		unimplemented!()
-	}
-
-	fn domain_context(&self) -> &impl DomainContext<Field = DC::Field> {
-		&self.domain_context
+		if B::ASCENDING {
+			run_shared(data.as_mut());
+			run_independent(data.as_mut());
+		} else {
+			run_independent(data.as_mut());
+			run_shared(data.as_mut());
+		}
 	}
 }
 
@@ -741,7 +1022,11 @@ mod tests {
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::{ntt::domain_context::GaoMateerPreExpanded, test_utils::random_field_buffer};
+	use crate::{
+		inner_product::inner_product,
+		ntt::domain_context::GaoMateerPreExpanded,
+		test_utils::{B128, Packed128b, random_field_buffer},
+	};
 
 	/// The shared-layer window the multithreaded transform would pick for these parameters.
 	///
@@ -760,7 +1045,7 @@ mod tests {
 	}
 
 	/// Asserts the fused dispatcher and the one-pass-per-layer loop agree bit for bit.
-	fn check_fused_matches_per_layer<P: PackedField<Scalar: BinaryField>>(
+	fn check_fused_matches_per_layer<B: Butterfly, P: PackedField<Scalar: BinaryField>>(
 		log_d: usize,
 		skip_early: usize,
 		skip_late: usize,
@@ -780,27 +1065,35 @@ mod tests {
 		let mut fused = random_field_buffer::<P>(&mut rng, log_d);
 		let mut per_layer = fused.clone();
 
-		forward_shared_layers(
+		shared_layers::<B, P>(
 			&domain_context,
 			fused.as_mut(),
 			log_d,
 			layers.clone(),
 			actual_log_num_shares,
 		);
-		for layer in layers {
-			forward_shared_layer(
+
+		// The window runs from whichever end this map's layers start at, so the unfused loop has
+		// to walk it the same way.
+		let mut one_at_a_time = |layer| {
+			shared_layer::<B, P>(
 				&domain_context,
 				per_layer.as_mut(),
 				log_d,
 				layer,
 				actual_log_num_shares,
 			);
+		};
+		if B::ASCENDING {
+			layers.for_each(&mut one_at_a_time);
+		} else {
+			layers.rev().for_each(&mut one_at_a_time);
 		}
 
 		assert_eq!(fused, per_layer);
 	}
 
-	/// Asserts the whole multithreaded transform matches the independent reference transform.
+	/// Asserts every packed transform matches the scalar reference, for all three maps.
 	fn check_transform_matches_reference<P: PackedField<Scalar: BinaryField>>(
 		log_d: usize,
 		skip_early: usize,
@@ -810,23 +1103,54 @@ mod tests {
 	) {
 		let domain_context = GaoMateerPreExpanded::<P::Scalar>::generate(log_d);
 		let mut rng = StdRng::seed_from_u64(seed);
-
-		let mut actual = random_field_buffer::<P>(&mut rng, log_d);
-		let mut expected = actual.clone();
+		let input = random_field_buffer::<P>(&mut rng, log_d);
 
 		let multi_thread = NeighborsLastMultiThread {
 			domain_context: &domain_context,
 			log_base_len: 3,
 			log_num_shares,
 		};
+		let single_thread = NeighborsLastSingleThread {
+			domain_context: &domain_context,
+			log_base_len: 3,
+		};
+		let breadth_first = NeighborsLastBreadthFirst {
+			domain_context: &domain_context,
+		};
 		let reference = NeighborsLastReference {
 			domain_context: &domain_context,
 		};
 
-		multi_thread.forward_transform(actual.as_mut_view(), skip_early, skip_late);
-		reference.forward_transform(expected.as_mut_view(), skip_early, skip_late);
+		// The three maps are three layer orders and three butterflies, so a mix-up in either shows
+		// up here whichever one it is in. The scalar reference sets the answer for each, and the
+		// three packed engines have to reproduce it bit for bit from the same input.
+		macro_rules! check_map {
+			($map:ident) => {
+				let mut expected = input.clone();
+				reference.$map(expected.as_mut_view(), skip_early, skip_late);
 
-		assert_eq!(actual, expected);
+				let shape = format!(
+					"log_d={log_d} skip_early={skip_early} skip_late={skip_late} \
+					 log_num_shares={log_num_shares}"
+				);
+
+				let mut actual = input.clone();
+				multi_thread.$map(actual.as_mut_view(), skip_early, skip_late);
+				assert_eq!(actual, expected, "multi thread {} at {shape}", stringify!($map));
+
+				let mut actual = input.clone();
+				single_thread.$map(actual.as_mut_view(), skip_early, skip_late);
+				assert_eq!(actual, expected, "single thread {} at {shape}", stringify!($map));
+
+				let mut actual = input.clone();
+				breadth_first.$map(actual.as_mut_view(), skip_early, skip_late);
+				assert_eq!(actual, expected, "breadth first {} at {shape}", stringify!($map));
+			};
+		}
+
+		check_map!(forward_transform);
+		check_map!(inverse_transform);
+		check_map!(transpose_transform);
 	}
 
 	/// Every window width from one shared layer up to five, at every start offset that fits.
@@ -841,7 +1165,11 @@ mod tests {
 					continue;
 				}
 				// Ending the shared phase at `skip_early + width` is what sets the window width.
-				check_fused_matches_per_layer::<P>(log_d, skip_early, 0, skip_early + width, seed);
+				// All three maps fuse the same window, from their own end of it.
+				let end = skip_early + width;
+				check_fused_matches_per_layer::<Forward, P>(log_d, skip_early, 0, end, seed);
+				check_fused_matches_per_layer::<Inverse, P>(log_d, skip_early, 0, end, seed);
+				check_fused_matches_per_layer::<Transpose, P>(log_d, skip_early, 0, end, seed);
 			}
 		}
 	}
@@ -866,13 +1194,13 @@ mod tests {
 		//
 		//     log_d = 8, LOG_WIDTH = 2, skip_early = 1, width = 4
 		//     plane length = 2^(8 - 1 - 4 - 2) = 2 packed elements, the smallest fusable plane
-		check_fused_matches_per_layer::<PackedBinaryGhash4x128b>(8, 1, 0, 5, 7);
+		check_fused_matches_per_layer::<Forward, PackedBinaryGhash4x128b>(8, 1, 0, 5, 7);
 
 		// One layer deeper the plane would hold a single packed element, so this shape falls back.
 		//
 		//     log_d = 8, LOG_WIDTH = 2, skip_early = 0, width = 5 -> plane length 2^1
 		//     the same start with width 6 would need plane length 2^0, refused
-		check_fused_matches_per_layer::<PackedBinaryGhash4x128b>(8, 0, 0, 5, 8);
+		check_fused_matches_per_layer::<Forward, PackedBinaryGhash4x128b>(8, 0, 0, 5, 8);
 	}
 
 	#[test]
@@ -918,13 +1246,13 @@ mod tests {
 			// one, for every shape the multithreaded transform can hand the shared phase.
 			prop_assume!(skip_early + skip_late <= log_d);
 
-			check_fused_matches_per_layer::<PackedBinaryGhash1x128b>(
+			check_fused_matches_per_layer::<Forward, PackedBinaryGhash1x128b>(
 				log_d, skip_early, skip_late, log_num_shares, seed,
 			);
-			check_fused_matches_per_layer::<PackedBinaryGhash2x128b>(
+			check_fused_matches_per_layer::<Forward, PackedBinaryGhash2x128b>(
 				log_d, skip_early, skip_late, log_num_shares, seed,
 			);
-			check_fused_matches_per_layer::<PackedBinaryGhash4x128b>(
+			check_fused_matches_per_layer::<Forward, PackedBinaryGhash4x128b>(
 				log_d, skip_early, skip_late, log_num_shares, seed,
 			);
 		}
@@ -947,6 +1275,67 @@ mod tests {
 			check_transform_matches_reference::<PackedBinaryGhash4x128b>(
 				log_d, skip_early, skip_late, log_num_shares, seed,
 			);
+		}
+	}
+
+	#[test]
+	fn the_inverse_undoes_the_forward_transform() {
+		// Property: the two maps are inverse, which no reference implementation takes part in.
+		//
+		// Every skip split matters, since a skipped layer must be skipped by both.
+		for log_d in [1usize, 4, 6, 9, 12] {
+			let domain_context = GaoMateerPreExpanded::<B128>::generate(log_d);
+			let ntt = NeighborsLastMultiThread::new(&domain_context, 3);
+			let mut rng = StdRng::seed_from_u64(log_d as u64);
+
+			for skip_early in 0..=log_d {
+				for skip_late in 0..=(log_d - skip_early) {
+					let original = random_field_buffer::<Packed128b>(&mut rng, log_d);
+
+					let mut round_trip = original.clone();
+					ntt.forward_transform(round_trip.as_mut_view(), skip_early, skip_late);
+					ntt.inverse_transform(round_trip.as_mut_view(), skip_early, skip_late);
+
+					assert_eq!(
+						round_trip, original,
+						"log_d={log_d} skip_early={skip_early} skip_late={skip_late}"
+					);
+				}
+			}
+		}
+	}
+
+	#[test]
+	fn the_transpose_is_the_adjoint_of_the_forward_transform() {
+		// Property: the adjoint identity, which fixes the transpose without naming an
+		// implementation:
+		//
+		//     <transpose(a), m> = <a, forward(m)>
+		//
+		// An error in the layer order, the butterfly, or the twiddle indexing breaks it.
+		for log_d in [1usize, 4, 6, 9, 12] {
+			let domain_context = GaoMateerPreExpanded::<B128>::generate(log_d);
+			let ntt = NeighborsLastMultiThread::new(&domain_context, 3);
+			let mut rng = StdRng::seed_from_u64(log_d as u64);
+
+			for skip_early in 0..=log_d {
+				for skip_late in 0..=(log_d - skip_early) {
+					let a = random_field_buffer::<Packed128b>(&mut rng, log_d);
+					let m = random_field_buffer::<Packed128b>(&mut rng, log_d);
+
+					let mut transposed = a.clone();
+					ntt.transpose_transform(transposed.as_mut_view(), skip_early, skip_late);
+
+					let mut forward = m.clone();
+					ntt.forward_transform(forward.as_mut_view(), skip_early, skip_late);
+
+					assert_eq!(
+						inner_product(transposed.iter_scalars(), m.iter_scalars()),
+						inner_product(a.iter_scalars(), forward.iter_scalars()),
+						"log_d={log_d} skip_early={skip_early} skip_late={skip_late}"
+					);
+				}
+			}
 		}
 	}
 

--- a/crates/math/src/ntt/reference.rs
+++ b/crates/math/src/ntt/reference.rs
@@ -75,6 +75,38 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 		}
 	}
 
+	fn transpose_transform<P: PackedField<Scalar = Self::Field>>(
+		&self,
+		mut data: FieldSliceMut<'_, P>,
+		skip_early: usize,
+		skip_late: usize,
+	) {
+		let log_d = data.log_len();
+		input_check(&self.domain_context, log_d, skip_early, skip_late);
+
+		// Transposing a composition reverses it, so the layers run backwards and each keeps the
+		// twiddle it used going forward.
+		for layer in (skip_early..(log_d - skip_late)).rev() {
+			let num_blocks = 1 << layer;
+			let block_size_half = 1 << (log_d - layer - 1);
+			for block in 0..num_blocks {
+				let twiddle = self.domain_context.twiddle(layer, block);
+				let block_start = block << (log_d - layer);
+				for idx0 in block_start..(block_start + block_size_half) {
+					let idx1 = block_size_half | idx0;
+					// The transposed butterfly, which is the forward one with its two steps
+					// swapped: `u'' = u + v` and then `v'' = v + t * u''`.
+					let mut u = data.get(idx0);
+					let mut v = data.get(idx1);
+					u += v;
+					v += u * twiddle;
+					data.set(idx0, u);
+					data.set(idx1, v);
+				}
+			}
+		}
+	}
+
 	fn domain_context(&self) -> &impl DomainContext<Field = DC::Field> {
 		&self.domain_context
 	}


### PR DESCRIPTION
Closes [BINIUS-585](https://linear.app/jimpo/issue/BINIUS-585).

The additive NTT has three linear maps and only one of them was fast.
This makes the existing packed engine serve all three, which is a **17x** speedup on the two that were not, and fills in an inverse that used to panic.

### The problem

| | reference | breadth-first | single thread | multi thread |
|---|---|---|---|---|
| forward | slow | fast | fast | fast |
| inverse | slow | `todo!()` | `unimplemented!()` | `unimplemented!()` |
| transpose | slow | slow | slow | slow |

Three of four implementations panic on the inverse.
All four inherit a trait default for the adjoint that walks the network one element at a time through indexed reads and writes.

The trait's own doc said so:

> The default body mirrors the reference forward transform and is correspondingly slow.
> An implementation with a fast forward transform should override it.

None did.

And the adjoint is not a corner. The WHIR prover runs it once per level, to turn a level's opened rows into the weight they induce on the message. It is essentially the whole of that step.

### The idea

All three are the **same** network over the **same** twiddles, with the same butterfly count.
They differ in exactly two things:

```
    forward     layers ascending     u += v * t;  v += u
    inverse     layers descending    v += u;      u += v * t
    transpose   layers descending    u += v;      v += u * t
```

So the engine does not need three copies. It needs one parameter.

```rust
trait Butterfly {
    const ASCENDING: bool;
    fn apply<P: PackedField>(u: &mut P, v: &mut P, twiddle: P);
    fn apply_zero<P: PackedField>(u: &mut P, v: &mut P);
}
```

`ASCENDING` is a `const`, so each map compiles to a single arm — no branch survives into the inner loop.

### Where the order enters

Four places, and nowhere else:

- the depth-first recursion applies a level's own layer **before** recursing, or **after**
- the breadth-first base case runs whole-word layers then in-word layers, or the reverse
- the dispatcher that fuses layer pairs walks its window from one end or the other
- the multithreaded driver runs its shared phase before the independent one, or after

Everything else — the twiddle indexing, the block geometry, the zero-block peeling, the plane fusion, the task splitting — is shared unchanged.

### The change

```
- fn forward_depth_first<P: PackedField>(..)         + fn depth_first<B: Butterfly, P: PackedField>(..)
- fn forward_breadth_first<P: PackedField>(..)       + fn breadth_first<B: Butterfly, P: PackedField>(..)
- fn forward_shared_layer<P: PackedField>(..)        + fn shared_layer<B: Butterfly, P: PackedField>(..)
- fn forward_shared_layer_pair<P: PackedField>(..)   + fn shared_layer_pair<B: Butterfly, P: PackedField>(..)
- fn forward_shared_layers<P: PackedField>(..)       + fn shared_layers<B: Butterfly, P: PackedField>(..)
```

Each of the three engines then gets one private `run::<B, P>` and three one-line trait methods.

The breadth-first base case is also split into its two layer shapes, so the two orders become a four-line `if` rather than a duplicated body.

### Soundness

No protocol change, and the forward transform runs the code that was already there.

Two properties that name no implementation now cover the two new maps:

- **round trip** — forward then inverse is the identity, at every split of the layer range
- **adjoint identity** — `<transpose(a), m> = <a, forward(m)>`, at every split

Both run on the multithreaded engine. On top of that, all three maps are checked against the scalar reference on all three packed engines, over a sweep and a proptest of `(log_d, skip_early, skip_late, log_num_shares)`.

I checked the tests actually bite, by breaking the code two ways:

| mutation | tests that failed |
|---|---|
| transpose butterfly written as the inverse's | adjoint identity, reference match, proptest |
| descending base case run ascending | adjoint identity, round trip, reference match, proptest |

### Scope

- **removed:** the trait's default adjoint, so an implementation must now make a choice rather than inherit a slow one
- **moved:** that body into the scalar reference, which is what the fast engines are tested against
- no API change beyond the two methods that used to panic now working
- the benchmark used for the numbers below is **not** in the diff — it is reproduced at the end of this description for anyone who wants to rerun it

### Verification

- `cargo test -p binius-math --release` — 177 passed, 0 failed
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-math --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos` — clean
- `cargo check --workspace --all-targets` — clean
- `examples/sha256 prove --message-len 1000000 --pcs whir` — proof verifies

### Benchmark

128-bit scalars, 4-lane packing, 32 cores, `-C target-cpu=native`.
The benchmark source is at the end of this description; it is deliberately not part of the diff.

**19 layers, one skipped early** — the shape WHIR's induced weight runs:

| map | reference | multithread | speedup |
|---|---|---|---|
| forward | 10.76 ms | 0.587 ms | 18.3x |
| inverse | 10.69 ms | 0.605 ms | **17.7x** |
| transpose | 10.79 ms | 0.631 ms | **17.1x** |

**23 layers, rate 1, 16 lanes** — the commit-path encode shape:

| map | reference | multithread | speedup |
|---|---|---|---|
| forward | 205.6 ms | 12.91 ms | 15.9x |
| inverse | 195.9 ms | 11.03 ms | **17.8x** |
| transpose | 193.8 ms | 11.23 ms | **17.3x** |

All three now cost the same, which is the point: they are the same network.

End to end on `sha256 --message-len 1000000 --pcs whir`, three runs each, A/B on one tree with only the multithreaded adjoint flipped back to the reference:

| span | reference adjoint | packed adjoint |
|---|---|---|
| Glue induced weight, level 0 | 12.8 / 15.3 / 12.8 ms | 3.16 / 3.12 / 3.58 ms |
| WHIR level 0 | 41.1 / 47.7 / 38.9 ms | 31.2 / 30.3 / 30.3 ms |
| Prove (total) | 452 / 629 / 462 ms | 449 / 434 / 440 ms |

Two honest notes on that table.

The level-0 span drops 4x rather than 17x because it is not all transform. Measured separately, everything the encoder's adjoint does around the transform -- summing the repeats, the bit reversal, its own zeroed buffer -- comes to about 0.6 ms, and the fold in there is a contiguous streaming add already running at memory bandwidth (I tried splitting it across workers; it got slower). The rest of the remaining span sits above that call, in building the sparse codeword weight: an 8 MiB zeroed buffer taken fresh from the global allocator once per level. That is where the next bite is, not in the transform.

Level 1's span does not move, because at its shape the caller picks the row-by-row route instead. That choice is calibrated against a constant measured from the *old* adjoint — a "layer entry at 1.6 ns". That number is now roughly 17x smaller, so the crossover wants re-deriving, which is a follow-up on this.

<details>
<summary>The benchmark used above, for anyone who wants to rerun it</summary>

Drop this at `crates/math/benches/ntt_transforms.rs`, add the matching `[[bench]]` entry to
`crates/math/Cargo.toml`, and run `cargo bench -p binius-math --bench ntt_transforms`.

```rust
// Copyright 2026 The Binius Developers

use binius_field::{Ghash128b, PackedBinaryGhash4x128b};
use binius_math::{
	ntt::{
		AdditiveNTT, NeighborsLastMultiThread, NeighborsLastReference,
		domain_context::GaoMateerPreExpanded,
	},
	test_utils::random_field_buffer,
};
use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
use rand::{SeedableRng, rngs::StdRng};

type P = PackedBinaryGhash4x128b;
type F = Ghash128b;

/// The three maps the butterfly network computes, over the same network and the same twiddles.
///
/// The scalar reference is the baseline: it walks the network one element at a time, which is what
/// every map but the forward one used to cost.
fn bench_transforms(c: &mut Criterion) {
	let mut rng = StdRng::seed_from_u64(0);
	let mut group = c.benchmark_group("ntt_transforms");
	group.sample_size(10);

	// Two shapes the prover actually runs:
	//
	//     19 layers, one skipped early    the weight a WHIR level's opened rows induce
	//     23 layers, rate 1, 16 lanes     the commit-path encode
	for (log_d, skip_early, skip_late) in [(19usize, 1usize, 0usize), (23, 1, 4)] {
		let domain_context = GaoMateerPreExpanded::<F>::generate(log_d);
		let reference = NeighborsLastReference {
			domain_context: &domain_context,
		};
		let multi_thread = NeighborsLastMultiThread::new(&domain_context, 5);

		// Throughput counts butterflies, so every row of the group is directly comparable.
		let layers = (log_d - skip_early - skip_late) as u64;
		group.throughput(Throughput::Elements(layers << (log_d - 1)));

		let parameter = format!("log_d={log_d}/skip_early={skip_early}/skip_late={skip_late}");
		let mut data = random_field_buffer::<P>(&mut rng, log_d);

		macro_rules! bench_map {
			($engine:expr, $name:literal, $map:ident) => {
				group.bench_function(BenchmarkId::new($name, &parameter), |b| {
					b.iter(|| $engine.$map(data.as_mut_view(), skip_early, skip_late));
				});
			};
		}

		bench_map!(reference, "reference/forward", forward_transform);
		bench_map!(reference, "reference/inverse", inverse_transform);
		bench_map!(reference, "reference/transpose", transpose_transform);
		bench_map!(multi_thread, "multithread/forward", forward_transform);
		bench_map!(multi_thread, "multithread/inverse", inverse_transform);
		bench_map!(multi_thread, "multithread/transpose", transpose_transform);
	}

	group.finish();
}

criterion_group!(benches, bench_transforms);
criterion_main!(benches);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
