### PR TITLE
BINIUS-616: Require a cryptographic RNG where the ZK mask's entropy enters

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -30,7 +30,7 @@ use binius_utils::{
 	},
 };
 use itertools::izip;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{CryptoRng, SeedableRng, rngs::StdRng};
 
 use crate::{
 	basefold::prove_mlecheck_basefold,
@@ -122,13 +122,17 @@ where
 	/// parameters.
 	///
 	/// The FRI parameters should already account for ZK (log_batch_size = 1, doubled message
-	/// length). The `rng` is used to seed an internal `StdRng` for mask generation.
+	/// length).
+	///
+	/// The RNG seeds the channel's own generator, whose only output is the ZK masks.
+	/// A mask is what hides a committed witness at the positions the verifier opens.
+	/// Hiding is therefore only as strong as this RNG, so it must be a cryptographic one.
 	pub fn new(
 		channel: Channel,
 		ntt: &'a NTT,
 		oracle_specs: Vec<OracleSpec>,
 		fri_params: FRIParams<F>,
-		mut rng: impl Rng,
+		mut rng: impl CryptoRng,
 		alloc: A,
 	) -> Self {
 		Self {

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -15,7 +15,7 @@ use binius_math::ntt::AdditiveNTT;
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
 use digest::Output;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{CryptoRng, SeedableRng, rngs::StdRng};
 
 use crate::{
 	basefold::channel::BaseFoldProverChannel,
@@ -126,12 +126,15 @@ where
 	///
 	/// The returned channel drives all prover interaction through `channel`, committing and opening
 	/// oracles with this compiler's NTT, oracle specs, and combined FRI parameters. The caller
-	/// constructs the Merkle channel, so it decides how commitments are produced. The `rng` is used
-	/// to seed an internal `StdRng` for mask generation.
+	/// constructs the Merkle channel, so it decides how commitments are produced.
+	///
+	/// The RNG seeds the channel's own generator, whose only output is the ZK masks.
+	/// A mask is what hides a committed witness at the positions the verifier opens.
+	/// Hiding is therefore only as strong as this RNG, so it must be a cryptographic one.
 	pub fn create_channel<Channel, A>(
 		&self,
 		channel: Channel,
-		rng: impl Rng,
+		rng: impl CryptoRng,
 		alloc: A,
 	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel, A>
 	where
@@ -188,7 +191,7 @@ where
 	pub fn create_channel_from_transcript<H, Challenger_, T, A>(
 		&self,
 		transcript: T,
-		rng: impl Rng,
+		rng: impl CryptoRng,
 		alloc: A,
 	) -> TranscriptBaseFoldProverChannel<'_, F, P, NTT, T, Challenger_, H, A>
 	where


### PR DESCRIPTION
Closes [BINIUS-616](https://linear.app/jimpo/issue/BINIUS-616).

Tightens three prover signatures from any RNG to a cryptographic one. No behavior change, no runtime cost.

### The problem

The ZK mask is the only secret the BaseFold prover holds.

A masked oracle commits the interleaved pair (message ‖ mask), and the verifier opens a handful of codeword positions.
What keeps those openings from revealing the witness is that the mask is uniformly random and unknown to the verifier.
So the hiding property of every ZK proof this crate produces is exactly as strong as the entropy behind that mask.

The function that draws the mask asks for that entropy correctly:

```
pub fn encode_masked<..>(.., mut rng: impl CryptoRng, ..)
```

The channel that calls it did not.
It accepted any RNG, and reseeded a cryptographic generator from it:

```
pub fn new(.., mut rng: impl Rng, ..) -> Self {
    Self { .., rng: StdRng::from_rng(&mut rng), .. }
}
```

A seeded generator is a cryptographic type whatever it was seeded from.
So the bound the mask generator asks for was satisfied by construction, and carried no information about the entropy that actually reached it.

### What a weak RNG would cost

Nothing today — every in-tree caller already passes a cryptographic RNG.

The hazard is the next caller.
A prover seeded from a counter, a timestamp, or a small-state generator produces masks an observer can reproduce.
Reproducing the mask recovers the committed witness from the opened positions, and the proof stops being zero-knowledge — silently, with no test failing and no type error.

### The change

```diff
- rng: impl Rng
+ rng: impl CryptoRng
```

- `crates/iop-prover/src/basefold/channel.rs` — the channel constructor
- `crates/iop-prover/src/basefold/compiler.rs` — the two entry points that build a ZK channel

The non-ZK constructor is unaffected.
It supplies a fixed seed, which is already a cryptographic generator, and it is guarded by an assertion that no oracle is ZK.

### Every call site, checked

| call site | what it passes |
|---|---|
| `crates/prover/src/zk_config.rs:147` | the caller's own `impl CryptoRng`, forwarded |
| `crates/spartan-prover/src/lib.rs:408` | the caller's own `impl CryptoRng`, forwarded |
| `crates/iop-prover/src/logup_star.rs:678, 734` | a seeded `StdRng` |
| `crates/iop-prover/src/basefold/channel.rs` tests (5) | a seeded `StdRng` |
| `create_channel_without_zk` | a fixed-seed `StdRng`, behind the no-ZK assertion |

All already satisfy the tighter bound, so this is a pure tightening rather than an API break.

### Scope

- **changed:** three signatures, one import per file, and the doc lines saying what the entropy protects
- no behavior change, no runtime cost, no new dependency
- **left untouched:** the mask generator itself, which already had the right bound

### Verification

- `cargo check --workspace --all-targets` — clean, which is the whole gate for this change
- `cargo test -p binius-iop-prover` — 85 + 2 pass
- `cargo test -p binius-iop-prover --release` — 85 + 2 pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-iop-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-iop-prover --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos crates/iop-prover/` — clean

No benchmark: the change is a trait bound, erased at monomorphization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)