### PR TITLE
BINIUS-608: Give the batched interpreter row slices instead of per-element access

### DIFF
--- a/crates/frontend/src/eval_form/batch.rs
+++ b/crates/frontend/src/eval_form/batch.rs
@@ -19,6 +19,8 @@
 //!         ...
 //! ```
 
+use std::array;
+
 use binius_core::Word;
 use binius_utils::strided_array::StridedArray2DViewMut;
 
@@ -126,6 +128,63 @@ impl EvalContext for BatchExecutionContext<'_, '_> {
 		self.values[(reg as usize, instance)] = value;
 	}
 
+	/// Runs `op` over whole rows, one contiguous run of instances per register.
+	fn map<const D: usize, const S: usize, F>(&mut self, dsts: [u32; D], srcs: [u32; S], op: F)
+	where
+		F: Fn([Word; S]) -> [Word; D],
+	{
+		let n_instances = self.values.width();
+		let (mut dst_rows, src_rows) = self
+			.values
+			.rows_mut(dsts.map(|reg| reg as usize), srcs.map(|reg| reg as usize));
+		for i in 0..n_instances {
+			let out = op(array::from_fn(|k| src_rows[k][i]));
+			for (row, value) in dst_rows.iter_mut().zip(out) {
+				row[i] = value;
+			}
+		}
+	}
+
+	/// Folds one whole row into another.
+	fn update<F>(&mut self, dst: u32, src: u32, op: F)
+	where
+		F: Fn(Word, Word) -> Word,
+	{
+		let ([dst_row], [src_row]) = self.values.rows_mut([dst as usize], [src as usize]);
+		for (acc, &word) in dst_row.iter_mut().zip(src_row) {
+			*acc = op(*acc, word);
+		}
+	}
+
+	/// Scans whole rows for a violation before walking instances to record any.
+	///
+	/// A satisfied circuit never leaves the scan.
+	fn check<const S: usize, P, M>(
+		&mut self,
+		srcs: [u32; S],
+		path_spec: PathSpec,
+		fails: P,
+		message: M,
+	) where
+		P: Fn([Word; S]) -> bool,
+		M: Fn([Word; S]) -> String,
+	{
+		let n_instances = self.values.width();
+		let any = {
+			let rows = srcs.map(|reg| self.values.row(reg as usize));
+			(0..n_instances).any(|i| fails(array::from_fn(|k| rows[k][i])))
+		};
+		if !any {
+			return;
+		}
+		for i in 0..n_instances {
+			let words = srcs.map(|reg| self.load(reg, i));
+			if fails(words) {
+				self.note_assertion_failure(i, path_spec, message(words));
+			}
+		}
+	}
+
 	/// Record an assertion failure for one instance.
 	///
 	/// A failure for a higher instance than the current lowest-failing one is dropped.
