### PR TITLE
BINIUS-595: Stop zeroing the batch witness destination buffer that the gather then fully overwrites

### DIFF
--- a/crates/frontend/src/artifact/circuit.rs
+++ b/crates/frontend/src/artifact/circuit.rs
@@ -3,6 +3,8 @@
 
 //! The artifact a build hands back: a constraint system plus what it takes to fill a witness.
 
+use std::mem::MaybeUninit;
+
 use binius_compute::{Allocator, BufferData, VecLike};
 use binius_core::{
 	ValueTable,
@@ -342,11 +344,10 @@ impl Circuit {
 		// Each tile below gathers into one contiguous stripe of its columns.
 		let data_len = n_hidden_words << log_instances;
 		let mut data = alloc.alloc::<Word>(data_len);
-		data.resize(data_len, Word::ZERO);
 		{
-			let dest =
-				StridedArray2DViewMut::without_stride(&mut data, n_hidden_words, n_instances)
-					.expect("n_hidden_words * n_instances == data.len() by construction");
+			let spare = &mut data.spare_capacity_mut()[..data_len];
+			let dest = StridedArray2DViewMut::without_stride(spare, n_hidden_words, n_instances)
+				.expect("n_hidden_words * n_instances == spare.len() by construction");
 
 			(0..n_instances)
 				.into_par_iter()
@@ -384,7 +385,8 @@ impl Circuit {
 					// Gather the tile's hidden rows into their real position in the batch.
 					for row in 0..n_hidden_words {
 						for local in 0..tile_width {
-							dest_stripe[(row, local)] = tile_view[(row + offset_inout, local)];
+							dest_stripe[(row, local)] =
+								MaybeUninit::new(tile_view[(row + offset_inout, local)]);
 						}
 					}
 
@@ -392,6 +394,12 @@ impl Circuit {
 				})
 				.collect::<Result<Vec<()>, _>>()?;
 		}
+
+		// SAFETY: `data_len` slots must be initialized. The stripes tile `0..n_instances` and each
+		// writes all `n_hidden_words` rows of its own columns, so the gather covers every slot,
+		// short final stripe included. On the error path the `?` above returns first and the
+		// length stays zero. Narrowing the gather's row or column range would break this.
+		unsafe { data.set_len(data_len) };
 
 		Ok(ValueTable::from_hidden_words(layout, log_instances, data))
 	}
@@ -450,7 +458,7 @@ impl Circuit {
 mod tests {
 	use std::ops::IndexMut;
 
-	use binius_compute::GlobalAllocator;
+	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_core::{ValueVec, constraint_system::InoutSegment};
 	use proptest::prelude::*;
 
@@ -639,6 +647,61 @@ mod tests {
 				"stripe width {stripe_width} changed the populated table"
 			);
 		}
+	}
+
+	#[test]
+	fn parallel_population_overwrites_every_word_of_a_recycled_buffer() {
+		let c = mix_circuit();
+		let log_instances = 10;
+		let n_instances = 1usize << log_instances;
+		let fill = |i: usize, w: &mut BatchWitnessFiller<'_, '_>| {
+			c.fill(w, (i as u64).wrapping_mul(0x9e37_79b9), i as u64 ^ 0xdead_beef);
+		};
+
+		let serial = c
+			.circuit
+			.populate_batch(&GlobalAllocator, log_instances, fill)
+			.unwrap();
+
+		let n_hidden_words = c
+			.circuit
+			.constraint_system()
+			.n_hidden_words(InoutSegment::Hidden);
+		let data_len = n_hidden_words * n_instances;
+		let pool = BufferPool::new();
+		let mut poison = pool.alloc_vec::<Word>(data_len);
+		poison.resize(data_len, Word(0xa5a5_a5a5_a5a5_a5a5));
+		drop(poison);
+
+		// The destination is the first allocation the parallel path makes, so it draws that block
+		// back: a word the gather missed would still read as the sentinel.
+		let parallel = c
+			.circuit
+			.populate_batch_parallel(&&pool, log_instances, fill)
+			.unwrap();
+		assert_eq!(parallel.as_words(), serial.as_words());
+	}
+
+	#[test]
+	fn parallel_failure_in_a_short_final_stripe_reports_its_instance() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Width 3 over 8 instances leaves a short final stripe holding instances 6 and 7.
+		// Instance 7 fails there, so the destination is abandoned mid-gather.
+		let result =
+			circuit.populate_batch_parallel_with_stripe_width(&GlobalAllocator, 3, 3, |i, w| {
+				w[a] = Word(i as u64);
+				w[b] = Word(if i == 7 { 99 } else { i as u64 });
+			});
+
+		let err = result.expect_err("instance 7 violates a == b");
+		assert_eq!(err.instance, 7);
+		assert_eq!(err.source.total, 1);
 	}
 
 	#[test]

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -111,24 +111,28 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	where
 		T: Send + Sync,
 	{
-		self.cols
-			.clone()
-			.into_par_iter()
-			.step_by(stride)
-			.map(move |start| {
-				let end = (start + stride).min(self.cols.end);
-				// We are setting the same lifetime as `self` captures.
-				Self {
-					// Safety: different instances of StridedArray2DViewMut created with the same
-					// data slice do not access overlapping indices.
-					data: unsafe {
-						slice::from_raw_parts_mut(self.data.as_ptr().cast_mut(), self.data.len())
-					},
-					data_width: self.data_width,
-					height: self.height,
-					cols: start..end,
-				}
-			})
+		let Self {
+			data,
+			data_width,
+			height,
+			cols,
+		} = self;
+		let data_ptr = SendPtr(data.as_mut_ptr());
+		let data_len = data.len();
+		let cols_end = cols.end;
+
+		cols.into_par_iter().step_by(stride).map(move |start| {
+			let end = (start + stride).min(cols_end);
+			Self {
+				// Safety: the pointer is taken from the mutable slice above, outside the
+				// closure, which can capture only by shared borrow. Different instances created
+				// from the same data slice do not access overlapping indices.
+				data: unsafe { slice::from_raw_parts_mut(data_ptr.as_ptr(), data_len) },
+				data_width,
+				height,
+				cols: start..end,
+			}
+		})
 	}
 
 	/// Returns iterator over single-column mutable views of the data.


