### PR TITLE
BINIUS-628: Generate the constant-folding differential test's inputs

### DIFF
--- a/crates/frontend/src/eval_form/const_eval.rs
+++ b/crates/frontend/src/eval_form/const_eval.rs
@@ -172,6 +172,7 @@ pub fn evaluate_gate_constants(
 #[cfg(test)]
 mod tests {
 	use binius_core::Word;
+	use proptest::{prelude::*, test_runner::TestCaseResult};
 
 	use super::*;
 
@@ -248,134 +249,128 @@ mod tests {
 			.collect())
 	}
 
-	#[test]
-	fn differential_against_interpreter() {
-		let vals = [
-			Word::ZERO,
-			Word::ALL_ONE,
-			Word::MSB_ONE,
-			Word::from_u64(1),
-			Word::from_u64(0x8000000000000000),
-			Word::from_u64(0x123456789ABCDEF0),
-			Word::from_u64(0xFFFFFFFF),
-			Word::from_u64(0x5),
-			Word::from_u64(0x9),
-		];
-		let opcodes = [
-			(Opcode::Band, 2),
-			(Opcode::Bor, 2),
-			(Opcode::Bxor, 2),
-			(Opcode::Fax, 3),
-			(Opcode::Select, 3),
-			(Opcode::IaddCinCout, 3),
-			(Opcode::Iadd32, 2),
-			(Opcode::Iadd32CinCout, 3),
-			(Opcode::IsubBinBout, 3),
-			(Opcode::Imul, 2),
-			(Opcode::Bmul, 4),
-			(Opcode::IcmpUlt, 2),
-			(Opcode::IcmpEq, 2),
-			(Opcode::AssertEq, 2),
-			(Opcode::AssertEqCond, 3),
-			(Opcode::AssertZero, 1),
-			(Opcode::AssertNonZero, 1),
-			(Opcode::AssertFalse, 1),
-			(Opcode::AssertTrue, 1),
-		];
-		let mut checked = 0;
-		for (opcode, n_in) in opcodes {
-			// Enumerate every combination of `vals` of length `n_in`.
-			let total = vals.len().pow(n_in as u32);
-			for mut k in 0..total {
-				let inputs: Vec<Word> = (0..n_in)
-					.map(|_| {
-						let v = vals[k % vals.len()];
-						k /= vals.len();
-						v
-					})
-					.collect();
-				let (graph, gate, constants) = create_test_gate(opcode, &inputs);
-				let hints = HintRegistry::new();
-				let want = eval_via_interpreter(&graph, gate, &constants, &hints);
-				let got = evaluate_gate_constants(&graph, gate, &constants, &hints);
-				assert_eq!(
-					want.is_ok(),
-					got.is_ok(),
-					"{opcode:?} {inputs:?}: ok mismatch, interpreter={want:?} match={got:?}"
-				);
-				if let (Ok(want), Ok(got)) = (want, got) {
-					assert_eq!(want, got, "{opcode:?} {inputs:?}");
-				}
-				checked += 1;
-			}
-		}
-		println!("differential: {checked} cases checked");
+	/// Weighted into the generator: a uniform draw never reaches these corners.
+	const BOUNDARY_WORDS: [Word; 12] = [
+		Word::ZERO,
+		Word::ONE,
+		Word::ALL_ONE,
+		Word::MSB_ONE,
+		Word::MASK_32,
+		Word(0x7FFFFFFFFFFFFFFF),
+		Word(0xFFFFFFFF00000000),
+		Word(0x0000000100000000),
+		Word(0x0000000080000000),
+		Word(0x123456789ABCDEF0),
+		Word(0x5),
+		Word(0x9),
+	];
+
+	fn any_word() -> impl Strategy<Value = Word> {
+		prop_oneof![
+			3 => prop::sample::select(BOUNDARY_WORDS.to_vec()),
+			1 => any::<u64>().prop_map(Word),
+		]
 	}
 
-	#[test]
-	fn differential_shift_and_bxor_multi() {
-		let vals = [
-			Word::ZERO,
-			Word::ALL_ONE,
-			Word::MSB_ONE,
-			Word::from_u64(1),
-			Word::from_u64(0x123456789ABCDEF0),
-			Word::from_u64(0xFFFFFFFF),
-		];
-		let hints = HintRegistry::new();
-		let mut checked = 0;
+	/// Every opcode of fixed arity, with the number of inputs it takes.
+	const FIXED_ARITY: [(Opcode, usize); 19] = [
+		(Opcode::Band, 2),
+		(Opcode::Bor, 2),
+		(Opcode::Bxor, 2),
+		(Opcode::Fax, 3),
+		(Opcode::Select, 3),
+		(Opcode::IaddCinCout, 3),
+		(Opcode::Iadd32, 2),
+		(Opcode::Iadd32CinCout, 3),
+		(Opcode::IsubBinBout, 3),
+		(Opcode::Imul, 2),
+		(Opcode::Bmul, 4),
+		(Opcode::IcmpUlt, 2),
+		(Opcode::IcmpEq, 2),
+		(Opcode::AssertEq, 2),
+		(Opcode::AssertEqCond, 3),
+		(Opcode::AssertZero, 1),
+		(Opcode::AssertNonZero, 1),
+		(Opcode::AssertFalse, 1),
+		(Opcode::AssertTrue, 1),
+	];
 
-		for variant in 0..8u32 {
-			for n in [0u32, 1, 7, 31, 32, 63] {
-				for &x in &vals {
-					let mut graph = GateGraph::new();
-					let root = graph.path_spec_tree.root();
-					let input = graph.add_constant(x);
-					let out = graph.add_witness();
-					let gate = graph.emit_gate_generic(
-						root,
-						Opcode::Shift,
-						[input],
-						[out],
-						&[],
-						&[variant, n],
-					);
-					let want = eval_via_interpreter(&graph, gate, &[x], &hints);
-					let got = evaluate_gate_constants(&graph, gate, &[x], &hints);
-					assert_eq!(want, got, "shift variant={variant} n={n} x={x:?}");
-					checked += 1;
-				}
+	/// Holds one gate's folded outputs against the interpreter's.
+	fn check_agreement(graph: &GateGraph, gate: Gate, constants: &[Word]) -> TestCaseResult {
+		let hints = HintRegistry::new();
+		let data = &graph.gates[gate];
+		let (body, imms) = (data.body, &data.immediates);
+		let want = eval_via_interpreter(graph, gate, constants, &hints);
+		let got = evaluate_gate_constants(graph, gate, constants, &hints);
+		// An assertion gate reports a verdict rather than values.
+		prop_assert_eq!(
+			want.is_ok(),
+			got.is_ok(),
+			"{:?} imm={:?} in={:?}: interpreter={:?} folded={:?}",
+			body,
+			imms,
+			constants,
+			want,
+			got
+		);
+		if let (Ok(want), Ok(got)) = (want, got) {
+			prop_assert_eq!(want, got, "{:?} imm={:?} in={:?}", body, imms, constants);
+		}
+		Ok(())
+	}
+
+	proptest! {
+		#![proptest_config(ProptestConfig::with_cases(1024))]
+
+		#[test]
+		fn fixed_arity_gates_fold_as_the_interpreter_evaluates_them(
+			words in prop::collection::vec(any_word(), 4),
+		) {
+			for (opcode, n_in) in FIXED_ARITY {
+				let (graph, gate, constants) = create_test_gate(opcode, &words[..n_in]);
+				check_agreement(&graph, gate, &constants)?;
 			}
 		}
 
-		for n_in in 1..=5usize {
-			for mut k in 0..vals.len().pow(n_in as u32) {
-				let inputs: Vec<Word> = (0..n_in)
-					.map(|_| {
-						let v = vals[k % vals.len()];
-						k /= vals.len();
-						v
-					})
-					.collect();
+		#[test]
+		fn shift_folds_as_the_interpreter_evaluates_it(x in any_word(), amount in 0u32..64) {
+			for variant in ShiftVariant::ALL {
+				// A lane variant only takes amounts below 32.
+				let n = amount % variant.max_amount() as u32;
 				let mut graph = GateGraph::new();
 				let root = graph.path_spec_tree.root();
-				let input_wires: Vec<_> = inputs.iter().map(|&v| graph.add_constant(v)).collect();
+				let input = graph.add_constant(x);
 				let out = graph.add_witness();
 				let gate = graph.emit_gate_generic(
 					root,
-					Opcode::BxorMulti,
-					input_wires,
+					Opcode::Shift,
+					[input],
 					[out],
-					&[n_in],
 					&[],
+					&[variant as u32, n],
 				);
-				let want = eval_via_interpreter(&graph, gate, &inputs, &hints);
-				let got = evaluate_gate_constants(&graph, gate, &inputs, &hints);
-				assert_eq!(want, got, "bxor_multi {inputs:?}");
-				checked += 1;
+				check_agreement(&graph, gate, &[x])?;
 			}
 		}
-		println!("differential shift/bxor_multi: {checked} cases checked");
+
+		#[test]
+		fn bxor_multi_folds_as_the_interpreter_evaluates_it(
+			inputs in prop::collection::vec(any_word(), 1..=12),
+		) {
+			let mut graph = GateGraph::new();
+			let root = graph.path_spec_tree.root();
+			let input_wires: Vec<_> = inputs.iter().map(|&v| graph.add_constant(v)).collect();
+			let out = graph.add_witness();
+			let gate = graph.emit_gate_generic(
+				root,
+				Opcode::BxorMulti,
+				input_wires,
+				[out],
+				&[inputs.len()],
+				&[],
+			);
+			check_agreement(&graph, gate, &inputs)?;
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-628](https://linear.app/jimpo/issue/BINIUS-628).

Turns the constant-folding differential test into a property test. Test-only change — no library code touched.

### The problem

`crates/frontend` states each gate's semantics in three independent places.

- `constrain` — the constraint the gate contributes.
- `emit` plus the interpreter — the bytecode that fills the witness.
- `evaluate_gate_constants` — the compile-time fold taken when every input is constant.

If the fold disagrees with the interpreter, constant propagation bakes a different value into the circuit than evaluation would have produced.
That is a wrong witness, produced silently, at compile time.

The crate already guards this, and the guard is well built.
`differential_against_interpreter` compiles each gate to bytecode, runs the interpreter, and compares the result against the fold.
Its own doc says it best: the two are independent statements of the same gate semantics, so they must agree on every input.

The oracle is right. Its input set was the problem.

- Nine hand-picked words, crossed exhaustively over each opcode's arity.
- A sibling test covering `Shift` and `BxorMulti` over six words, six shift amounts, and arities 1 through 5.

So the shift amount grid was 6 values out of 64, and no multi-way exclusive-or was ever folded with more than five inputs.

### The idea

Keep the oracle exactly as it is. Generate the inputs.

The hand-picked words stay, as a weighted generator rather than as the whole alphabet.

```
3 parts   a boundary word   (zero, all-ones, MSB-only, the 32-bit lane masks, ...)
1 part    a uniform random u64
```

Boundary words are where carry chains, the MSB-boolean convention and the 32-bit lane split break.
A uniform draw essentially never produces them, so weighting them in is load-bearing rather than decorative.
The second injected bug below shrinks to exactly one of them, which is the point.

The two fixed grids fold into three properties, so there is one mechanism instead of two.

| property | per generated case |
|---|---|
| fixed-arity opcodes | all 19 opcodes, on the same generated words |
| `Shift` | all 8 variants, at a generated amount inside each variant's range |
| `BxorMulti` | one arity drawn from 1 through 12 |

The verdict check is preserved.
An assertion gate returns an error rather than values, so the property is that the `is_ok` verdict agrees, and where both sides are `Ok`, the values agree.

### Scope

- **changed:** the test module of `crates/frontend/src/eval_form/const_eval.rs`, nothing else.
- **untouched:** `evaluate_gate_constants` itself, and the oracle helper together with its doc comment.
- **left alone:** the per-opcode known-answer tests below the property block — they pin published values and stay as they are.

### Soundness

Nothing in the library changes, so nothing about the protocol changes.

What this test protects is a compiler invariant: the value the fold bakes in must equal the value the interpreter would have computed.
A disagreement there does not surface as a failed proof.
It surfaces as a constant-propagated wire holding the wrong value, which the prover then commits to and proves honestly.

The property found no such disagreement — see the soak below.

### Verification

Local gate, all clean:

- `cargo test -p binius-frontend` (debug, the profile CI uses) — 260 passed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p binius-frontend --release` — 260 passed
- `RUSTFLAGS="-Ctarget-cpu=native" cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --document-private-items --no-deps` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `cargo check --workspace --all-targets`, `python3 tools/check_copyright_notice.py`, `typos` — clean

Runtime, debug, for the three properties together:

| cases | debug runtime |
|---|---|
| 1024 (the default set here) | 0.01 s |
| 20,000 | 0.21 s |
| 100,000 | 0.96 s |

1024 cases run all 19 fixed-arity opcodes each, so the default is already ~19k gate evaluations and costs about ten milliseconds.
The 100,000-case soak found no disagreement.

### Does the property have teeth

Two arms of `evaluate_gate_constants` were deliberately broken, then reverted.
Both breaks are invisible to the old fixed alphabet — the old tests were kept alongside the new ones during the experiment to confirm that directly.

**1. `BxorMulti` folds only its first five inputs.**

A fixed-size assumption. The old grid stopped at arity 5, so it stayed green.

```
old fixed-alphabet tests   pass
property                   FAIL, shrunk to:
  inputs = [0x0, 0x0, 0x0, 0x0, 0x0, 0x1]
```

Six inputs, five zeros and a one — the minimum arity and the minimum value that can expose it.

**2. `Iadd32CinCout` reads the low lane's carry-in from bit 28 instead of bit 31.**

An off-by-something at the 32-bit lane boundary.

```
old fixed-alphabet tests   pass
property                   FAIL, shrunk to:
  a = 0x0000000000000000
  b = 0x0000000000000000
  cin = 0x0000000080000000
```

The shrunk carry-in is the lane's carry-in bit on its own — a word the nine-word alphabet did not contain.

Bit 28 is not arbitrary. Exhausting the alphabet over every wrong bit position shows that positions 4, 5, 6, 7, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 23, 25, 27 and 28 are all invisible to it, while 29, 30 and 32 are caught.
Bit 28 is the nearest wrong bit the old alphabet could not distinguish from bit 31. The new generator catches it on about 19% of cases.

### One thing worth flagging

`Bmul` is not actually a third independent statement.
Both the fold and the interpreter call the same `ghash_mul`, so the differential test proves nothing about GHASH multiplication itself — it only proves the four operands are threaded in the same order.
That is not changed here, and not a bug, but it is a blind spot in the oracle and worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)