### PR TITLE
BINIUS-627: Decide once which gates survive, and use that decision for both the constraints and the bytecode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           set -e
           # Keep this list in sync with the committed snapshots in crates/examples/snapshots:
           # every example that ships a .snap must be checked here, or it can drift undetected.
-          for example in ethsign zklogin sha256 sha512 keccak blake2s blake2b blake3_compress blake3 hashsign ec_msm bitcoin_header_chain bitcoin_p2pkh; do
+          for example in ethsign zklogin sha256 sha512 sha3 sha3_512 keccak blake2s blake2b blake3_compress blake3 hashsign ec_msm bitcoin_header_chain bitcoin_p2pkh; do
             echo "::group::${example}"
             cargo run --example "${example}" -- check-snapshot
             echo "::endgroup::"

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -2,7 +2,7 @@ bitcoin_headers circuit
 --
 Gates & Instructions
 ├─ Number of gates: 38,898
-└─ Number of evaluation instructions: 39,018
+└─ Number of evaluation instructions: 38,050
 
 Constraints
 ├─ ZERO constraints: 3,412 used (83.3% of 2^12)

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -2,7 +2,7 @@ bitcoin_p2pkh circuit
 --
 Gates & Instructions
 ├─ Number of gates: 149,311
-└─ Number of evaluation instructions: 175,129
+└─ Number of evaluation instructions: 161,206
 
 Constraints
 ├─ ZERO constraints: 15,896 used (97.0% of 2^14)

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -2,7 +2,7 @@ blake2s circuit
 --
 Gates & Instructions
 ├─ Number of gates: 10,392
-└─ Number of evaluation instructions: 10,392
+└─ Number of evaluation instructions: 10,315
 
 Constraints
 ├─ ZERO constraints: 2,069 used (50.5% of 2^12)

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -2,7 +2,7 @@ blake3 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 7,256
-└─ Number of evaluation instructions: 7,256
+└─ Number of evaluation instructions: 7,120
 
 Constraints
 ├─ ZERO constraints: 1,389 used (67.8% of 2^11)

--- a/crates/examples/snapshots/blake3_compress.snap
+++ b/crates/examples/snapshots/blake3_compress.snap
@@ -2,7 +2,7 @@ blake3_compress circuit
 --
 Gates & Instructions
 ├─ Number of gates: 6,336
-└─ Number of evaluation instructions: 6,336
+└─ Number of evaluation instructions: 0
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -2,7 +2,7 @@ ec_msm circuit
 --
 Gates & Instructions
 ├─ Number of gates: 207,250
-└─ Number of evaluation instructions: 242,366
+└─ Number of evaluation instructions: 221,735
 
 Constraints
 ├─ ZERO constraints: 20,982 used (64.0% of 2^15)

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -2,7 +2,7 @@ ethsign circuit
 --
 Gates & Instructions
 ├─ Number of gates: 213,301
-└─ Number of evaluation instructions: 248,630
+└─ Number of evaluation instructions: 227,851
 
 Constraints
 ├─ ZERO constraints: 20,958 used (64.0% of 2^15)

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -2,7 +2,7 @@ hashsign circuit
 --
 Gates & Instructions
 ├─ Number of gates: 275,391
-└─ Number of evaluation instructions: 276,525
+└─ Number of evaluation instructions: 232,413
 
 Constraints
 ├─ ZERO constraints: 42,501 used (64.9% of 2^16)

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -2,7 +2,7 @@ keccak circuit
 --
 Gates & Instructions
 ├─ Number of gates: 22,189
-└─ Number of evaluation instructions: 22,189
+└─ Number of evaluation instructions: 22,107
 
 Constraints
 ├─ ZERO constraints: 4 used (100.0% of 2^2)

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -2,7 +2,7 @@ sha256 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 19,465
-└─ Number of evaluation instructions: 19,465
+└─ Number of evaluation instructions: 19,407
 
 Constraints
 ├─ ZERO constraints: 1,695 used (82.8% of 2^11)

--- a/crates/examples/snapshots/sha3.snap
+++ b/crates/examples/snapshots/sha3.snap
@@ -2,7 +2,7 @@ sha3 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 22,189
-└─ Number of evaluation instructions: 22,189
+└─ Number of evaluation instructions: 22,107
 
 Constraints
 ├─ ZERO constraints: 4 used (100.0% of 2^2)