### PR DESCRIPTION
Closes [BINIUS-595](https://linear.app/jimpo/issue/BINIUS-595).

Stops initializing the parallel batch witness destination buffer, which the gather then overwrites in full.
No change to what the buffer ends up holding — only to when it is initialized.

### The problem

The parallel batch witness path allocates the destination value table, fills it with zeros, then overwrites every single word of it.

The fill runs in the caller, before any worker thread starts.

So it is serial time sitting in front of an otherwise fully parallel routine — the one term that does not shrink when you add cores.

On a Keccak-f1600 permutation circuit at $2^{13}$ instances the buffer is 625 rows by 8192 columns, or 41 MB.

### The idea

The parallel region cuts the instance range into stripes, and every stripe writes **all** of its rows.

One worked count:

```
gather writes:  625 rows x 8192 instances = 5,120,000 words
buffer holds:                               5,120,000 words
```

Every slot is written before anything reads it, so the fill contributes nothing that survives.

### The change

Hand the parallel region the buffer's spare capacity, and commit the length only once every stripe has returned successfully.

```diff
- data.resize(data_len, Word::ZERO);
- let dest = StridedArray2DViewMut::without_stride(&mut data, n_hidden_words, n_instances)?;
+ let spare = &mut data.spare_capacity_mut()[..data_len];
+ let dest = StridedArray2DViewMut::without_stride(spare, n_hidden_words, n_instances)?;
  ... the parallel region writes every slot ...
+ unsafe { data.set_len(data_len) };
```

The strided view is generic in its element type, so it takes `&mut [MaybeUninit<Word>]` as readily as `&mut [Word]`.

Keeping the element type uninitialized all the way down is what avoids a cast: the stripes only ever hold `&mut MaybeUninit<Word>`, which is valid to point at uninitialized memory, so nothing here rests on `Word` being plain data.

That leaves exactly one `unsafe` in the change — the `set_len` — rather than a laundering cast repeated at the write site.

### Soundness

This is the frontend crate's first `unsafe`, so the argument is stated in full.

**The invariant.** The stripes tile `0..n_instances`, and each writes all `n_hidden_words` rows of its own columns, so the gather covers every one of the `data_len` slots.

**What enforces it.** `parallel_population_matches_serial_for_varied_stripe_widths` sweeps widths 1, 2, 3, 8, 64, 256, 1024 and 4096 against a 1024-instance batch.

Widths 3 and 4096 do not divide the batch, which is precisely the case where a short final stripe could leave slots uninitialized. That test is why this change is safe.

**The error path.** If any stripe fails, `?` returns before the length is ever committed, so the buffer is dropped at length zero: nothing uninitialized is read, and nothing is dropped.

`parallel_failure_in_a_short_final_stripe_reports_its_instance` pins this, driving a failing batch at a width that does not divide the instance count.

**What would break it.** Narrowing the gather's row or column range, or committing the length before the stripes are collected.

**Proof soundness is untouched.** This changes when a buffer is initialized, not what it ends up holding. Every instance still goes through `ConstraintSystem::verify` in `every_instance_satisfies_the_constraint_system`, and the batch is still pinned to the single-instance reference by the existing proptest.

### The pre-existing aliasing defect this uncovers

`StridedArray2DViewMut::into_par_strides` derived its write pointer from `as_ptr().cast_mut()` — a *shared* reborrow — and then wrote through it.

Under Tree Borrows the parent tag is `Frozen`, so **every stripe write was undefined behaviour**. On `main`, today, independent of this change.

`par_iter_cols`, a few lines below in the same file, already had the right shape: hoist `SendPtr(data.as_mut_ptr())` out before the closure. This matches it.

```diff
- data: unsafe { slice::from_raw_parts_mut(self.data.as_ptr().cast_mut(), self.data.len()) },
+ let data_ptr = SendPtr(data.as_mut_ptr());   // taken outside the closure
+ data: unsafe { slice::from_raw_parts_mut(data_ptr.as_ptr(), data_len) },
```

It lands here because without it Miri cannot reach this change's `unsafe` at all — the run aborts on the first stripe write.

`into_par_strides` has exactly one caller in the workspace, the one this PR touches.

### Scope

- **changed:** the destination buffer in `populate_batch_parallel_with_stripe_width`
- **changed:** `into_par_strides` in `binius-utils`, the aliasing fix above
- **new:** two tests — the error path at a non-dividing stripe width, and a recycled pool block proving every word really is overwritten
- **left untouched:** the per-tile working buffer and the serial path's buffer, which stay zeroed because a witness wire the caller never assigns must read as zero
- **left untouched:** the interpreter and the gather's element-wise indexing

### Known, not addressed here

`iter_cols` / `par_iter_cols` hand out sibling column views that each hold a `&mut` over the *whole* backing slice.

Tree Borrows rejects that as soon as two siblings are live at once, which `test_col_mut_indexing` and `test_parallel_strides` both do.

That is a separate design issue in `binius-utils`, pre-existing and off this PR's path — the frontend consumes each stripe inside one closure invocation, which is clean.

### Verification

Local, since fork PR workflows need maintainer approval before CI reports anything.

- `cargo test -p binius-frontend -p binius-utils` (debug, so `debug_assert!` fires) — 297 passed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend -p binius-utils --release` — 297 passed
- `cargo check --workspace --all-targets` — clean
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend -p binius-utils --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos`, copyright — clean

**Miri, on the tests that exercise the new `unsafe`:**

| model | result |
|---|---|
| Tree Borrows | **5 passed, 0 failed** |
| Stacked Borrows | blocked in `crossbeam-epoch` 0.9.20 |

Stacked Borrows aborts inside `crossbeam-epoch::internal::Global::try_advance`, on a rayon worker's thread-local registration, before any of this crate's code runs.

That reproduces identically on `main` for the pre-existing `parallel_unsatisfiable_instance_reports_global_index_across_stripes`, so it is a dependency incompatibility rather than a finding against this change.

`-Zmiri-disable-isolation` is needed either way, because proptest's failure-persistence file probe is an unsupported filesystem operation under isolation.

The trailing "main thread terminated without waiting for all remaining threads" is rayon's global pool never being joined at exit; it is reported after the passing test result.

### Benchmark

Keccak-f1600 permutation circuit, 2760 gates, $2^{13}$ instances, tile 256, `BufferPool` held across iterations, `-Ctarget-cpu=native`, AMD Ryzen 9 9950X3D (16c/32t).

201 reps per run, reported at the 25th percentile; both binaries interleaved over three rounds to cancel thermal drift.

| threads | baseline | this PR | ratio |
|---|---|---|---|
| 1 | 23.41 ms | 24.14 ms | 0.97× |
| 4 | 7.19 ms | 6.58 ms | 1.09× |
| 16 | 3.66 ms | 2.65 ms | 1.38× |
| 32 (all) | 4.38 ms | 2.83 ms | **1.55×** |

The win grows with thread count, which is the signature of removing a serial term: the fill never got faster with more cores, so it dominated more and more of the parallel wall time.

At one thread the change is a ~3% regression, and reproducibly so. The fill was a large streaming memset, which writes without pulling lines in for ownership; removing it makes the gather's scattered writes miss cold instead. With one thread there is no serial phase to amortize, so that trade is a small net loss. From four threads up the serial fill dominates and the trade pays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
