### PR TITLE
BINIUS-617: Bench both routes to a WHIR level's induced weight

### DIFF
--- a/crates/iop-prover/Cargo.toml
+++ b/crates/iop-prover/Cargo.toml
@@ -39,3 +39,7 @@ default = []
 [[bench]]
 name = "binary_merkle_tree"
 harness = false
+
+[[bench]]
+name = "induced_weight"
+harness = false

--- a/crates/iop-prover/benches/induced_weight.rs
+++ b/crates/iop-prover/benches/induced_weight.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 The Binius Developers
+
+use binius_compute::BufferPool;
+use binius_core::word::Word;
+use binius_field::{Ghash128b as B128, Random, arch::OptimalPackedB128};
+use binius_iop::whir::WHIRLevel;
+use binius_iop_prover::whir::induced_weight::InducedWeight;
+use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded};
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::current_num_threads};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+/// The three levels a 2^22-scalar message is proved over at 96-bit security.
+///
+/// Each entry is a message dimension, an inverse rate, and the queries drawn at that rate.
+const LADDER: [(usize, usize, usize); 3] = [(18, 1, 232), (14, 4, 106), (10, 5, 101)];
+
+/// The lane count of that ladder, which enters neither route.
+const LOG_LANES: usize = 4;
+
+/// Benchmarks both routes to a level's induced weight, at every shape of the shipped ladder.
+///
+/// The two are alternatives, so they are timed in one binary and meet one machine state.
+/// Their ratio at a shape is the constant the selection rule between them encodes.
+///
+/// Throughput is the weight's own bytes, which both routes produce equally many of.
+fn bench_induced_weight(c: &mut Criterion) {
+	let mut rng = StdRng::seed_from_u64(0);
+	let log_num_shares = log2_ceil_usize(current_num_threads());
+
+	let mut group = c.benchmark_group("whir_induced_weight");
+
+	for (log_msg_cols, log_inv_rate, n_queries) in LADDER {
+		let level = WHIRLevel {
+			log_msg_cols,
+			log_lanes: LOG_LANES,
+			log_inv_rate,
+			n_queries,
+		};
+
+		// The transform the adjoint route runs its layers over, as the prover holds it.
+		let domain_context = GaoMateerPreExpanded::<B128>::generate(level.log_codeword_len());
+		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
+
+		// Sampling is with replacement, exactly as the channel draws it.
+		let indices = (0..n_queries)
+			.map(|_| Word::from_u64(rng.random_range(0..1u64 << level.log_codeword_len())))
+			.collect::<Vec<_>>();
+		let weight = InducedWeight::new(&level, &ntt, &indices, B128::random(&mut rng));
+
+		let shape = format!("cols=2^{log_msg_cols} rate=2^{log_inv_rate} t={n_queries}");
+		group.throughput(Throughput::Bytes(((1 << log_msg_cols) * size_of::<B128>()) as u64));
+
+		// One pool per arm, recycled across iterations, which is how the prover allocates.
+		group.bench_function(BenchmarkId::new("rows", &shape), |b| {
+			let pool = BufferPool::new();
+			b.iter(|| weight.by_rows::<OptimalPackedB128, _>(&&pool));
+		});
+		group.bench_function(BenchmarkId::new("adjoint", &shape), |b| {
+			let pool = BufferPool::new();
+			b.iter(|| weight.by_adjoint::<OptimalPackedB128, _>(&&pool));
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group! {
+	name = default;
+	config = Criterion::default().sample_size(10).significance_level(0.01);
+	targets = bench_induced_weight
+}
+criterion_main!(default);

--- a/crates/iop-prover/src/whir/induced_weight.rs
+++ b/crates/iop-prover/src/whir/induced_weight.rs
@@ -23,7 +23,7 @@ use binius_math::{
 ///
 /// Two routes produce the same `w`, and which is cheaper turns on the level's shape alone.
 /// Holding the inputs together is what lets the choice be a method rather than a parameter.
-pub(super) struct InducedWeight<'a, F, NTT> {
+pub struct InducedWeight<'a, F, NTT> {
 	/// The level whose rows were opened, whose shape picks the route.
 	level: &'a WHIRLevel,
 	/// The transform the adjoint route runs its layers over.
@@ -44,7 +44,7 @@ where
 	/// ## Preconditions
 	///
 	/// * `ntt`'s domain covers the level's codeword domain.
-	pub(super) fn new(level: &'a WHIRLevel, ntt: &'a NTT, indices: &[Word], alpha: F) -> Self {
+	pub fn new(level: &'a WHIRLevel, ntt: &'a NTT, indices: &[Word], alpha: F) -> Self {
 		Self {
 			level,
 			ntt,
@@ -99,7 +99,7 @@ where
 	/// For `t` opened rows the whole build is therefore `2 * t * 2^log_msg_cols` multiplications.
 	///
 	/// This is the reference the adjoint route is tested against.
-	pub(super) fn by_rows<P, A>(&self, alloc: &A) -> FieldVec<P, A>
+	pub fn by_rows<P, A>(&self, alloc: &A) -> FieldVec<P, A>
 	where
 		P: PackedField<Scalar = F>,
 		A: Allocator,
@@ -124,7 +124,7 @@ where
 	///
 	/// The cost is `log_msg_cols` butterfly layers over `2^(log_msg_cols + log_inv_rate)` entries.
 	/// Nothing in it grows with the number of rows opened.
-	pub(super) fn by_adjoint<P, A>(&self, alloc: &A) -> FieldVec<P, A>
+	pub fn by_adjoint<P, A>(&self, alloc: &A) -> FieldVec<P, A>
 	where
 		P: PackedField<Scalar = F>,
 		A: Allocator,
@@ -209,15 +209,14 @@ mod tests {
 		}
 	}
 
-	/// The selection rule, at every level shape the ladder search picks at 96-bit security.
-	///
-	/// The last column is the row build's measured time over the transposed build's.
-	/// A value above one is therefore a shape where the transposed build won.
-	/// The rule must agree with that comparison at every shape.
 	#[test]
-	fn the_selection_rule_follows_the_measured_crossover() {
-		// (log_msg_cols, log_inv_rate, n_queries, measured speedup of the transposed build)
-		let measured: &[(usize, usize, usize, f64)] = &[
+	fn the_selection_rule_reproduces_a_recorded_speedup_table() {
+		// A fixture rather than a measurement, recorded on hardware this test cannot reach.
+		// Rerunning it is the induced-weight benchmark's job, at the shapes it covers.
+		//
+		// (log_msg_cols, log_inv_rate, n_queries, speedup of the transposed build)
+		// Above one is a shape where the transposed build won.
+		let recorded: &[(usize, usize, usize, f64)] = &[
 			(9, 1, 232, 26.43),
 			(9, 3, 116, 3.86),
 			(9, 5, 101, 0.88),
@@ -255,7 +254,7 @@ mod tests {
 			(24, 1, 232, 9.60),
 			(24, 2, 142, 2.96),
 		];
-		for &(log_msg_cols, log_inv_rate, n_queries, speedup) in measured {
+		for &(log_msg_cols, log_inv_rate, n_queries, speedup) in recorded {
 			let level = WHIRLevel {
 				log_msg_cols,
 				log_lanes: 1,

--- a/crates/iop-prover/src/whir/mod.rs
+++ b/crates/iop-prover/src/whir/mod.rs
@@ -8,7 +8,8 @@
 
 pub mod channel;
 pub mod compiler;
-mod induced_weight;
+#[doc(hidden)] // exposed for benchmarking (`benches/induced_weight.rs`), not a stable API
+pub mod induced_weight;
 pub(crate) mod opening;
 
 pub use opening::WHIRProver;


### PR DESCRIPTION
Closes [BINIUS-617](https://linear.app/jimpo/issue/BINIUS-617).

Adds a criterion bench for the two routes to a WHIR level's induced weight, and renames a test whose name promised a measurement it never made.
No prover code changes.

### The problem

A WHIR level opens `t` rows of its codeword, and those rows induce one weight vector on the message that level folded to.

Two routes build that vector, and which is cheaper turns on the level's shape alone:

```
row by row   t row entries
adjoint      cols * 2^rate layer entries
```

The rule that picks between them compares those two counts scaled by one constant — what a row entry costs over what a layer entry costs.

That constant was measured off this repository, on hardware the comment does not name, and nothing in the tree re-derives it.

Meanwhile the crate's only bench commits a Merkle tree.
Nothing on the WHIR opening path is timed, so every number about it so far has come from a throwaway crate.

And `the_selection_rule_follows_the_measured_crossover` measures nothing: it asserts the rule agrees with a hard-coded table of 36 speedups recorded elsewhere.

### The idea

Time both routes in one binary, at the three level shapes a $2^{22}$-scalar message is proved over.

Both arms then meet the same machine state, the same pool, and the same multi-threaded transform the prover holds.
Their ratio at a shape *is* the constant the rule encodes.

That is the shape the crate's Merkle bench already uses, where pooled and global allocation are benched side by side rather than against a separate build.

### The change

- **new:** `crates/iop-prover/benches/induced_weight.rs`, both routes at `cols=2^18 rate=2^1 t=232`, `cols=2^14 rate=2^4 t=106`, `cols=2^10 rate=2^5 t=101`.
- **changed:** the induced-weight module becomes `#[doc(hidden)] pub` so a bench target can reach it — same precedent as `benches/intmul.rs` in `binius-prover`.
- **changed:** the fixture test is renamed to `the_selection_rule_reproduces_a_recorded_speedup_table`, and its comment names the bench as where the table is rerun.
- Throughput is the weight's own bytes, which both routes produce equally many of, so the two arms are directly comparable.

### What it measures here

AMD Ryzen 9 9950X3D, 32 threads, `RUSTFLAGS="-Ctarget-cpu=native"`, criterion medians.
Load average 11.6 falling to 8.5 during the run — other work was on the box, so read the ratios rather than the absolute times.

| shape | rows | adjoint | ratio | rule picks |
|---|---:|---:|---:|---|
| `cols=2^18 rate=2^1 t=232` | 278.2 ms | 11.22 ms | 24.8x adjoint | adjoint |
| `cols=2^14 rate=2^4 t=106` | 7.64 ms | 4.18 ms | 1.83x adjoint | rows |
| `cols=2^10 rate=2^5 t=101` | 0.466 ms | 0.373 ms | 1.25x adjoint | rows |

The rule is wrong at two of the three shipped shapes on this machine, in the same direction both times.
That is what the bench exists to make visible.

A second back-to-back run of the same binary moved individual arms by up to 75% as another job started, which is exactly why both arms live in one binary rather than in two builds.

### Scope

- No change to any prover path: the bench is a new target, and the only source edit is a visibility widening plus a test rename.
- The constant itself is deliberately **not** re-derived here.
  An open PR makes the adjoint route's transform about 17x faster, and a separate change makes the row route about 7x faster.
  Those move the crossover in opposite directions and want deciding together, on this bench, once both land.

### Verification

- `cargo test -p binius-iop-prover` and `--release` — 85 + 2 pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-iop-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-iop-prover --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos crates/iop-prover/`, `cargo check --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)