--- a/crates/examples/snapshots/sha3_512.snap
+++ b/crates/examples/snapshots/sha3_512.snap
@@ -2,7 +2,7 @@ sha3_512 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 41,513
-└─ Number of evaluation instructions: 41,513
+└─ Number of evaluation instructions: 41,449
 
 Constraints
 ├─ ZERO constraints: 8 used (100.0% of 2^3)

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -2,7 +2,7 @@ sha512 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 24,839
-└─ Number of evaluation instructions: 24,839
+└─ Number of evaluation instructions: 24,748
 
 Constraints
 ├─ ZERO constraints: 2,015 used (98.4% of 2^11)

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -2,7 +2,7 @@ zklogin circuit
 --
 Gates & Instructions
 ├─ Number of gates: 388,535
-└─ Number of evaluation instructions: 456,622
+└─ Number of evaluation instructions: 335,768
 
 Constraints
 ├─ ZERO constraints: 33,513 used (51.1% of 2^16)

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -617,35 +617,33 @@ impl CircuitBuilder {
 			zero_fold::zero_propagation(&mut graph, &pinned, &shared.hint_registry);
 		}
 
+		// The gates that reach both the constraint system and the evaluation form.
+		// A pass left switched off excludes nothing.
+		let mut surviving = EntitySet::new();
+		surviving.extend(graph.gates.keys());
+
 		// Common-subexpression elimination: collapse structurally-identical gates.
 		// This runs first so the dead-code pass sees the canonicalized graph.
-		let dead_gates = shared
-			.opts
-			.enable_common_subexpression_elimination
-			.then(|| cse::dedup_gates(&mut graph, &pinned, &shared.hint_registry));
+		if shared.opts.enable_common_subexpression_elimination {
+			// A collapsed duplicate's outputs are read through the canonical gate.
+			for gate in cse::dedup_gates(&mut graph, &pinned, &shared.hint_registry).iter() {
+				surviving.remove(gate);
+			}
+		}
 
 		// Dead-code elimination: the gates that can affect the constraint system.
-		// A gate outside this set emits no constraint and no committed wire, so it is skipped
-		// below.
-		let live_gates = shared
-			.opts
-			.enable_dead_code_elimination
-			.then(|| dce::live_gates(&mut graph, &pinned, &shared.hint_registry));
+		if shared.opts.enable_dead_code_elimination {
+			// A gate outside the live set only writes wires that nothing reads.
+			let live = dce::live_gates(&mut graph, &pinned, &shared.hint_registry);
+			for gate in graph.gates.keys() {
+				if !live.contains(gate) {
+					surviving.remove(gate);
+				}
+			}
+		}
 
 		let mut builder = ConstraintBuilder::new();