@@ -166,21 +225,57 @@ mod tests {
 	// interpreter produces for the same inputs. This is the core equivalence guarantee.
 	#[test]
 	fn batched_matches_scalar_per_instance() {
-		// A circuit that exercises a spread of opcodes plus a constant, with only witness inputs
-		// and force-committed outputs (no inout wires — the M4 setting).
+		// A circuit that exercises every row-wise opcode plus a constant, with only witness
+		// inputs and force-committed outputs (no inout wires — the M4 setting).
 		let builder = CircuitBuilder::new();
 		let a = builder.add_witness();
 		let b = builder.add_witness();
+		// Two inputs the caller pins, so every assertion below holds for every instance.
+		let zero = builder.add_witness();
+		let msb = builder.add_witness();
 		let k = builder.add_constant_64(0x0123_4567_89ab_cdef);
 		let c = builder.band(a, b);
 		let d = builder.bxor(a, k);
-		let (sum, _cout) = builder.iadd(a, b);
+		let (sum, cout) = builder.iadd(a, b);
 		let e = builder.rotr(b, 7);
 		let f = builder.bor(c, e);
-		builder.force_commit(c);
-		builder.force_commit(d);
-		builder.force_commit(sum);
-		builder.force_commit(f);
+		let g = builder.fax(a, b, k);
+		let xs = builder.bxor_multi(&[a, b, k, e, f]);
+		// A condition that differs between instances, so both arms of the select are taken.
+		let lt = builder.icmp_ult(a, b);
+		let sel = builder.select(lt, d, e);
+		let (diff, bout) = builder.isub_bin_bout(a, b, lt);
+		let (mul_hi, mul_lo) = builder.imul(a, b);
+		let (gmul_lo, gmul_hi) = builder.bmul(a, b, k, e);
+		let lanes = builder.iadd_32(a, b);
+		let (lanes_sum, lanes_cout) = builder.iadd32_cin_cout(a, b, lt);
+		// One shift per variant.
+		let shifts = [
+			builder.shl(a, 13),
+			builder.shr(a, 13),
+			builder.sar(a, 13),
+			builder.rotr(a, 13),
+			builder.sll32(a, 13),
+			builder.srl32(a, 13),
+			builder.sra32(a, 13),
+			builder.rotr32(a, 13),
+		];
+		// Assertions that hold for every instance, so each scan runs but records nothing.
+		builder.assert_eq("xor_roundtrip", builder.bxor(d, k), a);
+		builder.assert_eq_cond("xor_roundtrip_cond", builder.bxor(d, k), a, lt);
+		builder.assert_zero("zero_is_zero", zero);
+		builder.assert_false("zero_msb_false", zero);
+		builder.assert_non_zero("msb_is_non_zero", msb);
+		builder.assert_true("msb_is_true", msb);
+		for wire in [
+			c, d, sum, cout, e, f, g, xs, lt, sel, diff, bout, mul_hi, mul_lo, gmul_lo, gmul_hi,
+			lanes, lanes_sum, lanes_cout,
+		]
+		.into_iter()
+		.chain(shifts)
+		{
+			builder.force_commit(wire);
+		}
 		let circuit = builder.build();
 
 		let layout = circuit.value_vec_layout().clone();
@@ -206,6 +301,8 @@ mod tests {
 				let mut filler = circuit.new_witness_filler();
 				filler[a] = Word(x);
 				filler[b] = Word(y);
+				filler[zero] = Word::ZERO;
+				filler[msb] = Word::MSB_ONE;
 				circuit.populate_wire_witness(&mut filler).unwrap();
 				filler.value_vec().combined_witness().to_vec()
 			})
@@ -214,11 +311,15 @@ mod tests {
 		// Batched: fill the input rows for every instance, then evaluate all at once.
 		let a_row = circuit.witness_row(a);
 		let b_row = circuit.witness_row(b);
+		let zero_row = circuit.witness_row(zero);
+		let msb_row = circuit.witness_row(msb);
 		let mut data = vec![Word::ZERO; full_len * n];
 		let mut view = StridedArray2DViewMut::without_stride(&mut data, full_len, n).unwrap();
 		for (instance, &(x, y)) in inputs.iter().enumerate() {
 			view[(a_row, instance)] = Word(x);
 			view[(b_row, instance)] = Word(y);
+			view[(zero_row, instance)] = Word::ZERO;
+			view[(msb_row, instance)] = Word::MSB_ONE;
 		}
 		circuit.populate_wire_witness_batched(&mut view).unwrap();
 

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -44,6 +44,56 @@ pub trait EvalContext {
 	/// Writes `value` to the register at index `reg` within instance `instance`.
 	fn store(&mut self, reg: u32, instance: usize, value: Word);
 
+	/// Applies `op` to every instance, reading the `srcs` registers and writing the `dsts`.
+	///
+	/// Every destination register must differ from every source register.
+	fn map<const D: usize, const S: usize, F>(&mut self, dsts: [u32; D], srcs: [u32; S], op: F)
+	where
+		F: Fn([Word; S]) -> [Word; D],
+	{
+		for i in 0..self.n_instances() {
+			let out = op(srcs.map(|reg| self.load(reg, i)));
+			for (dst, value) in dsts.into_iter().zip(out) {
+				self.store(dst, i, value);
+			}
+		}
+	}
+
+	/// Folds `src` into `dst` across every instance.
+	///
+	/// `dst` must differ from `src`.
+	fn update<F>(&mut self, dst: u32, src: u32, op: F)
+	where
+		F: Fn(Word, Word) -> Word,
+	{
+		for i in 0..self.n_instances() {
+			let value = op(self.load(dst, i), self.load(src, i));
+			self.store(dst, i, value);
+		}
+	}
+
+	/// Records a failure against `path_spec` for every instance whose `srcs` satisfy `fails`.
+	///
+	/// `message` renders the same words into the detail line of that failure.
+	/// It runs only for a failing instance, so it may allocate freely.
+	fn check<const S: usize, P, M>(
+		&mut self,
+		srcs: [u32; S],
+		path_spec: PathSpec,
+		fails: P,
+		message: M,
+	) where
+		P: Fn([Word; S]) -> bool,
+		M: Fn([Word; S]) -> String,
+	{
+		for i in 0..self.n_instances() {
+			let words = srcs.map(|reg| self.load(reg, i));
+			if fails(words) {
+				self.note_assertion_failure(i, path_spec, message(words));
+			}
+		}
+	}
+
 	/// Records an assertion violation for one instance.
 	///
 	/// The index is local to this context.
@@ -130,30 +180,21 @@ impl<'a> Executor<'a> {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src1, i) & ctx.load(src2, i);
-			ctx.store(dst, i, val);
-		}
+		ctx.map([dst], [src1, src2], |[a, b]| [a & b]);
 	}
 
 	fn exec_bor<C: EvalContext>(&mut self, ctx: &mut C) {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src1, i) | ctx.load(src2, i);
-			ctx.store(dst, i, val);
-		}
+		ctx.map([dst], [src1, src2], |[a, b]| [a | b]);
 	}
 
 	fn exec_bxor<C: EvalContext>(&mut self, ctx: &mut C) {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src1, i) ^ ctx.load(src2, i);
