### PR TITLE
BINIUS-598: Write product-check layers straight into the arena

### DIFF
--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -84,15 +84,40 @@ where
 			let next_log_len = prev_layer.log_len() - 1;
 			let (half_0, half_1) = prev_layer.split_half();
 
+			// A next-layer word is the product of its two sibling words, written into the pool.
 			// Each layer is half the width of the one below it, down to a single word.
-			// The last layers are too small to be worth splitting.
-			let next_layer_evals: Vec<P> = (half_0.as_ref(), half_1.as_ref())
+			// One word is one multiply, so a run must be long enough to pay back handing it off.
+			let out_len = half_0.as_ref().len();
+			let mut next_data = alloc.alloc::<P>(out_len);
+			(next_data.spare_capacity_mut(), half_0.as_ref(), half_1.as_ref())
 				.into_par_iter()
 				.with_min_task(WorkPerItem::FieldMuls)
-				.map(|(v0, v1)| *v0 * *v1)
-				.collect();
-			let mut next_data = alloc.alloc::<P>(next_layer_evals.len());
-			next_data.extend_from_slice(&next_layer_evals);
+				.for_each(|(out, &v0, &v1)| {
+					out.write(v0 * v1);
+				});
+			// Invariant: every zip input holds at least `out_len` words.
+			//
+			// A parallel zip yields as many items as its shortest input holds.
+			// A shorter input would leave trailing slots uninitialized.
+			//
+			//     spare capacity:  >= out_len   allocated for at least that many
+			//     sibling halves:  == out_len   halves of one buffer
+			assert!(
+				next_data.capacity() - next_data.len() >= out_len,
+				"the allocated buffer must hold every claimed slot"
+			);
+			assert_eq!(
+				half_1.as_ref().len(),
+				out_len,
+				"the two sibling halves must hold exactly one word per claimed slot"
+			);
+			// Safety: the length claim covers only initialized slots.
+			// - The assertions above bound every zip input below by `out_len`.
+			// - So the loop ran `out_len` items.
+			// - Each item wrote one slot.
+			unsafe {
+				next_data.set_len(out_len);
+			}
 			let next_layer = FieldBuffer::new(next_log_len, next_data);
 
 			layers.push(next_layer);
