### PR TITLE
BINIUS-596: Report an out-of-range logUp* index from the scatter that already checks it

### DIFF
--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -1054,8 +1054,16 @@ mod tests {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let gamma = IPProverChannel::<F>::sample(&mut transcript);
 
-		// The table has 2^2 = 4 positions, so index value 4 is out of range.
-		// The range check is a debug_assert precondition, so this panics in debug builds.
+		// Fixture state: the table has 2^2 = 4 positions, addressed 0..=3.
+		//
+		// Mutation: row 1 of the looker asks for position 4.
+		//
+		//     table positions:  [0, 1, 2, 3]
+		//     index column:     [0, 4]
+		//                           ^ one past the end
+		//
+		// The scatter that builds the pushforward writes into one slot per table position.
+		// So the row is rejected whether or not assertions are compiled in.
 		let _ = prove::<GlobalAllocator, F, P>(
 			&alloc,
 			gamma,

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -46,6 +46,10 @@ type LogupWitnesses<P, A> = (Vec<Vec<FieldVec<P, A>>>, Vec<FieldVec<P, A>>);
 /// * `tables` is non-empty, every table has at least one looker, every looker's index column has
 ///   `2^n` entries for its own evaluation point length `n`, and every index entry is less than its
 ///   table's size.
+///
+/// # Panics
+///
+/// Panics if any precondition is violated.
 #[tracing::instrument(
 	skip_all,
 	level = "debug",
@@ -66,20 +70,6 @@ where
 	assert!(
 		tables.iter().all(|table| !table.lookers.is_empty()),
 		"every table must have at least one looker"
-	);
-	// Every index must address a real position in its table, for the embedding and pushforward to
-	// be valid. This is a precondition: the O(n) scan is compiled out of release builds. It is
-	// checked up front because an out-of-range index would otherwise surface as an opaque
-	// out-of-bounds panic inside the scatter-add.
-	debug_assert!(
-		tables.iter().all(|table| {
-			let table_size = 1usize << table.table.log_len();
-			table
-				.lookers
-				.iter()
-				.all(|looker| looker.index.iter().all(|&j| j < table_size))
-		}),
-		"every index entry must be less than the size of the table its looker reads"
 	);
 
 	// Build one numerator per looker, fanned out across all of them at once.
@@ -135,6 +125,9 @@ where
 	// The tables are walked one at a time rather than in parallel: each scatter is already parallel
 	// over the looker rows that dominate its cost, and drawing a buffer from `alloc` inside a rayon
 	// task is not available here.
+	//
+	// The scatter reads every index entry into a cube that spans exactly the table.
+	// So it is also where each index is checked to address a real table position.
 	let mut remaining = flat_numerators.as_slice();
 	let mut grouped_slices = Vec::with_capacity(tables.len());
 	for table in tables {
@@ -255,6 +248,10 @@ where
 /// ```
 ///
 /// The numerator is read sequentially, so each row is a lane read, not an indexed lookup.
+///
+/// # Panics
+///
+/// Panics if a row indexes past the last table position.
 #[inline]
 fn scatter_add<F, P>(acc: &mut [F], numerator: &FieldSlice<'_, P>, index: &[usize])
 where
@@ -262,8 +259,15 @@ where
 	P: PackedField<Scalar = F>,
 {
 	// Row i's numerator value lands in the table position that row indexes into.
+	//
+	// The accumulator spans exactly the table.
+	// So resolving the slot is the range check on the index column.
+	// That check is the one the write already pays for.
 	for (value, &target) in numerator.iter_scalars().zip(index) {
-		acc[target] += value;
+		let slot = acc
+			.get_mut(target)
+			.expect("every index entry must be less than the size of the table its looker reads");
+		*slot += value;
 	}
 }
 


### PR DESCRIPTION
Closes [BINIUS-596](https://linear.app/jimpo/issue/BINIUS-596).

Makes an out-of-range logUp* index report itself in release builds, using the bounds check the pushforward scatter already performs. No behavior change on any valid input.

### The problem

`cargo test -p binius-ip-prover --release` fails on `main` today.

```
test logup_star::prove::tests::test_out_of_range_index_panics - should panic ... FAILED

thread '...' panicked at crates/ip-prover/src/logup_star/witness.rs:266:9:
index out of bounds: the len is 4 but the index is 4
note: panic did not contain expected string
      panic message: "index out of bounds: the len is 4 but the index is 4"
 expected substring: "every index entry must be less than the size of the table"
```

The witness builder documents a precondition: every index entry addresses a real position in the table its looker reads.

It enforced that with a `debug_assert!` scanning every index column up front.

Release compiles the assertion out, so the message it carried goes with it.

What surfaces instead is a raw slice bounds check, from inside a rayon closure, naming a length and an offset with no hint about which protocol object went wrong.

CI never sees this: the Compile step is `cargo build --workspace --lib --bins --tests --examples`, debug, and nextest runs over that. No leg builds this crate with `debug_assertions` off.

### The idea

The check does not need to be added. It is already there.

The pushforward is a scatter-add: for each looker row, the numerator value is accumulated into the table position that row indexes into.

The accumulator holds exactly one slot per table position, sized `1 << table.table.log_len()`.

So every index entry is already used as an offset into a buffer spanning exactly the legal range, and the write already pays a bounds check on each one.

Name the failure at that write, instead of testing the same predicate a second time beforehand.

```
- acc[target] += value
+ let slot = acc.get_mut(target).expect("every index entry must be ...");
+ *slot += value;
```

Same branch, same cost, and the diagnostic now holds in every build profile.

### Why not promote the up-front scan

The obvious alternative is `debug_assert!` -> `assert!`. It works, but it is not free.

The scan is a serial pass over every index entry of every looker.

Measured at the `intmul` shape — 12 limb columns reading one $2^{16}$-row power table, `-Ctarget-cpu=native`, 32 cores:

| looker size | up-front scan | witness build | share of build | whole reduction | share of reduction |
|---|---|---|---|---|---|
| $2^{16}$ | 0.19 ms | 4.7 ms | 4% | 15 ms | 1.2% |
| $2^{20}$ | 3.2 ms | 38 ms | 9% | 194 ms | 1.7% |
| $2^{22}$ | 12.2 ms | 150 ms | 8% | 780 ms | 1.6% |

Roughly 8% of the witness build, for a predicate the scatter re-tests a moment later.

The scatter route costs nothing. Timing the two loop bodies alternately in one process, 2^22 rows into a $2^{16}$-row table, median of 25:

| scatter write | median |
|---|---|
| raw index | 5.70 ms |
| named slot | 5.70 ms |

Ratio 1.00x. The `expect` is the same compare-and-branch the index was already emitting; only the cold panic payload differs.

### Scope

- **changed:** `crates/ip-prover/src/logup_star/witness.rs` — the up-front scan is gone; the scatter's slot lookup carries the message.
- **changed:** `crates/ip-prover/src/logup_star/prove.rs` — comments on the existing test; its body is untouched.
- **left alone:** the CI workflow. Nothing still builds this crate with assertions off, so a future test pinned to a `debug_assert` message would repeat this. That is a separate change.

Not a protocol change. No transcript, witness, or proof bytes move.

### Verification

- `cargo test -p binius-ip-prover` — 106 passed, 0 failed.
- `cargo test -p binius-ip-prover --release` — 106 passed, 0 failed. This is red on `main`.
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps` — clean.
- `cargo +nightly-2026-07-01 fmt --all --check` — clean.
- `typos crates/ip-prover/` — clean.
- `cargo check --workspace --all-targets` — clean.
- Downstream callers of the reduction: `cargo test -p binius-iop-prover --release logup` and `cargo test -p binius-prover --release intmul` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
