### PR TITLE
frontend: circuit compilation cache

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -12,6 +12,7 @@ binius-compute = { path = "../compute" }
 binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-utils = { path = "../utils" }
+bytes = { workspace = true }
 cranelift-entity = { workspace = true }
 itertools.workspace = true
 petgraph.workspace = true

--- a/crates/frontend/src/builder/compile_cache.rs
+++ b/crates/frontend/src/builder/compile_cache.rs
@@ -1,0 +1,397 @@
+// Copyright 2026 The Binius Developers
+
+//! Byte-serialized compilation cache: skip the optimization passes and constraint building when
+//! the same circuit is compiled again.
+//!
+//! [`CircuitBuilder::build`](super::CircuitBuilder::build) spends nearly all of its time in the
+//! optimization passes and constraint building; constructing the gate graph itself is cheap. For
+//! a fixed circuit compiled repeatedly — a prover service that starts one fresh process per
+//! proof, say — that cost recurs with an unchanging result. This module serializes the *outputs*
+//! of compilation (the constraint system, value-vector layout, wire mapping, inout list and
+//! evaluation bytecode), so a later process can reconstruct the gate graph — re-registering
+//! every hint handler along the way — and assemble the same [`Circuit`](crate::Circuit) by
+//! deserializing the rest. The usage example lives on
+//! [`CircuitBuilder::try_build_with_compile_cache`](super::CircuitBuilder::try_build_with_compile_cache),
+//! the public face of this module.
+//!
+//! A cache is only valid for the exact builder state that produced it: the same code building
+//! the same gate graph under the same options, so that the cached wire mapping and bytecode
+//! address the same wires. The loader recomputes a digest of its freshly built state — wire
+//! kinds, constant values, gate bodies, gate wires, immediates, dimensions, per-gate path
+//! references, the builder options and the force-committed set — and refuses a cache whose
+//! recorded digest differs; a cache written by a different published version of this crate is
+//! refused outright, since the digest cannot see changes to the passes or the lowering. Within
+//! one published version the header cannot tell two builds apart, so regenerate the cache
+//! whenever the code is rebuilt — the natural arrangement is writing it from a build script,
+//! which ties the cache's lifetime to the binary's. Under that discipline, drift between the
+//! builder's state and the cache is an error rather than a miscompiled circuit, and a trailing
+//! checksum over the serialized payload refuses a cache corrupted at rest or in transit. Path and
+//! assertion names are not digested: they are diagnostic metadata, and the loaded circuit reports
+//! failures under its own construction's names. The digest is an integrity check against accidental
+//! divergence, not a security boundary: a cache file is trusted input, on the same footing as the
+//! binary that loads it. Hint handlers are closures and are never serialized; they come from
+//! the fresh builder's registry, and hint ids are name hashes
+//! ([`hint_id_of`](crate::ir::hints::hint_id_of)), so the cached bytecode's references resolve
+//! against it. The name hash is stable within a toolchain; a toolchain that changed it would
+//! also change the digest of any hint-calling graph, refusing the cache rather than
+//! mis-resolving a handler.
+
+use binius_core::constraint_system::{ConstraintSystem, ValueIndex, ValueVecLayout};
+use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use bytes::Buf;
+use cranelift_entity::{EntityRef, EntitySet, SecondaryMap};
+
+use super::Options;
+use crate::ir::{GateBody, GateGraph, Wire, WireKind};
+
+/// Format magic, so a foreign or truncated file fails loudly instead of deserializing garbage.
+/// Little-endian serialization makes the file begin with the literal bytes `B64C`.
+const MAGIC: u32 = u32::from_le_bytes(*b"B64C");
+
+/// Version of the cache layout below. Bump on any change to the format; there is no
+/// cross-version compatibility, by design — a cache lives and dies with the build that wrote it.
+const CACHE_VERSION: u32 = 1;
+
+/// Why a compilation cache was refused.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CompileCacheError {
+	/// The bytes do not decode as a compilation cache of this version.
+	#[error("compilation cache: {0}")]
+	Deserialize(#[from] SerializationError),
+	/// The cache was written by a different published version of this crate. The digest cannot
+	/// see changes to the passes or the lowering, so a version mismatch is refused outright.
+	/// (Two builds of the same published version share a header; see the module docs.)
+	#[error(
+		"compilation cache was written by binius-frontend {cached}, this is {current}; \
+		 rebuild the cache"
+	)]
+	VersionMismatch {
+		cached: String,
+		current: &'static str,
+	},
+	/// The bytes decode, but were written for a different builder state than this one —
+	/// different construction code, parameters, options or force-committed wires.
+	#[error(
+		"compilation cache was written for a different builder state \
+		 (cached {cached_wires} wires / {cached_gates} gates, digest {cached_digest:#018x}; \
+		 built {built_wires} wires / {built_gates} gates, digest {built_digest:#018x})"
+	)]
+	StateMismatch {
+		cached_wires: usize,
+		cached_gates: usize,
+		cached_digest: u64,
+		built_wires: usize,
+		built_gates: usize,
+		built_digest: u64,
+	},
+	/// The bytes decode and pass the payload checksum, but the constraint system they carry
+	/// fails its own validation. On the build path this state is unreachable; reaching it here
+	/// means a deliberately altered cache file.
+	#[error("compilation cache carries an invalid constraint system: {0}")]
+	Validation(#[from] binius_core::error::ConstraintSystemError),
+}
+
+/// The deserialized compilation outputs, ready for
+/// [`Circuit::new`](crate::Circuit)-style assembly.
+pub(super) struct CompileCacheParts {
+	/// Wire count of the constructed (pre-pass) graph — what the loading builder holds.
+	pub n_wires: usize,
+	/// Gate count of the constructed (pre-pass) graph.
+	pub n_gates: usize,
+	/// [`graph_digest`] of the constructed state: graph, options and force-committed set.
+	pub digest: u64,
+	pub constraint_system: ConstraintSystem,
+	pub value_vec_layout: ValueVecLayout,
+	pub wire_mapping: SecondaryMap<Wire, ValueIndex>,
+	pub inout: Vec<Wire>,
+	pub bytecode: Vec<u8>,
+	pub n_eval_insn: usize,
+	pub scratch_peak_live: usize,
+	pub scratch_pooled: bool,
+}
+
+/// Fold the byte stream into one 64-bit word, one multiply per 8 bytes, so checksumming a
+/// multi-gigabyte cache runs at memory speed. An integrity tripwire for the serialized payload
+/// (bit flips at rest or in transit), same trust stance as the digest.
+fn payload_checksum(bytes: &[u8]) -> u64 {
+	const PRIME: u64 = 0x0000_0100_0000_01b3;
+	let mut h = 0xcbf2_9ce4_8422_2325_u64 ^ bytes.len() as u64;
+	let mut chunks = bytes.chunks_exact(8);
+	for chunk in &mut chunks {
+		h = (h ^ u64::from_le_bytes(chunk.try_into().expect("8-byte chunk"))).wrapping_mul(PRIME);
+	}
+	let mut tail = [0u8; 8];
+	tail[..chunks.remainder().len()].copy_from_slice(chunks.remainder());
+	(h ^ u64::from_le_bytes(tail)).wrapping_mul(PRIME)
+}
+
+/// FNV-1a over one 64-bit word. Stable by construction (no dependency on `Hash` impls or
+/// hasher internals), which is what lets the digest compare across processes and builds of the
+/// same code.
+#[inline]
+const fn fnv1a(hash: u64, word: u64) -> u64 {
+	const PRIME: u64 = 0x0000_0100_0000_01b3;
+	let mut h = hash;
+	let bytes = word.to_le_bytes();
+	let mut i = 0;
+	while i < 8 {
+		h ^= bytes[i] as u64;
+		h = h.wrapping_mul(PRIME);
+		i += 1;
+	}
+	h
+}
+
+/// Structural digest of the compilation inputs: every wire's kind (with constant values); every
+/// gate's body, wires, immediates, dimensions and path references; the builder options; and the
+/// force-committed set. Equal digests mean the same compilation for the cache's purposes: the
+/// cached wire mapping and bytecode address wires and gates by these indices, the options decide
+/// which passes produced the cached outputs, the force-committed set decides which wires stay
+/// readable from a witness filler, and the per-gate path references are the ids the cached
+/// bytecode symbolicates assertion failures with.
+pub(super) fn graph_digest(
+	graph: &GateGraph,
+	opts: &Options,
+	force_committed: &EntitySet<Wire>,
+) -> u64 {
+	const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+	let mut h = OFFSET_BASIS;
+	// Exhaustive destructuring, no `..`: a field added to `Options` fails to compile here
+	// rather than silently escaping the digest.
+	let Options {
+		enable_gate_fusion,
+		enable_constant_propagation,
+		enable_common_subexpression_elimination,
+		enable_dead_code_elimination,
+		enable_algebraic_folding,
+		enable_scratch_pooling,
+		enable_zero_propagation,
+	} = *opts;
+	for flag in [
+		enable_gate_fusion,
+		enable_constant_propagation,
+		enable_common_subexpression_elimination,
+		enable_dead_code_elimination,
+		enable_algebraic_folding,
+		enable_scratch_pooling,
+		enable_zero_propagation,
+	] {
+		h = fnv1a(h, flag as u64);
+	}
+	h = fnv1a(h, force_committed.iter().count() as u64);
+	for wire in force_committed.iter() {
+		h = fnv1a(h, wire.index() as u64);
+	}
+	h = fnv1a(h, graph.wires.len() as u64);
+	for (_, kind) in graph.wires.iter() {
+		match kind {
+			WireKind::Constant(word) => {
+				h = fnv1a(h, 1);
+				h = fnv1a(h, word.as_u64());
+			}
+			WireKind::Inout => h = fnv1a(h, 2),
+			WireKind::Witness => h = fnv1a(h, 3),
+			WireKind::Internal => h = fnv1a(h, 4),
+			WireKind::Scratch => h = fnv1a(h, 5),
+		}
+	}
+	h = fnv1a(h, graph.gates.len() as u64);
+	for (gate_id, gate) in graph.gates.iter() {
+		h = fnv1a(h, graph.gate_origin[gate_id].index() as u64);
+		h = fnv1a(h, graph.assertion_names[gate_id].index() as u64);
+		// Exhaustive destructuring, no `..`: a field added to `GateData` fails to compile
+		// here rather than silently escaping the digest.
+		let crate::ir::GateData {
+			body,
+			wires,
+			immediates,
+			dimensions,
+		} = gate;
+		match body {
+			GateBody::Op(opcode) => {
+				h = fnv1a(h, 1);
+				h = fnv1a(h, *opcode as u64);
+			}
+			GateBody::Hint(hint_id) => {
+				h = fnv1a(h, 2);
+				h = fnv1a(h, *hint_id as u64);
+			}
+		}
+		h = fnv1a(h, wires.len() as u64);
+		for wire in wires {
+			h = fnv1a(h, wire.index() as u64);
+		}
+		h = fnv1a(h, immediates.len() as u64);
+		for imm in immediates {
+			h = fnv1a(h, *imm as u64);
+		}
+		h = fnv1a(h, dimensions.len() as u64);
+		for dim in dimensions {
+			h = fnv1a(h, *dim as u64);
+		}
+	}
+	h
+}
+
+/// The compilation outputs by reference, named at the call site so a transposed argument is a
+/// compile error rather than a corrupt cache. The write side of [`CompileCacheParts`]'s
+/// `deserialize`; field order there must match [`write()`] exactly.
+pub(super) struct CacheWrite<'a> {
+	pub n_wires: usize,
+	pub n_gates: usize,
+	pub digest: u64,
+	pub n_mapped: usize,
+	pub constraint_system: &'a ConstraintSystem,
+	pub value_vec_layout: &'a ValueVecLayout,
+	pub wire_mapping: &'a SecondaryMap<Wire, ValueIndex>,
+	pub inout: &'a [Wire],
+	pub bytecode: &'a [u8],
+	pub n_eval_insn: usize,
+	pub scratch_peak_live: usize,
+	pub scratch_pooled: bool,
+}
+
+/// Serialize the compilation outputs, ending with a checksum of every preceding byte.
+pub(super) fn write(parts: &CacheWrite<'_>, out: &mut Vec<u8>) -> Result<(), SerializationError> {
+	let start = out.len();
+	let mut write_buf = out;
+	MAGIC.serialize(&mut write_buf)?;
+	CACHE_VERSION.serialize(&mut write_buf)?;
+	env!("CARGO_PKG_VERSION").serialize(&mut write_buf)?;
+	parts.n_wires.serialize(&mut write_buf)?;
+	parts.n_gates.serialize(&mut write_buf)?;
+	parts.digest.serialize(&mut write_buf)?;
+	parts.n_mapped.serialize(&mut write_buf)?;
+	parts.constraint_system.serialize(&mut write_buf)?;
+	parts.value_vec_layout.n_const.serialize(&mut write_buf)?;
+	parts.value_vec_layout.n_inout.serialize(&mut write_buf)?;
+	parts.value_vec_layout.n_witness.serialize(&mut write_buf)?;
+	parts
+		.value_vec_layout
+		.n_internal
+		.serialize(&mut write_buf)?;
+	parts.value_vec_layout.n_scratch.serialize(&mut write_buf)?;
+	// The wire mapping is dense over the post-pass graph's wires: one entry per wire, in
+	// index order.
+	for i in 0..parts.n_mapped {
+		parts.wire_mapping[Wire::new(i)].serialize(&mut write_buf)?;
+	}
+	parts.inout.len().serialize(&mut write_buf)?;
+	for wire in parts.inout {
+		(wire.index() as u32).serialize(&mut write_buf)?;
+	}
+	parts.bytecode.serialize(&mut write_buf)?;
+	parts.n_eval_insn.serialize(&mut write_buf)?;
+	parts.scratch_peak_live.serialize(&mut write_buf)?;
+	parts.scratch_pooled.serialize(&mut write_buf)?;
+	let checksum = payload_checksum(&write_buf[start..]);
+	checksum.serialize(write_buf)
+}
+
+impl CompileCacheParts {
+	pub(super) fn deserialize(bytes: &[u8]) -> Result<Self, CompileCacheError> {
+		// Peek the magic before checksumming, so pointing the loader at some other file reads
+		// as "not a compilation cache" rather than a checksum failure over megabytes of the
+		// wrong bytes.
+		if bytes.len() < 4 || bytes[..4] != MAGIC.to_le_bytes() {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::MAGIC",
+			}
+			.into());
+		}
+		// The last 8 bytes checksum everything before them; verify before parsing, so a bit
+		// flip anywhere in the payload is refused at the door rather than loading a subtly
+		// wrong circuit.
+		let Some(body_len) = bytes.len().checked_sub(8) else {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::checksum",
+			}
+			.into());
+		};
+		let (body, trailer) = bytes.split_at(body_len);
+		let stored = u64::from_le_bytes(trailer.try_into().expect("8-byte trailer"));
+		if payload_checksum(body) != stored {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::checksum",
+			}
+			.into());
+		}
+		let mut read_buf = body;
+		let magic = u32::deserialize(&mut read_buf)?;
+		if magic != MAGIC {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::MAGIC",
+			}
+			.into());
+		}
+		let version = u32::deserialize(&mut read_buf)?;
+		if version != CACHE_VERSION {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::CACHE_VERSION",
+			}
+			.into());
+		}
+		let pkg_version = String::deserialize(&mut read_buf)?;
+		if pkg_version != env!("CARGO_PKG_VERSION") {
+			return Err(CompileCacheError::VersionMismatch {
+				cached: pkg_version,
+				current: env!("CARGO_PKG_VERSION"),
+			});
+		}
+		let n_wires = usize::deserialize(&mut read_buf)?;
+		let n_gates = usize::deserialize(&mut read_buf)?;
+		let digest = u64::deserialize(&mut read_buf)?;
+		let n_mapped = usize::deserialize(&mut read_buf)?;
+		let constraint_system = ConstraintSystem::deserialize(&mut read_buf)?;
+		let value_vec_layout = ValueVecLayout {
+			n_const: usize::deserialize(&mut read_buf)?,
+			n_inout: usize::deserialize(&mut read_buf)?,
+			n_witness: usize::deserialize(&mut read_buf)?,
+			n_internal: usize::deserialize(&mut read_buf)?,
+			n_scratch: usize::deserialize(&mut read_buf)?,
+		};
+		// Scratch, like `value_vec_alloc`'s own default: a wire handle beyond the mapped range
+		// must not alias a real word.
+		let mut wire_mapping = SecondaryMap::with_default(ValueIndex::scratch(0));
+		for i in 0..n_mapped {
+			wire_mapping[Wire::new(i)] = ValueIndex::deserialize(&mut read_buf)?;
+		}
+		let n_inout = usize::deserialize(&mut read_buf)?;
+		// A length field can't promise more than the buffer holds; check before preallocating,
+		// so a truncated or corrupt file errors instead of reserving from a lie.
+		if n_inout.saturating_mul(4) > read_buf.remaining() {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::n_inout",
+			}
+			.into());
+		}
+		let mut inout = Vec::with_capacity(n_inout);
+		for _ in 0..n_inout {
+			inout.push(Wire::new(u32::deserialize(&mut read_buf)? as usize));
+		}
+		let bytecode = Vec::<u8>::deserialize(&mut read_buf)?;
+		let n_eval_insn = usize::deserialize(&mut read_buf)?;
+		let scratch_peak_live = usize::deserialize(&mut read_buf)?;
+		let scratch_pooled = bool::deserialize(&mut read_buf)?;
+		if read_buf.remaining() != 0 {
+			return Err(SerializationError::InvalidConstruction {
+				name: "compile_cache::trailing",
+			}
+			.into());
+		}
+		Ok(CompileCacheParts {
+			n_wires,
+			n_gates,
+			digest,
+			constraint_system,
+			value_vec_layout,
+			wire_mapping,
+			inout,
+			bytecode,
+			n_eval_insn,
+			scratch_peak_live,
+			scratch_pooled,
+		})
+	}
+}

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -38,7 +38,10 @@ use crate::{
 	},
 };
 
