### PR TITLE
BINIUS-620: Say that the sumcheck driver and three neighbouring modules are crate-internal

### DIFF
--- a/crates/ip-prover/src/logup_star/pushforward.rs
+++ b/crates/ip-prover/src/logup_star/pushforward.rs
@@ -31,30 +31,30 @@ use crate::{
 };
 
 /// One table's witnesses and claims entering the pushforward reduction.
-pub struct TableWitness<'a, P: PackedField> {
+pub(crate) struct TableWitness<'a, P: PackedField> {
 	/// The table `T_t` over its `m_t`-variable cube.
-	pub table: FieldSlice<'a, P>,
+	pub(crate) table: FieldSlice<'a, P>,
 	/// The pushforward `Y_t` over the same cube.
-	pub pushforward: FieldSlice<'a, P>,
+	pub(crate) pushforward: FieldSlice<'a, P>,
 	/// The product claim `e_t = <T_t, Y_t>`.
-	pub eval_claim: P::Scalar,
+	pub(crate) eval_claim: P::Scalar,
 	/// The fractional-addition leaf claim `Y_t(z_t)`.
-	pub pushforward_eval_claim: P::Scalar,
+	pub(crate) pushforward_eval_claim: P::Scalar,
 	/// The leaf point `z_t`, of length `m_t`.
-	pub pushforward_eval_point: &'a [P::Scalar],
+	pub(crate) pushforward_eval_point: &'a [P::Scalar],
 }
 
 /// The evaluation claims that the pushforward reduction ends in.
