### PR TITLE
BINIUS-587: Build the barycentric weight from the subspace recurrence

### DIFF
--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -154,30 +154,71 @@ impl<F: BinaryField, Data: Deref<Target = [F]>> EvaluationDomain<F> for BinarySu
 /// One weight therefore serves every point:
 ///
 /// ```text
-///     w = (prod_{j >= 1} d_j)^{-1}
+///     w = (prod_{d != 0} d)^{-1}
 /// ```
+///
+/// # Algorithm
+///
+/// That product is the linear coefficient of the subspace polynomial, and the subspace polynomial
+/// has a recurrence:
+///
+/// ```text
+///     W_0(X)     = X
+///     W_{i+1}(X) = W_i(X) * (W_i(X) + W_i(b_i))
+/// ```
+///
+/// Squaring a linearized polynomial doubles every exponent, so it contributes no linear term.
+/// Each step therefore multiplies the linear coefficient by one number, leaving
+///
+/// ```text
+///     prod_{d != 0} d = prod_i W_i(b_i)
+/// ```
+///
+/// which costs a square of the dimension rather than one multiplication per point of the domain.
+///
+/// The weight depends on the subspace alone, so all of it runs in the domain's own field and
+/// crosses into the arithmetic field once.
+/// That is what allows the checked inversion below: one wrapper channel's element type offers the
+/// unchecked inverse alone.
+///
+/// # Panics
+///
+/// Panics if the basis is linearly dependent, which makes the product vanish.
 fn barycentric_weight<F, E, Data>(subspace: &BinarySubspace<F, Data>) -> E
 where
 	F: BinaryField,
 	E: FieldOps + From<F>,
 	Data: Deref<Target = [F]>,
 {
-	let product = subspace
-		.iter()
-		.skip(1)
-		.map(E::from)
-		.fold(E::one(), |acc, d| acc * d);
+	// Seed the recurrence at the polynomial `X`, whose values on the basis are the basis itself.
+	let mut evals = subspace.basis().to_vec();
 
-	// SAFETY: the product runs over the subspace's non-zero elements — `skip(1)` drops index 0,
-	// which is the zero element — so it is non-zero by construction, whatever the caller passes.
-	// Inverting without the zero case spares the wrapper channels a constraint that could never
-	// fire.
-	unsafe { product.invert() }
+	let mut product = F::ONE;
+	for i in 0..evals.len() {
+		// Entry `i` has reached the polynomial vanishing on everything below it, so it is the
+		// factor this step contributes.
+		let normalizer = evals[i];
+		product *= normalizer;
+
+		// Advance the entries still to come one polynomial along.
+		for eval in &mut evals[i + 1..] {
+			*eval *= *eval + normalizer;
+		}
+	}
+
+	// Invariant: each factor is a subspace polynomial evaluated off the subspace it vanishes on,
+	// which is nonzero exactly when the basis is independent. The subspace type leaves that to its
+	// caller, so it is checked here rather than assumed.
+	assert_ne!(product, F::ZERO, "precondition: the subspace basis must be independent");
+
+	E::from(product.invert_or_zero())
 }
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{Field, Ghash128b, Random, util::powers};
+	use binius_field::{
+		Field, Ghash128b, Random, Rijndael8b, arithmetic_traits::InvertOrZero, util::powers,
+	};
 	use proptest::prelude::*;
 	use rand::prelude::*;
 
@@ -216,6 +257,48 @@ mod tests {
 				numerator * denominator.invert_or_zero()
 			})
 			.collect()
