### PR TITLE
BINIUS-625: State the two invariants the relation queue and the FRI first fold rely on

### DIFF
--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -55,6 +55,8 @@ pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Sca
 	/// * `remaining_oracle_specs()` must be empty (all oracles committed).
 	/// * `oracle` must be a valid handle returned by `send_oracle()`.
 	/// * `transparent.log_len()` must match the oracle's message length.
+	/// * The claim must already be bound to the transcript, since the coefficient that batches the
+	///   queued relations is drawn only after the queue closes.
 	fn prove_oracle_relation(
 		&mut self,
 		oracle: Self::Oracle,

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -562,8 +562,15 @@ impl<F: Field, P: PackedField<Scalar = F>, C, Data: Deref<Target = [P]>>
 							acc.write(value);
 						}
 					});
+				// Pairing two chunk iterators stops at the shorter one.
+				// So every slot is written only when the two sides hold equally many chunks.
+				debug_assert_eq!(
+					code_len >> log_lift,
+					1 << (codeword.log_len() - log_batch_size),
+					"the folded codeword must hold one entry per lifted output chunk"
+				);
 				// SAFETY: the chunks partition the slots, and each writes all of its own.
-				// So the loop above wrote every one of the `code_len` slots.
+				// The counts above are equal, so the loop wrote every one of them.
 				unsafe { values.set_len(code_len) };
 			} else {
 				values


### PR DESCRIPTION
Closes [BINIUS-625](https://linear.app/jimpo/issue/BINIUS-625).

Two call sites rely on a fact they never state. Both are correct today — this writes the fact down, and makes one of them checkable where it is used.

### The relation queue

A queued oracle relation is one claimed inner product of the committed multilinear with a transparent one. The queue folds into a single relation with the powers of one coefficient, drawn once the queue closes:

```
T = sum_j lambda^j * t_j
S = sum_j lambda^j * s_j
```

That reduction is sound only when $\lambda$ is independent of the claims it combines.

**What breaks if it is not.** Suppose a prover could pick a claim after seeing $\lambda$, with two relations queued and $S$ the value it can honestly open. It picks $s_0$ freely and sets

$$ s_1 = \lambda^{-1} (S - s_0) $$

The batched check passes and neither individual claim is true. The batching error term $(k-1)/|F|$ assumes exactly the opposite ordering.

`QueuedRelation::batch` states this. `IOPProverChannel::prove_oracle_relation` — the method every caller actually reaches — lists the oracle handle and the transparent's length and stops there. Both channels draw $\lambda$ as the first act of `finish`, so the whole guarantee rests on the caller having already bound its claims.

Every caller today does the right thing: each claim it queues is a sumcheck output already sent over the same channel. That is a contract worth stating rather than a habit worth trusting.

**Could the type system enforce it instead?** Only at a price nobody would pay: the channel would have to hand back a token for each value it binds, and that token would have to thread through every sumcheck output across three crates. One precondition line is the right instrument here.

### The FRI first fold

The first oracle of a batch writes the combined codeword into uninitialized memory, then sets the length by hand.

The old note argued that the chunks partition the slots and each writes all of its own. Both true, neither load-bearing: rayon's paired iteration stops at the **shorter** side, so what actually makes the write cover every slot is that the two sides hold equally many chunks —

```
code_len >> log_lift  ==  1 << (codeword.log_len() - log_batch_size)
```

That equality is enforced two functions away, in `FRIFoldProver::new_batch`. The note never mentioned it, so the argument could not be checked where it was made. A `debug_assert_eq!` now restates it beside the write.

### The change

```diff
+	/// * The claim must already be bound to the transcript, since the coefficient that batches the
+	///   queued relations is drawn only after the queue closes.
```

```diff
+				// Pairing two chunk iterators stops at the shorter one.
+				// So every slot is written only when the two sides hold equally many chunks.
+				debug_assert_eq!(
+					code_len >> log_lift,
+					1 << (codeword.log_len() - log_batch_size),
+					"the folded codeword must hold one entry per lifted output chunk"
+				);
 				// SAFETY: the chunks partition the slots, and each writes all of its own.
-				// So the loop above wrote every one of the `code_len` slots.
+				// The counts above are equal, so the loop wrote every one of them.
 				unsafe { values.set_len(code_len) };
```

### Scope

- **changed:** `crates/iop-prover/src/channel/mod.rs` (one precondition), `crates/iop-prover/src/fri/fold.rs` (one assertion, one note).
- No behavior change in release builds; no signature, no API.
- The unsafe block itself is unchanged and was already sound.

### Verification

- `cargo test -p binius-iop-prover` — 85 + 2 pass, with the new debug assertion live on every fold
- `cargo test -p binius-iop-prover --release` — 85 + 2 pass
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-iop-prover --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-iop-prover --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `typos`, `cargo check --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)