-			ctx.store(dst, i, val);
-		}
+		ctx.map([dst], [src1, src2], |[a, b]| [a ^ b]);
 	}
 
 	fn exec_select<C: EvalContext>(&mut self, ctx: &mut C) {
@@ -161,15 +202,8 @@ impl<'a> Executor<'a> {
 		let cond = self.read_reg();
 		let t = self.read_reg();
 		let f = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			// Select t if MSB(cond) is 1, otherwise select f.
-			let val = if ctx.load(cond, i).is_msb_true() {
-				ctx.load(t, i)
-			} else {
-				ctx.load(f, i)
-			};
-			ctx.store(dst, i, val);
-		}
+		// Select t if MSB(cond) is 1, otherwise select f.
+		ctx.map([dst], [cond, t, f], |[cond, t, f]| [if cond.is_msb_true() { t } else { f }]);
 	}
 
 	fn exec_bxor_multi<C: EvalContext>(&mut self, ctx: &mut C) {
@@ -180,12 +214,15 @@ impl<'a> Executor<'a> {
 		let srcs = (0..n)
 			.map(|_| self.read_reg())
 			.collect::<SmallVec<[u32; 8]>>();
-		for i in 0..ctx.n_instances() {
-			let mut val = Word::ZERO;
-			for &src in &srcs {
-				val = val ^ ctx.load(src, i);
+		// The destination doubles as the accumulator, so it is seeded before the fold runs.
+		match srcs.split_first() {
+			None => ctx.map([dst], [], |[]| [Word::ZERO]),
+			Some((&first, rest)) => {
+				ctx.map([dst], [first], |[a]| [a]);
+				for &src in rest {
+					ctx.update(dst, src, |acc, w| acc ^ w);
+				}
 			}
-			ctx.store(dst, i, val);
 		}
 	}
 
@@ -194,10 +231,7 @@ impl<'a> Executor<'a> {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let src3 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = (ctx.load(src1, i) & ctx.load(src2, i)) ^ ctx.load(src3, i);
-			ctx.store(dst, i, val);
-		}
+		ctx.map([dst], [src1, src2, src3], |[a, b, c]| [(a & b) ^ c]);
 	}
 
 	// Shifts
@@ -229,9 +263,7 @@ impl<'a> Executor<'a> {
 	/// So the compiler monomorphizes this into a branch-free tight loop with the shift inlined.
 	#[inline]
 	fn shift_each<C: EvalContext>(ctx: &mut C, dst: u32, src: u32, op: impl Fn(Word) -> Word) {
-		for i in 0..ctx.n_instances() {
-			ctx.store(dst, i, op(ctx.load(src, i)));
-		}
+		ctx.map([dst], [src], |[w]| [op(w)]);
 	}
 
 	// Arithmetic operations
@@ -241,12 +273,11 @@ impl<'a> Executor<'a> {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let cin = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let cin_bit = ctx.load(cin, i) >> 63; // Use MSB as carry bit
-			let (sum, cout) = ctx.load(src1, i).iadd_cin_cout(ctx.load(src2, i), cin_bit);
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
+		ctx.map([dst_sum, dst_cout], [src1, src2, cin], |[a, b, cin]| {
+			// The carry in is the MSB of its word.
+			let (sum, cout) = a.iadd_cin_cout(b, cin >> 63);
+			[sum, cout]
+		});
 	}
 
 	/// Carry word of `src1 + src2`, discarding the sum.
@@ -254,13 +285,8 @@ impl<'a> Executor<'a> {
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			// No carry in, and the sum is dropped rather than stored.
-			let (_sum, cout) = ctx
-				.load(src1, i)
-				.iadd_cin_cout(ctx.load(src2, i), Word::ZERO);
-			ctx.store(dst_cout, i, cout);
-		}
+		// No carry in, and the sum is dropped rather than stored.
+		ctx.map([dst_cout], [src1, src2], |[a, b]| [a.iadd_cin_cout(b, Word::ZERO).1]);
 	}
 
 	fn exec_isub_bin_bout<C: EvalContext>(&mut self, ctx: &mut C) {
@@ -269,12 +295,11 @@ impl<'a> Executor<'a> {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let bin = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let bin_bit = ctx.load(bin, i) >> 63; // Use MSB as borrow bit
-			let (diff, bout) = ctx.load(src1, i).isub_bin_bout(ctx.load(src2, i), bin_bit);
-			ctx.store(dst_diff, i, diff);
-			ctx.store(dst_bout, i, bout);
-		}
+		ctx.map([dst_diff, dst_bout], [src1, src2, bin], |[a, b, bin]| {
+			// The borrow in is the MSB of its word.
+			let (diff, bout) = a.isub_bin_bout(b, bin >> 63);
+			[diff, bout]
+		});
 	}
 
 	fn exec_imul<C: EvalContext>(&mut self, ctx: &mut C) {
@@ -282,11 +307,10 @@ impl<'a> Executor<'a> {
 		let dst_lo = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (hi, lo) = ctx.load(src1, i).imul(ctx.load(src2, i));
-			ctx.store(dst_hi, i, hi);
-			ctx.store(dst_lo, i, lo);
-		}
+		ctx.map([dst_hi, dst_lo], [src1, src2], |[a, b]| {
+			let (hi, lo) = a.imul(b);
+			[hi, lo]
+		});
 	}
 
 	/// GHASH-field multiply: `(c_lo, c_hi) = (a_lo, a_hi) * (b_lo, b_hi)` in
@@ -301,16 +325,10 @@ impl<'a> Executor<'a> {
 		let a_hi = self.read_reg();
 		let b_lo = self.read_reg();
 		let b_hi = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (lo, hi) = ghash_mul(
-				ctx.load(a_lo, i),
-				ctx.load(a_hi, i),
-				ctx.load(b_lo, i),
-				ctx.load(b_hi, i),
-			);
-			ctx.store(dst_lo, i, lo);
-			ctx.store(dst_hi, i, hi);
-		}
+		ctx.map([dst_lo, dst_hi], [a_lo, a_hi, b_lo, b_hi], |[a_lo, a_hi, b_lo, b_hi]| {
+			let (lo, hi) = ghash_mul(a_lo, a_hi, b_lo, b_hi);
+			[lo, hi]
+		});
 	}
 
 	// 32-bit operations
@@ -320,13 +338,10 @@ impl<'a> Executor<'a> {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let cin = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (sum, cout) = ctx
-				.load(src1, i)
-				.iadd32_cin_cout(ctx.load(src2, i), ctx.load(cin, i));
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
+		ctx.map([dst_sum, dst_cout], [src1, src2, cin], |[a, b, cin]| {
+			let (sum, cout) = a.iadd32_cin_cout(b, cin);
+			[sum, cout]
+		});
 	}
 
 	fn exec_iadd32_cout<C: EvalContext>(&mut self, ctx: &mut C) {
@@ -334,11 +349,10 @@ impl<'a> Executor<'a> {
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (sum, cout) = ctx.load(src1, i).iadd_cout_32(ctx.load(src2, i));
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
+		ctx.map([dst_sum, dst_cout], [src1, src2], |[a, b]| {
+			let (sum, cout) = a.iadd_cout_32(b);
+			[sum, cout]
+		});
 	}
 
 	// Assertions
@@ -346,14 +360,7 @@ impl<'a> Executor<'a> {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let path_spec = self.read_path_spec();
-
-		for i in 0..ctx.n_instances() {
-			let val1 = ctx.load(src1, i);
-			let val2 = ctx.load(src2, i);
-			if val1 != val2 {
-				ctx.note_assertion_failure(i, path_spec, format!("{val1:?} != {val2:?}"));
-			}
-		}
+		ctx.check([src1, src2], path_spec, |[a, b]| a != b, |[a, b]| format!("{a:?} != {b:?}"));
 	}
 
 	fn exec_assert_eq_cond<C: EvalContext>(&mut self, ctx: &mut C) {
@@ -361,68 +368,36 @@ impl<'a> Executor<'a> {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let path_spec = self.read_path_spec();
-
-		for i in 0..ctx.n_instances() {
-			if ctx.load(cond, i).is_msb_true() {
-				let val1 = ctx.load(src1, i);
-				let val2 = ctx.load(src2, i);
-				if val1 != val2 {
-					ctx.note_assertion_failure(
-						i,
-						path_spec,
-						format!("conditional assert: {val1:?} != {val2:?}"),
-					);
-				}
-			}
-		}
+		ctx.check(
+			[cond, src1, src2],
+			path_spec,
+			|[cond, a, b]| cond.is_msb_true() && a != b,
+			|[_, a, b]| format!("conditional assert: {a:?} != {b:?}"),
+		);
 	}
 
 	fn exec_assert_zero<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
 		let path_spec = self.read_path_spec();
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val != Word::ZERO {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} != 0"));
-			}
-		}
+		ctx.check([src], path_spec, |[v]| v != Word::ZERO, |[v]| format!("{v:?} != 0"));
 	}
 
 	fn exec_assert_non_zero<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
 		let path_spec = self.read_path_spec();
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val == Word::ZERO {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} == 0"));
-			}
-		}
+		ctx.check([src], path_spec, |[v]| v == Word::ZERO, |[v]| format!("{v:?} == 0"));
 	}
 
 	fn exec_assert_false<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
 		let path_spec = self.read_path_spec();
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val.is_msb_true() {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is true"));
-			}
-		}
+		ctx.check([src], path_spec, |[v]| v.is_msb_true(), |[v]| format!("{v:?} MSB is true"));
 	}
 
 	fn exec_assert_true<C: EvalContext>(&mut self, ctx: &mut C) {
 		let src = self.read_reg();
 		let path_spec = self.read_path_spec();
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val.is_msb_false() {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is false"));
-			}
-		}
+		ctx.check([src], path_spec, |[v]| v.is_msb_false(), |[v]| format!("{v:?} MSB is false"));
 	}
 
 	// Hint execution

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -46,7 +46,9 @@ pub trait EvalContext {
 
 	/// Applies `op` to every instance, reading the `srcs` registers and writing the `dsts`.
 	///
-	/// Every destination register must differ from every source register.
+	/// Every destination register must differ from every source register. Emitted bytecode
+	/// satisfies this: a gate's outputs are freshly allocated wires, and `pool_slots` reclaims
+	/// a scratch slot only after the whole gate that last read it has run.
 	fn map<const D: usize, const S: usize, F>(&mut self, dsts: [u32; D], srcs: [u32; S], op: F)
 	where
 		F: Fn([Word; S]) -> [Word; D],
@@ -246,24 +248,15 @@ impl<'a> Executor<'a> {
 		//
 		// Each arm is then a branch-free tight loop, the shape Keccak's many rotations need.
 		match variant {
-			ShiftVariant::Sll => Self::shift_each(ctx, dst, src, |w| w << amount),
-			ShiftVariant::Slr => Self::shift_each(ctx, dst, src, |w| w >> amount),
-			ShiftVariant::Sar => Self::shift_each(ctx, dst, src, |w| w.sar(amount)),
-			ShiftVariant::Rotr => Self::shift_each(ctx, dst, src, |w| w.rotr(amount)),
-			ShiftVariant::Sll32 => Self::shift_each(ctx, dst, src, |w| w.sll32(amount)),
-			ShiftVariant::Srl32 => Self::shift_each(ctx, dst, src, |w| w.srl32(amount)),
-			ShiftVariant::Sra32 => Self::shift_each(ctx, dst, src, |w| w.sra32(amount)),
-			ShiftVariant::Rotr32 => Self::shift_each(ctx, dst, src, |w| w.rotr32(amount)),
+			ShiftVariant::Sll => ctx.map([dst], [src], |[w]| [w << amount]),
+			ShiftVariant::Slr => ctx.map([dst], [src], |[w]| [w >> amount]),
+			ShiftVariant::Sar => ctx.map([dst], [src], |[w]| [w.sar(amount)]),
+			ShiftVariant::Rotr => ctx.map([dst], [src], |[w]| [w.rotr(amount)]),
+			ShiftVariant::Sll32 => ctx.map([dst], [src], |[w]| [w.sll32(amount)]),
+			ShiftVariant::Srl32 => ctx.map([dst], [src], |[w]| [w.srl32(amount)]),
+			ShiftVariant::Sra32 => ctx.map([dst], [src], |[w]| [w.sra32(amount)]),
+			ShiftVariant::Rotr32 => ctx.map([dst], [src], |[w]| [w.rotr32(amount)]),
 		}
-	}
-
-	/// Applies one fixed word-level shift across every instance.
-	///
-	/// The op is a distinct zero-sized closure per call site.
-	/// So the compiler monomorphizes this into a branch-free tight loop with the shift inlined.
-	#[inline]
-	fn shift_each<C: EvalContext>(ctx: &mut C, dst: u32, src: u32, op: impl Fn(Word) -> Word) {
-		ctx.map([dst], [src], |[w]| [op(w)]);
 	}
 
 	// Arithmetic operations

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -78,6 +78,53 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 		unsafe { &mut *self.data.add(i * self.data_width + j + self.cols.start) }
 	}
 
