### PR TITLE
BINIUS-614: Give the strided-array views a raw pointer instead of a whole-buffer \&mut

### DIFF
--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -1,7 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use core::slice;
-use std::ops::{Index, IndexMut, Range};
+use std::{
+	marker::PhantomData,
+	ops::{Index, IndexMut, Range},
+};
 
 use crate::rayon::prelude::*;
 
@@ -15,11 +17,17 @@ pub enum Error {
 /// vertical slices.
 #[derive(Debug)]
 pub struct StridedArray2DViewMut<'a, T> {
-	data: &'a mut [T],
+	data: *mut T,
 	data_width: usize,
 	height: usize,
 	cols: Range<usize>,
+	_marker: PhantomData<&'a mut [T]>,
 }
+
+// SAFETY: the view has exclusive access to its columns, matching `&mut [T]`.
+unsafe impl<T: Send> Send for StridedArray2DViewMut<'_, T> {}
+// SAFETY: a shared reference to the view yields only `&T`, matching `&mut [T]`.
+unsafe impl<T: Sync> Sync for StridedArray2DViewMut<'_, T> {}
 
 impl<'a, T> StridedArray2DViewMut<'a, T> {
 	/// Create a single-piece view of the data.
@@ -32,10 +40,11 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 			return Err(Error::DimensionMismatch);
 		}
 		Ok(Self {
-			data,
+			data: data.as_mut_ptr(),
 			data_width: width,
 			height,
 			cols: 0..width,
+			_marker: PhantomData,
 		})
 	}
 
@@ -45,10 +54,13 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	pub unsafe fn get_unchecked_ref(&self, i: usize, j: usize) -> &T {
 		debug_assert!(i < self.height);
 		debug_assert!(j < self.width());
-		unsafe {
-			self.data
-				.get_unchecked(i * self.data_width + j + self.cols.start)
-		}
+		// SAFETY:
+		// - Provenance: reborrowed from the exclusive borrow the view was built from.
+		// - Bounds: construction pairs the buffer length with the dimensions, and the caller
+		//   guarantees the indices are in range.
+		// - Non-overlap: sibling views hold disjoint column ranges.
+		// - Only the addressed element is ever referenced, never a span of the buffer.
+		unsafe { &*self.data.add(i * self.data_width + j + self.cols.start) }
 	}
 
 	/// Returns a mutable reference to the data at the given indices without bounds checking.
@@ -57,10 +69,13 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	pub unsafe fn get_unchecked_mut(&mut self, i: usize, j: usize) -> &mut T {
 		debug_assert!(i < self.height);
 		debug_assert!(j < self.width());
-		unsafe {
-			self.data
-				.get_unchecked_mut(i * self.data_width + j + self.cols.start)
-		}
+		// SAFETY:
+		// - Provenance: reborrowed from the exclusive borrow the view was built from.
+		// - Bounds: construction pairs the buffer length with the dimensions, and the caller
+		//   guarantees the indices are in range.
+		// - Non-overlap: sibling views hold disjoint column ranges.
+		// - Only the addressed element is ever referenced, never a span of the buffer.
+		unsafe { &mut *self.data.add(i * self.data_width + j + self.cols.start) }
 	}
 
 	pub const fn height(&self) -> usize {
@@ -75,13 +90,13 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	pub fn iter_column_mut(&mut self, col: usize) -> impl Iterator<Item = &mut T> + '_ {
 		assert!(col < self.width());
 		let start = col + self.cols.start;
-		let data_ptr = self.data.as_mut_ptr();
+		let data = self.data;
 		(0..self.height).map(move |i|
-				// Safety:
-				// - `data_ptr` points to the start of the data slice.
-				// - `col` is within bounds of the width.
-				// - different iterator values do not overlap.
-				unsafe { &mut *data_ptr.add(i * self.data_width + start) })
+				// SAFETY:
+				// - Provenance: reborrowed from the exclusive borrow the view was built from.
+				// - Bounds: the row is below the height and the column is checked above.
+				// - Non-overlap: one row per step, so no two yielded references coincide.
+				unsafe { &mut *data.add(i * self.data_width + start) })
 	}
 
 	/// Returns iterator over vertical slices of the data for the given stride.
@@ -91,17 +106,17 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 			data_width,
 			height,
 			cols,
+			..
 		} = self;
 
 		cols.clone().step_by(stride).map(move |start| {
 			let end = (start + stride).min(cols.end);
 			Self {
-				// Safety: different instances of StridedArray2DViewMut created with the same data
-				// slice do not access overlapping indices.
-				data: unsafe { slice::from_raw_parts_mut(data.as_mut_ptr(), data.len()) },
+				data,
 				data_width,
 				height,
 				cols: start..end,
+				_marker: PhantomData,
 			}
 		})
 	}