+mod compile_cache;
 mod gadget;
+
+pub use compile_cache::CompileCacheError;
 #[cfg(test)]
 mod tests;
 
@@ -493,12 +496,128 @@ impl CircuitBuilder {
 	///
 	/// Returns an error when an enabled constant-propagation pass finds an unsatisfiable gate.
 	pub fn try_build(self) -> Result<Circuit, AlwaysFailingGateError> {
-		let shared = self.into_shared();
-		assert!(
-			shared.chips.is_empty(),
-			"a builder carrying chips builds with CircuitBuilder::build_m4"
+		let shared = self.into_chipless_shared();
+		Self::compile(shared, &[], None)
+	}
+
+	/// Returns the circuit and a byte-serialized compilation cache for it.
+	/// Returns an error instead of panicking on an unsatisfiable constant gate.
+	///
+	/// The cache holds the outputs of compilation — the constraint system, value-vector layout,
+	/// wire mapping, inout list and evaluation bytecode — so a later process that runs the same
+	/// construction can assemble the same circuit with
+	/// [`Self::try_build_from_compile_cache`], skipping the optimization passes and constraint
+	/// building; the validity contract is documented on that method. The cache scales linearly
+	/// with the circuit (on the order of a hundred bytes per gate), and the load path pays
+	/// deserialization, a checksum and constraint-system validation, so the win is the passes
+	/// and constraint building it skips.
+	///
+	/// ```no_run
+	/// use binius_frontend::CircuitBuilder;
+	///
+	/// // The construction, exactly as it runs in every process.
+	/// fn construct() -> CircuitBuilder {
+	///     let builder = CircuitBuilder::new();
+	///     let x = builder.add_inout();
+	///     let y = builder.add_witness();
+	///     builder.assert_eq("xy", x, y);
+	///     builder
+	/// }
+	///
+	/// // Once, at build time:
+	/// let (_circuit, cache) = construct().try_build_with_compile_cache()?;
+	/// std::fs::write("circuit.cache", &cache)?;
+	///
+	/// // Later, in each fresh process: the same construction, loading instead of compiling.
+	/// let _circuit = construct().try_build_from_compile_cache(&std::fs::read("circuit.cache")?)?;
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	///
+	/// # Panics
+	///
+	/// Panics under the same conditions as [`Self::try_build`], and if any serialized count
+	/// exceeds `u32::MAX`, the byte format limit (`ConstraintSystem` serialization carries the
+	/// same one).
+	///
+	/// # Errors
+	///
+	/// Returns an error when an enabled constant-propagation pass finds an unsatisfiable gate.
+	pub fn try_build_with_compile_cache(
+		self,
+	) -> Result<(Circuit, Vec<u8>), AlwaysFailingGateError> {
+		let shared = self.into_chipless_shared();
+		let mut cache = Vec::new();
+		let circuit = Self::compile(shared, &[], Some(&mut cache))?;
+		Ok((circuit, cache))
+	}
+
+	/// Returns the circuit assembled from a compilation cache produced by
+	/// [`Self::try_build_with_compile_cache`], skipping the optimization passes and constraint
+	/// building.
+	///
+	/// The builder must be in exactly the state that produced the cache: the same code built the
+	/// same gate graph under the same options. The freshly constructed state is digested — wire
+	/// kinds, constant values, gate bodies, wires, immediates, dimensions, path references, the
+	/// builder options and the force-committed set — and a cache recorded for a different state
+	/// is refused with [`CompileCacheError::StateMismatch`]; one written by a different
+	/// published version of this crate is refused with [`CompileCacheError::VersionMismatch`],
+	/// since the digest cannot see changes to the passes or the lowering (two builds of the
+	/// same published version share a header, so regenerate the cache with the build — see the
+	/// error type's docs). The digest guards against accidental drift, not against a hostile
+	/// cache file: treat the bytes as trusted input, like the binary itself.
+	///
+	/// # Panics
+	///
+	/// Panics if a clone or a subcircuit still holds a live handle to the same shared state, or
+	/// if the builder carries a chip registered by [`Self::add_chip`] (a chip-composed circuit
+	/// builds with [`Self::build_m4`], which has no cached path).
+	///
+	/// # Errors
+	///
+	/// Returns an error when the bytes do not decode as a compilation cache, were written by a
+	/// different published version of this crate, were written for a different builder state,
+	/// or carry a constraint system that fails validation.
+	pub fn try_build_from_compile_cache(self, bytes: &[u8]) -> Result<Circuit, CompileCacheError> {
+		let shared = self.into_chipless_shared();
+		let parts = compile_cache::CompileCacheParts::deserialize(bytes)?;
+		let built_digest =
+			compile_cache::graph_digest(&shared.graph, &shared.opts, &shared.force_committed);
+		let graph = shared.graph;
+		if parts.n_wires != graph.wires.len()
+			|| parts.n_gates != graph.gates.len()
+			|| parts.digest != built_digest
+		{
+			return Err(CompileCacheError::StateMismatch {
+				cached_wires: parts.n_wires,
+				cached_gates: parts.n_gates,
+				cached_digest: parts.digest,
+				built_wires: graph.wires.len(),
+				built_gates: graph.gates.len(),
+				built_digest,
+			});
+		}
+
+		// The build path validates the constraint system it just produced as a debug check; here
+		// the constraint system is deserialized input, so validation always runs and a failure
+		// is an error, not a panic.
+		parts.constraint_system.validate()?;
+
+		let eval_form = eval_form::EvalForm::from_parts(
+			parts.bytecode,
+			parts.n_eval_insn,
+			shared.hint_registry,
 		);
-		Self::compile(shared, &[])
+		let built_gates = BuiltGates::from_graph(graph);
+		Ok(Circuit::new(
+			built_gates,
+			parts.constraint_system,
+			parts.value_vec_layout,
+			parts.wire_mapping,
+			parts.inout,
+			eval_form,
+			parts.scratch_peak_live,
+			parts.scratch_pooled,
+		))
 	}
 
 	/// Returns the chip-composed circuit built by this builder.
@@ -536,7 +655,7 @@ impl CircuitBuilder {
 		let mut shared = self.into_shared();
 		let chips = mem::take(&mut shared.chips);
 		let pending = mem::take(&mut shared.chip_calls);
-		let circuit = Self::compile(shared, &pending)?;
+		let circuit = Self::compile(shared, &pending, None)?;
 
 		// The instances and the active-instance counts are the whole call graph's to settle, so
 		// both are left to `recompute_instances` below.
@@ -576,6 +695,20 @@ impl CircuitBuilder {
 			.into_inner()
 	}
 
+	/// [`Self::into_shared`], for the build paths that do not compose chips.
+	///
+	/// # Panics
+	///
+	/// Panics if the builder carries a chip registered by [`Self::add_chip`].
+	fn into_chipless_shared(self) -> Shared {
+		let shared = self.into_shared();
+		assert!(
+			shared.chips.is_empty(),
+			"a builder carrying chips builds with CircuitBuilder::build_m4"
+		);
+		shared
+	}
+
 	/// Compiles the builder's state into a circuit, running every optimization pass it enables.
 	///
 	/// # Errors
@@ -584,8 +717,23 @@ impl CircuitBuilder {
 	fn compile(
 		shared: Shared,
 		chip_calls: &[PendingCall],
+		cache_out: Option<&mut Vec<u8>>,
 	) -> Result<Circuit, AlwaysFailingGateError> {
 		let mut graph = shared.graph;
+
+		// The cache's fingerprint is taken now, before any pass touches the graph and before
+		// the force-committed set is folded into `pinned`: the loading builder digests its
+		// state exactly as construction left it, since it runs no passes, so the two sides
+		// must digest the same objects. (CSE rewrites surviving gates' wires to canonical
+		// form, and constant propagation rewrites wire kinds, so a post-pass digest would
+		// not match.)
+		let fingerprint = cache_out.is_some().then(|| {
+			(
+				graph.wires.len(),
+				graph.gates.len(),
+				compile_cache::graph_digest(&graph, &shared.opts, &shared.force_committed),
+			)
+		});
 
 		// A chip call is a constraint on the words its wires hold, but the compiler passes have
 		// no notion of a call. Folding its wires into the pinned set gives them the treatment a
@@ -773,6 +921,36 @@ impl CircuitBuilder {
 			&value_vec_layout,
 			shared.hint_registry,
 		);
+
+		// The compilation cache is written here, while the graph is still whole: the digest
+		// above walked the constructed graph, and everything being serialized is now final.
+		if let Some(out) = cache_out {
+			let (n_wires, n_gates, digest) =
+				fingerprint.expect("fingerprint is taken whenever a cache is requested");
+			compile_cache::write(
+				&compile_cache::CacheWrite {
+					n_wires,
+					n_gates,
+					digest,
+					// The mapping is dense over the graph as the passes left it, which can
+					// hold more wires than construction made (interned constants); its
+					// length is its own field.
+					n_mapped: graph.wires.len(),
+					constraint_system: &cs,
+					value_vec_layout: &value_vec_layout,
+					wire_mapping: &wire_mapping,
+					inout: &inout,
+					bytecode: eval_form.bytecode(),
+					n_eval_insn: eval_form.n_eval_insn(),
+					scratch_peak_live: scratch_alloc.peak_live(),
+					scratch_pooled: scratch_policy == ScratchPolicy::Pooled,
+				},
+				out,
+			)
+			.expect(
+				"writing a compilation cache to a Vec fails only when a serialized count exceeds u32::MAX",
+			);
+		}
 
 		// Passes above needed the whole graph.
 		// A circuit only reads back path names and a per-gate record, so the rest drops now.

--- a/crates/frontend/src/eval_form/mod.rs
+++ b/crates/frontend/src/eval_form/mod.rs
@@ -113,6 +113,28 @@ impl EvalForm {
 		ctx.check_assertions(path_spec_tree)
 	}
 
+	/// Reassemble an evaluation form from cached bytecode and a freshly populated hint registry.
+	///
+	/// The bytecode must come from [`EvalForm::build`] in the compilation of an identical
+	/// builder state; hint ids are name hashes, so the fresh registry resolves the cached
+	/// references.
+	pub(crate) const fn from_parts(
+		bytecode: Vec<u8>,
+		n_eval_insn: usize,
+		hint_registry: HintRegistry,
+	) -> Self {
+		EvalForm {
+			bytecode,
+			n_eval_insn,
+			hint_registry,
+		}
+	}
+
+	/// The compiled bytecode, for the compilation cache.
+	pub(crate) fn bytecode(&self) -> &[u8] {
+		&self.bytecode
+	}
+
 	/// A fresh executor over this form's bytecode, with its cursor at the first instruction.
 	fn executor(&self) -> Executor<'_> {
 		Executor::new(&self.bytecode, &self.hint_registry)

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -54,9 +54,10 @@ pub use artifact::{
 	stat::{self, CircuitStat},
 	witness::{AssertionFailure, BatchWitnessFiller, PopulateError, WitnessFiller},
 };
-pub use builder::{CircuitBuilder, Options};
+pub use builder::{CircuitBuilder, CompileCacheError, Options};
 pub use eval_form::{BatchPopulateError, MAX_ASSERTION_FAILURES};
 pub use ir::{
 	Wire,
 	hints::{self, Hint},
 };
+pub use pass::AlwaysFailingGateError;

--- a/crates/frontend/tests/compile_cache.rs
+++ b/crates/frontend/tests/compile_cache.rs
@@ -1,0 +1,454 @@
+// Copyright 2026 The Binius Developers
+
+//! The compilation cache round-trips: a circuit assembled from its cache behaves exactly like
+//! the circuit a full build produces, and a cache written for a different builder state, by a
+//! different crate version, or corrupted in transit is refused.
+
+use binius_core::word::Word;
+use binius_frontend::{Circuit, CircuitBuilder, CompileCacheError, Hint, Options, Wire};
+use binius_utils::serialization::SerializeBytes;
+
+/// A witness-time computation the cache cannot serialize: hint handlers are closures, so the
+/// loading builder must re-register them and the cached bytecode must resolve against the fresh
+/// registry by stable hint id.
+struct SplitHint;
+
+impl Hint for SplitHint {
+	const NAME: &'static str = "compile_cache_test::split";
+
+	fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+		(1, 2)
+	}
+
+	fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let x = inputs[0].as_u64();
+		outputs[0] = Word::from_u64(x & 0xFFFF_FFFF);
+		outputs[1] = Word::from_u64(x >> 32);
+	}
+}
+
+/// A small circuit covering every wire kind and both gate bodies: constants, inouts, witnesses,
+/// gate-created internal wires, a hint call, and assertions that commit the hint's outputs.
+/// Returns the wires a test reads or writes.
+fn build_test_circuit(b: &CircuitBuilder) -> (Wire, Wire, Wire, Wire) {
+	let sub = b.subcircuit("cache_test");
+	let x = sub.add_inout();
+	let y = sub.add_witness();
+	let k = sub.add_constant_64(0xDEAD_BEEF_CAFE_F00D);
+	let masked = sub.band(x, k);
+	let sum = sub.iadd_32(masked, y);
+	let halves = sub.call_hint(SplitHint, &[], &[sum]);
+	let (lo, hi) = (halves[0], halves[1]);
+	// Recombine the hint's outputs and pin them to the value they split, so the hint wires are
+	// committed and a wrong hint execution fails witness population.
+	let shifted = sub.shl(hi, 32);
+	let recombined = sub.bxor(lo, shifted);
+	sub.assert_eq("split_recombines", recombined, sum);
+	// Promote a gate-created wire into the public interface, so the cached inout list carries
+	// a promoted wire as well as declared ones.
+	sub.mark_inout(recombined);
+	drop(sub);
+	(x, y, lo, hi)
+}
+
+/// Fill the two input wires, populate, and read back the hint's output wires.
+fn populate(circuit: &Circuit, wires: (Wire, Wire, Wire, Wire), x: u64, y: u64) -> (u64, u64) {
+	let (x_wire, y_wire, lo, hi) = wires;
+	let mut filler = circuit.new_witness_filler();
+	filler[x_wire] = Word::from_u64(x);
+	filler[y_wire] = Word::from_u64(y);
+	circuit
+		.populate_wire_witness(&mut filler)
+		.expect("population succeeds");
+	(filler[lo].as_u64(), filler[hi].as_u64())
+}
+
+/// Mirror of `compile_cache::payload_checksum`, for tests that splice a field and re-seal the
+/// trailer so the header checks behind the checksum stay individually pinned.
+fn refresh_checksum(bytes: &mut [u8]) {
+	const PRIME: u64 = 0x0000_0100_0000_01b3;
+	let body_len = bytes.len() - 8;
+	let body = &bytes[..body_len];
+	let mut h = 0xcbf2_9ce4_8422_2325_u64 ^ body.len() as u64;
+	let mut chunks = body.chunks_exact(8);
+	for chunk in &mut chunks {
+		h = (h ^ u64::from_le_bytes(chunk.try_into().unwrap())).wrapping_mul(PRIME);
+	}
+	let mut tail = [0u8; 8];
+	tail[..chunks.remainder().len()].copy_from_slice(chunks.remainder());
+	h = (h ^ u64::from_le_bytes(tail)).wrapping_mul(PRIME);
+	bytes[body_len..].copy_from_slice(&h.to_le_bytes());
+}
+
+fn cs_bytes(circuit: &Circuit) -> Vec<u8> {
+	let mut buf = Vec::new();
+	circuit
+		.constraint_system()
+		.serialize(&mut buf)
+		.expect("serializing a constraint system to a Vec cannot fail");
+	buf
+}
+
+#[test]
+fn cached_build_matches_full_build() {
+	let full_builder = CircuitBuilder::new();
+	let full_wires = build_test_circuit(&full_builder);
+	let (full, cache) = full_builder
+		.try_build_with_compile_cache()
+		.expect("full build");
+
+	let cached_builder = CircuitBuilder::new();
+	let cached_wires = build_test_circuit(&cached_builder);
+	let cached = cached_builder
+		.try_build_from_compile_cache(&cache)
+		.expect("the same construction accepts its own cache");
+
+	// Requesting a cache must not perturb the build: a plain build of the same construction
+	// produces the identical constraint system.
+	let plain_builder = CircuitBuilder::new();
+	build_test_circuit(&plain_builder);
+	let plain = plain_builder.try_build().expect("plain build");
+	assert_eq!(cs_bytes(&full), cs_bytes(&plain));
+
+	// The constraint systems are byte-identical, so anything proven against one verifies
+	// against the other.
+	assert_eq!(cs_bytes(&full), cs_bytes(&cached));
+	// The public interface is the same wires in the same order.
+	assert_eq!(full.inout(), cached.inout());
+	assert_eq!(full.n_eval_insn(), cached.n_eval_insn());
+
+	// Witness generation agrees, hint execution included.
+	let inputs = (0x0123_4567_89AB_CDEF, 0x0000_0000_1111_2222);
+	assert_eq!(
+		populate(&full, full_wires, inputs.0, inputs.1),
+		populate(&cached, cached_wires, inputs.0, inputs.1)
+	);
+}
+
+#[test]
+fn optimized_away_gates_still_round_trip() {
+	// Common-subexpression elimination rewrites this graph: the two identical `band` gates
+	// collapse, and the survivors' operand wires are rewritten to canonical form. The cache
+	// fingerprint is taken before the passes run, so the loading builder — which runs no
+	// passes and still holds both gates — matches the cache all the same.
+	let build = || {
+		let b = CircuitBuilder::new();
+		let x = b.add_inout();
+		let out_io = b.add_inout();
+		let k1 = b.add_constant_64(0xFF00_FF00_FF00_FF00);
+		let dup_a = b.band(x, k1);
+		let dup_b = b.band(x, k1);
+		let mixed = b.iadd_32(dup_a, dup_b);
+		let out = b.bxor(mixed, dup_a);
+		b.assert_eq("out", out_io, out);
+		(b, x, out_io)
+	};
+
+	let (full_builder, _, _) = build();
+	let (full, cache) = full_builder
+		.try_build_with_compile_cache()
+		.expect("full build");
+
+	let (cached_builder, x, out_io) = build();
+	let cached = cached_builder
+		.try_build_from_compile_cache(&cache)
+		.expect("a CSE-rewritten circuit accepts its own cache");
+
+	assert_eq!(cs_bytes(&full), cs_bytes(&cached));
+
+	let input = 0x1234_5678_9ABC_DEF0_u64;
+	let masked = input & 0xFF00_FF00_FF00_FF00;
+	// `iadd_32` adds the two 32-bit halves independently, discarding each carry-out.
+	let hi = ((masked >> 32) as u32).wrapping_add((masked >> 32) as u32) as u64;
+	let lo = (masked as u32).wrapping_add(masked as u32) as u64;
+	let expected = ((hi << 32) | lo) ^ masked;
+	let mut filler = cached.new_witness_filler();
+	filler[x] = Word::from_u64(input);
+	filler[out_io] = Word::from_u64(expected);
+	cached
+		.populate_wire_witness(&mut filler)
+		.expect("the deduplicated output pins correctly");
+
+	let mut bad = cached.new_witness_filler();
+	bad[x] = Word::from_u64(input);
+	bad[out_io] = Word::from_u64(expected ^ 1);
+	cached
+		.populate_wire_witness(&mut bad)
+		.expect_err("a wrong output must fail the assertion through the cached bytecode");
+}
+
+#[test]
+fn cache_for_a_different_graph_is_refused() {
+	let builder = CircuitBuilder::new();
+	build_test_circuit(&builder);
+	let (_, cache) = builder.try_build_with_compile_cache().expect("full build");
+
+	// One extra gate: the counts and digest both move.
+	let drifted = CircuitBuilder::new();
+	let wires = build_test_circuit(&drifted);
+	let _ = drifted.band(wires.0, wires.1);
+	match drifted.try_build_from_compile_cache(&cache) {
+		Err(CompileCacheError::StateMismatch { .. }) => {}
+		Err(other) => panic!("expected StateMismatch, got {other}"),
+		Ok(_) => panic!("a drifted graph accepted the cache"),
+	}
+}
+
+#[test]
+fn same_shape_different_constant_is_refused() {
+	// Same wire and gate counts; only a constant's value differs. Only the digest catches it.
+	let build_with = |c: u64| {
+		let b = CircuitBuilder::new();
+		let x = b.add_inout();
+		let k = b.add_constant_64(c);
+		let y = b.band(x, k);
+		b.assert_eq("pin", y, y);
+		b
+	};
+	let (_, cache) = build_with(1)
+		.try_build_with_compile_cache()
+		.expect("full build");
+	match build_with(2).try_build_from_compile_cache(&cache) {
+		Err(CompileCacheError::StateMismatch { .. }) => {}
+		Err(other) => panic!("expected StateMismatch, got {other}"),
+		Ok(_) => panic!("a different constant accepted the cache"),
+	}
+}
+
+#[test]
+fn corrupt_bytes_are_refused() {
+	let builder = CircuitBuilder::new();
+	build_test_circuit(&builder);
+	let (_, cache) = builder.try_build_with_compile_cache().expect("full build");
+
+	for bytes in [&[][..], &cache[..4], &cache[..cache.len() - 1]] {
+		let fresh = CircuitBuilder::new();
+		build_test_circuit(&fresh);
+		match fresh.try_build_from_compile_cache(bytes) {
+			Err(CompileCacheError::Deserialize(_)) => {}
+			Err(other) => panic!("expected a deserialize error, got {other}"),
+			Ok(_) => panic!("corrupt bytes accepted"),
+		}
+	}
+
+	// A single bit flipped anywhere in the payload — mid-file and in the trailing checksum
+	// itself — is refused by the checksum, not loaded as a subtly wrong circuit.
+	for flip_at in [cache.len() / 2, cache.len() - 1] {
+		let mut bytes = cache.clone();
+		bytes[flip_at] ^= 0x01;
+		let fresh = CircuitBuilder::new();
+		build_test_circuit(&fresh);
+		match fresh.try_build_from_compile_cache(&bytes) {
+			Err(CompileCacheError::Deserialize(_)) => {}
+			Err(other) => panic!("expected a deserialize error, got {other}"),
+			Ok(_) => panic!("a flipped payload bit was accepted"),
+		}
+	}
+}
+
+#[test]
+fn options_change_is_refused() {
+	let (_, cache) = {
+		let b = CircuitBuilder::new();
+		build_test_circuit(&b);
+		b.try_build_with_compile_cache().expect("full build")
+	};
+	// Scratch pooling changes nothing about construction — the gate graph is byte-identical —
+	// but it decides the compiled layout and which wires a witness filler may read, so the
+	// cache must be refused on the option alone.
+	let mut opts = Options::default();
+	opts.enable_scratch_pooling = false;
+	let loader = CircuitBuilder::with_opts(opts);
+	build_test_circuit(&loader);
+	match loader.try_build_from_compile_cache(&cache) {
+		Err(CompileCacheError::StateMismatch { .. }) => {}
+		Err(other) => panic!("expected StateMismatch, got {other}"),
+		Ok(_) => panic!("different builder options accepted the cache"),
+	}
+}
+
+#[test]
+fn force_commit_drift_is_refused() {
+	let (_, cache) = {
+		let b = CircuitBuilder::new();
+		build_test_circuit(&b);
+		b.try_build_with_compile_cache().expect("full build")
+	};
+	// Same graph, byte for byte; the only change is which wires must stay readable — which
+	// changes the compiled layout, so the cache must be refused.
+	let loader = CircuitBuilder::new();
+	let (_, _, lo, _) = build_test_circuit(&loader);
+	loader.force_commit(lo);
+	match loader.try_build_from_compile_cache(&cache) {
+		Err(CompileCacheError::StateMismatch { .. }) => {}
+		Err(other) => panic!("expected StateMismatch, got {other}"),
+		Ok(_) => panic!("a changed force-committed set accepted the cache"),
+	}
+}
+
+#[test]
+fn interned_constants_round_trip() {
+	// With constant propagation enabled the passes fold gates and can intern constants the
+	// construction never made, so the cached wire mapping runs past the constructed graph's
+	// wire count — the one case where the mapping length and the fingerprint's wire count
+	// differ.
+	let opts = || {
+		let mut opts = Options::default();
+		opts.enable_constant_propagation = true;
+		opts
+	};
+	let build = |b: &CircuitBuilder| {
+		let x = b.add_inout();
+		let out_io = b.add_inout();
+		let k1 = b.add_constant_64(0x1111_2222_3333_4444);
+		let k2 = b.add_constant_64(0x0F0F_0F0F_0F0F_0F0F);
+		let folded = b.band(k1, k2);
+		let out = b.bxor(x, folded);
+		b.assert_eq("out", out_io, out);
+		(x, out_io)
+	};
+
+	let full_builder = CircuitBuilder::with_opts(opts());
+	build(&full_builder);
+	let (full, cache) = full_builder
+		.try_build_with_compile_cache()
+		.expect("full build");
+
+	let loader = CircuitBuilder::with_opts(opts());
+	let (x, out_io) = build(&loader);
+	let cached = loader
+		.try_build_from_compile_cache(&cache)
+		.expect("a constant-folding build accepts its own cache");
+
+	assert_eq!(cs_bytes(&full), cs_bytes(&cached));
+	let input = 0xAAAA_BBBB_CCCC_DDDD_u64;
+	let expected = input ^ (0x1111_2222_3333_4444 & 0x0F0F_0F0F_0F0F_0F0F);
+	let mut filler = cached.new_witness_filler();
+	filler[x] = Word::from_u64(input);
+	filler[out_io] = Word::from_u64(expected);
+	cached
+		.populate_wire_witness(&mut filler)
+		.expect("the folded constant evaluates correctly from the cache");
+}
+
+#[test]
+fn wrong_magic_and_version_are_refused() {
+	let builder = CircuitBuilder::new();
+	build_test_circuit(&builder);
+	let (_, cache) = builder.try_build_with_compile_cache().expect("full build");
+
+	// Byte 0 is the magic, byte 4 the format version; each flip is re-sealed under a fresh
+	// checksum, and the error's field name is asserted, so the header check itself — not the
+	// checksum, and not a drifted `refresh_checksum` mirror — does the refusing.
+	use binius_utils::serialization::SerializationError;
+	for (corrupt_at, expected) in [
+		(0usize, "compile_cache::MAGIC"),
+		(4, "compile_cache::CACHE_VERSION"),
+	] {
+		let mut bytes = cache.clone();
+		bytes[corrupt_at] ^= 0xFF;
+		refresh_checksum(&mut bytes);
+		let fresh = CircuitBuilder::new();
+		build_test_circuit(&fresh);
+		match fresh.try_build_from_compile_cache(&bytes) {
+			Err(CompileCacheError::Deserialize(SerializationError::InvalidConstruction {
+				name,
+			})) => {
+				assert_eq!(name, expected);
+			}
+			Err(other) => panic!("expected the {expected} check to refuse, got {other}"),
+			Ok(_) => panic!("corrupt header accepted"),
+		}
+	}
+
+	// Trailing garbage after a valid cache is refused too.
+	let mut bytes = cache;
+	bytes.push(0);
+	let fresh = CircuitBuilder::new();
+	build_test_circuit(&fresh);
+	match fresh.try_build_from_compile_cache(&bytes) {
+		Err(CompileCacheError::Deserialize(_)) => {}
+		Err(other) => panic!("expected a deserialize error, got {other}"),
+		Ok(_) => panic!("trailing bytes accepted"),
+	}
+}
+
+#[test]
+fn different_crate_version_is_refused() {
+	let builder = CircuitBuilder::new();
+	build_test_circuit(&builder);
+	let (_, cache) = builder.try_build_with_compile_cache().expect("full build");
+
+	// Header layout: magic (4) ‖ format version (4) ‖ crate version as len-prefixed string.
+	// Bump the last character of the crate version in place and re-seal the checksum, so the
+	// version check itself — not the checksum — does the refusing.
+	let mut bytes = cache;
+	let len = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+	let last = 12 + len - 1;
+	bytes[last] = bytes[last].wrapping_add(1);
+	refresh_checksum(&mut bytes);
+	let fresh = CircuitBuilder::new();
+	build_test_circuit(&fresh);
+	match fresh.try_build_from_compile_cache(&bytes) {
+		Err(CompileCacheError::VersionMismatch { cached, current }) => {
+			assert_eq!(current, env!("CARGO_PKG_VERSION"));
+			assert_ne!(cached, current);
+		}
+		Err(other) => panic!("expected VersionMismatch, got {other}"),
+		Ok(_) => panic!("a different crate version accepted the cache"),
+	}
+}
+
+#[test]
+fn renamed_paths_are_accepted() {
+	// Same structure, different subcircuit name: path and assertion names are diagnostic
+	// metadata, deliberately outside the digest, so the cache is accepted and failures report
+	// under the loader's own names.
+	let build_named = |name: &str| {
+		let b = CircuitBuilder::new();
+		let sub = b.subcircuit(name);
+		let x = sub.add_inout();
+		let out_io = sub.add_inout();
+		let k = sub.add_constant_64(0x5555_5555_5555_5555);
+		let out = sub.band(x, k);
+		sub.assert_eq("pin", out_io, out);
+		drop(sub);
+		(b, x, out_io)
+	};
+
+	let (writer, _, _) = build_named("original");
+	let (_, cache) = writer.try_build_with_compile_cache().expect("full build");
+
+	let (loader, x, out_io) = build_named("renamed");
+	let cached = loader
+		.try_build_from_compile_cache(&cache)
+		.expect("a renamed but structurally identical construction accepts the cache");
+
+	let mut bad = cached.new_witness_filler();
+	bad[x] = Word::from_u64(0xFFFF_0000_FFFF_0000);
+	bad[out_io] = Word::from_u64(0);
+	let err = cached
+		.populate_wire_witness(&mut bad)
+		.expect_err("the pinned output is wrong");
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("renamed.pin"),
+		"assertion failures report under the loader's names, got: {msg}"
+	);
+}
+
+#[test]
+fn scratch_peak_live_round_trips() {
+	let full_builder = CircuitBuilder::new();
+	build_test_circuit(&full_builder);
+	let (full, cache) = full_builder
+		.try_build_with_compile_cache()
+		.expect("full build");
+
+	let loader = CircuitBuilder::new();
+	build_test_circuit(&loader);
+	let cached = loader
+		.try_build_from_compile_cache(&cache)
+		.expect("round trip");
+	assert_eq!(full.scratch_peak_live(), cached.scratch_peak_live());
+}


### PR DESCRIPTION
Caches a circuit's compilation, so a fresh process skips the optimization passes and constraint building instead of re-running them.

### What

`CircuitBuilder::try_build_with_compile_cache()` returns the built circuit together with a byte-serialized cache of its compilation outputs: the constraint system, value-vector layout, wire mapping, inout list and evaluation bytecode. `CircuitBuilder::try_build_from_compile_cache(bytes)` assembles the same `Circuit` from a freshly constructed gate graph plus those bytes. The graph construction it re-runs is the cheap part, and re-running it is also what re-registers every hint handler — hints are closures and are never serialized; the cached bytecode's references resolve against the fresh registry by stable name-hash ids.

`build()` and `try_build()` pay nothing: the digest below only runs when a cache is requested, and a test pins that requesting one leaves the constraint system byte-identical.

### The guards

Four checks make a wrong cache an error instead of a miscompiled circuit.

- **The builder state is digested** — wire kinds, constant values, gate bodies, wires, immediates, dimensions, per-gate path references, the builder options and the force-committed set — and a mismatch is refused. The fingerprint is taken before the passes run on both sides, since CSE rewrites surviving gates' wires and constant propagation rewrites wire kinds, so a post-pass digest would never match the loader's constructed graph.
- **A crate-version header refuses a cache from a different published version.** The digest cannot see changes to the passes or the lowering; within one version, regenerating the cache with the build (a build script is the natural place) ties its lifetime to the binary's.
- **A trailing checksum refuses payload corruption** before any parsing.
- **The carried constraint system is validated on load** — it is deserialized input, so the check the build path runs in debug always runs here, as an error.

### Numbers

| circuit | size | compile | cache load | cache on disk |
| --- | ---: | ---: | ---: | ---: |
| ours, laptop-sized | 48.7M terms | 19.5 s | ~5 s | ~2.0 GB |
| ours, production | 449.6M terms | ~4 min | — | — |
| sha256 × 512 messages | 3.0M gates | 2.4 s | 0.69 s | 276 MB |

The 19.5 s splits as 9.3 s of optimization passes, 7.2 s of constraint building, and the rest materialization and bytecode emission. The cache is about 100 bytes per gate, two writes of the same build are byte-identical, and the load path pays deserialization, the checksum and validation — which is why load is not free.

### Testing

12 integration tests in `crates/frontend/tests/compile_cache.rs`: byte-identical constraint system and witness agreement (hint execution included) between full and cache-assembled builds; a CSE-rewritten graph accepting its own cache; refusal of graph drift, a changed constant under identical counts, changed options, a changed force-committed set, a different crate version, header flips, truncation, trailing garbage and single-bit payload flips; renamed paths accepted, with failures reported under the loader's names; and interned constants, the one case where the mapping outgrows the constructed wire count. Each guard test was checked by reinstating the bug it pins and watching it fail. A separate 20,000-case corruption fuzz of the loader produced errors on every mutated buffer and no panics.

### Why

We prove with fixed circuits from short-lived processes, so compilation dominates our cold start and recurs with an unchanging result. For a long-lived process that builds once, this adds nothing.

If another shape fits better — different entry points, a feature gate, a struct in place of `Vec<u8>` — I can adjust.

### Checks

`cargo +nightly fmt --check`; `cargo clippy -p binius-frontend --all-targets -- -D warnings`; `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps -p binius-frontend`; `cargo test -p binius-frontend` (lib, integration, doc); `typos`; `tools/check_copyright_notice.py`; `cargo machete --with-metadata`.