+	/// Returns this view's columns of row `i`, which are contiguous in memory.
+	///
+	/// # Panics
+	///
+	/// Panics if `i` is out of bounds.
+	pub fn row(&self, i: usize) -> &[T] {
+		assert!(i < self.height);
+		let start = i * self.data_width + self.cols.start;
+		&self.data[start..start + self.width()]
+	}
+
+	/// Returns the `dsts` rows mutably alongside the `srcs` rows.
+	///
+	/// # Panics
+	///
+	/// Panics if any index is out of bounds.
+	/// Panics if a destination row repeats, or appears among the sources.
+	pub fn rows_mut<const D: usize, const S: usize>(
+		&mut self,
+		dsts: [usize; D],
+		srcs: [usize; S],
+	) -> ([&mut [T]; D], [&[T]; S]) {
+		for &src in &srcs {
+			assert!(src < self.height);
+		}
+		for (k, &dst) in dsts.iter().enumerate() {
+			assert!(dst < self.height);
+			assert!(!dsts[..k].contains(&dst), "a destination row repeats");
+			assert!(!srcs.contains(&dst), "a destination row is also a source row");
+		}
+
+		let (data_width, start, width) = (self.data_width, self.cols.start, self.width());
+		let base = self.data.as_mut_ptr();
+		// SAFETY:
+		// Row `i` occupies `i * data_width + start .. + width`, inside `data` because
+		// `i < height` and the column range is a subrange of the row.
+		// The asserts above make the destination rows pairwise distinct and disjoint from the
+		// sources, so no two of the returned slices ever overlap.
+		// Dropping either assert would hand out two references to one element.
+		unsafe {
+			(
+				dsts.map(|i| slice::from_raw_parts_mut(base.add(i * data_width + start), width)),
+				srcs.map(|i| slice::from_raw_parts(base.add(i * data_width + start), width)),
+			)
+		}
+	}
+
 	pub const fn height(&self) -> usize {
 		self.height
 	}
