### PR TITLE
BINIUS-626: Check the FRI prover's two uninitialized writes with Miri in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,52 @@ jobs:
         if: github.event_name != 'push'
         run: cargo test --doc --workspace
 
+  # The IOP prover writes a buffer through its spare capacity from a rayon loop and then sets the
+  # length by hand, in two places. Nothing else here can see whether every slot was really written.
+  #
+  # Miri interprets rather than executes, so a test costs minutes rather than milliseconds. Only
+  # three tests are run: the smallest one reaching each of those two writes, plus the one that
+  # duplicates each folded entry, where the slots a chunk covers are no longer one apiece.
+  miri:
+    name: miri-fri
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    # A fixed budget. Anything past this is a hang, not a slow run.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+      # Pinned like the rustfmt nightly above: Miri's aliasing model and its shims change between
+      # nightlies, and a floating channel can also ship without the component altogether.
+      #
+      # No `setup-rust` step, and so no build cache. Miri needs its own sysroot and its own target
+      # directory, which would compete for the repository's cache quota with the workspace legs —
+      # and those are where a restore actually pays.
+      - name: Install nightly toolchain for Miri
+        run: rustup toolchain install nightly-2026-08-26 --component miri --component rust-src
+      # Tree Borrows rather than the default Stacked Borrows. The latter rejects an
+      # integer-to-pointer cast inside crossbeam-epoch, reached from rayon's idle steal loop,
+      # before any code in this repository runs.
+      #
+      # The explicit target features keep the field crate on the packed paths that actually ship.
+      # Without them it falls back to portable code; with `-Ctarget-cpu=native`, as the workspace
+      # legs use, it would reach AVX-512, which Miri has no shims for.
+      #
+      # Every proptest case is a separate interpreted run, so the property tests get one case each.
+      #
+      # Widening the filter to the whole module buys more shapes over the same two writes, at many
+      # times the interpreted cost. Add a name here when a new write appears.
+      - name: Run Miri over the FRI prover
+        run: >-
+          cargo +nightly-2026-08-26 miri test -p binius-iop-prover --lib --
+          fri::encode::
+          fri::tests::test_commit_prove_verify_success_without_folding
+          fri::tests::test_commit_prove_verify_lifted_multi_oracle
+        env:
+          PROPTEST_CASES: 1
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tree-borrows"
+          RUSTFLAGS: "-Ctarget-feature=+sse4.1,+pclmulqdq,+avx,+avx2"
+
   unused-deps:
     name: unused-deps
     if: github.event_name != 'push'


### PR DESCRIPTION
Closes [BINIUS-626](https://linear.app/jimpo/issue/BINIUS-626).

Adds one CI job — about three minutes — that interprets the three tests reaching `binius-iop-prover`'s two `unsafe` blocks. CI-only; no crate is touched.

### The problem

`binius-iop-prover` has exactly two `unsafe` blocks, and both are the same shape:

```rust
values.spare_capacity_mut()[..code_len]
    .par_chunks_mut(1 << log_lift)
    .zip(codeword.par_chunks(log_batch_size))
    .for_each(|(copies, chunk)| { ... });
unsafe { values.set_len(code_len) };
```

`fri/fold.rs:568` and `fri/encode.rs:149`. Write through spare capacity from a rayon loop, then set the length by hand.

Nothing in CI can see whether every slot was really written. Fresh pages read as zero, so an unwritten slot is undefined behavior whose observable value may well be one a proof accepts — a wrong answer would at least be caught by a test.

### Why Miri is not here already

The default aliasing model cannot run this workspace at all:

```
error: Undefined Behavior: trying to retag from <...> for SharedReadWrite permission
  --> crossbeam-epoch-0.9.20/src/internal.rs:562:9
```

That is an integer-to-pointer cast inside `crossbeam-epoch`, reached from rayon's idle steal loop, and it aborts before any code in this repository runs. Tree Borrows reports the same cast as a warning and runs the tests to completion.

### The scope, and why not the whole module

Interpreted cost, measured on a Ryzen 9 9950X3D:

| test | interpreted |
|---|---:|
| `fri::encode::tests::test_encode_masked` | 3.9 s |
| `fri::tests::test_commit_prove_verify_success_without_folding` | 14.1 s |
| `fri::tests::test_commit_prove_verify_lifted_multi_oracle` | 133.4 s |
| `fri::tests::test_commit_prove_verify_batched_multi_oracle` (not run) | 296.3 s |
| **the three above, as the job runs them** | **155.6 s** |
| the whole `fri::` module, 13 tests | 1316.6 s |

The first two are the smallest tests reaching each `unsafe` block — confirmed by putting a temporary `panic!` at the fold's `set_len` and watching the no-folding test hit it. The third is the only test with a non-zero lift, where a chunk covers several slots instead of one, which is exactly where "each chunk writes all of its own" stops being trivial.

The remaining ten tests reach the same two writes at bigger shapes, for eight times the cost.

### Total job cost

| step | wall |
|---|---:|
| Miri sysroot, from empty | 10.7 s |
| dependencies + crate, from an empty target dir | 10.8 s |
| the three tests | 2 min 36 s |
| **total, as run locally** | **~3 min** |
| **the job on this PR, on a hosted runner** | **3 min 36 s** |

Miri builds MIR only, so the compile is much cheaper than a normal one — which is why the hosted runner is barely slower than the desktop. For scale, `rust-checks-x86_64` on run 33434273257 took 22 min 40 s, so this is nowhere near the critical path.

### That it actually catches something

With the first fold deliberately writing one chunk short, the job fails:

```
error: Undefined Behavior: constructing invalid value of type binius_field::Ghash128b:
       at .0.0.0[0], encountered uninitialized memory, but expected an integer
```

exit code 1. Restored, all three pass.

### Scope

- **new:** one job in `.github/workflows/ci.yml`, running on the same events as the other checks.
- The nightly is pinned (`nightly-2026-08-26`) the way the rustfmt nightly already is: Miri's aliasing model and shims move between nightlies, and a floating channel can ship without the component at all.
- No `setup-rust`, so no cache: Miri needs its own sysroot and target directory, and those would compete for the repo's cache quota with the workspace legs, where a restore actually pays.
- The explicit target features keep the field crate on its packed paths — without them it falls back to portable code, and with `-Ctarget-cpu=native` it would reach AVX-512, which Miri has no shims for.
- `timeout-minutes: 20` bounds a hang.

### The follow-up this leaves open

The filter names tests, so a new `unsafe` block elsewhere in the module is not covered until someone adds its test to the list — the comment says so. The durable version is `#[cfg_attr(miri, ignore)]` on the ten expensive tests, which would let the filter go back to plain `fri::`; that belongs with whoever owns those tests.

### Verification

- The job itself, green on this PR: `miri-fri` in 3 min 36 s, of which 8 s is the toolchain install
- The job's exact command locally — 3 passed, 2 min 36 s
- The whole module, for the comparison above — 13 passed, 22 min 07 s
- `nightly-2026-08-26` ships `miri-preview` for `x86_64-unknown-linux-gnu` (checked against the dist manifest); it is the same rustc this was run with
- `typos`, `cargo +nightly-2026-07-01 fmt --all --check`, and a YAML parse of the workflow — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
