### PR TITLE
BINIUS-591: Check the prover's unsafe premises and lookup identity in release

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/circuit.rs
+++ b/crates/ip-prover/src/fracaddcheck/circuit.rs
@@ -115,12 +115,12 @@ where
 			//
 			//     spare capacity:  >= out_len   allocated for at least that many
 			//     sibling halves:  == out_len   halves of two equal-length buffers
-			debug_assert!(
+			assert!(
 				num_data.capacity() - num_data.len() >= out_len
 					&& den_data.capacity() - den_data.len() >= out_len,
 				"allocated buffers must hold every claimed slot"
 			);
-			debug_assert!(
+			assert!(
 				[den_0.as_ref(), num_1.as_ref(), den_1.as_ref()]
 					.iter()
 					.all(|half| half.len() == out_len),

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -351,7 +351,10 @@ where
 	// A witness satisfying the lookup identity zeroes the root numerator, so it is not sent: the
 	// verifier supplies the zero itself, and a prover whose lookups do not match cannot make the
 	// rest of the GKR agree with it.
-	debug_assert_eq!(
+	//
+	// One field comparison against a 2^n circuit, so it runs in every build.
+	// A mismatched witness then fails here instead of as an opaque verification failure later.
+	assert_eq!(
 		top_root.num.get(0),
 		F::ZERO,
 		"the lookup identities must hold: each table's looker fractions must sum to its own"


### PR DESCRIPTION
Closes [BINIUS-591](https://linear.app/jimpo/issue/BINIUS-591).

Turns three debug-only assertions into real ones. No logic change.

### The problem

The fractional-addition circuit builder writes each layer straight into a pooled buffer's spare capacity, then calls an unsafe length-set to publish the slots it filled.

Its safety comment names its premise explicitly:

```
// Safety: both length claims cover only initialized slots.
// - The assertions above bound every zip input below by `out_len`.
// - So the loop ran `out_len` items.
// - Each item wrote one numerator slot and one denominator slot.
```

"The assertions above" are two `debug_assert!`s.

In a release build they do not exist.

So the premise of a soundness argument is checked in the configuration that never ships, and unchecked in the one that does.

The invariant does hold today — the two witness buffers are asserted equal in length up front, an allocation of `out_len` gives at least that capacity, and a parallel zip yields the minimum of its inputs.

That is an argument, not a check.

### A second debug-only check

The logUp* prover asserts that the root numerator of its combined circuit is zero.

That is the statement that every table's looker fractions sum to the table's own.

It is a `debug_assert_eq!`, so a release prover with a mismatched witness gets no signal at the point that detects it.

It gets a verification failure much later, in a different crate, with nothing pointing back.

### The idea

Make each premise a real assertion.

None of them is proportional to the buffer they guard:

| check | work | guards |
|---|---|---|
| spare capacity | 2 subtractions, 2 comparisons | 2 buffers of $2^n$ words |
| sibling lengths | 3 slice lengths | 4 halves of $2^n$ words |
| lookup identity | 1 field comparison against zero | a $2^n$ circuit |

### The change

```
crates/ip-prover/src/fracaddcheck/circuit.rs
- debug_assert!(num_data.capacity() - num_data.len() >= out_len && ...)
+ assert!(num_data.capacity() - num_data.len() >= out_len && ...)
- debug_assert!([den_0, num_1, den_1].iter().all(|half| half.len() == out_len))
+ assert!([den_0, num_1, den_1].iter().all(|half| half.len() == out_len))

crates/ip-prover/src/logup_star/prove.rs
- debug_assert_eq!(top_root.num.get(0), F::ZERO, ...)
+ assert_eq!(top_root.num.get(0), F::ZERO, ...)
```

The logUp* site also gains two comment lines stating why the comparison is affordable in every build.

### Soundness

Nothing about the protocol moves.

An assertion that already held in debug still holds; it is now also enforced in release.

The lookup identity is a diagnostic, not a soundness gate — the verifier supplies the zero itself, so a false witness could never produce an accepting proof either way.

### Scope

- **changed:** two assertion macros in the fractional-addition circuit builder, one in the logUp* prover.
- **untouched:** every other `debug_assert` in the crate — only the ones a safety argument or a witness identity rests on are promoted.

### Verification

Run on this machine, all clean:

- `cargo test -p binius-ip-prover` — 106 passed
- `cargo test -p binius-ip-prover --release` — 105 passed, 1 pre-existing failure (`logup_star::prove::tests::test_out_of_range_index_panics`, which fails identically on `main` and is fixed separately)
- `cargo test -p binius-prover` — 98 passed, exercises the product-check and fractional-addition paths end to end
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps`
- `cargo +nightly fmt --all --check`, `typos crates/ip-prover/`, `cargo check --workspace --all-targets`

The release leg is the one that matters here: it is the first time these three checks have ever executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)