### PR TITLE
BINIUS-597: Bench the three-column quadratic MLE check and the logUp* table denominator

### DIFF
--- a/crates/ip-prover/Cargo.toml
+++ b/crates/ip-prover/Cargo.toml
@@ -33,3 +33,11 @@ default = []
 [[bench]]
 name = "bivariate_product"
 harness = false
+
+[[bench]]
+name = "quadratic_mlecheck"
+harness = false
+
+[[bench]]
+name = "logup_star_witness"
+harness = false

--- a/crates/ip-prover/benches/logup_star_witness.rs
+++ b/crates/ip-prover/benches/logup_star_witness.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 The Binius Developers
+
+//! Benchmarks the logUp* table-side denominator build.
+//!
+//! The build is one pass over a table's whole cube, so it scales with the table and not the lookup.
+
+use binius_compute::BufferPool;
+use binius_field::{FieldOps, arch::OptimalPackedB128};
+use binius_ip_prover::logup_star::witness::table_denominator;
+use binius_math::test_utils::random_scalars;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use rand::{SeedableRng, rngs::StdRng};
+
+type P = OptimalPackedB128;
+type F = <P as FieldOps>::Scalar;
+
+// Builds the denominator column of one table's fractional-addition circuit.
+fn bench_table_denominator(criterion: &mut Criterion) {
+	let mut group = criterion.benchmark_group("logup_star_witness/table_denominator");
+	let mut rng = StdRng::seed_from_u64(0);
+
+	// 2^8 is a byte table, 2^22 a large one; the span covers both ends of the realistic range.
+	for table_n_vars in [8, 12, 16, 20, 22] {
+		group.throughput(Throughput::Elements(1 << table_n_vars));
+		group.bench_function(format!("n_vars={table_n_vars}"), |bench| {
+			// One logUp challenge per table, drawn from the transcript in production.
+			let c = random_scalars::<F>(&mut rng, 1)[0];
+			let pool = BufferPool::new();
+			let alloc = &pool;
+
+			// Each run drops its buffer back into the pool, so no run pays for fresh pages.
+			bench.iter(|| table_denominator::<_, F, P>(&alloc, c, table_n_vars));
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(logup_star_witness, bench_table_denominator);
+criterion_main!(logup_star_witness);

--- a/crates/ip-prover/benches/quadratic_mlecheck.rs
+++ b/crates/ip-prover/benches/quadratic_mlecheck.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 The Binius Developers
+
+//! Benchmarks the MLE-check prover on the three-column quadratic composition `a * b - c`.
+//!
+//! That composition is the bit-AND constraint, the widest quadratic the crate proves.
+
+use binius_compute::BufferPool;
+use binius_field::{FieldOps, PackedField, arch::OptimalPackedB128};
+use binius_ip_prover::sumcheck::{
+	self, mle_store::MleStore, quadratic_mle_evaluator::QuadraticMleEvaluator,
+	round_evaluator::SharedMleCheckProver,
+};
+use binius_math::{
+	FieldBuffer,
+	multilinear::evaluate::evaluate_inplace,
+	test_utils::{random_field_buffer, random_scalars},
+};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{SeedableRng, rngs::StdRng};
+
+type P = OptimalPackedB128;
+type F = <P as FieldOps>::Scalar;
+type StdChallenger = HasherChallenger<sha2::Sha256>;
+
+// A bit-AND constraint vanishes exactly where the product of the two operands equals the result.
+fn and_constraint<Pf: PackedField>([a, b, c]: [Pf; 3]) -> Pf {
+	a * b - c
+}
+
+// The degree-2 part of that constraint, which is what the Karatsuba point at infinity reads.
+fn and_constraint_infinity<Pf: PackedField>([a, b, _c]: [Pf; 3]) -> Pf {
+	a * b
+}
+
+// The claim the MLE check opens: the composition's multilinear extension at the evaluation point.
+fn and_constraint_eval_claim(
+	a: &FieldBuffer<P>,
+	b: &FieldBuffer<P>,
+	c: &FieldBuffer<P>,
+	eval_point: &[F],
+) -> F {
+	let n_vars = eval_point.len();
+	// The composition is elementwise, so it applies a packed word at a time.
+	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
+	let composite = (0..packed_len)
+		.map(|i| and_constraint([a.as_ref()[i], b.as_ref()[i], c.as_ref()[i]]))
+		.collect::<Vec<_>>();
+	evaluate_inplace(FieldBuffer::new(n_vars, composite), eval_point)
+}
+
+// Proves one bit-AND constraint as an MLE-check claim: a shared MLE-check prover driving a single
+// three-column quadratic evaluator.
+fn bench_quadratic_mlecheck_and_constraint(criterion: &mut Criterion) {
+	let mut group = criterion.benchmark_group("quadratic_mlecheck/and_constraint");
+	let mut rng = StdRng::seed_from_u64(0);
+
+	// 2^22 is the size the bit-AND reduction runs at on a million-byte message.
+	for n_vars in [16, 20, 22] {
+		group.throughput(Throughput::Elements(1 << n_vars));
+		group.bench_function(format!("n_vars={n_vars}"), |bench| {
+			// Three unrelated columns: the constraint does not hold, which the prover never checks
+			// and which does not change the work it does.
+			let a_buffer = random_field_buffer::<P>(&mut rng, n_vars);
+			let b_buffer = random_field_buffer::<P>(&mut rng, n_vars);
+			let c_buffer = random_field_buffer::<P>(&mut rng, n_vars);
+
+			let eval_point = random_scalars::<F>(&mut rng, n_vars);
+			let eval_claim =
+				and_constraint_eval_claim(&a_buffer, &b_buffer, &c_buffer, &eval_point);
+			let transcript = ProverTranscript::new(StdChallenger::default());
+
+			let pool = BufferPool::new();
+			let alloc = &pool;
+
+			bench.iter_batched(
+				|| {
+					// The prover folds its columns in place, so each run needs its own copies.
+					(
+						transcript.clone(),
+						FieldBuffer::from_view_in(&alloc, a_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, b_buffer.as_view()),
+						FieldBuffer::from_view_in(&alloc, c_buffer.as_view()),
+						eval_point.clone(),
+					)
+				},
+				|(mut transcript, a, b, c, eval_point)| {
+					let mut store = MleStore::new(n_vars, &alloc);
+					let cols = [a, b, c].map(|col| store.push_owned(col));
+					let evaluator = QuadraticMleEvaluator::new(
+						cols,
+						and_constraint::<P>,
+						and_constraint_infinity::<P>,
+					);
+					let prover =
+						SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point);
+
+					sumcheck::prove_single_mlecheck(prover, &mut transcript)
+				},
+				BatchSize::PerIteration,
+			);
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(quadratic_mlecheck, bench_quadratic_mlecheck_and_constraint);
+criterion_main!(quadratic_mlecheck);


### PR DESCRIPTION
Closes [BINIUS-597](https://linear.app/jimpo/issue/BINIUS-597).

Adds two criterion targets to `binius-ip-prover`. No library code changes.

### The problem

The crate ships one bench, and it covers a two-column bivariate product.

Two shapes that carry real time have no bench anywhere in the workspace.

- The bit-AND reduction proves a three-column quadratic MLE check with the composition `a * b - c`. That span is 8.1% of a million-byte `sha256` prove.
- The logUp* table-side denominator is one pass over a whole table cube.

The three-column case is not a cosmetic variation on the two-column one.
It reads seven streams per chunk instead of five, so it sits differently against memory.

### The change

- **new** `crates/ip-prover/benches/quadratic_mlecheck.rs` — the shared MLE-check prover over three store columns, composition `a * b - c`, Karatsuba infinity part `a * b`.
- **new** `crates/ip-prover/benches/logup_star_witness.rs` — the table denominator across table sizes.
- **changed** `crates/ip-prover/Cargo.toml` — two bench targets.
- **untouched** everything else, including the existing bivariate-product bench.

### Sizes, and why

The quadratic bench runs at 16, 20 and 22 variables.
$2^{22}$ is the size the bit-AND reduction runs at on a million-byte message.

The denominator bench runs at 8, 12, 16, 20 and 22 variables.
The low end is deliberate: a byte-sized table is small enough that entering the rayon pool costs more than the work, so a bench that starts at $2^{16}$ would hide a regression there.

### Verification

- `cargo test -p binius-ip-prover` — 106 passed.
- `cargo test -p binius-ip-prover --release` — 105 passed, 1 failed: `logup_star::prove::tests::test_out_of_range_index_panics`, which fails on `main` today and is fixed separately.
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps` — clean.
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos crates/ip-prover/`, `cargo check --workspace --all-targets` — clean.

### Benchmark

Both benches, run under `RUSTFLAGS="-Ctarget-cpu=native"` on a 32-core machine that was carrying other work at the time, so treat these as a first reading rather than a quiet-machine baseline.

`quadratic_mlecheck/and_constraint`:

| n_vars | time | throughput |
|---|---|---|
| 16 | 716.54 µs | 91.5 Melem/s |
| 20 | 5.0122 ms | 209.2 Melem/s |
| 22 | 18.103 ms | 231.7 Melem/s |

`logup_star_witness/table_denominator`:

| n_vars | time | throughput |
|---|---|---|
| 8 | 130.39 ns | 1.96 Gelem/s |
| 12 | 1.6460 µs | 2.49 Gelem/s |
| 16 | 27.580 µs | 2.38 Gelem/s |
| 20 | 2.0782 ms | 504.6 Melem/s |
| 22 | 33.020 ms | 127.0 Melem/s |

The denominator's throughput falls off a cliff between $2^{16}$ and $2^{20}$, which is the working set leaving cache — $2^{16}$ elements is 1 MiB, $2^{20}$ is 16 MiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)