-		for (gate_id, _) in graph.gates.iter() {
-			// Drop collapsed duplicates: their outputs are now read through the canonical gate.
-			if let Some(dead_gates) = &dead_gates
-				&& dead_gates.contains(gate_id)
-			{
-				continue;
-			}
-			// Drop dead gates: they would only add constraints on wires that nothing reads.
-			if let Some(live_gates) = &live_gates
-				&& !live_gates.contains(gate_id)
-			{
-				continue;
-			}
+		for gate_id in surviving.iter() {
 			gate_id.constrain(&graph, &mut builder, &shared.hint_registry);
 		}
 
@@ -769,6 +767,7 @@ impl CircuitBuilder {
 		// Build evaluation form (consumes the hint registry the user populated via call_hint).
 		let eval_form = eval_form::EvalForm::build(
 			&graph,
+			&surviving,
 			&wire_mapping,
 			&value_vec_layout,
 			shared.hint_registry,

--- a/crates/frontend/src/eval_form/mod.rs
+++ b/crates/frontend/src/eval_form/mod.rs
@@ -22,13 +22,13 @@ use binius_core::{ValueIndex, ValueVec, ValueVecLayout, Word};
 use binius_utils::strided_array::StridedArray2DViewMut;
 pub use builder::BytecodeBuilder;
 pub use const_eval::evaluate_gate_constants;
-use cranelift_entity::SecondaryMap;
+use cranelift_entity::{EntitySet, SecondaryMap};
 use exec::Executor;
 use scalar::ExecutionContext;
 
 use crate::{
 	artifact::witness::PopulateError,
-	ir::{GateGraph, Wire, hints::HintRegistry, path::PathSpecTree},
+	ir::{Gate, GateGraph, Wire, hints::HintRegistry, path::PathSpecTree},
 };
 
 /// Compiled evaluation form for circuit witness computation
@@ -44,10 +44,15 @@ pub struct EvalForm {
 impl EvalForm {
 	/// Build the evaluation form from the gate graph.
 	///
+	/// `surviving` names the gates the compiler passes kept, a subset of the graph's gates. A
+	/// gate left out of it emits no bytecode, so its output wires are never written; the passes
+	/// guarantee no surviving gate reads them and none of them is committed.
+	///
 	/// The registry already holds every hint the circuit called.
 	/// Emission only reads it to resolve each gate's arity.
 	pub(crate) fn build(
 		gate_graph: &GateGraph,
+		surviving: &EntitySet<Gate>,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 		layout: &ValueVecLayout,
 		hint_registry: HintRegistry,
@@ -70,8 +75,8 @@ impl EvalForm {
 			word_offset as u32
 		};
 
-		// Build bytecode for each gate
-		for gate_id in gate_graph.gates.keys() {
+		// Build bytecode for each surviving gate
+		for gate_id in surviving.iter() {
 			gate_id.emit_bytecode(gate_graph, &mut builder, wire_to_reg, &hint_registry);
 		}
 


### PR DESCRIPTION
Closes [BINIUS-627](https://linear.app/jimpo/issue/BINIUS-627).

Folds the two gate-exclusion sets the compiler passes produce into one positive set, and uses it for the constraint system *and* the evaluation form.

Not one constraint moves. What moves is how much work witness generation does.

### The problem

Two passes decide that a gate does not need to exist, and they report it in opposite polarity.

- Common-subexpression elimination returns the gates it **collapsed** onto a canonical twin.
- Dead-code elimination returns the gates that are still **live**.

`compile` threaded both by hand — two `Option` checks per gate, one asking `contains`, the other `!contains`:

```rust
for (gate_id, _) in graph.gates.iter() {
    if let Some(dead_gates) = &dead_gates && dead_gates.contains(gate_id) { continue; }
    if let Some(live_gates) = &live_gates && !live_gates.contains(gate_id) { continue; }
    gate_id.constrain(&graph, &mut builder, &shared.hint_registry);
}
```

Then it handed the **whole, unfiltered** graph to the evaluation form, which emits bytecode for every gate the graph holds.

So a gate that either pass removed from the constraint system still ran at witness-generation time, writing into a scratch slot nothing reads.

### The idea

Decide once, use twice.

One `EntitySet<Gate>` of surviving gates, computed in `compile`.
The constraint loop tests membership in it.
`EvalForm::build` is given the same set and tests membership in it too.

Expressed **positively**, so there is one polarity, not two.
A pass left switched off excludes nothing, so the set is seeded with every gate rather than wrapped in an `Option`.

### The change

```
-let dead_gates = opts.enable_cse.then(|| cse::dedup_gates(...));      // negative
-let live_gates = opts.enable_dce.then(|| dce::live_gates(...));       // positive
+let mut surviving = EntitySet::new();
+surviving.extend(graph.gates.keys());
+if opts.enable_cse { for g in cse::dedup_gates(...).iter() { surviving.remove(g); } }
+if opts.enable_dce { let live = dce::live_gates(...); /* remove !live */ }

-EvalForm::build(&graph, &wire_mapping, &value_vec_layout, hint_registry)
+EvalForm::build(&graph, &surviving, &wire_mapping, &value_vec_layout, hint_registry)
```

Both loops still walk `graph.gates.keys()` in graph order, so constraint order and bytecode order are byte-for-byte what they were.

### Soundness

A gate stops running at witness time. That is safe only if nothing reads its outputs. Both claims are enforced in the passes themselves:

**A collapsed gate.** `cse.rs` sweeps in emission (topological) order and rewrites each gate's own input wires through the remap table before keying it. A reader is always visited after the gate that feeds it, so every reader of a collapsed duplicate is redirected onto the canonical output. And `produces_observable` blocks the collapse outright when any output is `WireKind::Inout` or in the pinned set — chip-call wires are folded into that set in `compile`. So a collapsed gate's outputs are read by nothing and committed nowhere.

**A dead gate.** `dce.rs` seeds liveness from assertions (a gate with no outputs) and from gates defining an observable wire (inout, or pinned), then propagates backward along def→use edges. A gate outside the result transitively reaches no assertion, no public output and no pinned wire.

An assertion gate has no output wires, so it is a dead-code seed and is never dropped — assertions still fire at witness time.

### Scratch allocation

Worked out before touching anything, since this was the one place a layout could shift.

`ScratchAlloc::new`, `order_deaths` and `pool_slots` all walk `graph.gates` — every gate, excluded or not — and this PR does not change that. So lifetimes and slot assignment are **unchanged**: an excluded gate's output still takes a slot and still extends its neighbours' lifetimes. The segment is merely larger than it strictly needs to be, which is safe.

No stale read is possible either. An excluded gate no longer writes its slot, and under pooling that slot may be reclaimed by a later value — but that value is written by its own gate before anything reads it.

Confirmed empirically: `n_scratch` and `scratch_peak_live` are unchanged in every committed snapshot.

### Scope

- **changed:** `compile` in `crates/frontend/src/builder/mod.rs`, and `EvalForm::build` in `crates/frontend/src/eval_form/mod.rs`.
- **re-blessed:** 14 statistics snapshots under `crates/examples/snapshots/`.
- **one CI line:** `sha3` and `sha3_512` ship snapshots but were missing from the `circuits-snapshot` example list, so both had silently drifted stale — exactly the failure mode that job's own comment warns about ("every example that ships a `.snap` must be checked here, or it can drift undetected"). They are re-blessed here, so they are added to the list in the same change rather than left inconsistent.
- **untouched:** `cse.rs` and `dce.rs` — no pass changes what it decides, only how the decision is carried.
- `EvalForm::build` is `pub(crate)`, so no public surface moves.

### Verification — the snapshots

The `circuits-snapshot` job pins the rendered `CircuitStat` for every example. Those snapshots are re-blessed here, and **the only line that moves in any of them is the instruction count**:

```
$ git diff upstream/main -U0 -- crates/examples/snapshots/ | grep '^@@' | sort | uniq -c
     14 @@ -5 +5 @@ Gates & Instructions
```

Fourteen files, one hunk each, all at line 5. Gate counts, all four constraint counts, distinct shifted and unshifted value indices, every value-vector section, the committed trace and both scratch figures are byte-identical everywhere. `blake2b` did not change at all.

| example | gates | instructions before | after | drop | drop % |
|---|---|---|---|---|---|
| `blake3_compress` | 6,336 | 6,336 | 0 | 6,336 | 100.00% |
| `zklogin` | 388,535 | 456,622 | 335,768 | 120,854 | 26.47% |
| `hashsign` | 275,391 | 276,525 | 232,413 | 44,112 | 15.95% |
| `ec_msm` | 208,914 | 244,030 | 223,399 | 20,631 | 8.45% |
| `ethsign` | 214,965 | 250,294 | 229,515 | 20,779 | 8.30% |
| `bitcoin_p2pkh` | 150,143 | 175,961 | 162,038 | 13,923 | 7.91% |
| `bitcoin_header_chain` | 38,898 | 39,018 | 38,050 | 968 | 2.48% |
| `blake3` | 7,256 | 7,256 | 7,120 | 136 | 1.87% |
| `blake2s` | 10,392 | 10,392 | 10,315 | 77 | 0.74% |
| `sha3` | 22,189 | 22,189 | 22,107 | 82 | 0.37% |
| `keccak` | 22,189 | 22,189 | 22,107 | 82 | 0.37% |
| `sha512` | 24,839 | 24,839 | 24,748 | 91 | 0.37% |
| `sha256` | 19,465 | 19,465 | 19,407 | 58 | 0.30% |
| `sha3_512` | 41,513 | 41,513 | 41,449 | 64 | 0.15% |
| `blake2b` | 10,824 | 10,824 | 10,824 | 0 | 0.00% |

Summed over the fifteen circuits CI now checks: **1,607,453 → 1,379,260 instructions, a 14.2% cut**.

Counts are taken against this PR's rebased base, since #2400 (BINIUS-582) moved the SHA-256-derived circuits under it.

**Read the size of this honestly.** These are counts of bytecode instructions the interpreter runs, not wall-clock measurements — per-opcode cost varies, and no benchmark is claimed here. What the table does establish is that the gap was real and, on the larger circuits, not small.

`blake3_compress` going to zero is the sharpest illustration of the underlying defect. On the base commit that example already reports **0 constraints of every kind, 0 inout, 0 internal, 0 distinct value indices**. It builds a chain of compressions and never asserts anything or promotes an output, so the whole circuit is dead by construction. Dead-code elimination had already emptied its constraint system, and the bytecode was the only thing still running all 6,336 gates — a circuit proving nothing, yet paying full price at witness time. That is a pre-existing defect in the example, not something this PR introduces, and fixing it would change constraint counts, so it is left for a separate change.

### Verification — the rest

Commands run on the rebased tree, all clean:

- `cargo check --workspace --all-targets`
- `cargo test -p binius-frontend` (debug, so `debug_assert!` fires) and `--release` with `-Ctarget-cpu=native` — 265 tests, including `batched_matches_scalar_per_instance`, `test_scratch_pooling_preserves_the_committed_witness` and `parallel_population_matches_serial_for_varied_stripe_widths`
- `cargo test -p binius-circuits` — 412 tests over the real gadget library
- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --document-private-items --no-deps`
- `cargo +nightly-2026-07-01 fmt --all --check`, `tools/check_copyright_notice.py`, `typos`
- the `circuits-snapshot` loop itself, all fifteen examples green

The random-circuit differential from #2428 was copied onto this branch and run at `PROPTEST_CASES=20000` in debug: all three tests pass, so the committed witness is identical per `Wire` and `verify` accepts under all eleven `Options` settings. It is not committed here — it belongs to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