@@ -347,6 +394,52 @@ mod tests {
 
 		assert_eq!(data[0], 88);
 		assert_eq!(data[5], 99);
+	}
+
+	#[test]
+	fn a_row_covers_only_the_columns_the_view_holds() {
+		let mut data = array::from_fn::<_, 12, _>(|i| i);
+		let arr = StridedArray2DViewMut::without_stride(&mut data, 4, 3).unwrap();
+
+		// Row 1 of the array is 3, 4, 5, and a full-width view sees all of it.
+		assert_eq!(arr.row(1), &[3, 4, 5]);
+
+		// The second stride of width 2 holds column 2 alone.
+		let stride = arr.into_strides(2).nth(1).unwrap();
+		assert_eq!(stride.row(1), &[5]);
+	}
+
+	#[test]
+	fn split_rows_alias_nothing_and_write_through() {
+		let mut data = array::from_fn::<_, 12, _>(|i| i);
+		let mut arr = StridedArray2DViewMut::without_stride(&mut data, 4, 3).unwrap();
+
+		let ([sum, diff], [x, y]) = arr.rows_mut([0, 1], [2, 3]);
+		assert_eq!(x, &[6, 7, 8]);
+		assert_eq!(y, &[9, 10, 11]);
+		for i in 0..3 {
+			sum[i] = x[i] + y[i];
+			diff[i] = y[i] - x[i];
+		}
+
+		assert_eq!(&data[0..3], &[15, 17, 19]);
+		assert_eq!(&data[3..6], &[3, 3, 3]);
+	}
+
+	#[test]
+	#[should_panic(expected = "a destination row is also a source row")]
+	fn a_destination_row_may_not_be_a_source_row() {
+		let mut data = array::from_fn::<_, 12, _>(|i| i);
+		let mut arr = StridedArray2DViewMut::without_stride(&mut data, 4, 3).unwrap();
+		arr.rows_mut([1], [0, 1]);
+	}
+
+	#[test]
+	#[should_panic(expected = "a destination row repeats")]
+	fn two_destinations_may_not_name_one_row() {
+		let mut data = array::from_fn::<_, 12, _>(|i| i);
+		let mut arr = StridedArray2DViewMut::without_stride(&mut data, 4, 3).unwrap();
+		arr.rows_mut([2, 2], [0]);
 	}
 
 	#[test]

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -3,6 +3,7 @@
 use std::{
 	marker::PhantomData,
 	ops::{Index, IndexMut, Range},
+	slice,
 };
 
 use crate::rayon::prelude::*;
