### PR TITLE
BINIUS-592: Assert that a ZK mask covers the round polynomial it masks

### DIFF
--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -347,9 +347,17 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> MleCheckPr
 /// Returns [`ProveZKOutput`] containing the main polynomial's multilinear evaluations
 /// and the round challenges.
 ///
+/// # Pre-conditions
+///
+/// * The mask's univariate degree must be at least the degree of the main prover's round
+///   polynomials.
+/// * The two round polynomials are added coefficient by coefficient, so a shorter mask leaves the
+///   high-degree coefficients uncovered and the protocol is no longer hiding.
+///
 /// # Panics
 ///
 /// Panics if the main prover emits more than one round polynomial.
+/// Panics if the mask's round polynomial is shorter than the main prover's.
 pub fn prove<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>(
 	mut main_prover: impl MleCheckProver<F>,
 	mask: Mask<P, Data>,
@@ -384,6 +392,21 @@ pub fn prove<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>(
 		let mask_round_coeffs = mask_round_coeffs_vec
 			.pop()
 			.expect("mask prover has 1 claim");
+
+		// The batching below pads the shorter polynomial with zeros, so any coefficient beyond
+		// the mask's degree would reach the channel exactly as the witness produced it.
+		//
+		//     main   : [a_0, a_1, a_2]
+		//     mask   : [b_0, b_1]      -> padded to [b_0, b_1, 0]
+		//     batched: [a_0 + c*b_0, a_1 + c*b_1, a_2]
+		//                                         ^^^ unmasked
+		assert!(
+			mask_round_coeffs.0.len() >= main_round_coeffs.0.len(),
+			"the mask round polynomial has {} coefficients against the main round polynomial's \
+			 {}, so the excess would be sent unmasked",
+			mask_round_coeffs.0.len(),
+			main_round_coeffs.0.len()
+		);
 
 		// Batch the round coefficients: batched = main + batch_challenge * mask
 		let batched_round_coeffs = main_round_coeffs + &(mask_round_coeffs * batch_challenge);
@@ -540,11 +563,8 @@ mod tests {
 		assert_eq!(output.multilinear_evals[0], expected_eval);
 	}
 
-	#[test]
-	fn test_prove() {
+	fn test_prove_with_degrees(main_degree: usize, mask_degree: usize) {
 		let n_vars = 6;
-		let main_degree = 2;
-		let mask_degree = 2;
 		let mut rng = StdRng::seed_from_u64(0);
 
 		// Generate random main mask buffer (using Mask as a simple MleCheckProver for testing)
@@ -608,6 +628,38 @@ mod tests {
 		let zk_mask = Mask::new(n_vars, mask_degree, zk_buffer.as_view());
 		let expected_mask_eval = evaluate_mask_polynomial(&zk_mask, &challenge_point);
 		assert_eq!(mask_eval, expected_mask_eval);
+	}
+
+	#[test]
+	fn test_prove() {
+		// Both round polynomials carry three coefficients, so every one of them is covered.
+		test_prove_with_degrees(2, 2);
+	}
+
+	#[test]
+	fn test_prove_mask_above_main_degree() {
+		// A mask that overshoots is still hiding.
+		//
+		//     main   : [a_0, a_1]
+		//     mask   : [b_0, b_1, b_2]
+		//     batched: [a_0 + c*b_0, a_1 + c*b_1, c*b_2]
+		//
+		// The verifier is told the batched degree, so the proof still checks out.
+		test_prove_with_degrees(1, 2);
+	}
+
+	#[test]
+	#[should_panic(expected = "would be sent unmasked")]
+	fn test_prove_mask_below_main_degree() {
+		// A mask one degree short leaves the top coefficient of every round in the clear.
+		//
+		//     main   : [a_0, a_1, a_2]
+		//     mask   : [b_0, b_1]      -> zero-padded to [b_0, b_1, 0]
+		//     batched: [a_0 + c*b_0, a_1 + c*b_1, a_2]
+		//                                         ^^^ witness-dependent, unmasked
+		//
+		// The transcript truncates the constant term, so this coefficient is sent every round.
+		test_prove_with_degrees(2, 1);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-592](https://linear.app/jimpo/issue/BINIUS-592).

Refuses a Libra mask whose degree is below the round polynomial it is supposed to hide.
Prover-side precondition only — the transcript is byte-for-byte unchanged on every input that was already valid.

### The problem

The ZK MLE-check hides each round polynomial by adding a random mask polynomial to it, then sends the sum.

That addition is the coefficient-wise sum of two univariates, and it zero-pads the shorter side.

So a mask of lower degree than the main prover's round polynomial contributes a zero to the top coefficients.
Those coefficients ship exactly as the witness produced them.

Nothing compared the two degrees, and no precondition said they had to be compared.

### The evidence

Same quadratic main prover, run twice with mask buffers drawn from two different seeds.
Reading the top coefficient of round 1 straight off the transcript:

| mask degree | seed 11 | seed 22 |
|---|---|---|
| 2 | `0x8a0a0156a6c9c5259c768960fc6d95ec` | `0x8e302ec31945a5a66a87b270f786557a` |
| 1 | `0x166d45842a6f3545de2674d5410142c3` | `0x166d45842a6f3545de2674d5410142c3` |

A degree-2 mask moves the coefficient and moves it differently per seed — the mask is doing its job.
A degree-1 mask leaves it bit-identical across seeds, because it never reached that coefficient.

One witness-dependent $\mathbb{F}_{2^{128}}$ element in the clear, every round.

(The MLE-check round proof truncates the *constant* coefficient, not the top one, so the leaking coefficient is genuinely on the wire.)

### The change

One comparison per round, before the batching step.

```
main   : [a_0, a_1, a_2]
mask   : [b_0, b_1]      -> zero-padded to [b_0, b_1, 0]
batched: [a_0 + c*b_0, a_1 + c*b_1, a_2]
                                    ^^^ unmasked
```

The invariant enforced is: **every coefficient of the main round polynomial has a partner in the mask's**.
That is "at least as many coefficients", not "exactly as many" — a longer mask still hides, and the verifier is told the batched degree independently.
A test pins that overshoot case so nobody later tightens the relation to equality.

### Soundness

- The check runs before anything is written, so an accepted run produces the identical transcript.
- The masking algebra itself was already correct — the audit of the Libra prime polynomial found no defect. Only the contract between the two degrees was missing.
- The one live caller already satisfies it: the Spartan prover pairs a degree-2 mask with a quadratic composition. The hazard was that this pairing lived as a comment in another crate, so a cubic composition added later would have broken hiding with no signal.

### Scope

- **changed:** the batching step and the proving routine's docs in `crates/ip-prover/src/sumcheck/zk_mlecheck.rs`
- **tests:** the existing end-to-end test is parameterized by the two degrees, then driven at equal, over-, and under-degree
- **untouched:** the mask type, the mask prover, the verifier, and every other crate

### Verification

The new test was watched failing before it was trusted:

- assert removed → `test_prove_mask_below_main_degree ... FAILED` (`test did not panic as expected`)
- assert restored → 9 passed in the module, 108 passed in the crate

Gates, all clean:

- `cargo test -p binius-ip-prover` — 108 passed
- `cargo test -p binius-ip-prover --release` — 107 passed, 1 pre-existing failure (`logup_star::prove::tests::test_out_of_range_index_panics`, unrelated to this change and failing on `main` too)
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps`
- `cargo +nightly fmt --all --check`, `typos crates/ip-prover/`, `cargo check --workspace --all-targets`
- `cargo test -p binius-spartan-prover` — the live caller, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)