### PR TITLE
BINIUS-619: Draw the WHIR ladder's codewords from the prover's buffer pool

### DIFF
--- a/crates/iop-prover/src/whir/channel/prover.rs
+++ b/crates/iop-prover/src/whir/channel/prover.rs
@@ -63,7 +63,7 @@ where
 	/// The oracles this channel expects, in the order it will commit them.
 	oracle_specs: Vec<OracleSpec>,
 	/// The committed level-0 codewords, in the order their commitments were sent.
-	oracles: Vec<BrakedownOracleProver<P, Channel::Commitment>>,
+	oracles: Vec<BrakedownOracleProver<P, Channel::Commitment, A::Vec<P>>>,
 	/// The committed messages, each handed over when the caller finalizes its oracle.
 	/// One entry per committed oracle, absent until that oracle is finalized.
 	messages: Vec<Option<FieldVec<P, A>>>,
@@ -189,7 +189,7 @@ where
 	/// Only the committed ones have to be sent, since the verifier builds the transparents itself.
 	fn prove(
 		channel: &mut Channel,
-		prover: &WHIRProver<'_, P, Channel::Commitment, NTT>,
+		prover: &WHIRProver<'_, P, Channel::Commitment, NTT, A::Vec<P>>,
 		oracle_specs: &[OracleSpec],
 		messages: &[FieldVec<P, A>],
 		queue: Vec<Vec<QueuedRelation<P, A>>>,
@@ -353,7 +353,7 @@ where
 		// The deeper levels only exist once the folds above them have run.
 		let index = self.oracles.len();
 		self.oracles
-			.push(commit_level(&level, self.ntt, message, &mut self.channel));
+			.push(commit_level(&level, self.ntt, message, &self.alloc, &mut self.channel));
 		self.messages.push(None);
 		self.queue.push(Vec::new());
 

--- a/crates/iop-prover/src/whir/opening.rs
+++ b/crates/iop-prover/src/whir/opening.rs
@@ -12,9 +12,9 @@
 //! The proof of work is paid at exactly the two points the verifier checks it.
 //! That module's `Where the proof of work stands` section draws them.
 
-use std::iter::zip;
+use std::{iter::zip, ops::Deref};
 
-use binius_compute::{Allocator, GlobalAllocator};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_iop::whir::{WHIRLevel, WHIRParams};
@@ -57,23 +57,24 @@ use crate::{
 ///
 /// One leaf is one codeword position across every lane, so a leaf is `2^log_lanes` scalars.
 ///
-/// The codeword is allocated globally rather than from an arena.
-/// A level's codeword outlives the call that builds it, and nothing here is on a hot path yet.
+/// The encode writes every word of the codeword, so a recycled block leaks nothing it held.
 ///
 /// ## Preconditions
 ///
 /// * `message` has `level.log_msg_len()` variables.
 /// * `ntt`'s domain covers the level's codeword domain.
-pub(crate) fn commit_level<F, P, NTT, Channel>(
+pub(crate) fn commit_level<F, P, NTT, A, Channel>(
 	level: &WHIRLevel,
 	ntt: &NTT,
 	message: FieldSlice<'_, P>,
+	alloc: &A,
 	channel: &mut Channel,
-) -> BrakedownOracleProver<P, Channel::Commitment>
+) -> BrakedownOracleProver<P, Channel::Commitment, A::Vec<P>>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
+	A: Allocator,
 	Channel: MerkleIPProverChannel<F>,
 {
 	assert_eq!(
@@ -90,7 +91,7 @@ where
 		log_lanes = level.log_lanes,
 		log_inv_rate = level.log_inv_rate
 	)
-	.in_scope(|| code.encode_batch(ntt, message, level.log_lanes, &GlobalAllocator));
+	.in_scope(|| code.encode_batch(ntt, message, level.log_lanes, alloc));
 	let commitment = tracing::debug_span!("Merkle commit level")
 		.in_scope(|| channel.send_merkle_commitment(codeword.as_view(), 1 << level.log_lanes));
 
@@ -101,20 +102,25 @@ where
 ///
 /// Holds the ladder's shape, the transform its levels encode over, and level 0's oracles.
 /// Deeper levels only exist once the folds above them have run, so [`Self::prove`] commits those.
-pub struct WHIRProver<'a, P: PackedField, C, NTT> {
+pub struct WHIRProver<'a, P, C, NTT, Data = Vec<P>>
+where
+	P: PackedField,
+	Data: Deref<Target = [P]>,
+{
 	/// The ladder's shape, one [`WHIRLevel`] per committed level.
 	params: &'a WHIRParams,
 	/// The transform every level encodes over, sized for the largest of them.
 	ntt: &'a NTT,
 	/// Level 0's committed interleaved codewords, in the order their openings are written.
-	oracles: BatchBrakedownOracleProver<P, C>,
+	oracles: BatchBrakedownOracleProver<P, C, Data>,
 }
 
-impl<'a, F, P, C, NTT> WHIRProver<'a, P, C, NTT>
+impl<'a, F, P, C, NTT, Data> WHIRProver<'a, P, C, NTT, Data>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
+	Data: Deref<Target = [P]>,
 {
 	/// Encodes and commits level 0, sending its Merkle root.
 	///
@@ -127,17 +133,19 @@ where
 	///
 	/// * `message` has `params.log_msg_len()` variables.
 	/// * `ntt`'s domain covers every level's codeword domain.
-	pub fn commit<Channel>(
+	pub fn commit<A, Channel>(
 		params: &'a WHIRParams,
 		ntt: &'a NTT,
 		message: FieldSlice<'_, P>,
+		alloc: &A,
 		channel: &mut Channel,
 	) -> Self
 	where
+		A: Allocator<Vec<P> = Data>,
 		Channel: MerkleIPProverChannel<F, Commitment = C>,
 	{
 		let level = &params.levels()[0];
-		let oracle = commit_level(level, ntt, message, channel);
+		let oracle = commit_level(level, ntt, message, alloc, channel);
 		Self::new(params, ntt, BatchBrakedownOracleProver::new(vec![oracle]))
 	}
 
@@ -152,7 +160,7 @@ where
 	pub const fn new(
 		params: &'a WHIRParams,
 		ntt: &'a NTT,
-		oracles: BatchBrakedownOracleProver<P, C>,
+		oracles: BatchBrakedownOracleProver<P, C, Data>,
 	) -> Self {
 		Self {
 			params,
@@ -211,7 +219,7 @@ where
 		let mut weight: Option<FieldVec<P, A>> = None;
 		let mut sum = eval_claim;
 		// Level 0's oracle lives in `self`; every deeper level's is built in this loop.
-		let mut deeper: Option<BrakedownOracleProver<P, C>> = None;
+		let mut deeper: Option<BrakedownOracleProver<P, C, A::Vec<P>>> = None;
 
 		for (i, level) in levels.iter().enumerate() {
 			let n_vars = level.log_msg_len();
@@ -265,7 +273,7 @@ where
 			// Whatever this level folded to is bound here, before a query position exists.
 			let next = match levels.get(i + 1) {
 				Some(next_level) => {
-					Some(commit_level(next_level, self.ntt, current.as_view(), channel))
+					Some(commit_level(next_level, self.ntt, current.as_view(), alloc, channel))
 				}
 				None => {
 					let _residual_guard = tracing::debug_span!("Send residual").entered();
@@ -333,8 +341,10 @@ mod tests {
 		cell::Cell,
 		iter::{Product, Sum},
 		ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+		ptr,
 	};
 
+	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_field::{
 		ExtensionField, Field, Ghash128b as B128, Random,
 		arithmetic_traits::{InvertOrZero, Square},
@@ -402,11 +412,12 @@ mod tests {
 	///
 	/// Returns the finished transcript alongside the point and claim it opens at.
 	/// A verifier can then be pointed at it through whichever channel a test wants to watch.
-	fn write_proof(
+	fn write_proof<A: Allocator>(
 		params: &WHIRParams,
 		committed: &FieldBuffer<B128>,
 		opened: &FieldBuffer<B128>,
 		claim_offset: B128,
+		alloc: &A,
 	) -> (Vec<u8>, Vec<B128>, B128) {
 		let n_vars = params.log_msg_len();
 		let mut rng = StdRng::seed_from_u64(n_vars as u64);
@@ -425,8 +436,8 @@ mod tests {
 			ProverMerkleTranscriptChannel::<_, StdChallenger, B128, StdHashSuite>::new(
 				&mut transcript,
 			);
-		let prover = WHIRProver::commit(params, &ntt, committed.as_view(), &mut channel);
-		prover.prove(opened.as_view(), &eval_point, eval_claim, &GlobalAllocator, &mut channel);
+		let prover = WHIRProver::commit(params, &ntt, committed.as_view(), alloc, &mut channel);
+		prover.prove(opened.as_view(), &eval_point, eval_claim, alloc, &mut channel);
 		channel.into_transcript();
 
 		(transcript.finalize(), eval_point, eval_claim)
@@ -470,7 +481,8 @@ mod tests {
 		opened: &FieldBuffer<B128>,
 		claim_offset: B128,
 	) -> Result<usize, Error> {
-		let (proof, eval_point, eval_claim) = write_proof(params, committed, opened, claim_offset);
+		let (proof, eval_point, eval_claim) =
+			write_proof(params, committed, opened, claim_offset, &GlobalAllocator);
 		verify_proof(params, proof, &eval_point, eval_claim)
 	}
 
@@ -483,7 +495,8 @@ mod tests {
 		verifier_params: &WHIRParams,
 	) -> Result<usize, Error> {
 		let msg = message(prover_params, 0);
-		let (proof, eval_point, eval_claim) = write_proof(prover_params, &msg, &msg, B128::ZERO);
+		let (proof, eval_point, eval_claim) =
+			write_proof(prover_params, &msg, &msg, B128::ZERO, &GlobalAllocator);
 		verify_proof(verifier_params, proof, &eval_point, eval_claim)
 	}
 
@@ -518,6 +531,31 @@ mod tests {
 			run(&params, &msg, &msg, B128::ZERO)
 				.unwrap_or_else(|err| panic!("{log_msg_cols} {lanes:?}: {err}"));
 		}
+	}
+
+	#[test]
+	fn a_recycled_block_writes_the_same_proof_as_a_fresh_one() {
+		let params = ladder(6, &[2, 2, 2], 5);
+		let msg = message(&params, 0);
+
+		// A pool hands out whatever a freed block last held.
+		// Filling one block per size with a marker leaves every later allocation starting dirty.
+		let log_codeword_len = params.max_log_codeword_len();
+		let pool = BufferPool::new();
+		let mut released = ptr::null();
+		for log_len in 0..=log_codeword_len {
+			let mut dirt = FieldBuffer::<B128, _>::zeros_in(&&pool, log_len);
+			dirt.as_mut().fill(B128::new(0xdead_beef));
+			released = dirt.as_ref().as_ptr();
+		}
+		// Invariant: the fixture only bites while the pool hands the released block back in place.
+		let reused = FieldBuffer::<B128, _>::zeros_in(&&pool, log_codeword_len);
+		assert_eq!(reused.as_ref().as_ptr(), released);
+		drop(reused);
+
+		let (from_pool, ..) = write_proof(&params, &msg, &msg, B128::ZERO, &&pool);
+		let (from_global, ..) = write_proof(&params, &msg, &msg, B128::ZERO, &GlobalAllocator);
+		assert_eq!(from_pool, from_global);
 	}
 
 	/// A codeword that does not encode the message the prover reduced must be caught.
@@ -1182,7 +1220,8 @@ mod tests {
 	/// The prover runs first, under the shipped suite, so nothing it does reaches an instrument.
 	fn measure(params: &WHIRParams) -> Result<Measured, Error> {
 		let msg = message(params, 0);
-		let (proof, eval_point, eval_claim) = write_proof(params, &msg, &msg, B128::ZERO);
+		let (proof, eval_point, eval_claim) =
+			write_proof(params, &msg, &msg, B128::ZERO, &GlobalAllocator);
 
 		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
 		let inner =

--- a/crates/iop-prover/tests/merkle_pool_allocations.rs
+++ b/crates/iop-prover/tests/merkle_pool_allocations.rs
@@ -2,10 +2,10 @@
 
 //! That a pooled prover stops going to the global allocator for its large buffers.
 //!
-//! Covers the two buffers a BaseFold prover allocates per committed oracle: the Merkle tree's
-//! nodes, and the Reed-Solomon codeword.
+//! Covers the buffers a prover allocates per committed oracle: the Merkle tree's nodes, the
+//! BaseFold codeword, and the WHIR ladder's level-0 codeword.
 //!
-//! Wall-clock is the wrong instrument for either: the saving is a handful of large allocations
+//! Wall-clock is the wrong instrument for any of them: the saving is a handful of large allocations
 //! against work dominated by hashing and NTTs, well inside the run-to-run spread of a loaded
 //! machine. The count of large global allocations is the same fact measured exactly, and it does
 //! not depend on how busy the box is.
@@ -23,16 +23,24 @@ use std::{
 
 use binius_compute::{BufferPool, GlobalAllocator};
 use binius_field::{Ghash128b as B128, PackedBinaryGhash1x128b};
-use binius_hash::StdHashSuite;
-use binius_iop::{channel::OracleSpec, fri::FRIParams};
+use binius_hash::{StdDigest, StdHashSuite};
+use binius_iop::{
+	channel::OracleSpec,
+	fri::FRIParams,
+	soundness::SoundnessRegime,
+	whir::{WHIRLevel, WHIRParams},
+};
 use binius_iop_prover::{
 	fri,
+	merkle_channel::ProverMerkleTranscriptChannel,
 	merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver},
+	whir::WHIRProver,
 };
 use binius_math::{
 	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 	test_utils::{random_field_buffer, random_scalars},
 };
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use rand::{SeedableRng, rngs::StdRng};
 
 /// Allocations at or above this size are counted.
@@ -186,5 +194,70 @@ fn a_pooled_encode_stops_allocating_the_codeword_globally() {
 
 	println!(
 		"large allocations over {COMMITS} encodes: {global_allocs} global, {pooled_allocs} pooled"
+	);
+}
+
+#[test]
+fn a_pooled_whir_commit_stops_allocating_the_codeword_globally() {
+	// Invariant: a WHIR level's codeword is drawn from the allocator the caller hands the commit,
+	// so a repeat commitment against a warm pool asks the OS for nothing.
+	//
+	// Fixture state: one level of 2^16 columns at rate 2^1, committed four times per allocator.
+	// Both arms share one pooled Merkle prover, so the tree's nodes never reach the counter and
+	// the codeword is the only buffer that differs between them.
+	let _measuring = MEASURING
+		.lock()
+		.expect("no test in this binary panics while holding this");
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let level = WHIRLevel {
+		log_msg_cols: LOG_DIM,
+		log_lanes: 0,
+		log_inv_rate: 1,
+		n_queries: 1,
+	};
+	let params = WHIRParams::new(vec![level], SoundnessRegime::default(), 32);
+	let ntt =
+		NeighborsLastSingleThread::new(GaoMateerOnTheFly::generate(params.max_log_codeword_len()));
+	let message = random_field_buffer::<PackedBinaryGhash1x128b>(&mut rng, params.log_msg_len());
+
+	let pool = BufferPool::new();
+	let mut transcript = ProverTranscript::new(HasherChallenger::<StdDigest>::default());
+	let merkle_prover = BinaryMerkleTreeProver::<B128, StdHashSuite, _>::with_allocator(&pool);
+	let mut channel = ProverMerkleTranscriptChannel::<_, HasherChallenger<StdDigest>, B128, _, _>::
+		with_merkle_prover(&mut transcript, merkle_prover);
+
+	// Warm both paths, so neither count includes one-off setup unrelated to the allocator.
+	drop(WHIRProver::commit(&params, &ntt, message.as_view(), &GlobalAllocator, &mut channel));
+	drop(WHIRProver::commit(&params, &ntt, message.as_view(), &&pool, &mut channel));
+
+	let global_allocs = count_large_allocs(|| {
+		for _ in 0..COMMITS {
+			drop(WHIRProver::commit(
+				&params,
+				&ntt,
+				message.as_view(),
+				&GlobalAllocator,
+				&mut channel,
+			));
+		}
+	});
+	let pooled_allocs = count_large_allocs(|| {
+		for _ in 0..COMMITS {
+			drop(WHIRProver::commit(&params, &ntt, message.as_view(), &&pool, &mut channel));
+		}
+	});
+
+	assert!(
+		global_allocs >= COMMITS,
+		"expected at least one large allocation per commit, got {global_allocs} for {COMMITS}"
+	);
+	assert!(
+		pooled_allocs < global_allocs,
+		"pooling must remove large allocations: {pooled_allocs} pooled against {global_allocs} global"
+	);
+
+	println!(
+		"large allocations over {COMMITS} WHIR commits: {global_allocs} global, {pooled_allocs} pooled"
 	);
 }

--- a/crates/recursion/tests/whir_opening.rs
+++ b/crates/recursion/tests/whir_opening.rs
@@ -215,7 +215,13 @@ impl Shape {
 		WordIPProverChannel::<B128>::observe_words(&mut channel, &point_words);
 
 		// Encodes level 0 lane by lane and sends its Merkle root.
-		let prover = WHIRProver::commit(&setup.params, &setup.ntt, witness.as_view(), &mut channel);
+		let prover = WHIRProver::commit(
+			&setup.params,
+			&setup.ntt,
+			witness.as_view(),
+			&GlobalAllocator,
+			&mut channel,
+		);
 		WordIPProverChannel::<B128>::observe_words(&mut channel, &element_words(eval_claim));
 
 		prover.prove(witness.as_view(), &eval_point, eval_claim, &GlobalAllocator, &mut channel);


### PR DESCRIPTION
Closes [BINIUS-619](https://linear.app/jimpo/issue/BINIUS-619).

The WHIR level commit encodes its codeword into the caller's allocator instead of the global one, so the prover's pool recycles it.
No protocol change — the transcript is byte-identical.

### The problem

The prover holds one buffer pool for its lifetime and hands `&pool` to everything that allocates.
The BaseFold path honours it, because its encoder takes the allocator as a parameter.
WHIR's level commit hard-codes the global allocator.

On the 1 MB SHA-256 workload the ladder encodes three codewords per proof: $2^{23}$, $2^{22}$ and $2^{18}$ scalars, so 128 MiB, 64 MiB and 4 MiB.
Each is an `mmap`, faulted in page by page during the encode, and `munmap`ped on drop.
That is about 200 MiB of global churn per proof, which is precisely what the pool exists to absorb.

The comment that put it there says the codeword is not on a hot path yet.
It is: the three encode spans are 6% of a 455 ms prove.

### The idea

Thread the allocator through, the way the BaseFold encoder already does.

The per-oracle type that holds a codeword already carries the backing-store parameter — that is what the FRI path uses.
What was missing is that the ladder prover and its batch oracle pinned the store to a plain heap vector.
Both now carry the parameter, defaulting to a heap vector, so every existing spelling of the type still compiles.

### The change

```
commit_level(level, ntt, message, channel)                 -> commit_level(level, ntt, message, alloc, channel)
    code.encode_batch(.., &GlobalAllocator)                       code.encode_batch(.., alloc)

WHIRProver<'a, P, C, NTT>                                  -> WHIRProver<'a, P, C, NTT, Data = Vec<P>>
```

The channel passes the allocator it already holds, so nothing above it changes.

`fri/query.rs` needed no change: both oracle types already had the parameter with the right default.

### Correctness

A pooled block arrives holding whatever its last owner wrote, so this has to be checked rather than assumed.

The encoder's postcondition is that every element of its output is initialized.
It copies the message into the head of the store, repeats it across the tail, then transforms in place, and nothing downstream reads past the codeword's live length.

A test pins that: the same statement proved through a pool deliberately filled with a marker writes a byte-identical transcript to the same statement proved through the global allocator.
The fixture also asserts that the pool really does hand the released block back, so it cannot silently stop testing anything.

### Scope

- **changed:** the level commit's signature, the ladder prover's and batch oracle's store parameter, one channel call site
- **new:** a byte-identical-transcript test against a dirtied pool, and a WHIR arm in the existing large-allocation counting test
- **untouched:** the FRI oracle types, which already had the parameter

One out-of-crate caller exists — a recursion test — and it gains one argument.

### Verification

- `cargo test -p binius-iop-prover` (debug), `--release`, `cargo test -p binius-prover`, `cargo test -p binius-recursion --test whir_opening` — all pass
- `RUSTFLAGS=\"-Ctarget-cpu=native\" cargo clippy -p binius-iop-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p binius-iop-prover --document-private-items --no-deps` — clean
- `cargo check --workspace --all-targets`, `cargo +nightly-2026-07-01 fmt --all --check`, `typos crates/iop-prover/` — clean

### Benchmark

The exact fact first, since it does not depend on machine load.
Four repeat commits of a $2^{16}$-column level, counting global allocations of 256 KiB or more:

| allocator | large global allocations over 4 commits |
|---|---:|
| global | 4 |
| pooled | 0 |

Wall clock, end to end.
`./target/release/examples/sha256 prove --message-len 1000000 --pcs whir`, built with `-Ctarget-cpu=native`.
Six paired runs, the two binaries alternating back to back in one shell, three with the unpatched arm first and three with the patched arm first, on a machine shared with other builds.
Load average 2.2 to 13.7 across the window.

| span | before, 6 runs (ms) | after, 6 runs (ms) | median before | median after |
|---|---|---|---:|---:|
| `Encode level` cols $2^{18}$ rate $2^1$ | 29.5, 23.4, 23.9, 30.8, 28.6, 25.9 | 22.5, 22.4, 21.6, 41.9, 25.6, 25.0 | 27.3 | 23.8 |
| `Encode level` cols $2^{14}$ rate $2^4$ | 9.7, 7.6, 5.8, 7.7, 6.6, 6.1 | 6.1, 4.2, 5.0, 6.5, 5.0, 4.8 | 7.1 | 5.0 |
| `Encode level` cols $2^{10}$ rate $2^5$ | 0.65, 0.83, 0.79, 0.70, 0.71, 0.69 | 0.35, 0.40, 0.52, 0.38, 0.47, 0.36 | 0.71 | 0.39 |
| `Commit witness` | 35.0, 29.0, 29.5, 36.4, 34.1, 30.7 | 28.0, 27.8, 27.0, 48.3, 30.8, 29.9 | 32.3 | 29.0 |
| `Prove` | 459, 457, 453, 454, 457, 446 | 446, 450, 432, 480, 455, 444 | 455.5 | 448.0 |

The two smaller shapes drop in all six paired comparisons; the largest drops in five of six, the exception being one cold first run of the patched binary that also inflates its `Commit witness`.
Median across the three encode spans is about 6 ms, roughly 1.3% of prove.

Corroborated in isolation, both allocators alternating inside one process, median of 40 rounds each, four repetitions of the whole harness:

| shape | global (ms) | pooled (ms) |
|---|---|---|
| cols $2^{18}$ lanes $2^4$ rate $2^1$ | 26.2, 26.0, 29.6, 28.7 | 24.9, 25.1, 26.9, 27.4 |
| cols $2^{14}$ lanes $2^4$ rate $2^4$ | 7.5, 13.0, 7.8, 18.4 | 5.9, 10.9, 6.0, 17.5 |
| cols $2^{10}$ lanes $2^4$ rate $2^5$ | 0.40, 0.77, 0.38, 0.52 | 0.40, 0.81, 0.38, 0.53 |

Worth stating plainly: an earlier estimate of 9.4 ms + 5.7 ms came from running the two allocators in separate benchmark loops minutes apart.
Alternating them in one process shrinks it to about 1% of prove.
The reason is that the encode faults its pages in from 32 rayon workers, so the first-touch cost the pool saves is already divided across the machine.
The allocation count is the part that is exact, and the churn it removes is 200 MiB per proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)