### PR TITLE
BINIUS-622: Hold one inversion context per padded batch, and call the claim fold's own axis split

### DIFF
--- a/crates/ip-prover/src/claim_fold.rs
+++ b/crates/ip-prover/src/claim_fold.rs
@@ -125,17 +125,9 @@ where
 	let mut point = output.challenges;
 	point.reverse();
 
-	// Cut the point into one run per axis, matching the shape the claims came in with.
-	let mut runs = Vec::with_capacity(axes.len());
-	let mut rest = point.as_slice();
-	for width in axes {
-		let (run, tail) = rest.split_at(width);
-		runs.push(run.to_vec());
-		rest = tail;
-	}
-
 	AxisClaim {
-		point: runs,
+		// Cut the point into one run per axis, matching the shape the claims came in with.
+		point: split_axes(&point, &axes),
 		value: tensor_eval,
 	}
 }

--- a/crates/ip-prover/src/fracaddcheck/padding.rs
+++ b/crates/ip-prover/src/fracaddcheck/padding.rs
@@ -109,6 +109,10 @@ pub(super) struct PaddedBatch<'a, A: Allocator, P: PackedField> {
 	pad_lens: Vec<usize>,
 	/// The depth every tree is padded to, which is how many layers the schedule runs.
 	n_layers: usize,
+	/// Scratch space for the inversion that de-pads a layer's claims.
+	///
+	/// Every layer inverts one weight per tree, so the size never changes.
+	pad_eq_inversion: BatchInversion<P::Scalar>,
 }
 
 impl<'a, A, F, P> PaddedBatch<'a, A, P>
@@ -135,10 +139,13 @@ where
 			.map(|tree| n_layers - tree.n_layers())
 			.collect();
 
+		let pad_eq_inversion = BatchInversion::new(trees.len());
+
 		Self {
 			trees,
 			pad_lens,
 			n_layers,
+			pad_eq_inversion,
 		}
 	}
 
@@ -200,7 +207,7 @@ where
 			pad_eq_invs.iter().all(|&pad_eq| pad_eq != F::ZERO),
 			"a padding coordinate of the claim point equals one"
 		);
-		BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
+		self.pad_eq_inversion.invert_nonzero(&mut pad_eq_invs);
 
 		izip!(&mut self.trees, &self.pad_lens, claims, &pad_eq_invs)
 			.map(|(tree, &tree_pad_len, &Fraction { num, den }, &pad_eq_inv)| {


### PR DESCRIPTION
Closes [BINIUS-622](https://linear.app/jimpo/issue/BINIUS-622).

Two independent cleanups in `binius-ip-prover`. Pure refactor — no behaviour change.

### The problem

**The batch inversion context is built and thrown away at its only call site.**

`BatchInversion`'s own doc says it owns scratch buffers so that reusing one instance across same-size calls avoids reallocating. `PaddedBatch::pop_layer` constructs a fresh one every layer, which is exactly the pattern the type exists to replace.

**The claim fold cuts a point into axis runs twice.** `claim_fold.rs` exports `split_axes`, and seventy lines later `prove` writes the same four-line loop inline.

### The change

```diff
-BatchInversion::<F>::new(pad_eq_invs.len()).invert_nonzero(&mut pad_eq_invs);
+self.pad_eq_inversion.invert_nonzero(&mut pad_eq_invs);
```

The context moves onto `PaddedBatch`, sized in `new` from the tree count. Every layer inverts one weight per tree and the tree count never changes, so one size fits every call. `new` already asserts the batch is non-empty, which is the constructor's own precondition.

```diff
-let mut runs = Vec::with_capacity(axes.len());
-let mut rest = point.as_slice();
-for width in axes {
-    let (run, tail) = rest.split_at(width);
-    runs.push(run.to_vec());
-    rest = tail;
-}
+point: split_axes(&point, &axes),
```

### Scope

The saving is negligible on its own terms — the element count is the tree count and the call count is the layer depth. The point is that the code now matches what the type documents.

### What is deliberately not here

Four other candidates from the same reading pass were dropped. Three died on contact, and those are the useful part of this PR.

**Trimming the quadratic evaluator's column halves to the indicator length is a regression, not a wash.**

The idea was to state the length relation once per chunk rather than leaving it implicit at every element, mirroring the pattern `MultilinearEvalEvaluator` documents. Benched with `bivariate_product`, native, against one saved baseline:

| bench | baseline | trimmed | reverted |
|---|---|---|---|
| `shared_mlecheck/n_vars=16` | — | +5.6% / +5.3% | −7.8% |
| `shared_mlecheck/n_vars=20` | — | +12.1% / +16.2% | −2.7% |
| `shared_sumcheck/n_vars=20` (untouched arm) | — | +2.2% | +2.0% |

Two runs of the trimmed arm, all `p < 0.05`, against an untouched arm whose drift stays under 4%. This is the hottest evaluator in the crate, so a readability preference does not get to cost that.

**Reserving capacity for the batched round polynomials would be a pessimization.**

`Vec::new()` followed by `extend` from `vec::IntoIter` — which is `TrustedLen` — already allocates once, at exactly the right size. Reserving one slot per prover instead under-reserves whenever a prover carries several claims, which is what `SharedSumcheckProver` is, and turns one exact allocation into two.

**Skipping the redundant padding write in `finish_and_transpose` is not much of a saving.**

Each of the four selector columns writes every slot exactly once already. The only avoidable work is a numerator column writing `F::ZERO` into a slot `zeros_in` had already zeroed, which is at most `2^k - n` writes with `k` the log of the instance count. Every way of skipping it costs more clarity than the write costs time.

**Caching `FactoredMultilinear`'s variable count is on hold.**

#2381 generifies that type over where its factors live, and the assertion in question is a real bounds precondition on a path with no callers yet.

### Verification

- `cargo test -p binius-ip-prover` — 106 passed
- `cargo check --workspace --all-targets` — clean
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-ip-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos crates/ip-prover/` — clean

`cargo test -p binius-ip-prover --release` fails on `test_out_of_range_index_panics`, unchanged by this branch and unrelated to it — that is the failure #2421 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)