+	}
+
+	#[test]
+	fn the_weight_recurrence_matches_the_product_over_the_subspace() {
+		// Invariant: the weight is the inverse of the product of every nonzero point of the
+		// domain. That product is what the weight is defined as, so it is the reference here.
+		//
+		// Fixture state: dim 0 is the one-point domain, whose empty product is one.
+		// Dim 8 is 255 factors, enough that a wrong recurrence cannot coincide.
+		for dim in 0..=8 {
+			let subspace = BinarySubspace::<F>::with_dim(dim);
+
+			let product: F = subspace.iter().skip(1).product();
+			let expected = product.invert_or_zero();
+
+			assert_eq!(barycentric_weight::<F, F, _>(&subspace), expected, "dim={dim}");
+		}
+	}
+
+	#[test]
+	fn the_weight_crosses_fields_once_and_lands_on_the_same_value() {
+		// Invariant: which field the arithmetic runs in cannot change the weight.
+		//
+		// The recurrence runs entirely in the domain's own field and embeds its result, so this
+		// pins that the embedding lands on the finished weight rather than partway through.
+		for dim in 0..=6 {
+			let subspace = BinarySubspace::<Rijndael8b>::with_dim(dim);
+
+			let native = barycentric_weight::<Rijndael8b, Rijndael8b, _>(&subspace);
+			let embedded = barycentric_weight::<Rijndael8b, B128, _>(&subspace);
+
+			assert_eq!(embedded, B128::from(native), "dim={dim}");
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "precondition")]
+	fn a_dependent_basis_is_rejected() {
+		// A repeated basis element spans fewer dimensions than the basis claims, so some index
+		// past zero also maps to the zero point and the product vanishes.
+		let subspace = BinarySubspace::<F>::new_unchecked(vec![F::ONE, F::ONE]);
+		let _ = barycentric_weight::<F, F, _>(&subspace);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-587](https://linear.app/jimpo/issue/BINIUS-587).

Same weight, computed from the subspace polynomial's recurrence instead of by multiplying out the domain — and computed in the domain's own field rather than the arithmetic one.

This started as a question about the `E::from` in that fold. Measured, the conversion itself costs nothing (see **On the conversion** below); the loop around it is the real problem.

### The problem

Interpolating over a binary subspace is cheap because every point of the domain shares **one** barycentric weight, where the textbook formula needs one per point. That weight is the inverse of the product of every nonzero point:

```
    w = (prod_{d != 0} d)^{-1}
```

It was computed exactly that way — one multiplication per point of the domain. So "one weight, whatever the domain size" was paid for by a loop that is itself linear in the domain size, landing on the same order as the interpolation it exists to make cheap. It measures at 30% of a `lagrange_evals` call and 37% of an `extrapolate`.

Two more things were wrong with it.

**It ran in the wrong field.** Every point was lifted into the arithmetic field `E` before being multiplied:

```rust
subspace.iter().skip(1).map(E::from).fold(E::one(), |acc, d| acc * d)
```

A recursion channel therefore pays a symbolic multiplication per point, plus a symbolic inversion, to produce a value that depends on nothing the channel knows.

**Its safety argument was wrong.** The unchecked inversion was justified by:

> the product runs over the subspace's non-zero elements — `skip(1)` drops index 0, which is the zero element — so it is non-zero by construction, whatever the caller passes

`skip(1)` drops the zero *index*. Under a linearly dependent basis some other index also maps to the zero point, the product vanishes, and `unsafe { invert() }` is called on zero. `BinarySubspace::new_unchecked` says in its own doc that it does not check independence, so "whatever the caller passes" was not true.

### The idea

The subspace polynomial of the span of the first `i` basis elements satisfies

```
    W_0(X)     = X
    W_{i+1}(X) = W_i(X) * (W_i(X) + W_i(b_i))
```

$W_i$ is $\mathbb{F}_2$-linear, so it is a sum of terms $X^{2^j}$. Squaring doubles every exponent, so $W_i(X)^2$ has **no linear term**. Expanding the recurrence, each step therefore multiplies the linear coefficient by a single number:

```
    prod_{d != 0} d = prod_i W_i(b_i)
```

and those numbers come from one triangular sweep over the basis.

### Per domain

| dimension | before | after |
|---|---:|---:|
| 6 | 63 multiplications | ~21 |
| 12 | 4095 multiplications | ~78 |

→ one multiplication per *point* becomes a square of the *dimension*.

### The change

```rust
- let product = subspace.iter().skip(1).map(E::from).fold(E::one(), |acc, d| acc * d);
- unsafe { product.invert() }

+ let mut evals = subspace.basis().to_vec();
+ let mut product = F::ONE;
+ for i in 0..evals.len() {
+     let normalizer = evals[i];
+     product *= normalizer;
+     for eval in &mut evals[i + 1..] {
+         *eval *= *eval + normalizer;
+     }
+ }
+ assert_ne!(product, F::ZERO, "precondition: the subspace basis must be independent");
+ E::from(product.invert_or_zero())
```

Everything runs in `F`; `E` sees exactly one embedding, of a finished constant.

### On the conversion

The original prompt for this was: is lifting into `E` before multiplying wasteful, since `E * F` is usually cheaper than `E * E`?

Measured, no — it costs exactly nothing, because every native caller has `E = F`, so `E::from` is the identity and `E * E` *is* `F * F`:

| dim | product built in `E` | product built in `F`, one lift at the end |
|---|---|---|
| 3 | 116 ns | 116 ns |
| 8 | 1.064 us | 1.063 us |
| 12 | 15.441 us | 15.421 us |

The instinct is right in general; there is just no subfield multiplication to reach for here. What the field choice *does* buy is the recursion channel, where `E * E` is constraint rows rather than nanoseconds.

### Soundness

The value is unchanged, pinned three ways:

- against the product it is defined as, at every dimension from 0 to 8
- against the textbook per-point Lagrange weights, which an existing test already compares to
- by checking the two field parameters land on the same weight

Breaking the recurrence (dropping the addition — a plausible slip) fails 5 tests including all three of these, so they bite.

The unchecked inversion becomes checked, with the precondition stated. Because the inversion moved into `F`, that check costs a recursion channel nothing — which is exactly what the old comment was trying to buy by skipping it.

### Scope

One function, one file. No API change, no signature change.

### Verification

- `cargo test -p binius-math` (debug) — 178 passed; and `--release` — 178 passed
- `cargo test -p binius-verifier -p binius-prover -p binius-m4-prover` — all pass
- `cargo clippy -p binius-math --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-math --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos` — clean
- `cargo check --workspace --all-targets` — clean

### Benchmark

A/B on one tree with only this function's body swapped. 128-bit scalars, `-C target-cpu=native`.

| dimension | operation | before | after | speedup |
|---|---|---:|---:|---|
| 6 | `lagrange_evals` | 0.907 us | 0.739 us | 1.23x |
| 6 | `extrapolate` | 0.727 us | 0.563 us | 1.29x |
| 7 | `lagrange_evals` | 1.722 us | 1.341 us | 1.28x |
| 7 | `extrapolate` | 1.379 us | 0.993 us | 1.39x |
| 10 | `lagrange_evals` | 13.058 us | 9.695 us | 1.35x |
| 12 | `lagrange_evals` | 51.959 us | 37.135 us | 1.40x |
| 12 | `extrapolate` | 41.990 us | 27.089 us | 1.55x |

**Read this honestly.** Every production domain is dimension 6 or 7, and the weight is built a handful of times per proof, so this is worth **microseconds** on a 440 ms prove — it will not show up in a proof timing at all. The reasons to take it are that the algorithm is right, the safety argument is now true, and a recursion channel stops spending constraints on a constant.

<details>
<summary>The benchmark used above</summary>

```rust
use std::time::Instant;

use binius_field::{Ghash128b, Random};
use binius_math::{BinarySubspace, univariate::EvaluationDomain};
use rand::{SeedableRng, rngs::StdRng};

type F = Ghash128b;

fn bench<T>(name: &str, iters: usize, mut f: impl FnMut() -> T) {
    for _ in 0..3 {
        std::hint::black_box(f());
    }
    let t = Instant::now();
    for _ in 0..iters {
        std::hint::black_box(f());
    }
    let e = t.elapsed().as_secs_f64() / iters as f64;
    println!("{name:<44} {:>10.3} us", e * 1e6);
}

fn main() {
    let mut rng = StdRng::seed_from_u64(0);
    for dim in [6usize, 7, 10, 12] {
        let s = BinarySubspace::<F>::with_dim(dim);
        let z = F::random(&mut rng);
        let values: Vec<F> = (0..1 << dim).map(|_| F::random(&mut rng)).collect();
        bench(&format!("lagrange_evals dim={dim}"), 20000, || s.lagrange_evals(&z));
        bench(&format!("extrapolate    dim={dim}"), 20000, || s.extrapolate(&values, &z));
    }
}
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