-pub struct PushforwardOutput<F> {
+pub(crate) struct PushforwardOutput<F> {
 	/// The point spanning the widest table, at which every table's claims are taken.
 	///
 	/// Table `t`, over `m_t` variables, is claimed at the **first `m_t`** coordinates: the batch
 	/// pads each table at its high coordinates.
-	pub table_eval_point: Vec<F>,
+	pub(crate) table_eval_point: Vec<F>,
 	/// The claimed evaluations of the tables `T_t`, each at its own prefix of the point.
-	pub table_eval_claims: Vec<F>,
+	pub(crate) table_eval_claims: Vec<F>,
 	/// The claimed evaluations of the pushforwards `Y_t`, each at the same prefix.
-	pub pushforward_eval_claims: Vec<F>,
+	pub(crate) pushforward_eval_claims: Vec<F>,
 }
 
 /// Reduce every table's pushforward and product claims to one evaluation point.
@@ -93,7 +93,7 @@ pub struct PushforwardOutput<F> {
 /// * `tables` is non-empty.
 /// * For each table, `table.log_len() == pushforward.log_len() == pushforward_eval_point.len()`.
 #[tracing::instrument(skip_all, level = "debug", name = "logup* pushforward reduction")]
-pub fn prove_pushforward<'a, A, F, P>(
+pub(crate) fn prove_pushforward<'a, A, F, P>(
 	alloc: &'a A,
 	tables: impl IntoIterator<Item = TableWitness<'a, P>>,
 	channel: &mut impl IPProverChannel<F>,

--- a/crates/ip-prover/src/sumcheck/drive.rs
+++ b/crates/ip-prover/src/sumcheck/drive.rs
@@ -32,7 +32,7 @@ use crate::channel::IPProverChannel;
 /// - The verifier reconstructs the omitted coefficient from the round claim it already holds.
 /// - The two protocols omit opposite ends, so sending the wrong one yields a rejected proof.
 #[derive(Debug, Clone, Copy)]
-pub enum RoundProofKind {
+pub(crate) enum RoundProofKind {
 	/// Omits the highest-degree coefficient, recovered from `claim = R(0) + R(1)`.
 	Sumcheck,
 	/// Omits the constant term, recovered from `claim = (1 - alpha) * R(0) + alpha * R(1)`.
@@ -55,7 +55,7 @@ impl RoundProofKind {
 /// The format is a constant on the type rather than an argument to the loop.
 /// A caller could pass an argument naming a format its prover does not emit; it cannot pick a
 /// wrong constant, because wrapping is the only way in and each wrapper sets its own.
-pub trait RoundProver<F: Field> {
+pub(crate) trait RoundProver<F: Field> {
 	/// The round-proof format this prover's round polynomials must be sent in.
 	const ROUND_PROOF_KIND: RoundProofKind;
 
@@ -76,7 +76,7 @@ pub trait RoundProver<F: Field> {
 ///
 /// The layout matches the wrapped prover, so mapping a vector reuses its allocation.
 #[repr(transparent)]
-pub struct SumcheckRounds<Prover>(pub Prover);
+pub(crate) struct SumcheckRounds<Prover>(pub(crate) Prover);
 
 impl<F: Field, Prover: SumcheckProver<F>> RoundProver<F> for SumcheckRounds<Prover> {
 	const ROUND_PROOF_KIND: RoundProofKind = RoundProofKind::Sumcheck;
@@ -102,7 +102,7 @@ impl<F: Field, Prover: SumcheckProver<F>> RoundProver<F> for SumcheckRounds<Prov
 ///
 /// The layout serves the same purpose as it does for the plain sumcheck wrapper.
 #[repr(transparent)]
-pub struct MleCheckRounds<Prover>(pub Prover);
+pub(crate) struct MleCheckRounds<Prover>(pub(crate) Prover);
 
 impl<F: Field, Prover: MleCheckProver<F>> RoundProver<F> for MleCheckRounds<Prover> {
 	const ROUND_PROOF_KIND: RoundProofKind = RoundProofKind::MleCheck;
@@ -129,7 +129,7 @@ impl<F: Field, Prover: MleCheckProver<F>> RoundProver<F> for MleCheckRounds<Prov
 /// # Panics
 ///
 /// Panics if the prover returns more than one composition from a round.
-pub fn single<F, Prover>(
+pub(crate) fn single<F, Prover>(
 	mut prover: Prover,
 	channel: &mut impl IPProverChannel<F>,
 ) -> ProveSingleOutput<F>
@@ -172,7 +172,7 @@ where
 /// # Panics
 ///
 /// Panics if the provers do not all have the same number of rounds.
-pub fn batch<F, Prover>(
+pub(crate) fn batch<F, Prover>(
 	provers: impl IntoIterator<Item = Prover>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchSumcheckOutput<F>

--- a/crates/ip-prover/src/sumcheck/round_state.rs
+++ b/crates/ip-prover/src/sumcheck/round_state.rs
@@ -9,7 +9,7 @@
 /// A prover holds exactly one of the two at any time.
 /// Tracking which one lets the mandated call order be validated in a single place.
 #[derive(Debug, Clone)]
-pub enum RoundState<Coeffs, Claim> {
+pub(crate) enum RoundState<Coeffs, Claim> {
 	/// Round polynomial(s) already produced for this variable, awaiting the reduction step.
 	Coeffs(Coeffs),
 	/// Claim(s) awaiting the next round polynomial(s): the initial claim, or a reduction result.
@@ -23,7 +23,7 @@ impl<Coeffs, Claim> RoundState<Coeffs, Claim> {
 	///
 	/// Panics when the prover still holds an unreduced round polynomial.
 	/// That means execute was called before the previous round's fold.
-	pub fn claim(&self) -> &Claim {
+	pub(crate) fn claim(&self) -> &Claim {
 		match self {
 			// A carried claim is the expected input to the round-polynomial phase.
 			Self::Claim(claim) => claim,
@@ -38,7 +38,7 @@ impl<Coeffs, Claim> RoundState<Coeffs, Claim> {
 	///
 	/// Panics when the prover instead holds a claim.
 	/// That means fold was called before this round's execute produced a polynomial.
-	pub fn coeffs(&self) -> &Coeffs {
+	pub(crate) fn coeffs(&self) -> &Coeffs {
 		match self {
 			// The round polynomial is the expected input to the reduction phase.
 			Self::Coeffs(coeffs) => coeffs,

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -34,7 +34,7 @@ use binius_utils::{
 ///
 /// Choosing switchover round value is a balancing act between peak memory consumption and
 /// performance.
-pub struct BinarySwitchover<'b, P: PackedField, B: Bitwise> {
+pub(crate) struct BinarySwitchover<'b, P: PackedField, B: Bitwise> {
 	n_multilinears: usize,
 	bitmasks: &'b [B],
 	// The folding tensor grows one variable per pre-switchover round, so it is backed by a `Vec`.
@@ -55,7 +55,7 @@ where
 	/// * `bitmasks`       - bitmask representation of 1-bit multilinears
 	/// * `n_multilinears` - number of  lower bitmask bits that become multilinears
 	/// * `switchover`     - number of rounds after which to do the folding
-	pub fn new(n_multilinears: usize, switchover: usize, bitmasks: &'b [B]) -> Self {
+	pub(crate) fn new(n_multilinears: usize, switchover: usize, bitmasks: &'b [B]) -> Self {
 		assert!(
 			bitmasks.len().is_power_of_two(),
 			"Bitmasks represent a collection of multilinears and thus should be of power of two length"
@@ -86,7 +86,7 @@ where
 	/// Get a power-of-two sized aligned chunk of the multilinear at `bit_offset` in the current
 	/// round. This method abstracts transparent/folded state handling. Pre-switchover logic
 	/// requires a chunk sized scratchpad to hold the result.
-	pub fn get_chunk<'switchover, 'scratchpad, Data: DerefMut<Target = [P]>>(
+	pub(crate) fn get_chunk<'switchover, 'scratchpad, Data: DerefMut<Target = [P]>>(
 		&'switchover self,
 		scratchpad: &'scratchpad mut FieldBuffer<P, Data>,
 		bit_offset: usize,
@@ -114,7 +114,7 @@ where
 		)
 	}
 
-	pub fn fold(&mut self, challenge: F) {
+	pub(crate) fn fold(&mut self, challenge: F) {
 		if let Some(folded) = &mut self.folded {
 			// Post-switchover: fold high as usual
 			folded
@@ -165,7 +165,7 @@ where
 		self.folded = Some(all_folded);
 	}
 
-	pub fn finalize(mut self) -> Vec<FieldBuffer<P>> {
+	pub(crate) fn finalize(mut self) -> Vec<FieldBuffer<P>> {
 		self.perform();
 		self.folded.expect("explicit call to perform()")
 	}


### PR DESCRIPTION
Closes [BINIUS-620](https://linear.app/jimpo/issue/BINIUS-620).

Narrows eleven items in four never-re-exported modules from `pub` to `pub(crate)`.
Pure visibility change — no item moves, no signature changes, no behaviour change.

### The problem

Four modules of this crate are declared private and never re-exported.

```
crates/ip-prover/src/sumcheck/mod.rs:    mod drive;  mod round_state;  mod switchover;
crates/ip-prover/src/logup_star/mod.rs:  mod pushforward;
```

Everything inside them is written `pub`.

That reads as "part of this crate's API", and it is not: no downstream crate can name any of it, because no path reaches it.

A reader auditing the crate's surface has to reconstruct the module tree before they can rule these out.

### The idea

Write the visibility the items actually have.

`pub(crate)` is the exact reach of every one of them today, so this is the source agreeing with the compiler.

### The change

| module | items |
|---|---|
| `sumcheck/drive.rs` | `RoundProofKind`, `RoundProver`, `SumcheckRounds`, `MleCheckRounds`, `single`, `batch` |
| `sumcheck/round_state.rs` | `RoundState` and its two accessors |
| `sumcheck/switchover.rs` | `BinarySwitchover` and its four methods |
| `logup_star/pushforward.rs` | `TableWitness`, `PushforwardOutput`, `prove_pushforward` |

```diff
-pub struct SumcheckRounds<Prover>(pub Prover);
+pub(crate) struct SumcheckRounds<Prover>(pub(crate) Prover);
```

### Scope

Deliberately left alone:

- every module the crate does re-export, which is genuinely public
- the wider in-crate-only surface behind the `pub mod`s that *are* reachable

That second one is roughly forty items, and narrowing it is not mechanical: it decides whether this crate is a closed engine or an open toolkit, which the crate-level docs currently claim it is. Worth its own discussion rather than riding along here.

One trap in it, recorded so a later pass does not walk into it: `ColId` leaks into the signature of two externally called constructors, so it has to stay public even though nothing outside names it directly.

### Verification

- `cargo check --workspace --all-targets` — clean, which is what proves nothing outside was reaching in
- `cargo test -p binius-ip-prover` — 106 passed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos crates/ip-prover/` — clean

`cargo test -p binius-ip-prover --release` fails on `test_out_of_range_index_panics`, unchanged by this branch and unrelated to it — that is the failure #2421 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)