@@ -111,6 +126,7 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	where
 		T: Send + Sync,
 	{
+		let data = SendPtr(self.data);
 		self.cols
 			.clone()
 			.into_par_iter()
@@ -119,29 +135,24 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 				let end = (start + stride).min(self.cols.end);
 				// We are setting the same lifetime as `self` captures.
 				Self {
-					// Safety: different instances of StridedArray2DViewMut created with the same
-					// data slice do not access overlapping indices.
-					data: unsafe {
-						slice::from_raw_parts_mut(self.data.as_ptr().cast_mut(), self.data.len())
-					},
+					data: data.as_ptr(),
 					data_width: self.data_width,
 					height: self.height,
 					cols: start..end,
+					_marker: PhantomData,
 				}
 			})
 	}
 
 	/// Returns iterator over single-column mutable views of the data.
 	pub fn iter_cols(&mut self) -> impl Iterator<Item = StridedArray2DColMut<'_, T>> + '_ {
-		let data_ptr = self.data.as_mut_ptr();
-		let data_len = self.data.len();
+		let data = self.data;
 		self.cols.clone().map(move |col| StridedArray2DColMut {
-			// Safety: different instances of StridedArray2DColMut created with the same data
-			// slice do not access overlapping indices since each accesses a different column.
-			data: unsafe { slice::from_raw_parts_mut(data_ptr, data_len) },
+			data,
 			data_width: self.data_width,
 			height: self.height,
 			col,
+			_marker: PhantomData,
 		})
 	}
 
@@ -152,31 +163,36 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	where
 		T: Send + Sync,
 	{
-		let data_ptr = SendPtr(self.data.as_mut_ptr());
-		let data_len = self.data.len();
+		let data = SendPtr(self.data);
 		let data_width = self.data_width;
 		let height = self.height;
-		self.cols.clone().into_par_iter().map(move |col| {
-			StridedArray2DColMut {
-				// Safety: different instances of StridedArray2DColMut created with the same data
-				// slice do not access overlapping indices since each accesses a different column.
-				data: unsafe { slice::from_raw_parts_mut(data_ptr.as_ptr(), data_len) },
+		self.cols
+			.clone()
+			.into_par_iter()
+			.map(move |col| StridedArray2DColMut {
+				data: data.as_ptr(),
 				data_width,
 				height,
 				col,
-			}
-		})
+				_marker: PhantomData,
+			})
 	}
 }
 
 /// A mutable view of a single column (vertical slice) of a 2D array in row-major order.
 #[derive(Debug)]
 pub struct StridedArray2DColMut<'a, T> {
-	data: &'a mut [T],
+	data: *mut T,
 	data_width: usize,
 	height: usize,
 	col: usize,
+	_marker: PhantomData<&'a mut [T]>,
 }
