### PR TITLE
BINIUS-615: Correct two documentation claims in the sumcheck prover

### DIFF
--- a/crates/ip-prover/src/claim_fold.rs
+++ b/crates/ip-prover/src/claim_fold.rs
@@ -144,6 +144,9 @@ where
 ///
 /// This is the reference a folded claim is settled against.
 /// It reads the entries and the point, and nothing from the run that raised the claim.
+///
+/// The indicator is materialized in full, so the cost is one element per vertex of the point.
+/// Call it only where that fits.
 pub fn evaluate<F: Field>(entries: &[TensorEntry<F>], point: &[Vec<F>]) -> F {
 	let flat = point.concat();
 	let indicator = eq_ind_partial_eval_scalars(&flat);

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -141,8 +141,11 @@ pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 
 /// Maximum log2 chunk size of the parallel round pass.
 ///
-/// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
-/// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
+/// Chunked accumulation keeps the equality-indicator chunk resident while all evaluators read it,
+/// mirroring the chunking of the pre-store quadratic prover.
+///
+/// A chunk is 64 KiB at 128-bit scalars.
+/// A group of `N` claims reads `2N + 1` of them, so the working set is second-level, not first.
 const MAX_CHUNK_VARS: usize = 12;
 
 /// The state a group of claims shares, whichever protocol drives them.
@@ -344,9 +347,6 @@ where
 
 		// One parallel pass over the halved hypercube feeds every evaluator, so shared columns
 		// and eq-indicator chunks are read once per round while they are cache-resident.
-		//
-		// TODO: dynamically choose chunk size based on the number of columns and P byte-size,
-		// based on estimated L1 cache size.
 		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
 
 		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker


### PR DESCRIPTION
Closes [BINIUS-615](https://linear.app/jimpo/issue/BINIUS-615).

Two documentation claims that do not hold, and a note whose answer has now been measured. Docs only — no code changes.

### The chunk bound claimed a cache level it cannot reach

```
/// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
/// evaluators read it
```

A chunk is `2^12` scalars. At 128 bits per scalar that is **64 KiB**, against a **48 KiB** L1d on this machine — so a single chunk does not fit, let alone stay resident.

And a group does not read one chunk. With `N` claims it reads `2N + 1` of them, so the AND-check group at `N = 3` has a **448 KiB** working set. That is L2 (1 MiB per core), and comfortably so.

The doc now states the two numbers and lets the reader draw the conclusion:

```diff
-/// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
-/// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
+/// Chunked accumulation keeps the equality-indicator chunk resident while all evaluators read it,
+/// mirroring the chunking of the pre-store quadratic prover.
+///
+/// A chunk is 64 KiB at 128-bit scalars.
+/// A group of `N` claims reads `2N + 1` of them, so the working set is second-level, not first.
```

### The `TODO` next to it has an answer now

```
// TODO: dynamically choose chunk size based on the number of columns and P byte-size,
// based on estimated L1 cache size.
```

Swept against the fixed bound, using the real `a*b - c` composition at `N = 3`: worth **at most 5% at `n_vars = 20`, and nothing at all at `n_vars = 22`**, where the round is bound by memory bandwidth rather than by residency.

That is not worth deriving a constant per call site for, so the `TODO` is removed rather than left to be re-chased. The measurement lives here, in the PR, rather than in the source.

### The fold's reference evaluation is exponential and said nothing

`claim_fold::evaluate` calls `eq_ind_partial_eval_scalars` on the concatenated point, materializing the full tensor — precisely the cost a sumcheck exists to avoid. It is documented as *"the reference a folded claim is settled against"*, which is right where it is used, at a leaf.

Nothing warned a caller reaching for it higher up a tree, where the point is long and the allocation is `2^(total variables)`:

```diff
 /// This is the reference a folded claim is settled against.
 /// It reads the entries and the point, and nothing from the run that raised the claim.
+///
+/// The indicator is materialized in full, so the cost is one element per vertex of the point.
+/// Call it only where that fits.
```

### Scope

Two files, docs only. No signature, behaviour or test changes.

Worth saying: the inspection that found these rated this crate's documentation **unusually high** overall — it documents alternatives that were measured and rejected, and why two near-identical traits must not inherit from one another. These two are the exceptions, not the pattern.

### Verification

- `cargo test -p binius-ip-prover` — 106 passed, 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
