### PR TITLE
BINIUS-612: Drive zero propagation from a worklist

### DIFF
--- a/crates/frontend/src/pass/zero_fold.rs
+++ b/crates/frontend/src/pass/zero_fold.rs
@@ -1,8 +1,11 @@
 // Copyright 2026 The Binius Developers
 //! Zero propagation over the gate graph.
 
+use std::collections::VecDeque;
+
 use binius_core::word::Word;
 use cranelift_entity::EntitySet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
 	gates::Opcode,
@@ -23,14 +26,10 @@ use crate::{
 ///
 /// # Algorithm
 ///
-/// Zeros travel: clearing a zero leaves zero, and packing zero into a lane leaves zero. So one
-/// sweep is not enough, and the sweeps repeat until one changes nothing.
+/// A gate matches a rule only while it reads the zero wire.
+/// So the worklist starts at that wire's readers, and grows by the gates a rewrite hands a zero.
 ///
-/// Each sweep rebuilds the reader index first. Forwarding to an ordinary wire grows that wire's
-/// set of readers, which a stale index would not list, and a later sweep forwarding that same
-/// wire would then miss those readers.
-///
-/// Only the reader half is rebuilt. This pass follows readers, never definitions.
+/// The reader index is a snapshot, so the readers a rewrite moves are tracked alongside it.
 pub fn zero_propagation(
 	graph: &mut GateGraph,
 	force_committed: &EntitySet<Wire>,
@@ -42,29 +41,83 @@ pub fn zero_propagation(
 		return 0;
 	};
 
+	graph.rebuild_wire_uses(hint_registry);
+
+	let mut queue: VecDeque<Gate> = graph.get_wire_uses(zero).collect();
+	let mut queued: FxHashSet<Gate> = queue.iter().copied().collect();
+	let mut readers = Readers::default();
 	let mut total_rewritten = 0;
-	loop {
-		graph.rebuild_wire_uses(hint_registry);
 
-		// Gathered before any rewriting, since reading the graph and mutating it cannot overlap.
-		let mut forwardings = Vec::new();
-		for gate in graph.gates() {
-			if let Some(pairs) = zero_identity(graph, gate, zero, force_committed, hint_registry) {
-				forwardings.extend(pairs);
-			}
-		}
+	while let Some(gate) = queue.pop_front() {
+		queued.remove(&gate);
+		let Some(forwardings) = zero_identity(graph, gate, zero, force_committed, hint_registry)
+		else {
+			continue;
+		};
 
-		let mut rewritten = 0;
 		for (from, to) in forwardings {
-			rewritten += graph.replace_wire_with_wire(from, to).n_slots_rewritten;
-		}
+			if from == to {
+				continue;
+			}
 
-		// A sweep that moved no reader has reached the fixpoint.
-		if rewritten == 0 {
-			return total_rewritten;
+			let moving = readers.take(graph, from);
+			let mut landed = Vec::with_capacity(moving.len());
+			for reader in moving {
+				// Asked before the rewrite, after which every reader holds the target.
+				let had_target = reads(graph, reader, to, hint_registry);
+				total_rewritten += graph.replace_gate_wire(reader, from, to);
+				if !had_target {
+					landed.push(reader);
+				}
+				// A rewrite makes a gate newly match only by handing it a zero operand.
+				if to == zero && queued.insert(reader) {
+					queue.push_back(reader);
+				}
+			}
+			readers.record(to, landed);
 		}
-		total_rewritten += rewritten;
 	}
+
+	total_rewritten
+}
+
+/// The gates reading each wire, past the point the snapshot index still describes them.
+#[derive(Default)]
+struct Readers {
+	/// Wires whose snapshot run has already been handed out.
+	drained: FxHashSet<Wire>,
+	/// Readers a rewrite moved onto a wire.
+	moved: FxHashMap<Wire, Vec<Gate>>,
+}
+
+impl Readers {
+	/// Removes and returns every gate reading the wire.
+	fn take(&mut self, graph: &GateGraph, wire: Wire) -> Vec<Gate> {
+		let mut readers: Vec<Gate> = if self.drained.insert(wire) {
+			graph.get_wire_uses(wire).collect()
+		} else {
+			Vec::new()
+		};
+		readers.extend(self.moved.remove(&wire).into_iter().flatten());
+		readers
+	}
+
+	/// Adds gates that now read the wire.
+	fn record(&mut self, wire: Wire, gates: Vec<Gate>) {
+		if !gates.is_empty() {
+			self.moved.entry(wire).or_default().extend(gates);
+		}
+	}
+}
+
+/// Whether the gate takes the wire as a constant or input operand.
+fn reads(graph: &GateGraph, gate: Gate, wire: Wire, hint_registry: &HintRegistry) -> bool {
+	let param = graph.gate_data(gate).gate_param(hint_registry);
+	param
+		.constants
+		.iter()
+		.chain(param.inputs)
+		.any(|w| *w == wire)
 }
 
 /// The zero constant wire, if the circuit already has one.
@@ -110,7 +163,7 @@ fn zero_identity(
 		return None;
 	}
 
-	// The padding pair, which `replace_wire_with_wire` recognises as a no-op.
+	// The padding pair, which the forwarding loop skips.
 	let nothing = (zero, zero);
 
 	match (opcode, param.inputs, param.outputs) {
@@ -131,6 +184,9 @@ fn zero_identity(
 
 #[cfg(test)]
 mod tests {
+	use binius_core::constraint_system::ShiftVariant;
+	use proptest::prelude::*;
+
 	use super::*;
 	use crate::{Options, builder::CircuitBuilder};
 
@@ -206,5 +262,192 @@ mod tests {
 		// Only the all-one word the gate graph seeds, plus the one the assertion uses.
 		let constants = &circuit.constraint_system().constants;
 		assert!(!constants.contains(&Word::ZERO));
+	}
+
+	fn zero_propagation_by_sweeps(
+		graph: &mut GateGraph,
+		force_committed: &EntitySet<Wire>,
+		hint_registry: &HintRegistry,
+	) -> usize {
+		let Some(zero) = find_zero_constant(graph) else {
+			return 0;
+		};
+
+		let mut total_rewritten = 0;
+		loop {
+			graph.rebuild_wire_uses(hint_registry);
+
+			let mut forwardings = Vec::new();
+			for gate in graph.gates() {
+				if let Some(pairs) =
+					zero_identity(graph, gate, zero, force_committed, hint_registry)
+				{
+					forwardings.extend(pairs);
+				}
+			}
+
+			let mut rewritten = 0;
+			for (from, to) in forwardings {
+				rewritten += graph.replace_wire_with_wire(from, to).n_slots_rewritten;
+			}
+
+			if rewritten == 0 {
+				return total_rewritten;
+			}
+			total_rewritten += rewritten;
+		}
+	}
+
+	/// One gate of a generated fixture, naming its operands by position in the wire pool.
+	#[derive(Clone, Copy, Debug)]
+	enum Op {
+		Shift(usize, u32),
+		Bxor(usize, usize),
+		Iadd32(usize, usize),
+		Band(usize, usize),
+	}
+
+	/// Builds the fixture, returning the graph and the wire pool the operand positions index.
+	fn build_fixture(ops: &[Op]) -> (GateGraph, Vec<Wire>) {
+		let mut graph = GateGraph::new();
+		let root = graph.path_spec_tree.root();
+
+		// Position 0 is the zero constant, position 1 an ordinary input.
+		let mut pool = vec![graph.add_constant(Word::ZERO), graph.add_inout()];
+
+		for &op in ops {
+			let n = pool.len();
+			match op {
+				Op::Shift(a, amount) => {
+					let out = graph.add_internal();
+					graph.emit_gate_generic(
+						root,
+						Opcode::Shift,
+						vec![pool[a % n]],
+						vec![out],
+						&[],
+						&[ShiftVariant::Sll as u32, amount % 64],
+					);
+					pool.push(out);
+				}
+				Op::Bxor(a, b) => {
+					let out = graph.add_internal();
+					graph.emit_gate(root, Opcode::Bxor, vec![pool[a % n], pool[b % n]], vec![out]);
+					pool.push(out);
+				}
+				Op::Iadd32(a, b) => {
+					let sum = graph.add_internal();
+					let cout = graph.add_internal();
+					graph.emit_gate(
+						root,
+						Opcode::Iadd32,
+						vec![pool[a % n], pool[b % n]],
+						vec![sum, cout],
+					);
+					pool.push(sum);
+					pool.push(cout);
+				}
+				Op::Band(a, b) => {
+					let out = graph.add_internal();
+					graph.emit_gate(root, Opcode::Band, vec![pool[a % n], pool[b % n]], vec![out]);
+					pool.push(out);
+				}
+			}
+		}
+
+		// An assertion per wire, so every forwarding has a reader to move.
+		for &wire in &pool {
+			graph.emit_gate(root, Opcode::AssertZero, vec![wire], vec![]);
+		}
+
+		(graph, pool)
+	}
+
+	/// The pinned set the fixture's operand positions name.
+	fn pin_wires(pool: &[Wire], pins: &[usize]) -> EntitySet<Wire> {
+		let mut pinned = EntitySet::new();
+		for &pin in pins {
+			pinned.insert(pool[pin % pool.len()]);
+		}
+		pinned
+	}
+
+	/// Every gate's wire slots, which is the whole of what the pass rewrites.
+	fn wiring(graph: &GateGraph) -> Vec<Vec<Wire>> {
+		graph
+			.gates
+			.values()
+			.map(|data| data.wires.to_vec())
+			.collect()
+	}
+
+	/// A cone whose every level turns zero only once the level below it has.
+	fn deep_zero_cone(depth: usize) -> Vec<Op> {
+		let mut ops = Vec::new();
+		let mut zero_at = 0;
+		let mut next = 2;
+		for _ in 0..depth {
+			// The shift and the exclusive-or each hand their level's zero one step further on.
+			ops.push(Op::Shift(zero_at, 3));
+			let shifted = next;
+			ops.push(Op::Bxor(shifted, 1));
+			let folded = next + 1;
+			// The carry-out is the next level's zero, and it is zero only once both above fired.
+			ops.push(Op::Iadd32(folded, shifted));
+			zero_at = next + 3;
+			next += 4;
+		}
+		ops
+	}
+
+	#[test]
+	fn a_deep_zero_cone_reaches_the_sweep_fixpoint() {
+		let registry = HintRegistry::new();
+		let ops = deep_zero_cone(16);
+
+		let (mut swept, _) = build_fixture(&ops);
+		zero_propagation_by_sweeps(&mut swept, &EntitySet::new(), &registry);
+
+		let (mut worked, _) = build_fixture(&ops);
+		zero_propagation(&mut worked, &EntitySet::new(), &registry);
+
+		assert_eq!(wiring(&swept), wiring(&worked));
+
+		// The cone really does collapse, so the comparison above is not between two untouched
+		// graphs.
+		let (untouched, _) = build_fixture(&ops);
+		assert_ne!(wiring(&untouched), wiring(&worked));
+	}
+
+	fn any_op() -> impl Strategy<Value = Op> {
+		prop_oneof![
+			(0usize..64, 0u32..64).prop_map(|(a, n)| Op::Shift(a, n)),
+			(0usize..64, 0usize..64).prop_map(|(a, b)| Op::Bxor(a, b)),
+			(0usize..64, 0usize..64).prop_map(|(a, b)| Op::Iadd32(a, b)),
+			(0usize..64, 0usize..64).prop_map(|(a, b)| Op::Band(a, b)),
+		]
+	}
+
+	proptest! {
+		#[test]
+		fn the_worklist_reaches_the_sweep_fixpoint(
+			ops in prop::collection::vec(any_op(), 1..48),
+			pins in prop::collection::vec(0usize..64, 0..4),
+		) {
+			let registry = HintRegistry::new();
+
+			let (mut swept, pool) = build_fixture(&ops);
+			let pinned = pin_wires(&pool, &pins);
+			zero_propagation_by_sweeps(&mut swept, &pinned, &registry);
+
+			let (mut worked, _) = build_fixture(&ops);
+			zero_propagation(&mut worked, &pinned, &registry);
+
+			// The two schedules land on the same graph, slot for slot.
+			prop_assert_eq!(wiring(&swept), wiring(&worked));
+
+			// And the worklist result is a sweep fixpoint in its own right.
+			prop_assert_eq!(zero_propagation_by_sweeps(&mut worked, &pinned, &registry), 0);
+		}
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-612](https://linear.app/jimpo/issue/BINIUS-612).

Zero propagation keeps the same rules and the same fixpoint, but reaches it from a worklist instead of re-sweeping the whole gate graph.
Output is byte-identical — every `CircuitStat` field is unchanged on every fixture measured.

### The problem

Zeros travel: shifting a zero leaves zero, and adding a zero carries nothing.
So one scan of the graph is not enough, and the pass repeats until a scan changes nothing.

Every repeat rebuilds the whole reader index first — three linear passes over every gate, plus two vectors sized by the wire count.

On `sha256_fixed` over 8 KiB (147,152 gates, 188,212 wires at pass entry) the scans rewrite:

```
scan 1:  93 wire slots
scan 2:  48
scan 3:  33
scan 4:  64
scan 5:  15
scan 6:   0
```

Six index rebuilds and six full gate scans to move 253 wire slots out of 188,212 wires.

On a 512-hash circuit (676,352 gates, 832,044 wires) it is four rebuilds for 19,968 slots.

This is a scheduling problem, not a verdict on the pass.
On a padded circuit zero propagation is one of the most valuable passes in the pipeline; it just reaches its answer the expensive way.

### The idea

A gate can match a rule only while one of its operands **is** the zero wire.
So the candidate set is exactly the readers of that one wire — never the whole graph.

- Build the reader index **once**.
- Seed a worklist with the gates that read the zero constant.
- Pop a gate, test it against the rules, apply the forwarding.
- When a forwarding writes a zero into an operand, push the gates it touched.

### The catch: the index is a snapshot

`replace_wire_with_wire` says so itself — forwarding onto an ordinary wire grows that wire's reader set, and the snapshot never lists the readers it moved.
That is precisely why the pass re-sweeps today, and a worklist has to carry the information itself.

So the pass now keeps the reader sets it changes: a forwarding takes every reader off its source and records them on its target, and the union is handed out when that target is forwarded in turn.
That set is exact, because forwarding is the only thing that changes who reads what.

### Why re-queuing on a zero target is enough

Three facts, and the schedule is pinned:

1. **A rewrite can only create a new match by writing a zero.**
   A forwarding replaces operand `from` with operand `to`.
   `from` is always a gate output and the zero wire is a constant, so `from` is never zero.
   A gate's set of zero-valued operands is therefore unchanged unless `to` is the zero wire.

2. **A gate that has fired never needs re-examining.**
   Firing leaves its forwarded outputs with no readers.
   A wire's reader set can only grow through a forwarding that targets it, and every rule targets one of the firing gate's own operands — so a wire nobody reads is a wire nobody can target, and it stays at zero readers forever.

3. **The definer of a forwarding target never needs re-queuing.**
   The target is one of the firing gate's own operands, so the firing gate reads it both before and after.
   The target's reader set was therefore already non-empty, so its definer — if it matches a rule — already had pending work and was already on the worklist.

### Soundness

Zero propagation feeds dead-code elimination, which decides which gates emit constraints.
A missed rewrite is a silently larger constraint system; an extra one is a soundness question.
So the bar here is the *same* fixpoint, not a similar one.

Three checks, in increasing strength:

- `the_worklist_reaches_the_sweep_fixpoint` — a property test over random gate graphs. It builds the same graph twice, runs the old sweep schedule on one and the worklist on the other, and asserts the two agree **slot for slot across every gate**. It then runs the sweep schedule on the worklist's output and asserts it rewrites nothing.
- `a_deep_zero_cone_reaches_the_sweep_fixpoint` — the same comparison on a 16-level cone whose every level only turns zero once the level below it has, which is where the two schedules would diverge if they ever could.
- On real circuits, every one of the 19 `CircuitStat` fields is identical before and after, and running the old sweep schedule on the worklist's output rewrites **0** further slots.

The old sweep-to-fixpoint implementation is kept in the test module as the reference the property test compares against.

### One number that does change

The pass returns a count of wire slots rewritten, which the caller discards.

| fixture | sweeps | worklist |
|---|---:|---:|
| `sha256_fixed(8 KiB)` | 253 | 205 |
| 512 x `sha256_fixed(4 B)` | 19,968 | 19,968 |

The 48-slot gap is double work in the sweep schedule, not missing work: within one scan it forwards into a wire that a later forwarding in the same scan moves again.
The resulting graph is identical either way, which is what the tests above assert.

### Scope

- `crates/frontend/src/pass/zero_fold.rs` only — no change to `GateGraph`.
- The rule table is untouched. It still covers `Shift`, `Bxor` and `Iadd32`; widening it is a separate question with its own evidence to gather.
- The pass still rebuilds only the reader half of the use-def analysis, and still returns immediately when the graph holds no zero constant.

### Verification

- `cargo test -p binius-frontend` (debug, so `debug_assert!` fires) — 265 tests pass
- `cargo test -p binius-frontend --release` with `-Ctarget-cpu=native` — pass
- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `cargo doc -p binius-frontend --document-private-items --no-deps` with `RUSTDOCFLAGS="-D warnings"` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `tools/check_copyright_notice.py`, `typos` — clean
- The property test was additionally run at 20,000 cases and on graphs up to 120 gates — clean

### Benchmark

AMD Ryzen 9 9950X3D, `-Ctarget-cpu=native`, pinned with `taskset`, 10 interleaved repetitions of 9 builds per fixture, the two sides alternating order so neither always runs warm.
Both arms have zero propagation **enabled**, so the only difference is the schedule.

| fixture | gates | slots rewritten | before (min / median) | after (min / median) | delta |
|---|---:|---:|---:|---:|---:|
| `sha256_fixed(8 KiB)` | 147,152 | 253 | 85.5 / 90.9 ms | 72.4 / 77.0 ms | **-15.3%** |
| 512 x `sha256_fixed(4 B)` | 676,352 | 19,968 | 463.7 / 481.4 ms | 416.9 / 431.4 ms | **-10.1%** |
| `sha256_varlen(1 KiB cap)` | 175,226 | 0 | 83.8 / 91.4 ms | 84.2 / 89.7 ms | +0.5% |
| `sha3_256_varlen(512 B cap)` | 90,340 | 0 | 36.8 / 38.8 ms | 37.2 / 39.0 ms | +1.0% |
| `keccak256(8 blocks)` | 22,198 | 0 | 7.7 / 8.0 ms | 7.9 / 8.8 ms | +2.6% |

The two fixtures where the pass actually rewrites something get faster; the three where it rewrites nothing do not move, which is exactly right — with nothing to rewrite both schedules do one index build and stop.

Control, with the pass disabled in **both** arms, to establish the noise floor:

| fixture | delta (min) | delta (median) |
|---|---:|---:|
| `sha256_fixed(8 KiB)` | +2.9% | -1.0% |
| 512 x `sha256_fixed(4 B)` | +0.7% | +0.2% |

The machine was shared, so the floor is about 3%. Both wins sit well outside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
