### PR TITLE
BINIUS-593: Resolve a hint's handler once per instruction, not once per instance

### DIFF
--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -449,12 +449,12 @@ impl<'a> Executor<'a> {
 
 		let mut inputs: SmallVec<[Word; 8]> = smallvec![Word::ZERO; n_inputs];
 		let mut outputs: SmallVec<[Word; 8]> = smallvec![Word::ZERO; n_outputs];
+		let handler = self.hints.handler(hint_id);
 		for i in 0..ctx.n_instances() {
 			for (input, &reg) in inputs.iter_mut().zip(&input_regs) {
 				*input = ctx.load(reg, i);
 			}
-			self.hints
-				.execute(hint_id, &dimensions, &inputs, &mut outputs);
+			handler.execute(&dimensions, &inputs, &mut outputs);
 			for (&reg, &output) in output_regs.iter().zip(&outputs) {
 				ctx.store(reg, i, output);
 			}

--- a/crates/frontend/src/ir/hints.rs
+++ b/crates/frontend/src/ir/hints.rs
@@ -7,12 +7,10 @@
 //! They can be used for operations that require many constraints to compute but few constraints
 //! to verify.
 
-use std::{
-	collections::HashMap,
-	hash::{DefaultHasher, Hash, Hasher},
-};
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use binius_core::Word;
+use rustc_hash::FxHashMap;
 
 pub type HintId = u32;
 
@@ -77,7 +75,7 @@ pub fn hint_id_of(name: &str) -> HintId {
 ///
 /// `Hint` itself is not dyn-compatible because it carries an associated `const NAME`.
 /// A blanket impl adapts any `Hint` to this trait.
-trait ErasedHint: Send + Sync {
+pub(crate) trait ErasedHint: Send + Sync {
 	fn shape(&self, dimensions: &[usize]) -> (usize, usize);
 	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]);
 }
@@ -97,13 +95,13 @@ impl<T: Hint> ErasedHint for T {
 /// Registration is idempotent: the same hint type always hashes to the same id, so a second
 /// call to [`HintRegistry::register`] with the same concrete type is a no-op.
 pub struct HintRegistry {
-	handlers: HashMap<HintId, Box<dyn ErasedHint>>,
+	handlers: FxHashMap<HintId, Box<dyn ErasedHint>>,
 }
 
 impl HintRegistry {
 	pub fn new() -> Self {
 		Self {
-			handlers: HashMap::new(),
+			handlers: FxHashMap::default(),
 		}
 	}
 
@@ -127,7 +125,14 @@ impl HintRegistry {
 		inputs: &[Word],
 		outputs: &mut [Word],
 	) {
-		self.handlers[&hint_id].execute(dimensions, inputs, outputs);
+		self.handler(hint_id).execute(dimensions, inputs, outputs);
+	}
+
+	/// Resolve the handler registered under `hint_id`.
+	///
+	/// Lets a caller invoking one hint many times pay for the lookup once.
+	pub(crate) fn handler(&self, hint_id: HintId) -> &dyn ErasedHint {
+		&*self.handlers[&hint_id]
 	}
 }
 


### PR DESCRIPTION
Closes [BINIUS-593](https://linear.app/jimpo/issue/BINIUS-593).

Resolves a hint gate's handler once per instruction instead of once per instance, and stops hashing a `u32` key with SipHash.
Pure optimization — no behavior change, no change to what a hint computes or how it is identified.

### The problem

Batched witness generation runs one bytecode instruction across every instance before moving to the next.

For a hint gate, the inner loop is:

```
for i in 0..n_instances {
    load the input registers for instance i
    hints.execute(hint_id, dimensions, inputs, outputs)
    store the output registers for instance i
}
```

`hints.execute` begins by looking the handler up in a map keyed by `hint_id`.

Two things are wrong with that.

**The key never changes.** `hint_id` is decoded once from the instruction and is constant for the whole loop.
Every iteration after the first re-derives an answer it already had.

**The compiler cannot hoist it.** The lookup goes through a `&self` method on a registry the optimizer cannot prove is unaliased across the `ctx` mutations in the loop body, so it stays inside.

And the map was a `std::collections::HashMap`, whose default hasher is SipHash — a cryptographic-strength hash, applied to a 32-bit integer, once per instance.

At $2^{12}$ instances a single hint gate hashes the same key 4096 times to find the same handler 4096 times.
Measured, that is ~27 cycles of overhead in front of a call that should cost about 2.

### The change

Two halves.

**Resolve once.** `HintRegistry` gains a resolver that hands back the handler; `exec_hint` calls it before the loop.

```diff
+ let handler = self.hints.handler(hint_id);
  for i in 0..ctx.n_instances() {
      for (input, &reg) in inputs.iter_mut().zip(&input_regs) {
          *input = ctx.load(reg, i);
      }
-     self.hints
-         .execute(hint_id, &dimensions, &inputs, &mut outputs);
+     handler.execute(&dimensions, &inputs, &mut outputs);
      for (&reg, &output) in output_regs.iter().zip(&outputs) {
          ctx.store(reg, i, output);
      }
  }
```

**Stop paying SipHash for an integer key.** `handlers` moves from `HashMap` to `rustc_hash::FxHashMap`.

This is the same reasoning already applied to `GateGraph::const_pool` and to `pass/cse.rs`, and it makes the remaining `shape` lookups cheaper too.

`HintRegistry::execute` stays, now expressed in terms of the resolver.
Constant propagation calls it once per gate, where there is no loop to hoist out of.

### How this relates / what it is not

**The API-surface decision.** `ErasedHint` was private to its module, and `HintRegistry` is reachable from outside the crate — `pub use ir::hints::{self, Hint}` re-exports the `hints` module wholesale.

So a `pub fn handler(..) -> &dyn ErasedHint` would have made a private trait part of the public API by leakage.

I checked every caller first. `HintRegistry` is only ever named inside `binius-frontend`; downstream crates use the `Hint` trait and `CircuitBuilder::call_hint`, never the registry.

So the narrowest surface that works is `pub(crate)` on both: `ErasedHint` becomes crate-visible, and the resolver is `pub(crate)`.
**No public API changes.**

Two alternatives were considered and rejected.
Making `ErasedHint` `pub` would commit the crate to a dyn-dispatch shape it may want to change, in exchange for nothing any caller asked for.
An opaque wrapper type would add a type to the surface for no benefit while every caller is in-crate.

**What this is not.** Hint *identity* is untouched.
`hint_id_of` still folds a 64-bit hash down to 32 bits, and `register` still silently keeps the first handler on a collision.
Both are real problems, and both belong to their own separate issue rather than being smuggled in here.

### Scope

- **changed:** `crates/frontend/src/ir/hints.rs` — map type, the new resolver, `ErasedHint` visibility.
- **changed:** `crates/frontend/src/eval_form/exec.rs` — `exec_hint` only; the other opcodes are untouched.
- **unchanged:** hint identity, arity, dispatch semantics, and the public API.

### Verification

- `cargo test -p binius-frontend` (debug, so `debug_assert!` fires) — 259 + 1 + 1 + 2 + 2 pass.
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend --release` — same, all pass.
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --document-private-items --no-deps` — clean.
- `cargo +nightly-2026-07-01 fmt --all --check` — clean.
- `cargo check --workspace --all-targets` — clean.
- `cargo build -p binius-circuits -p binius-recursion -p binius-m4-prover --tests` — clean.
- `python3 tools/check_copyright_notice.py` and `typos` — clean.

The correctness proof is `tests/crc64_chip.rs`: a chip-accelerated CRC-64 circuit where every register state comes from a hint and is checked against a reference implementation. Green.
The builder hint tests and the two hint proptests in `pass/cse.rs` also cover this path.

### Benchmark

AMD Ryzen 9 9950X3D, `RUSTFLAGS="-Ctarget-cpu=native"`, best-of-10 within a run, median of 5 interleaved before/after rounds.

| fixture | before | after | speedup |
|---|---|---|---|
| one-XOR hint, 512 gates $\times$ 4096 instances, serial | 9.93 ns | 2.52 ns | **3.9×** |
| CRC-64 chip, 64 hint gates $\times$ 4096 instances, serial | 49.17 ns | 43.89 ns | 1.12× |
| CRC-64 chip, same, parallel wall-clock | 4.51 ns | 3.96 ns | 1.14× |

All figures are nanoseconds per hint invocation.

**Read the two rows together, and prefer the second.**
The synthetic fixture exaggerates the ratio on purpose: its hint body is a single XOR, so dispatch overhead is nearly the whole cost and removing it looks like a 3.9× win.

The CRC-64 hint does real work — 64 rounds of a bit-at-a-time loop — so the same saving is only 1.12× of its total.

What actually carries over is the **absolute** saving: ~5–7 ns removed from every hint invocation, whatever the hint body costs.
That is the number to use when estimating a circuit, and it scales with invocation count, so it matters most on the M4 chip path where every registered gadget call becomes a hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