@@ -736,6 +761,75 @@ mod tests {
 	#[test]
 	fn test_prodcheck_layer_computation() {
 		test_prodcheck_layer_computation_helper::<Packed128b>(4, 3);
+	}
+
+	/// Builds the same product layers serially, through a temporary vector.
+	///
+	/// The layer recurrence is written twice, so it can drift once.
+	fn reference_layers<P: PackedField>(
+		k: usize,
+		alloc: &GlobalAllocator,
+		witness: FieldBuffer<P>,
+	) -> Vec<FieldBuffer<P>> {
+		let mut layers = Vec::with_capacity(k + 1);
+		layers.push(witness);
+
+		for _ in 0..k {
+			let prev_layer = layers.last().expect("layers is non-empty");
+			let next_log_len = prev_layer.log_len() - 1;
+			let (half_0, half_1) = prev_layer.split_half();
+
+			// Pair each word of the low half with the word of the high half above it.
+			let evals = half_0
+				.as_ref()
+				.iter()
+				.zip(half_1.as_ref())
+				.map(|(v0, v1)| *v0 * *v1)
+				.collect::<Vec<P>>();
+
+			let mut next_data = alloc.alloc::<P>(evals.len());
+			next_data.extend_from_slice(&evals);
+			layers.push(FieldBuffer::new(next_log_len, next_data));
+		}
+
+		layers
+	}
+
+	#[test]
+	fn layers_match_the_reference_word_for_word() {
+		let mut rng = StdRng::seed_from_u64(7);
+		let alloc = GlobalAllocator;
+
+		// Invariant: the layers are compared as packed words, not as scalars.
+		// So the lanes past a short layer's length are compared too.
+		//
+		// Fixture state: four scalars per packed word.
+		//
+		//     log_len:   6   5   4   3   2   1   0
+		//     words:    16   8   4   2   1   1   1
+		//
+		// From log_len 2 down a layer is one word whose trailing lanes are not elements.
+		// Sweeping every depth at every witness size covers both sides of that line.
+		for log_len in 1..=6 {
+			for k in 1..=log_len {
+				let witness = random_field_buffer::<Packed128b>(&mut rng, log_len);
+
+				let (prover, products) = ProdcheckProver::new(k, &alloc, witness.clone());
+				let reference = reference_layers(k, &alloc, witness);
+
+				// The constructor keeps the first k layers and hands back the last one.
+				let built = prover.layers.iter().chain(iter::once(&products));
+
+				for (depth, (built, reference)) in built.zip(&reference).enumerate() {
+					assert_eq!(built.log_len(), reference.log_len(), "log_len at depth {depth}");
+					assert_eq!(
+						built.as_ref(),
+						reference.as_ref(),
+						"layer words at depth {depth}, witness log_len {log_len}, k {k}"
+					);
+				}
+			}
+		}
 	}
 
 	// ==================== batch_prove tests ====================


### PR DESCRIPTION
Closes [BINIUS-598](https://linear.app/jimpo/issue/BINIUS-598).

Builds each product-check layer directly in its pooled buffer instead of gathering it into a temporary first. Output is bit-identical — no protocol change.

### The problem

The product-check prover builds its layer tree by halving the previous layer and multiplying the two halves together.

Every layer is written twice.

First the products are gathered into a fresh vector, then that vector is copied into a pooled buffer:

```
let next_layer_evals: Vec<P> = (half_0, half_1)
    .into_par_iter()
    .map(|(v0, v1)| *v0 * *v1)
    .collect();
let mut next_data = alloc.alloc::<P>(next_layer_evals.len());
next_data.extend_from_slice(&next_layer_evals);
```

The destination is pooled in either case.

So the temporary is the entire difference: one allocation outside the pool, one extra full write and one extra full read, per layer.

### The idea

Allocate the pooled buffer first, and have the workers write their products into its spare capacity.

The sibling fractional-addition circuit builder already does exactly this, with the same shape of parallel zip and the same safety argument.

### Per layer

- **before:** read $2^n$ words, write $2^n$ words to a temporary, read them back, write $2^n$ words to the pool
- **after:** read $2^n$ words, write $2^n$ words to the pool

### The change

```
crates/ip-prover/src/prodcheck/mod.rs, the constructor's layer loop:
- collect the products into a Vec, then copy the Vec into a pooled buffer
+ allocate the pooled buffer, write the products into its spare capacity, publish the length
```

The length is published with `set_len`, so it needs an argument that the loop initialized every slot it claims.

Following BINIUS-591, the premises are `assert!`s rather than `debug_assert!`s, so the argument holds in the build that ships:

```
spare capacity:  >= out_len   allocated for at least that many
sibling halves:  == out_len   halves of one buffer
```

A parallel zip yields as many items as its shortest input, so those two bounds mean the loop ran `out_len` items and wrote `out_len` slots.

### Soundness

Nothing on the wire moves.

The layers are the same field elements in the same order, so every transcript is byte-identical.

The lanes past a short layer's length are unchanged too: a layer below the packing width is split by interleaving against zero, so those lanes carry a product of zeros in both arms.

### Scope

- **changed:** the layer loop of the product-check constructor, ~20 lines.
- **new:** one test pinning the layers against an independent, serial implementation.
- **untouched:** the rest of the product check, and the sibling padding module.

### Verification

- `cargo test -p binius-ip-prover` — 107 passed
- `cargo test -p binius-ip-prover --release` — 106 passed, 1 pre-existing failure (`logup_star::prove::tests::test_out_of_range_index_panics`, which fails identically on `main` and is fixed separately)
- `cargo test -p binius-prover` — 98 passed, exercises the product check end to end
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps`
- `cargo +nightly fmt --all --check`, `typos crates/ip-prover/`, `cargo check --workspace --all-targets`

**The correctness test.** The new layers are compared to an independent serial implementation as **packed words**, not as scalars, so the lanes past a short layer's length are compared too and a stale lane fails the test. It sweeps every reduction depth at every witness size from 2 up to 64 scalars, which covers both sides of the four-scalars-per-word boundary. Flipping one operand in the product makes it fail, so it is not vacuous.

**Miri.** Under tree borrows, all 17 product-check tests pass:

```
PROPTEST_CASES=1 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tree-borrows" \
  RUSTFLAGS="-Ctarget-feature=+sse4.1,+pclmulqdq,+avx,+avx2" \
  cargo +nightly miri test -p binius-ip-prover --lib prodcheck
  -> test result: ok. 17 passed; 0 failed
```

The run then reports `the main thread terminated without waiting for all remaining threads`, which is Miri objecting to rayon's parked workers at process exit, after every test has passed.

Under stacked borrows the run aborts inside `crossbeam-epoch`'s garbage collector, on an idle rayon worker's steal loop — never in this crate. The identical abort reproduces on unmodified `main`, so it is pre-existing and unrelated.

### Benchmark

Both layer loops compiled into one process and alternated round by round, so drift and machine load hit both arms equally. Same witness, same warm pool, only the loop differs. Best of 240 rounds per arm, `-Ctarget-cpu=native`, 32 cores.

| n_vars | collect then copy | write in place | speedup |
|---|---|---|---|
| 16 | 0.050 ms | 0.037 ms | 1.35x |
| 18 | 0.199 ms | 0.148 ms | 1.34x |
| 20 | 0.564 ms | 0.337 ms | 1.67x |
| 22 | 7.907 ms | 3.243 ms | 2.44x |

Three independent repetitions agreed to within 1.34–1.39x at 16, 1.33–1.35x at 18, 1.67–2.05x at 20 and 2.44–2.79x at 22.

The crate's existing constructor benchmark, run before and after on the real code path, corroborates it:

| `prodcheck/new` | before | after | speedup |
|---|---|---|---|
| n_vars=12 | 10.98 µs | 6.73 µs | 1.63x |
| n_vars=16 | 129.9 µs | 81.0 µs | 1.60x |
| n_vars=20 | 2.642 ms | 2.009 ms | 1.32x |

All three report `Performance has improved` at $p < 0.05$.

The win grows with size because the top layers dominate the tree and are the ones that miss cache on the extra pass. The machine was shared with another job throughout, which is why the alternating harness rather than a plain criterion run is the primary evidence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)