### PR TITLE
BINIUS-594: Fix the contradictory layout docs on the ZK mask buffer

### DIFF
--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -101,8 +101,8 @@ pub struct Mask<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
 	/// Degree of each univariate polynomial (d)
 	degree: usize,
 	/// Coefficients stored as a FieldBuffer with log_len = m_n + m_d.
-	/// Layout: row i contains [g_i(0), g_i(1), ..., g_i(d), 0, ..., 0]
-	/// where row i spans indices [i * 2^m_d, (i+1) * 2^m_d).
+	/// Layout: row i contains the monomial coefficients [a_{i,0}, ..., a_{i,d}, 0, ..., 0].
+	/// Row i spans indices [i * 2^m_d, (i+1) * 2^m_d).
 	buffer: FieldBuffer<P, Data>,
 }
 
@@ -145,7 +145,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 		self.buffer.get(var_index * row_stride + coeff_index)
 	}
 
-	/// Returns coefficients for variable i as an iterator over [g_i(0), g_i(1), ..., g_i(d)].
+	/// Returns the monomial coefficients [a_{i,0}, a_{i,1}, ..., a_{i,d}] for variable i.
 	pub fn coeffs_for_var(&self, var_index: usize) -> impl Iterator<Item = F> + '_ {
 		debug_assert!(var_index < self.n_vars);
 		let m_d = self.log_degree_plus_one();

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -101,7 +101,7 @@ pub struct Mask<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
 	/// Degree of each univariate polynomial (d)
 	degree: usize,
 	/// Coefficients stored as a FieldBuffer with log_len = m_n + m_d.
-	/// Layout: row i contains the monomial coefficients [a_{i,0}, ..., a_{i,d}, 0, ..., 0].
+	/// Layout: row i contains the monomial coefficients [g_{i,0}, ..., g_{i,d}, 0, ..., 0].
 	/// Row i spans indices [i * 2^m_d, (i+1) * 2^m_d).
 	buffer: FieldBuffer<P, Data>,
 }
@@ -145,7 +145,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 		self.buffer.get(var_index * row_stride + coeff_index)
 	}
 
-	/// Returns the monomial coefficients [a_{i,0}, a_{i,1}, ..., a_{i,d}] for variable i.
+	/// Returns the monomial coefficients [g_{i,0}, g_{i,1}, ..., g_{i,d}] for variable i.
 	pub fn coeffs_for_var(&self, var_index: usize) -> impl Iterator<Item = F> + '_ {
 		debug_assert!(var_index < self.n_vars);
 		let m_d = self.log_degree_plus_one();


### PR DESCRIPTION
Closes [BINIUS-594](https://linear.app/jimpo/issue/BINIUS-594).

Docs only — no code, no behavior change.

### The problem

The ZK mask buffer stores, per variable, one univariate of degree $d$ as a row of $d+1$ field elements.

Two doc comments call that row a list of **evaluations** at the points $0, \dots, d$.
A third, fourteen lines away, calls the same row **monomial coefficients**.

```
field doc      : row i contains [g_i(0), g_i(1), ..., g_i(d), 0, ..., 0]     <- evaluations
row accessor   : returns [g_i(0), g_i(1), ..., g_i(d)]                       <- evaluations
coeff accessor : the coefficient of X^j in g_i                               <- monomial
```

These are the docs somebody reads to fill the buffer.

### Which reading is right

Monomial, on three independent counts:

- The single-coefficient accessor is documented as the coefficient of `X^j`.
- Evaluating a row runs Horner's method over it, which is monomial evaluation. The evaluation at 1 is then read off as the sum of the whole row, which is only true for coefficients.
- The powers tensor used for the final opening is built as `r[j]^k`. Its inner product with the buffer is `sum_j sum_k a_{j,k} * r_j^k`, which equals the mask at `r` only under the monomial reading — and an existing test pins exactly that equality.

So the code is monomial throughout and self-consistent. Only the two doc lines disagree.

### Why it matters

A caller who follows the evaluation-notation docs fills the buffer with the wrong numbers.

The mask is still uniformly random, so the proof still hides.
It just does not verify, and the failure surfaces in the verifier, far from the mistake.

### The change

```diff
-/// Layout: row i contains [g_i(0), g_i(1), ..., g_i(d), 0, ..., 0]
-/// where row i spans indices [i * 2^m_d, (i+1) * 2^m_d).
+/// Layout: row i contains the monomial coefficients [a_{i,0}, ..., a_{i,d}, 0, ..., 0].
+/// Row i spans indices [i * 2^m_d, (i+1) * 2^m_d).

-/// Returns coefficients for variable i as an iterator over [g_i(0), g_i(1), ..., g_i(d)].
+/// Returns the monomial coefficients [a_{i,0}, a_{i,1}, ..., a_{i,d}] for variable i.
```

The evaluation notation elsewhere in the file is left alone — the MLE formula genuinely does read the univariate at 0 and 1, so `g_i(0)` and `g_i(1)` are correct there.

### Verification

- `cargo test -p binius-ip-prover` — 106 passed
- `cargo test -p binius-ip-prover --release` — 105 passed, 1 pre-existing failure (`logup_star::prove::tests::test_out_of_range_index_panics`, unrelated and failing on `main` too)
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps`
- `cargo +nightly fmt --all --check`, `typos crates/ip-prover/`, `cargo check --workspace --all-targets`, `cargo test -p binius-spartan-prover` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)