### PR TITLE
BINIUS-588: Reject a hint arity the witness bytecode cannot encode

### DIFF
--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 		chip::{ChipGadget, ChipRef, CircuitM4, EmbeddedCircuit},
 		circuit::Circuit,
 	},
-	eval_form,
+	eval_form::{self, BytecodeBuilder},
 	gates::Opcode,
 	ir::{
 		GateGraph, Wire, WireKind,
@@ -1722,9 +1722,24 @@ impl CircuitBuilder {
 	///
 	/// # Panics
 	///
+	/// Panics if the declared arity or a dimension exceeds what the witness bytecode encodes.
+	///
 	/// Panics if `inputs.len()` does not match the hint's declared input arity.
 	pub fn call_hint<T: Hint>(&self, hint: T, dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
 		let (n_in, n_out) = hint.shape(dimensions);
+
+		// A hint instruction names each of these in four bytes.
+		let max = BytecodeBuilder::MAX_HINT_FIELD;
+		assert!(
+			n_in <= max
+				&& n_out <= max
+				&& dimensions.len() <= max
+				&& dimensions.iter().all(|&dim| dim <= max),
+			"call_hint: hint {} declares a shape the witness bytecode cannot encode \
+			 ({n_in} inputs, {n_out} outputs, dimensions {dimensions:?}; each is capped at {max})",
+			T::NAME,
+		);
+
 		assert_eq!(
 			inputs.len(),
 			n_in,

--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -295,6 +295,77 @@ fn test_call_hint_user_registered() {
 	assert_eq!(w[out2[0]], expected);
 }
 
+/// A hint folding however many input words its caller asks for into one.
+struct WideXor;
+
+impl Hint for WideXor {
+	const NAME: &'static str = "test.wide_xor";
+
+	fn shape(&self, dimensions: &[usize]) -> (usize, usize) {
+		let [n_in] = dimensions else {
+			panic!("test.wide_xor takes exactly 1 dimension");
+		};
+		(*n_in, 1)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		outputs[0] = inputs.iter().fold(Word::ZERO, |acc, &w| Word(acc.0 ^ w.0));
+	}
+}
+
+#[test]
+fn test_call_hint_arity_beyond_a_two_byte_count() {
+	for n_in in [65_535usize, 65_536] {
+		let builder = CircuitBuilder::new();
+		let inputs = (0..n_in).map(|_| builder.add_inout()).collect::<Vec<_>>();
+		let out = builder.call_hint(WideXor, &[n_in], &inputs);
+		// A hint emits no constraint of its own, so promote its output to read it back.
+		builder.mark_inout(out[0]);
+		let circuit = builder.build();
+
+		// Distinct odd multiples, so dropping or repeating any input moves the fold.
+		let mut w = circuit.new_witness_filler();
+		let mut expected = Word::ZERO;
+		for (i, &wire) in inputs.iter().enumerate() {
+			let value = Word(0x9e37_79b9_7f4a_7c15u64.wrapping_mul(i as u64 + 1));
+			w[wire] = value;
+			expected = Word(expected.0 ^ value.0);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+		assert_eq!(w[out[0]], expected, "wide hint fold at arity {n_in}");
+	}
+}
+
+/// A hint declaring more inputs than any encoding could name.
+struct UnencodableArity;
+
+impl Hint for UnencodableArity {
+	const NAME: &'static str = "test.unencodable_arity";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(usize::MAX, 1)
+	}
+
+	fn execute(&self, _dimensions: &[usize], _inputs: &[Word], outputs: &mut [Word]) {
+		outputs[0] = Word::ZERO;
+	}
+}
+
+#[test]
+#[should_panic(expected = "test.unencodable_arity")]
+fn test_call_hint_rejects_an_arity_the_bytecode_cannot_encode() {
+	CircuitBuilder::new().call_hint(UnencodableArity, &[], &[]);
+}
+
+#[test]
+#[should_panic(expected = "test.and_then_xor")]
+fn test_call_hint_rejects_a_dimension_the_bytecode_cannot_encode() {
+	// A dimension is four bytes on the wire, so it is bounded like an arity is.
+	let builder = CircuitBuilder::new();
+	let inputs = [builder.add_inout(), builder.add_inout()];
+	builder.call_hint(AndThenXor, &[usize::MAX], &inputs);
+}
+
 #[test]
 fn test_try_build_reports_an_always_failing_constant_gate() {
 	// Constant propagation evaluates a gate once every one of its inputs is a constant.

--- a/crates/frontend/src/eval_form/builder.rs
+++ b/crates/frontend/src/eval_form/builder.rs
@@ -14,6 +14,9 @@ pub struct BytecodeBuilder {
 }
 
 impl BytecodeBuilder {
+	/// The largest number a hint instruction's counts and dimensions can each carry.
+	pub const MAX_HINT_FIELD: usize = u32::MAX as usize;
+
 	pub const fn new() -> Self {
 		Self {
 			bytecode: Vec::new(),
@@ -244,6 +247,9 @@ impl BytecodeBuilder {
 	}
 
 	// Hint calls
+	/// One instruction carrying a hint call's parameterization and its register operands.
+	///
+	/// Layout: `[Hint][id u32][n dims u32][dims u32..][n in u32][n out u32][in regs][out regs]`.
 	pub fn emit_hint(
 		&mut self,
 		hint_id: u32,
@@ -251,15 +257,24 @@ impl BytecodeBuilder {
 		inputs: &[u32],
 		outputs: &[u32],
 	) {
+		// Invariant: each count below is four bytes on the wire.
+		debug_assert!(
+			dimensions.len() <= Self::MAX_HINT_FIELD
+				&& dimensions.iter().all(|&dim| dim <= Self::MAX_HINT_FIELD)
+				&& inputs.len() <= Self::MAX_HINT_FIELD
+				&& outputs.len() <= Self::MAX_HINT_FIELD,
+			"a hint instruction's counts and dimensions each fit in four bytes"
+		);
+
 		self.n_eval_insn += 1;
 		self.emit_opcode(EvalOpcode::Hint);
 		self.emit_u32(hint_id);
-		self.emit_u16(dimensions.len() as u16);
+		self.emit_u32(dimensions.len() as u32);
 		for &dim in dimensions {
 			self.emit_u32(dim as u32);
 		}
-		self.emit_u16(inputs.len() as u16);
-		self.emit_u16(outputs.len() as u16);
+		self.emit_u32(inputs.len() as u32);
+		self.emit_u32(outputs.len() as u32);
 		for &input in inputs {
 			self.emit_reg(input);
 		}
@@ -275,10 +290,6 @@ impl BytecodeBuilder {
 
 	fn emit_u8(&mut self, val: u8) {
 		self.bytecode.push(val);
-	}
-
-	fn emit_u16(&mut self, val: u16) {
-		self.bytecode.extend_from_slice(&val.to_le_bytes());
 	}
 
 	fn emit_u32(&mut self, val: u32) {

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -430,14 +430,14 @@ impl<'a> Executor<'a> {
 		let hint_id = self.read_u32();
 
 		// Read dimensions
-		let n_dimensions = self.read_u16() as usize;
+		let n_dimensions = self.read_u32() as usize;
 		let mut dimensions: SmallVec<[usize; 4]> = SmallVec::with_capacity(n_dimensions);
 		for _ in 0..n_dimensions {
 			dimensions.push(self.read_u32() as usize);
 		}
 
-		let n_inputs = self.read_u16() as usize;
-		let n_outputs = self.read_u16() as usize;
+		let n_inputs = self.read_u32() as usize;
+		let n_outputs = self.read_u32() as usize;
 
 		// Read the input and output registers once; they are shared across every instance.
 		let input_regs = (0..n_inputs)
@@ -481,10 +481,6 @@ impl<'a> Executor<'a> {
 			.expect("the slice is exactly N bytes long");
 		self.pc += N;
 		bytes
-	}
-
-	fn read_u16(&mut self) -> u16 {
-		u16::from_le_bytes(self.read_bytes())
 	}
 
 	fn read_u32(&mut self) -> u32 {

--- a/crates/frontend/src/eval_form/mod.rs
+++ b/crates/frontend/src/eval_form/mod.rs
@@ -62,7 +62,13 @@ impl EvalForm {
 		// every load and store.
 		//
 		// Invariant: every wire the graph holds was given a value index before this runs.
-		let wire_to_reg = |wire: Wire| -> u32 { layout.word_offset(wire_mapping[wire]) as u32 };
+		//
+		// Invariant: a register index is four bytes on the wire.
+		let wire_to_reg = |wire: Wire| -> u32 {
+			let word_offset = layout.word_offset(wire_mapping[wire]);
+			debug_assert!(word_offset <= u32::MAX as usize, "a register index fits in four bytes");
+			word_offset as u32
+		};
 
 		// Build bytecode for each gate
 		for gate_id in gate_graph.gates.keys() {

--- a/crates/frontend/src/gates/shift.rs
+++ b/crates/frontend/src/gates/shift.rs
@@ -45,6 +45,10 @@ impl GateKind for Shift {
 		let [variant, n] = gate.imms();
 
 		// One instruction carrying the variant and the amount.
+		//
+		// Invariant: the amount is one byte on the wire.
+		// Every builder entry point rejects an amount of 64 or more before emitting this gate.
+		debug_assert!(n < 64, "a shift amount fits in one byte");
 		bc.emit_shift(ctx.reg(z), ctx.reg(x), variant_of(variant), n as u8);
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-588](https://linear.app/jimpo/issue/BINIUS-588).

Bounds a hint gate's arity to what the witness bytecode can actually encode, and widens that encoding so the bound is no longer reachable in practice.

### The problem

A hint gate's input, output and dimension counts are written into the witness bytecode as **two bytes each**.

Nothing bounds the arity a hint may declare.
`Hint::shape` returns whatever the hint says, and the builder emits it.

At 65,536 the count wraps to 0.
The interpreter reads 0 and consumes **none** of the 65,536 register indices that follow.
Those bytes are still in the stream, so the decoder is now reading operands as opcodes — and every instruction after that hint decodes against a shifted cursor.

Measured on unmodified `main`, with a hint whose shape is `(n, 1)`:

| `n` | result |
|---|---|
| 65,535 | correct |
| 65,536 | panic: `index out of bounds: the len is 65538 but the index is 67108864` |
| 65,537 | panic: `Unknown opcode: 0x4 at pc=23` |

`67108864` is four bytes of a register index read as an index.

**The crash is luck.**
A desynchronised decode that happened to land on a valid opcode with in-range registers would quietly fill a **wrong witness** instead of panicking.
For a proving system, that silent case is the one that matters.

The same truncation exists on a dimension *value*, which is cast down to four bytes.

### The idea

Two layers, because either alone is incomplete.

A circuit whose hint has no encoding should be rejected where the author writes it — not silently mangled at emission time.
And the encoding should not have a limit as low as $2^{16}$ in the first place.

### The change

**1. Reject at the boundary.**

`CircuitBuilder::call_hint` now checks the declared shape against what the instruction can carry, and names the hint so a circuit author knows which one is at fault.

```rust
let (n_in, n_out) = hint.shape(dimensions);

// The hint instruction names each of these in four bytes.
let max = BytecodeBuilder::MAX_HINT_FIELD;
assert!(
    n_in <= max
        && n_out <= max
        && dimensions.len() <= max
        && dimensions.iter().all(|&dim| dim <= max),
    "call_hint: hint {} declares a shape the witness bytecode cannot encode ...",
    T::NAME,
);
```

It runs **before** the existing input-arity equality check, so a bad shape is caught before a single wire is allocated.

**2. Widen the encoding.**

```diff
- self.emit_u16(dimensions.len() as u16);
+ self.emit_u32(dimensions.len() as u32);
  for &dim in dimensions {
      self.emit_u32(dim as u32);
  }
- self.emit_u16(inputs.len() as u16);
- self.emit_u16(outputs.len() as u16);
+ self.emit_u32(inputs.len() as u32);
+ self.emit_u32(outputs.len() as u32);
```

and the matching `read_u16` → `read_u32` in `exec_hint`.

`emit_bxor_multi` already writes a four-byte count for exactly this reason, so the hint instruction is now consistent with it.
The `u16` emit/read helpers had no other caller and are gone.

The bytecode is an internal format rebuilt on every `build()` and never persisted, so widening it breaks nothing.

**3. Pin the remaining narrowing casts.**

Two other casts in the emitter narrow, and both are safe today for reasons that were nowhere written down:

- a register index is four bytes — overflowing it needs a value vector of $2^{32}$ words, i.e. 32 GiB per instance;
- a shift amount is one byte — every `CircuitBuilder` shift/rotate entry point already asserts the amount is below 64, and no other production path emits a shift gate.

Each gets a `debug_assert!` at the cast site, matching how `lower/operand.rs` pins its own arena-position assumption.

### Assert, not `Result`

`call_hint` panics today and documents that it panics.
Its existing arity check is an `assert_eq!`, as is every arity check in `build_gadget` beside it.

An unencodable hint is a circuit-construction bug, not a runtime condition a caller can recover from.
So this is an `assert!` — matching the surrounding API rather than splitting it into two error styles.

### Soundness

**This cannot forge a proof.**

A wrong witness fails `ConstraintSystem::verify`, so a corrupted decode produces a proof that does not verify — never a proof of a false statement.

The hazard is a **wrong witness and a confusing failure**, not a broken proof system.
Nothing here touches the constraint system, the transcript, or any soundness parameter.

### Scope

- **changed:** the hint instruction's three counts, in the emitter and the decoder.
- **changed:** one assertion added to the builder's hint call.
- **changed:** two `debug_assert!`s pinning existing narrowing casts.
- **untouched:** the `Hint` trait contract and `call_hint`'s signature — verified by building `binius-circuits` and `binius-recursion` against the change.
- **no benchmark:** this is a correctness fix with no hot-path change. The widened counts add 6 bytes per hint instruction, which nothing measures.

### Verification

The new arity test was first run against unmodified `main` and reproduced the reported panic exactly (`index out of bounds: the len is 65538 but the index is 67108864`), then run again against the fix.

- `cargo test -p binius-frontend` (debug, so the new `debug_assert!`s fire) — 268 passed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend --release` — 268 passed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `python3 tools/check_copyright_notice.py` — clean
- `typos` — clean
- `cargo build -p binius-circuits -p binius-recursion --tests` — clean
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-circuits --release` — 412 passed (the hint-heavy bignum, secp256k1, keccak and WOTS circuits all decode against the widened encoding)

Three tests pin the fix:

- arity 65,535 and 65,536 both evaluate to the reference fold, computed independently in the test from distinct per-wire values — so the assertion proves the **decoder stayed in step with the encoder**, not merely that nothing crashed;
- a hint declaring `usize::MAX` inputs panics at `call_hint` naming the hint;
- a dimension of `usize::MAX` panics the same way.

Both arities together cost 4 ms in the debug profile (the workspace's `profile.dev` sets `opt-level = 1`), so the wide case is cheap enough to keep in the normal test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
