### PR TITLE
BINIUS-618: Panic when two hint names share an id, and warn that hint fields are ignored

### DIFF
--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -1718,18 +1718,23 @@ impl CircuitBuilder {
 
 	/// Invoke a [`Hint`] and emit the corresponding gate.
 	///
-	/// Registers `hint` in the builder's hint registry (idempotent, keyed by `T::NAME`),
-	/// allocates output wires according to `hint.shape(dimensions)`, and emits a
-	/// generic hint gate. Returns the freshly allocated output wires.
+	/// Registers `hint` in the builder's hint registry (keyed by `T::NAME`), allocates output
+	/// wires according to `hint.shape(dimensions)`, and emits a generic hint gate. Returns the
+	/// freshly allocated output wires.
 	///
 	/// `dimensions` is passed verbatim to [`Hint::shape`] and [`Hint::execute`]; it is the
 	/// hint's parameterization (e.g., limb counts for a bignum hint).
+	///
+	/// The registry keys on the name alone.
+	/// Only the first value passed under a name survives; a later value's fields are ignored.
+	/// Per-call parameters belong in `dimensions`, not in the hint's fields.
 	///
 	/// # Panics
 	///
 	/// Panics if the declared arity or a dimension exceeds what the witness bytecode encodes.
 	///
 	/// Panics if `inputs.len()` does not match the hint's declared input arity.
+	/// Panics if another hint name already holds this hint's id.
 	pub fn call_hint<T: Hint>(&self, hint: T, dimensions: &[usize], inputs: &[Wire]) -> Vec<Wire> {
 		let (n_in, n_out) = hint.shape(dimensions);
 

--- a/crates/frontend/src/ir/hints.rs
+++ b/crates/frontend/src/ir/hints.rs
@@ -7,7 +7,10 @@
 //! They can be used for operations that require many constraints to compute but few constraints
 //! to verify.
 
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::{
+	collections::hash_map::Entry,
+	hash::{DefaultHasher, Hash, Hasher},
+};
 
 use binius_core::Word;
 use rustc_hash::FxHashMap;
@@ -19,9 +22,15 @@ pub type HintId = u32;
 
 /// Hint handler trait for extensible operations.
 ///
-/// Each implementor declares a globally unique `NAME`. The registry identifies hints by the
-/// hash of this name, so registering the same hint twice is a no-op and every gate using the
-/// same hint type shares a single handler entry.
+/// Each implementor declares a globally unique name, and the registry keys on the hash of that
+/// name alone.
+///
+/// Every gate using the same hint type therefore shares one handler entry.
+///
+/// A hint's fields are not part of its identity.
+/// Only the first value registered under a name is kept; later values are dropped.
+/// Gates that differ only in those fields fold together under deduplication.
+/// Parameterize a hint through its dimensions, never through its fields.
 ///
 /// # The `dimensions` parameter
 ///
@@ -65,8 +74,10 @@ pub trait Hint: Send + Sync + 'static {
 
 /// Derive a [`HintId`] from a hint's name.
 ///
-/// Hashes the name with `std::hash::DefaultHasher` (fixed seed, deterministic across runs)
-/// and folds the resulting 64-bit value down to 32 bits by XORing its two halves.
+/// Hashes the name and folds the resulting 64-bit value down to 32 bits by XORing its two halves.
+///
+/// The hash algorithm is unspecified, so an id is stable only within one process.
+/// Never persist an id or compare one across builds.
 pub fn hint_id_of(name: &str) -> HintId {
 	let mut hasher = DefaultHasher::new();
 	name.hash(&mut hasher);
@@ -95,10 +106,10 @@ impl<T: Hint> ErasedHint for T {
 
 /// Registry for hint handlers keyed by [`HintId`].
 ///
-/// Registration is idempotent: the same hint type always hashes to the same id, so a second
-/// call to [`HintRegistry::register`] with the same concrete type is a no-op.
+/// Each entry keeps the name it was registered under.
+/// An id shared by two names is then caught, instead of running one hint as the other.
 pub struct HintRegistry {
-	handlers: FxHashMap<HintId, Box<dyn ErasedHint>>,
+	handlers: FxHashMap<HintId, (&'static str, Box<dyn ErasedHint>)>,
 }
 
 impl HintRegistry {
@@ -109,17 +120,33 @@ impl HintRegistry {
 		}
 	}
 
-	/// Register a hint, returning its stable [`HintId`]. No-op if the same hint is already
-	/// registered.
+	/// Register a hint, returning its [`HintId`].
+	///
+	/// Registering a name already present is a no-op, the handler's fields included.
+	///
+	/// # Panics
+	///
+	/// Panics if a different name already holds this id.
 	pub fn register<T: Hint>(&mut self, handler: T) -> HintId {
 		let id = hint_id_of(T::NAME);
-		self.handlers.entry(id).or_insert_with(|| Box::new(handler));
+		match self.handlers.entry(id) {
+			Entry::Vacant(entry) => {
+				entry.insert((T::NAME, Box::new(handler)));
+			}
+			Entry::Occupied(entry) => assert_eq!(
+				entry.get().0,
+				T::NAME,
+				"hint id collision: {} and {}",
+				entry.get().0,
+				T::NAME,
+			),
+		}
 		id
 	}
 
 	/// Compute the `(n_in, n_out)` arity of the hint identified by `hint_id`.
 	pub fn shape(&self, hint_id: HintId, dimensions: &[usize]) -> (usize, usize) {
-		self.handlers[&hint_id].shape(dimensions)
+		self.handlers[&hint_id].1.shape(dimensions)
 	}
 
 	/// Run the handler under `hint_id`, writing its results into `outputs`.
@@ -141,12 +168,68 @@ impl HintRegistry {
 	///
 	/// Lets a caller invoking one hint many times pay for the lookup once.
 	pub(crate) fn handler(&self, hint_id: HintId) -> &dyn ErasedHint {
-		&*self.handlers[&hint_id]
+		&*self.handlers[&hint_id].1
 	}
 }
 
 impl Default for HintRegistry {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	struct AddK {
+		k: u64,
+	}
+
+	impl Hint for AddK {
+		const NAME: &'static str = "test::add_k";
+
+		fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+			(1, 1)
+		}
+
+		fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+			outputs[0] = Word(inputs[0].0.wrapping_add(self.k));
+		}
+	}
+
+	fn run(registry: &HintRegistry, id: HintId, input: u64) -> u64 {
+		let mut outputs = [Word::ZERO];
+		registry.execute(id, &[], &[Word(input)], &mut outputs);
+		outputs[0].0
+	}
+
+	#[test]
+	fn re_registering_one_hint_type_keeps_a_single_entry() {
+		let mut registry = HintRegistry::new();
+		let first = registry.register(AddK { k: 7 });
+		let second = registry.register(AddK { k: 7 });
+		assert_eq!(first, second);
+		assert_eq!(registry.handlers.len(), 1);
+	}
+
+	// Pins the known limitation the trait doc warns about.
+	#[test]
+	fn fields_of_a_second_registration_are_ignored() {
+		let mut registry = HintRegistry::new();
+		let id = registry.register(AddK { k: 7 });
+		registry.register(AddK { k: 1000 });
+		assert_eq!(run(&registry, id, 0), 7);
+	}
+
+	// A 32-bit collision is out of reach of a search over static names, so it is planted.
+	#[test]
+	#[should_panic(expected = "hint id collision: test::squatter and test::add_k")]
+	fn colliding_names_panic() {
+		let mut registry = HintRegistry::new();
+		registry
+			.handlers
+			.insert(hint_id_of(AddK::NAME), ("test::squatter", Box::new(AddK { k: 7 })));
+		registry.register(AddK { k: 7 });
 	}
 }

--- a/crates/frontend/src/ir/hints.rs
+++ b/crates/frontend/src/ir/hints.rs
@@ -7,17 +7,15 @@
 //! They can be used for operations that require many constraints to compute but few constraints
 //! to verify.
 
-use std::{
-	collections::hash_map::Entry,
-	hash::{DefaultHasher, Hash, Hasher},
-};
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use binius_core::Word;
 use rustc_hash::FxHashMap;
 
 /// Registry key for one prover-side computation.
 ///
-/// Derived from the declared name rather than assigned in order, so it is stable across runs.
+/// Derived from the declared name rather than assigned in order, so registration order never
+/// changes it.
 pub type HintId = u32;
 
 /// Hint handler trait for extensible operations.
@@ -50,7 +48,7 @@ pub type HintId = u32;
 /// - A parameterized hint reads limb counts from `dimensions` and derives its arity from them.
 /// - A fixed-arity hint ignores `dimensions` (an empty slice) and returns a constant shape.
 pub trait Hint: Send + Sync + 'static {
-	/// Globally unique name for this hint. Used to derive a stable [`HintId`].
+	/// Globally unique name for this hint, which the registry hashes into its key.
 	const NAME: &'static str;
 
 	/// Compute the gate's input/output arity as a function of `dimensions`.
@@ -129,18 +127,11 @@ impl HintRegistry {
 	/// Panics if a different name already holds this id.
 	pub fn register<T: Hint>(&mut self, handler: T) -> HintId {
 		let id = hint_id_of(T::NAME);
-		match self.handlers.entry(id) {
-			Entry::Vacant(entry) => {
-				entry.insert((T::NAME, Box::new(handler)));
-			}
-			Entry::Occupied(entry) => assert_eq!(
-				entry.get().0,
-				T::NAME,
-				"hint id collision: {} and {}",
-				entry.get().0,
-				T::NAME,
-			),
-		}
+		let entry = self
+			.handlers
+			.entry(id)
+			.or_insert_with(|| (T::NAME, Box::new(handler)));
+		assert_eq!(entry.0, T::NAME, "hint id collision: {} and {}", entry.0, T::NAME);
 		id
 	}
 


### PR DESCRIPTION
Closes [BINIUS-618](https://linear.app/jimpo/issue/BINIUS-618).

Makes one of the two silent hint-identity hazards loud, and documents the other precisely.
No behavior change for any hint in the workspace — nothing here trips the new assert.

### The problem

The hint registry keys every handler on the hint's name alone.
Two consequences follow, and today both are silent.

**Defect 1 — a hint carrying state runs with the state of the first instance registered.**

```rust
pub fn register<T: Hint>(&mut self, handler: T) -> HintId {
    let id = hint_id_of(T::NAME);
    self.handlers.entry(id).or_insert_with(|| Box::new(handler));
    id
}
```

The second `handler` value is dropped on the floor.
`call_hint` takes the hint **by value**, which reads as an invitation to parameterise it by its fields.

Reproduced on unmodified `main`, with a hint that adds a constant `k`:

```rust
struct AddK { k: u64 }
impl Hint for AddK {
    const NAME: &'static str = "probe.add_k";
    fn shape(&self, _d: &[usize]) -> (usize, usize) { (1, 1) }
    fn execute(&self, _d: &[usize], i: &[Word], o: &mut [Word]) {
        o[0] = Word(i[0].0.wrapping_add(self.k));
    }
}

let a = b.call_hint(AddK { k: 7 },    &[], &[x]);
let c = b.call_hint(AddK { k: 1000 }, &[], &[x]);
```

```
x=0  ->  AddK{k:7} gave 7   AddK{k:1000} gave 7
expected 7 and 1000
```

And it compounds.
Both gates carry the same id, the same input wire and the same dimensions, so CSE collapses them into one gate.
The author wrote two values; the circuit has one.

**Defect 2 — the id is a 32-bit fold of an unspecified hasher.**

```rust
pub fn hint_id_of(name: &str) -> HintId {
    let mut hasher = DefaultHasher::new();
    name.hash(&mut hasher);
    let h = hasher.finish();
    (h as u32) ^ ((h >> 32) as u32)
}
```

Two distinct names that collide in 32 bits get one entry, and `or_insert_with` keeps whichever registered first.
So one hint silently executes as another.
The birthday bound is ~65,536 distinct names, so it will not happen by accident — but nothing detects it if it does.

Separately, the doc claimed the name is hashed with a fixed seed, deterministic across runs.
`std` specifies neither the algorithm nor its instances, and says both may change between releases.
Ids are only ever produced and consumed inside one process, so nothing breaks today — but the doc should not claim a guarantee that does not exist.

### The change

Each entry now carries the name it was registered under, and a mismatch is a panic.

```diff
- handlers: HashMap<HintId, Box<dyn ErasedHint>>
+ handlers: HashMap<HintId, (&'static str, Box<dyn ErasedHint>)>
```

```rust
match self.handlers.entry(id) {
    Entry::Vacant(entry) => {
        entry.insert((T::NAME, Box::new(handler)));
    }
    Entry::Occupied(entry) => assert_eq!(
        entry.get().0,
        T::NAME,
        "hint id collision: {} and {}",
        entry.get().0,
        T::NAME,
    ),
}
```

That closes Defect 2 outright.
Re-registering the *same* name stays a silent no-op, which is load-bearing — `call_hint` registers on every call.

The `hint_id_of` doc now says the id is stable only within one process, and must never be persisted or compared across builds.

### How this relates / what it is not

**Defect 1 is mitigated, not closed.**
Two `AddK` values share a name, so the assert passes and the second value is still dropped.

Closing it means requiring `Hint: Default` and dropping the value parameter from `register` / `call_hint`.
That makes the hazard unrepresentable, and breaks every call site across `binius-circuits`, `binius-recursion` and `binius-m4-prover`.
Out of scope here — a later PR.

No sound and cheap equivalence check exists inside this PR's scope:

- bytewise comparison of the two values is unsound the moment a hint owns heap data or a pointer;
- a `size_of::<T>() == 0` check is sound as a sufficient condition, but rejects `Secp256k1EndosplitHint`, which legitimately carries constant `BigUint` fields;
- a `Hash` / `Eq` bound on `Hint` is the same API break by another name.

So Defect 1 is handled by two things instead.
The trait doc now states the hazard rather than describing idempotence as harmless, and points parameterisation at `dimensions`.
A test pins the current behaviour so the limitation lives in the suite, not in a comment.

### Soundness

A hint value whose fields are ignored produces a **wrong witness**, not a wrong constraint system.
`ConstraintSystem::verify` rejects that witness.
So both defects are correctness and confusing-failure hazards for the circuit author, not proof-soundness breaks — a prover cannot exploit either to pass verification with a false statement.

The new assert only turns a previously silent mis-dispatch into a panic at circuit-build time.

### Scope

- **changed:** `crates/frontend/src/ir/hints.rs` — the map's value type, `register`, and the `Hint` / `hint_id_of` / `HintRegistry` docs
- **changed:** `crates/frontend/src/builder/mod.rs` — the `call_hint` doc gains the hazard and one `# Panics` line
- **untouched:** `exec_hint` and the dispatch path
- **new tests** (3): the collision panic, the same-type no-op, and the pinned dropped-fields behaviour
- rebases onto #2418, which switched this map to `FxHashMap` and added a `pub(crate)` handler resolver

### On testing the collision

A natural 32-bit collision between two `&'static str` names is not findable — `NAME` is a `const`, so names cannot be generated at test time, and a search over a fixed set would need ~65,536 candidates.
So the colliding entry is planted directly against the private map, then a real `register` call is made against it:

```rust
registry
    .handlers
    .insert(hint_id_of(AddK::NAME), ("test::squatter", Box::new(AddK { k: 7 })));
registry.register(AddK { k: 7 });   // panics, naming both
```

That exercises the exact branch a real collision would take.

### Verification

- `cargo test -p binius-frontend` (debug) — 268 pass, including the 3 new ones
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend --release` — clean
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `tools/check_copyright_notice.py`, `typos` — clean
- `cargo build -p binius-circuits -p binius-recursion -p binius-m4-prover --tests` — clean
- `cargo test -p binius-circuits` — 412 pass, so **no real gadget in the workspace has a colliding hint name**

No benchmark: this adds one pointer-comparison per registration, on the circuit-build path, and nothing on the witness path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)