@@ -86,41 +87,47 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	pub fn row(&self, i: usize) -> &[T] {
 		assert!(i < self.height);
 		let start = i * self.data_width + self.cols.start;
-		&self.data[start..start + self.width()]
+		// SAFETY:
+		// - Provenance: reborrowed from the exclusive borrow the view was built from.
+		// - Bounds: construction pairs the buffer length with the dimensions, `i` is checked above,
+		//   and the column range is a subrange of the row.
+		// - Non-overlap: the slice spans only this view's columns, which no sibling view holds.
+		unsafe { slice::from_raw_parts(self.data.add(start), self.width()) }
 	}
 
-	/// Returns the `dsts` rows mutably alongside the `srcs` rows.
+	/// Returns the `mut_rows` rows mutably alongside the `shared_rows` rows.
 	///
 	/// # Panics
 	///
 	/// Panics if any index is out of bounds.
-	/// Panics if a destination row repeats, or appears among the sources.
-	pub fn rows_mut<const D: usize, const S: usize>(
+	/// Panics if a mutable row repeats, or appears among the shared rows.
+	pub fn rows_mut<const M: usize, const S: usize>(
 		&mut self,
-		dsts: [usize; D],
-		srcs: [usize; S],
-	) -> ([&mut [T]; D], [&[T]; S]) {
-		for &src in &srcs {
-			assert!(src < self.height);
+		mut_rows: [usize; M],
+		shared_rows: [usize; S],
+	) -> ([&mut [T]; M], [&[T]; S]) {
+		for &shared in &shared_rows {
+			assert!(shared < self.height);
 		}
-		for (k, &dst) in dsts.iter().enumerate() {
-			assert!(dst < self.height);
-			assert!(!dsts[..k].contains(&dst), "a destination row repeats");
-			assert!(!srcs.contains(&dst), "a destination row is also a source row");
+		for (k, &row) in mut_rows.iter().enumerate() {
+			assert!(row < self.height);
+			assert!(!mut_rows[..k].contains(&row), "a mutable row repeats");
+			assert!(!shared_rows.contains(&row), "a mutable row is also a shared row");
 		}
 
 		let (data_width, start, width) = (self.data_width, self.cols.start, self.width());
-		let base = self.data.as_mut_ptr();
+		let base = self.data;
 		// SAFETY:
 		// Row `i` occupies `i * data_width + start .. + width`, inside `data` because
 		// `i < height` and the column range is a subrange of the row.
-		// The asserts above make the destination rows pairwise distinct and disjoint from the
-		// sources, so no two of the returned slices ever overlap.
+		// The asserts above make the mutable rows pairwise distinct and disjoint from the
+		// shared rows, so no two of the returned slices ever overlap.
 		// Dropping either assert would hand out two references to one element.
 		unsafe {
 			(
-				dsts.map(|i| slice::from_raw_parts_mut(base.add(i * data_width + start), width)),
-				srcs.map(|i| slice::from_raw_parts(base.add(i * data_width + start), width)),
+				mut_rows
+					.map(|i| slice::from_raw_parts_mut(base.add(i * data_width + start), width)),
+				shared_rows.map(|i| slice::from_raw_parts(base.add(i * data_width + start), width)),
 			)
 		}
 	}
@@ -427,16 +434,16 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "a destination row is also a source row")]
-	fn a_destination_row_may_not_be_a_source_row() {
+	#[should_panic(expected = "a mutable row is also a shared row")]
+	fn a_mutable_row_may_not_be_a_shared_row() {
 		let mut data = array::from_fn::<_, 12, _>(|i| i);
 		let mut arr = StridedArray2DViewMut::without_stride(&mut data, 4, 3).unwrap();
 		arr.rows_mut([1], [0, 1]);
 	}
 
 	#[test]
-	#[should_panic(expected = "a destination row repeats")]
-	fn two_destinations_may_not_name_one_row() {
+	#[should_panic(expected = "a mutable row repeats")]
+	fn two_mutable_rows_may_not_name_one_row() {
 		let mut data = array::from_fn::<_, 12, _>(|i| i);
 		let mut arr = StridedArray2DViewMut::without_stride(&mut data, 4, 3).unwrap();
 		arr.rows_mut([2, 2], [0]);


### PR DESCRIPTION
Closes [BINIUS-608](https://linear.app/jimpo/issue/BINIUS-608).

Makes the batched interpreter work a row at a time instead of a word at a time, so the optimiser can vectorise it.
Same bytecode, same results — the equivalence test against the single-instance interpreter is the proof.

### The problem

The batched interpreter runs one bytecode instruction across every instance of the batch.
It does that one word at a time.

```rust
for i in 0..ctx.n_instances() {
    let val = ctx.load(src1, i) ^ ctx.load(src2, i);
    ctx.store(dst, i, val);
}
```

Two things stop that from going fast.

- `load` and `store` resolve through the 2D view's `Index` impl, which recomputes `row * data_width + col` on every access.
- `store` takes `&mut self`, so the compiler must assume a store may alias the next load, and cannot widen the loop.

Here is the whole fused-AND-XOR loop body, disassembled out of `Executor::run` monomorphised for the batched context, from a release build with `-Ctarget-cpu=native`:

```
imul   %r10,%r15            ; recompute row * data_width
imul   %r8,%r13
imul   %r14,%rbp
imul   %rax,%r14
mov    (%rbx,%r15,8),%r15
and    (%rbx,%r13,8),%r15   ; one word
xor    (%rbx,%r14,8),%r15   ; one word
mov    %r15,(%r11,%rsi,8)   ; one word
inc    %rsi
jne    <top>
```

Four multiplies and three memory operations to move one 64-bit word.
Across the whole 2,480-instruction function there is not one vector arithmetic instruction.

A row of a stripe is contiguous in memory. That fact never reaches the optimiser.

### The idea

Give the execution-context trait row-wise operations, with today's scalar loop as the default body.

```rust
fn map<const D: usize, const S: usize, F>(&mut self, dsts: [u32; D], srcs: [u32; S], op: F)
where F: Fn([Word; S]) -> [Word; D];
```

The single-instance context inherits the default and does not change at all.
The batched context overrides it with contiguous row slices and one loop.

Two more methods cover what `map` cannot express:

- `update` folds one row into another, which is what the multi-way exclusive-or needs.
- `check` scans rows for an assertion violation, and only then walks instances to record any.

The row split lives in `StridedArray2DViewMut`, the type that owns the layout.
That keeps the pointer arithmetic where the layout is defined and leaves the frontend with a safe surface and no `unsafe` of its own.

### The change

```diff
 fn exec_fax<C: EvalContext>(&mut self, ctx: &mut C) {
     let (dst, src1, src2, src3) = (...);
-    for i in 0..ctx.n_instances() {
-        let val = (ctx.load(src1, i) & ctx.load(src2, i)) ^ ctx.load(src3, i);
-        ctx.store(dst, i, val);
-    }
+    ctx.map([dst], [src1, src2, src3], |[a, b, c]| [(a & b) ^ c]);
 }
```

Same instruction after the change, on the same machine:

```
vmovdqu64 -0xc0(%r15,%r13,8),%zmm0
vmovdqu64 -0x80(%r15,%r13,8),%zmm1
vmovdqu64 -0x40(%r15,%r13,8),%zmm2
vmovdqu64 (%r15,%r13,8),%zmm3
...
vpternlogq $0x78,-0xc0(%r12,%r13,8),%zmm0,%zmm4   ; (a & b) ^ c, 8 words
vpternlogq $0x78,-0x80(%r12,%r13,8),%zmm1,%zmm5
vpternlogq $0x78,-0x40(%r12,%r13,8),%zmm2,%zmm6
vpternlogq $0x78,(%r12,%r13,8),%zmm3,%zmm7
```

Thirty-two words per iteration, and the AND and the XOR fold into one instruction.

### Vector instructions in the batched run loop

Counted over `Executor::run` monomorphised for the batched context plus the `map` / `update` / `check` bodies the compiler outlines from it.

| | before | after |
|---|---|---|
| functions | 1 | 21 |
| total instructions | 2,480 | 6,196 |
| vector logic ops (`vpternlogq` / `vpxorq` / `vpandq` / `vporq`) | 3 | 34 |
| `%ymm` operands | 16 | 150 |
| `%zmm` operands | 4 | 353 |

The three "before" logic ops are the GHASH reduction on `%xmm`, which is per-word scalar helper code and unchanged.
Every wide operand in the before column is a `vmovdqu` move: no arithmetic on instances was vectorised at all.

### Scope

- **new:** `StridedArray2DViewMut::row` and `StridedArray2DViewMut::rows_mut`.
- **new:** `EvalContext::map`, `EvalContext::update`, `EvalContext::check`, each with the current scalar loop as its default body.
- **changed:** 20 of the 21 opcodes routed through them, and the batched overrides.
- **untouched:** the single-instance context, which keeps the default bodies verbatim.
- **untouched:** the hint opcode's per-instance loop, the constant broadcast, and the tile gather.

### Soundness

`rows_mut` carves mutable and shared slices out of one allocation, so it must never be handed a destination row that is also a source row.

That invariant already holds in the bytecode.
A gate's outputs are freshly allocated wires.
`pool_slots` reclaims a scratch slot only once the whole gate that last read it has run, so no gate is ever handed a slot still holding one of its own inputs.

Rather than assume it, `rows_mut` asserts it — destinations pairwise distinct, and disjoint from the sources — at the point the slices are formed.
The check is a handful of register compares per instruction against a loop over hundreds of words, and it is what the `unsafe` block below it rests on.
A future scratch-allocator change that broke the invariant would panic, not miscompile.

`batched_matches_scalar_per_instance` is the equivalence proof: it runs a mixed-opcode circuit over 1024 instances and asserts every instance's committed witness equals what the single-instance interpreter produces for the same inputs.
Its fixture now exercises all 20 converted opcodes — multiply, GHASH multiply, select, fused-AND-XOR, subtract with borrow, both 32-bit lane adds, a five-way exclusive-or, all eight shift variants, and all six assertions.
A bad row split is exactly what that test would catch.

Miri, on the tests that exercise the row path:

| | Stacked Borrows | Tree Borrows |
|---|---|---|
| `binius-frontend` `eval_form::batch` (4 tests) | pass | pass |
| `binius-utils` row / row-split tests (4 tests) | pass | pass |

Two frontend tests are not covered by those runs, and neither is skipped silently:

- `const_eval::differential_against_interpreter` enumerates roughly 13,000 gate builds and evaluations, which does not finish under Miri in a workable time.
- `parallel_population_matches_serial_for_varied_stripe_widths` is rayon-based, and additionally trips a pre-existing Stacked Borrows violation in `StridedArray2DViewMut::into_strides`: each stride re-derives a mutable slice over the whole buffer, invalidating the tag of every stride handed out before it. That is untouched by this PR — the existing `test_strides` unit test reproduces it on its own, on `main`.

### Verification

All clean:

- `cargo test -p binius-frontend -p binius-utils` (debug, so the row-split assert is live)
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend -p binius-utils --release`
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend -p binius-utils --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend -p binius-utils --document-private-items --no-deps`
- `cargo check --workspace --all-targets`
- `cargo +nightly-2026-07-01 fmt --all --check`, `python3 tools/check_copyright_notice.py`, `typos`

`cargo test -p binius-circuits` also passes end to end (407 tests), which is the broadest evidence that no gate in the circuit library ever emits an instruction whose destination is one of its own sources.

### Benchmark

AMD Ryzen 9 9950X3D, 16 cores / 32 threads, `RUSTFLAGS="-Ctarget-cpu=native"`.
Circuit: one `keccak_f1600`, 2,760 gates and 2,760 eval instructions.

One 256-instance tile through `populate_wire_witness_batched`, single-threaded and core-pinned, 300 reps, best of 5 runs:

| | before | after | speedup |
|---|---|---|---|
| ms per tile | 0.613 | 0.083 | 7.4x |
| M word-ops/s | 1,152 | 8,520 | 7.4x |

`populate_batch_parallel` at `log_instances = 13`, with the `BufferPool` held outside the timed loop, best of 3 runs:

| threads | before | after | speedup |
|---|---|---|---|
| 1 | 24.02 ms | 6.75 ms | 3.56x |
| 4 | 7.63 ms | 2.81 ms | 2.71x |
| 16 | 4.02 ms | 2.36 ms | 1.70x |
| 32 (all) | 4.06 ms | 3.48 ms | 1.17x |

The interpretation phase itself gets 7.4x faster, but `populate_batch_parallel` also zeroes a per-tile buffer, runs the caller's fill, broadcasts constants, and gathers the tile into the batch layout — none of which this PR touches.
So the end-to-end gain shrinks as thread count rises and the path becomes memory-bandwidth bound.
The single-thread and low-core columns are where this change shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