+
+// SAFETY: the view has exclusive access to its column, matching `&mut [T]`.
+unsafe impl<T: Send> Send for StridedArray2DColMut<'_, T> {}
+// SAFETY: a shared reference to the view yields only `&T`, matching `&mut [T]`.
+unsafe impl<T: Sync> Sync for StridedArray2DColMut<'_, T> {}
 
 impl<'a, T> StridedArray2DColMut<'a, T> {
 	pub const fn height(&self) -> usize {
@@ -188,7 +204,13 @@ impl<'a, T> StridedArray2DColMut<'a, T> {
 	/// The caller must ensure that `i < self.height`.
 	pub unsafe fn get_unchecked_ref(&self, i: usize) -> &T {
 		debug_assert!(i < self.height);
-		unsafe { self.data.get_unchecked(i * self.data_width + self.col) }
+		// SAFETY:
+		// - Provenance: reborrowed from the exclusive borrow the parent view was built from.
+		// - Bounds: the parent's dimensions cover the buffer, and the caller guarantees the row is
+		//   below the height.
+		// - Non-overlap: the constructors give each view its own column.
+		// - Only the addressed element is ever referenced, never a span of the buffer.
+		unsafe { &*self.data.add(i * self.data_width + self.col) }
 	}
 
 	/// Returns a mutable reference to the data at the given row index without bounds checking.
@@ -196,7 +218,13 @@ impl<'a, T> StridedArray2DColMut<'a, T> {
 	/// The caller must ensure that `i < self.height`.
 	pub unsafe fn get_unchecked_mut(&mut self, i: usize) -> &mut T {
 		debug_assert!(i < self.height);
-		unsafe { self.data.get_unchecked_mut(i * self.data_width + self.col) }
+		// SAFETY:
+		// - Provenance: reborrowed from the exclusive borrow the parent view was built from.
+		// - Bounds: the parent's dimensions cover the buffer, and the caller guarantees the row is
+		//   below the height.
+		// - Non-overlap: the constructors give each view its own column.
+		// - Only the addressed element is ever referenced, never a span of the buffer.
+		unsafe { &mut *self.data.add(i * self.data_width + self.col) }
 	}
 }
 
@@ -375,6 +403,13 @@ mod tests {
 		assert_eq!(data[0], 88); // row 0, col 0
 		assert_eq!(data[4], 99); // row 1, col 1
 		assert_eq!(data[11], 77); // row 3, col 2
+	}
+
+	#[test]
+	fn test_views_are_send_and_sync() {
+		fn assert_send_sync<T: Send + Sync>() {}
+		assert_send_sync::<StridedArray2DViewMut<'_, usize>>();
+		assert_send_sync::<StridedArray2DColMut<'_, usize>>();
 	}
 
 	#[test]

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -126,18 +126,24 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	where
 		T: Send + Sync,
 	{
-		let data = SendPtr(self.data);
-		self.cols
-			.clone()
+		let Self {
+			data,
+			data_width,
+			height,
+			cols,
+			..
+		} = self;
+		let data = SendPtr(data);
+
+		cols.clone()
 			.into_par_iter()
 			.step_by(stride)
 			.map(move |start| {
-				let end = (start + stride).min(self.cols.end);
-				// We are setting the same lifetime as `self` captures.
+				let end = (start + stride).min(cols.end);
 				Self {
 					data: data.as_ptr(),
-					data_width: self.data_width,
-					height: self.height,
+					data_width,
+					height,
 					cols: start..end,
 					_marker: PhantomData,
 				}


### PR DESCRIPTION
Closes [BINIUS-614](https://linear.app/jimpo/issue/BINIUS-614).

Makes the strided-array views hold a raw pointer instead of a `&mut` over the whole backing buffer.
No API change, no behaviour change — the fix is that the borrows are now real.

### The problem

Both view types stored a `&'a mut [T]` covering the **entire** backing buffer:

```rust
pub struct StridedArray2DColMut<'a, T> {
    data: &'a mut [T],      // the WHOLE backing slice
    data_width: usize,
    height: usize,
    col: usize,
}
```

`iter_cols` / `par_iter_cols` hand out one of these per column, and `into_strides` hands out one view per stripe.
All of them are materialised from the same pointer, and several are live at the same time.

The safety comment argued that two views never touch the same *element*:

```rust
// Safety: different instances of StridedArray2DColMut created with the same data
// slice do not access overlapping indices since each accesses a different column.
```

That is true, and it is the wrong argument.
Rust's rule is one live `&mut` per location, and every one of these views claims the whole buffer.
Disjoint indexing does not license overlapping borrows.

### The idea

Stop storing a reference to memory the view does not exclusively own.

Hold a raw pointer plus a `PhantomData` lifetime, and form a reference only at the accessed element:

```
- data: &'a mut [T]                 // the whole buffer, per view
+ data: *mut T
+ _marker: PhantomData<&'a mut [T]>
```

Each reference then covers exactly one element.
Two views address distinct elements, so no two live references overlap and there is nothing left to justify.

The `PhantomData` keeps the lifetime tied to the parent borrow, so a view still cannot outlive the array.

### The change

At every access site, the slice indexing becomes a one-element reborrow:

```diff
- unsafe { self.data.get_unchecked_mut(i * self.data_width + self.col) }
+ unsafe { &mut *self.data.add(i * self.data_width + self.col) }
```

Constructing a view no longer needs `unsafe` at all — `iter_cols` and `into_strides` just copy the pointer.
The only `unsafe` blocks that remain are the four accessors, each with a safety comment naming provenance, the bound, and what enforces non-overlap.

`Send` and `Sync` were previously inherited from the slice field.
They are now restated by hand with the same bounds, and pinned by a static assertion so the behaviour cannot silently widen:

```rust
unsafe impl<T: Send> Send for StridedArray2DColMut<'_, T> {}
unsafe impl<T: Sync> Sync for StridedArray2DColMut<'_, T> {}
```

The public API is untouched: `height`, `get_unchecked_ref`, `get_unchecked_mut`, `Index`, `IndexMut` all keep their signatures, their bounds assertions, and their behaviour.

### Soundness

The existing unit tests are the reproducers, so before/after is measurable directly.

Commands:

```
MIRIFLAGS="-Zmiri-disable-isolation" \
  cargo +nightly miri test -p binius-utils --lib strided_array -- --skip par

MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tree-borrows" \
  cargo +nightly miri test -p binius-utils --lib strided_array
```

| test | entry point | SB before | SB after | TB before | TB after |
|---|---|---|---|---|---|
| `test_indexing` | `without_stride` | pass | pass | pass | pass |
| `test_iter_column_mut` | `iter_column_mut` | pass | pass | pass | pass |
| `test_strides` | `into_strides` | **UB** | pass | **UB** | pass |
| `test_col_mut_indexing` | `iter_cols` | **UB** | pass | **UB** | pass |
| `test_iter_cols` | `iter_cols` | **UB** | pass | **UB** | pass |
| `test_par_iter_cols` | `par_iter_cols` | n/a | n/a | **UB** | pass |
| `test_parallel_strides` | `into_par_strides` | n/a | n/a | **UB** | pass |

The two models disagree about *which* entry point they catch first, so both were needed:

```
# Stacked Borrows, test_strides
error: Undefined Behavior: trying to retag from <191849> for SharedReadWrite permission
at alloc56126[0x0], but that tag does not exist in the borrow stack for this location
help: <191849> was created by a Unique retag  (the first stride handed out)
help: <191849> was later invalidated at offsets [0x0..0x60] by a Unique function-entry
      retag inside this call   (the second stride re-deriving the same &mut)
```

```
# Tree Borrows, test_col_mut_indexing
error: Undefined Behavior: reborrow through <159704> at alloc58308[0x30] is forbidden
help: the accessed tag <159704> has state Disabled which forbids this reborrow
help: <159704> later transitioned to Disabled due to a foreign write access
   --> crates/utils/src/strided_array.rs:347:3   (cols[0][2] = 88)
```

**What could not be run, honestly:** the two `n/a` cells.
Stacked Borrows aborts inside `crossbeam-epoch` during rayon worker registration, before any workspace code executes, so it cannot cover either rayon test in either direction.
That is why the Stacked Borrows column is scoped with `--skip par`.
Tree Borrows runs both fine (with `-Zmiri-ignore-leaks`, since rayon's pool outlives `main`).

`test_parallel_strides` was also failing under Tree Borrows for a *different* reason — the shared-reborrow write pointer in `into_par_strides` that #2420 fixes. That line is removed here as a side effect of the field type changing, so both are green.

### `iter_column_mut` — checked, and it was already fine

It builds a `&mut T` per row from a raw pointer, which is the shape this PR is moving everything else towards.
It never materialises a reference wider than one element, so the defect does not apply.
Miri confirms: it passes under both models before and after.
Only its safety comment changed, to match the others.

### Scope

- **changed:** `crates/utils/src/strided_array.rs` — both view structs, four accessors, `iter_column_mut`, `into_strides`, `iter_cols`, `par_iter_cols`.
- **one external caller:** `crates/prover/src/protocols/intmul/witness.rs:423` (`par_iter_cols`). `iter_cols` and `into_strides` have no callers outside the file.
- **added:** one static assertion test pinning `Send`/`Sync`.
- **not touched:** `SendPtr`.

**Overlap with #2420, flagged deliberately.**
Changing the field type forces two lines inside `into_par_strides` to change: the struct literal loses its `slice::from_raw_parts_mut` call, and the pointer is hoisted into a `SendPtr` because closure field capture would otherwise make the closure `!Send`.
That is exactly where #2420 is working, so expect a small conflict there. Resolving it means keeping this PR's `data: data.as_ptr()` line — #2420's bug disappears with the whole-buffer slice.

**Follow-up, not done here:** `into_strides` and `into_par_strides` now build the same struct two slightly different ways for the closure-capture reason above. Worth unifying once #2420 lands.

### Verification

- `cargo test -p binius-utils` and `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-utils --release` — 30 pass
- `cargo test -p binius-prover --lib protocols::intmul` — 7 pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-utils -p binius-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-utils --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `python3 tools/check_copyright_notice.py` — clean

### Benchmark

`crates/prover/benches/intmul.rs`, the `components/b_leaves` case, which is the one that goes through `par_iter_cols`.
Two binaries built from the two revisions, then run alternating — 14 interleaved pairs.

| statistic | before | after | delta |
|---|---|---|---|
| median of 14 | 3.797 ms | 3.727 ms | −1.8% |
| minimum of 14 | 3.491 ms | 3.519 ms | +0.8% |

The two statistics disagree in sign, which is the honest reading: this is noise.
Run-to-run spread on this machine is around ±20%, an order of magnitude larger than either number above.

A noise-free check agrees. Disassembling the per-column dispatch function in both binaries:

| | before | after |
|---|---|---|
| instructions | 50 | 48 |
| `StridedArray2DColMut` size | 40 bytes | 32 bytes |

Dropping the slice length field removes a word from the struct and two `mov`s from the loop. Nothing was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
