### PR TITLE
BINIUS-623: Delete the FRI terminal-codeword type alias

### DIFF
--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -18,9 +18,6 @@ use crate::{
 	merkle_channel::MerkleIPProverChannel,
 };
 
-/// The type of the termination round codeword in the FRI protocol.
-pub type TerminateCodeword<F> = FieldBuffer<F>;
-
 enum FRIFolderState<P, C, Data = Vec<P>>
 where
 	P: PackedField,
@@ -310,7 +307,7 @@ where
 	/// * All fold rounds must have been executed (`curr_round == n_rounds()`).
 	#[instrument(skip_all, name = "fri::FRIFolder::finalize", level = "debug")]
 	#[allow(clippy::type_complexity)]
-	pub fn finalize(mut self) -> (TerminateCodeword<F>, C, FRIQueryProver<F, P, C, Data>) {
+	pub fn finalize(mut self) -> (FieldBuffer<F>, C, FRIQueryProver<F, P, C, Data>) {
 		assert_eq!(
 			self.curr_round,
 			self.n_rounds(),


### PR DESCRIPTION
Closes [BINIUS-623](https://linear.app/jimpo/issue/BINIUS-623).

Removes a public type alias that expands to the type it is written next to. Pure cleanup — no behavior change.

### The problem

The FRI fold module exports an alias for the terminal codeword:

```rust
pub type TerminateCodeword<F> = FieldBuffer<F>;
```

It is the identity — same type, no wrapper, no invariant, no extra parameter.

It has exactly one use in the workspace, the return type of the folder's finalize step, and no user outside the crate.

It also hides something worth seeing. The concrete type says the terminal codeword is a *scalar* buffer on the default heap backing, which is precisely the fact a later change to draw FRI round codewords from the prover's allocator has to act on.

### The alternative, and why not

The other option was to give the alias a `Data` parameter, matching the rest of the FRI prover types, which all carry one.

The terminal codeword is built by a `collect()` into a `Vec`, so that parameter would have exactly one inhabitant today. It only becomes real once the round codewords come from the prover's allocator — a separate change that wants a measurement first. The alias can come back then, if it earns its place.

### The change

```diff
-/// The type of the termination round codeword in the FRI protocol.
-pub type TerminateCodeword<F> = FieldBuffer<F>;
-
-    pub fn finalize(mut self) -> (TerminateCodeword<F>, C, FRIQueryProver<F, P, C, Data>) {
+    pub fn finalize(mut self) -> (FieldBuffer<F>, C, FRIQueryProver<F, P, C, Data>) {
```

### Scope

- **changed:** `crates/iop-prover/src/fri/fold.rs`, one file, four lines.
- The alias is public through a glob re-export, but no file in the workspace names it, and no pull request ever has — it arrived with the original FRI import in 2024 (#101, #102) and has only been moved by directory chores since.
- The verifier side has no counterpart alias, so no symmetry is broken.

### Verification

- `cargo test -p binius-iop-prover` — 85 + 2 pass
- `cargo test -p binius-iop-prover --release` — 85 + 2 pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-iop-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-iop-prover --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos`, `cargo check --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)