### PR TITLE
BINIUS-589: Walk the gate-fusion inlining cone iteratively

### DIFF
--- a/crates/frontend/src/pass/fusion/patch.rs
+++ b/crates/frontend/src/pass/fusion/patch.rs
@@ -17,6 +17,9 @@ use crate::{
 // Rebuilding an operand means appending to that same arena, not allocating one of its own.
 // That is why every function below takes mutable access to the constraint builder.
 
+/// The stack an operand rebuild walks its cone with: a wire plus the shifts accumulated to it.
+type PendingTerms = Vec<(Wire, [Shift; 2])>;
+
 /// A patch is a description of a change to the constraint system.
 ///
 /// It specifies a list of constraints that are going to be removed and a list of constraints that
@@ -110,17 +113,23 @@ fn retain_unsubsumed<T>(constraints: &mut Vec<T>, subsumed: &[bool]) {
 ///
 /// NB: patches may have overlapping subsumes.
 pub fn build(cb: &mut ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
+	let mut pending = Vec::new();
 	let mut patches = vec![];
-	build_root_patches(cb, leg, &mut patches);
+	build_root_patches(cb, leg, &mut pending, &mut patches);
 	for committed in leg.commit_set().iter() {
-		let patch = build_committed_lin_def_patch(cb, leg, committed);
+		let patch = build_committed_lin_def_patch(cb, leg, &mut pending, committed);
 		patches.push(patch);
 	}
 	patches
 }
 
 /// Collect patches for the root constraints that inline linear definitions.
-fn build_root_patches(cb: &mut ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<Patch>) {
+fn build_root_patches(
+	cb: &mut ConstraintBuilder,
+	leg: &LeGraph,
+	pending: &mut PendingTerms,
+	patches: &mut Vec<Patch>,
+) {
 	// Collect *distinct* constraint references.
 	// Several roots may name the same constraint, e.g. two operands of one AND both inlined.
 	let mut constraints: Vec<ConstraintRef> = leg.roots.values().copied().collect();
@@ -129,7 +138,7 @@ fn build_root_patches(cb: &mut ConstraintBuilder, leg: &LeGraph, patches: &mut V
 
 	// Create a patch for each distinct constraint.
 	for constraint_ref in constraints {
-		let patch = build_root_patch(cb, leg, constraint_ref);
+		let patch = build_root_patch(cb, leg, pending, constraint_ref);
 		patches.push(patch);
 	}
 }
@@ -137,6 +146,7 @@ fn build_root_patches(cb: &mut ConstraintBuilder, leg: &LeGraph, patches: &mut V
 fn build_root_patch(
 	cb: &mut ConstraintBuilder,
 	leg: &LeGraph,
+	pending: &mut PendingTerms,
 	constraint_ref: ConstraintRef,
 ) -> Patch {
 	let mut subsumes = vec![constraint_ref];
@@ -147,9 +157,9 @@ fn build_root_patch(
 				let and = &cb.and_constraints[index];
 				(and.a, and.b, and.c)
 			};
-			let a = process_operand(cb, leg, &mut subsumes, old_a);
-			let b = process_operand(cb, leg, &mut subsumes, old_b);
-			let c = process_operand(cb, leg, &mut subsumes, old_c);
+			let a = process_operand(cb, leg, &mut subsumes, pending, old_a);
+			let b = process_operand(cb, leg, &mut subsumes, pending, old_b);
+			let c = process_operand(cb, leg, &mut subsumes, pending, old_c);
 			AddedConstraint::And(WireAndConstraint { a, b, c })
 		}
 		ConstraintRef::Imul { index } => {
@@ -157,10 +167,10 @@ fn build_root_patch(
 				let mul = &cb.imul_constraints[index];
 				(mul.a, mul.b, mul.lo, mul.hi)
 			};
-			let a = process_operand(cb, leg, &mut subsumes, old_a);
-			let b = process_operand(cb, leg, &mut subsumes, old_b);
-			let lo = process_operand(cb, leg, &mut subsumes, old_lo);
-			let hi = process_operand(cb, leg, &mut subsumes, old_hi);
+			let a = process_operand(cb, leg, &mut subsumes, pending, old_a);
+			let b = process_operand(cb, leg, &mut subsumes, pending, old_b);
+			let lo = process_operand(cb, leg, &mut subsumes, pending, old_lo);
+			let hi = process_operand(cb, leg, &mut subsumes, pending, old_hi);
 			AddedConstraint::Imul(WireImulConstraint { a, b, lo, hi })
 		}
 		ConstraintRef::Bmul { index } => {
@@ -168,12 +178,12 @@ fn build_root_patch(
 				let bmul = &cb.bmul_constraints[index];
 				(bmul.a_lo, bmul.a_hi, bmul.b_lo, bmul.b_hi, bmul.c_lo, bmul.c_hi)
 			};
-			let a_lo = process_operand(cb, leg, &mut subsumes, old_a_lo);
-			let a_hi = process_operand(cb, leg, &mut subsumes, old_a_hi);
-			let b_lo = process_operand(cb, leg, &mut subsumes, old_b_lo);
-			let b_hi = process_operand(cb, leg, &mut subsumes, old_b_hi);
-			let c_lo = process_operand(cb, leg, &mut subsumes, old_c_lo);
-			let c_hi = process_operand(cb, leg, &mut subsumes, old_c_hi);
+			let a_lo = process_operand(cb, leg, &mut subsumes, pending, old_a_lo);
+			let a_hi = process_operand(cb, leg, &mut subsumes, pending, old_a_hi);
+			let b_lo = process_operand(cb, leg, &mut subsumes, pending, old_b_lo);
+			let b_hi = process_operand(cb, leg, &mut subsumes, pending, old_b_hi);
+			let c_lo = process_operand(cb, leg, &mut subsumes, pending, old_c_lo);
+			let c_hi = process_operand(cb, leg, &mut subsumes, pending, old_c_hi);
 			AddedConstraint::Bmul(WireBmulConstraint {
 				a_lo,
 				a_hi,
@@ -185,7 +195,7 @@ fn build_root_patch(
 		}
 		ConstraintRef::Zero { index } => {
 			let old_val = cb.zero_constraints[index].val;
-			let val = process_operand(cb, leg, &mut subsumes, old_val);
+			let val = process_operand(cb, leg, &mut subsumes, pending, old_val);
 			AddedConstraint::Zero(WireZeroConstraint { val })
 		}
 		ConstraintRef::Linear { .. } => unreachable!(),
@@ -210,13 +220,18 @@ fn build_root_patch(
 /// the Zero constraint
 /// [`ConstraintBuilder::build`](crate::lower::ConstraintBuilder::build)
 /// lowers it to.
-fn build_committed_lin_def_patch(cb: &mut ConstraintBuilder, leg: &LeGraph, root: Wire) -> Patch {
+fn build_committed_lin_def_patch(
+	cb: &mut ConstraintBuilder,
+	leg: &LeGraph,
+	pending: &mut PendingTerms,
+	root: Wire,
+) -> Patch {
 	// `subsumes` is a list of constraints that become redundant with application of this patch.
 	// The first redundant constraint is the linear definition that's being committed.
 	let mut subsumes = vec![leg.lin_def_constraint_ref(root)];
 
 	let old_operand = leg.lin_def_operand(cb, root);
-	let new_operand = process_operand(cb, leg, &mut subsumes, old_operand);
+	let new_operand = process_operand(cb, leg, &mut subsumes, pending, old_operand);
 
 	// Enforce: root = new_operand, over the inlined cone rather than the original definition.
 	Patch {
@@ -239,55 +254,52 @@ fn process_operand(
 	cb: &mut ConstraintBuilder,
 	leg: &LeGraph,
 	subsumes: &mut Vec<ConstraintRef>,
+	pending: &mut PendingTerms,
 	old_operand: WireOperand,
 ) -> WireOperand {
 	let start = cb.next_term_start();
 	for i in 0..old_operand.len() {
 		let term = cb.term(old_operand, i);
-		process_term(cb, leg, subsumes, term.wire, term.shift_seq);
+		process_term(cb, leg, subsumes, pending, term.wire, term.shift_seq);
 	}
 	cb.operand_since(start)
 }
 
-/// Recursively process a term, inlining non-committed linear definitions.
+/// Process a term, inlining every non-committed linear definition it reaches.
 ///
-/// `shift_seq` is what the consumers above have accumulated, to be applied to `wire`. Inlining
-/// folds the definition's own shift inside it, greedily, so a slot is spent only where the two
-/// genuinely do not collapse.
-///
-/// Every push lands at the tail of the operand under construction.
-/// Nothing else appends to the shared arena while one such call is still running.
+/// The shifts passed in are what the consumers above accumulated.
 fn process_term(
 	cb: &mut ConstraintBuilder,
 	leg: &LeGraph,
 	subsumes: &mut Vec<ConstraintRef>,
+	pending: &mut PendingTerms,
 	wire: Wire,
 	shift_seq: [Shift; 2],
 ) {
-	// Check if this wire is committed or not a linear def (i.e., opaque)
-	if leg.commit_set().contains(wire) || !leg.is_lin_def(wire) {
-		// This is a terminal or committed wire - add it to the result with the accumulated shifts
-		cb.push_term(ShiftedWire { wire, shift_seq });
-	} else {
-		// This is a non-committed linear def - we need to inline it!
+	debug_assert!(pending.is_empty(), "the walk drains its stack before it returns");
+	pending.push((wire, shift_seq));
+
+	while let Some((wire, shift_seq)) = pending.pop() {
+		if leg.commit_set().contains(wire) || !leg.is_lin_def(wire) {
+			cb.push_term(ShiftedWire { wire, shift_seq });
+			continue;
+		}
+
 		let inner_operand = leg.lin_def_operand(cb, wire);
 		let constraint_ref = leg.lin_def_constraint_ref(wire);
 		subsumes.push(constraint_ref);
 
-		// Distribute the accumulated shifts over all terms in the inner operand
-		// This is crucial for correctness: shift(a ^ b) = shift(a) ^ shift(b)
-		for i in 0..inner_operand.len() {
+		// shift(a ^ b) = shift(a) ^ shift(b)
+		//
+		// Pushed in reverse so terms pop in the order the definition spells them.
+		for i in (0..inner_operand.len()).rev() {
 			let inner_term = cb.term(inner_operand, i);
-			// The definition's own shift is applied before anything accumulated above it, so it
-			// folds into the sequence from the inside.
 			let inner_shift = inner_term.sole_shift();
 			match push_inner(shift_seq, inner_shift, LOWERED_SHIFT_SLOTS) {
 				PushInner::Seq(composed) => {
-					// Recursively process this term with the composed sequence
-					process_term(cb, leg, subsumes, inner_term.wire, composed);
+					pending.push((inner_term.wire, composed));
 				}
-				// The shifts clear the word, so the term is identically zero. An operand is
-				// an XOR, so a zero term contributes nothing and the inlining simply drops it.
+				// The shifts clear the word, and a zero term contributes nothing to an XOR.
 				PushInner::Zero => {}
 				// Needing a third slot means the commit set inlined a definition it should have
 				// committed: the two passes disagree about what is inlinable.
@@ -401,7 +413,8 @@ mod tests {
 		cb.linear(expr::xor2(w(0), w(2)), w(3));
 
 		let leg = LeGraph::new(&cb);
-		let patch = super::build_committed_lin_def_patch(&mut cb, &leg, w(3));
+		let patch =
+			super::build_committed_lin_def_patch(&mut cb, &leg, &mut PendingTerms::new(), w(3));
 		match patch.added {
 			AddedConstraint::Linear(ref linc) => {
 				assert!(!linc.rhs.is_empty());

--- a/crates/frontend/src/pass/fusion/tests/awhole.rs
+++ b/crates/frontend/src/pass/fusion/tests/awhole.rs
@@ -969,3 +969,31 @@ fn test_chained_shifts_beyond_the_word_width_evaluate() {
 	// The committed break carries its own Zero constraint, so check the constraints agree too.
 	circuit.constraint_system().verify(&w.value_vec).unwrap();
 }
+
+#[test]
+fn test_a_long_rotate_chain_compiles() {
+	// A rotate chain is single-term and always composes, so the cone is never truncated.
+	const LINKS: usize = 1_000_000;
+
+	let b = CircuitBuilder::new();
+	let x = b.add_witness();
+	let mask = b.add_witness();
+	let mut rotated = x;
+	for _ in 0..LINKS {
+		rotated = b.rotr(rotated, 1);
+	}
+	let out = b.band(rotated, mask);
+	b.force_commit(out);
+	let circuit = b.build();
+
+	let cs = circuit.constraint_system();
+	assert_eq!(cs.and_constraints.len(), 1);
+	assert_eq!(cs.zero_constraints.len(), 0);
+
+	// The run comes to one rotation by the link count taken modulo the word width.
+	let mut w = circuit.new_witness_filler();
+	w[x] = Word(0xDEAD_BEEF_CAFE_BABE);
+	w[mask] = Word(u64::MAX);
+	circuit.populate_wire_witness(&mut w).unwrap();
+	assert_eq!(w[out], Word(0xDEAD_BEEF_CAFE_BABE_u64.rotate_right((LINKS % 64) as u32)));
+}


### PR DESCRIPTION
Closes [BINIUS-589](https://linear.app/jimpo/issue/BINIUS-589).

Makes gate-fusion inlining walk its cone with an explicit stack instead of recursion, so a long chain of gates can no longer abort the process. No behavior change — every constraint the pass emits is byte-identical.

### The problem

A long enough chain of rotations takes the whole process down.

```rust
let b = CircuitBuilder::new();
let x = b.add_witness();
let y = b.add_witness();
let mut w = x;
for _ in 0..45_000 { w = b.rotr(w, 1); }
let z = b.band(w, y);
b.mark_inout(z);
b.build();
```

Unmodified `main`, release build, default 8 MiB stack:

| links | outcome |
|---|---|
| 40,000 | builds fine — 1 AND, 0 ZERO |
| 45,000 | `fatal runtime error: stack overflow, aborting` |

gdb pins the frame exactly:

```
#0  binius_frontend::pass::fusion::patch::process_term ... at src/pass/fusion/patch.rs:283
#1  ... at src/pass/fusion/patch.rs:287
#2  ... at src/pass/fusion/patch.rs:287
    (repeating)
```

That is a `SIGSEGV` turned abort, not a catchable panic.
For a service compiling circuits it does not control, it is a denial of service.
For a circuit author, it is a crash with no message and no line number.

### Why it happens — and why the exemption is right

The rebuild inlines a linear definition by walking into each of its terms, and it walked by recursing.

The commit-set pass is supposed to bound that with a depth cap of 6, but it exempts a definition of a single term:

```rust
let single_term = term_count == 1;
let too_deep = depth > MAX_DEPTH && !single_term;
```

**The exemption is correct and stays.**
The cap exists to stop operands from growing: inlining a `k`-term definition into `c` consumers multiplies out to `k * c` terms.
With `k = 1` there is no multiplication — one term goes in, one term comes out — so the thing the cap guards against cannot happen.
Removing the exemption would cost real fusion quality for no correctness gain.

But a shift gate *is* a single-term linear definition.
And a rotation is cyclic, so its shifts always compose and the run is never broken on width grounds either.
So a chain of rotations is never committed, and the walk descends once per link.

Which means the recursion depth was a property of the **input circuit**, not of the pass.

### The change

`crates/frontend/src/pass/fusion/patch.rs` — the term walk becomes a loop over an explicit stack of `(wire, accumulated shifts)` pairs.

```diff
-            PushInner::Seq(composed) => {
-                process_term(cb, leg, subsumes, inner_term.wire, composed);
-            }
+            PushInner::Seq(composed) => {
+                pending.push((inner_term.wire, composed));
+            }
```

Two properties are load-bearing and both are preserved.

**Term order.** Every push lands at the tail of one shared arena, and the operand claims the range only after the walk finishes — so the visit order *is* the spelling order.
A stack pops last-in first, so a definition's terms go on in reverse to come back off in source order.
That makes the loop the same depth-first pre-order walk the recursion was.

**The subsumed set.** Every inlined definition still pushes its constraint reference, at the same point in the walk.

The three outcomes of folding a shift inward keep their exact behavior: composed, cleared to zero (the term drops — an operand is an XOR), and over budget (still panics; it means the commit set and the patch builder disagree).

The stack is allocated once for the whole pass and threaded down, so the rewrite adds **zero allocations per term**.

### What this is not

It is not a depth bound.
A patch-time bound was considered and rejected: the patch builder cannot commit a definition the commit set already decided to inline, so any bound low enough to be a real safety net would change the output of chains that compile correctly today. The iterative walk removes the crash on its own, which is the point.

### Soundness

- An operand is an XOR over $\mathbb{F}_2$, so it is invariant under permutation of its terms — the rewrite could not break correctness even if it reordered.
- It does not reorder. It changes *how* the walk is driven, not which terms it produces or in what order.
- The repo pins exact constraint-system spellings with 31 inline `insta` snapshots in `pass/fusion/tests/awhole.rs`, and the prover keys shift-table rows on the spelling. **The snapshots are the proof the rewrite is order-preserving** — all 31 pass unchanged, and no snapshot update was accepted.

### Scope

- **changed:** the term walk and the operand rebuild in `pass/fusion/patch.rs`; five internal signatures thread the shared stack.
- **new:** one test — a 1,000,000-link rotate chain, more than 20× past the crashing length. It aborts the test binary with `SIGABRT` on `main` and passes in 0.56 s here.
- **untouched:** `commit_set.rs`. The depth cap, the single-term exemption, and the term-growth brake are all exactly as they were.

### Verification

Scoped to `binius-frontend`; the change is entirely inside a private module, so no downstream crate's compilation is affected.

- `cargo test -p binius-frontend` (debug, `debug_assert!` live) — 266 tests pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend --release` — 266 tests pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `python3 tools/check_copyright_notice.py`, `typos` — clean

The 41 tests in `pass/fusion/tests/commit_set.rs` and the 34 in `awhole.rs` all pass, snapshots included, with no `.snap.new` produced.

### Benchmark

Both binaries built from the same tree with `-Ctarget-cpu=native`, run interleaved and pinned to one core, 10 rounds each of 7 timed builds. The machine was shared, so the minimum is the load-robust estimator and the median is shown alongside.

| fixture | before (min) | after (min) | before (median) | after (median) |
|---|---|---|---|---|
| SHA-256, 8 KiB — 147,144 gates | 72.05 ms | 72.98 ms | 74.92 ms | 74.86 ms |
| Keccak-f1600 — 2,760 gates | 0.88 ms | 0.88 ms | 0.91 ms | 0.91 ms |

Build time is unchanged within noise; the medians cross, so the 1.3% gap in the minima is not a signal.

Every constraint count is identical, not merely close:

| fixture | AND | ZERO | IMUL | BMUL | shifted VI | unshifted VI | committed |
|---|---|---|---|---|---|---|---|
| SHA-256, 8 KiB — before | 47,271 | 12,735 | 0 | 0 | 92,821 | 60,072 | 65,536 |
| SHA-256, 8 KiB — after | 47,271 | 12,735 | 0 | 0 | 92,821 | 60,072 | 65,536 |
| Keccak-f1600 — before | 600 | 0 | 0 | 0 | 6,432 | 629 | 1,024 |
| Keccak-f1600 — after | 600 | 0 | 0 | 0 | 6,432 | 629 | 1,024 |

Gate counts, eval-instruction counts, wire counts, scratch peak and every allocation size matched too.

And the bound is gone:

| links | before | after |
|---|---|---|
| 40,000 | 9.4 ms | — |
| 45,000 | **abort** | 10.3 ms |
| 100,000 | abort | 55.2 ms |
| 1,000,000 | abort | 786 ms |

Each of those still fuses to exactly 1 AND and 0 ZERO constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
