### PR TITLE
BINIUS-630: Unify the two padded-layer MLE-check wrappers into one shared prover

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
+++ b/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
@@ -8,90 +8,42 @@
 //! fracadd checks of unequal depths pads each shallow tree up to the deepest one, so the batch's
 //! layer loop runs a single uniform schedule and the verifier never learns the individual depths.
 //!
-//! This is the fractional-addition analog of [`crate::prodcheck::one_pad_mle`]; the *Batched
-//! Product Checks of Unequal Depths* appendix of the Binius64 whitepaper derives the multiplicative
-//! case, whose one-padding is exactly the padding these denominators carry.
+//! The *Batched Product Checks of Unequal Depths* appendix of the Binius64 whitepaper derives the
+//! multiplicative case, whose one-padding is exactly the padding these denominators carry.
 //!
-//! The point of this module is that the prover never materializes a padded layer:
-//! [`ZeroPadMleCheckProver`] wraps the unpadded layer's own MLE-check and corrects its messages at
-//! a cost of $O(1)$ per round.
-
-use std::mem;
+//! No padded layer is ever materialized.
+//! The shared wrapper corrects the unpadded layer's own messages, at $O(1)$ per round.
 
 use binius_field::Field;
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::multilinear::eq::eq_one_var;
 
-use crate::sumcheck::common::MleCheckProver;
+use crate::sumcheck::{
+	common::MleCheckProver,
+	pad_mle::{Fill, PadMleCheckProver, PadShape, mul_linear},
+};
 
-/// The one-padding selector $\textsf{sel}(s, v) = 1 + (v - 1) s$.
+/// The composition one fractional-addition layer reduces.
 ///
-/// It interpolates between the constant one at $s = 0$ and $v$ at $s = 1$, which is how a padded
-/// leaf position holds the zero fraction's denominator while a real one holds the witness value.
-fn select<F: Field>(s: F, v: F) -> F {
-	F::ONE + (v - F::ONE) * s
-}
+/// Two sibling fractions add by $(a_0 b_1 + a_1 b_0) / (b_0 b_1)$, so the layer carries a numerator
+/// claim and a denominator claim over the four halves $[a_0, a_1, b_0, b_1]$.
+pub struct FractionAdd;
 
-/// The product of two linear polynomials, in monomial coefficients.
-fn mul_linear<F: Field>([p_0, p_1]: [F; 2], [q_0, q_1]: [F; 2]) -> RoundCoeffs<F> {
-	RoundCoeffs(vec![p_0 * q_0, p_0 * q_1 + p_1 * q_0, p_1 * q_1])
+impl<F: Field> PadShape<F, 4> for FractionAdd {
+	const CHILDREN: [Fill; 4] = [Fill::Zero, Fill::Zero, Fill::One, Fill::One];
+	const CLAIMS: &'static [Fill] = &[Fill::Zero, Fill::One];
+
+	#[inline(always)]
+	fn compose([a_0, a_1, b_0, b_1]: [[F; 2]; 4]) -> Vec<RoundCoeffs<F>> {
+		vec![
+			mul_linear(a_0, b_1) + &mul_linear(a_1, b_0),
+			mul_linear(b_0, b_1),
+		]
+	}
 }
 
 /// MLE-check prover for one layer of a fractional-addition check over a zero-fraction-padded
 /// witness.
-///
-/// The tree's fractional sum is a scalar, so the layer's claim point is node coordinates only,
-/// split into two segments with the padding ones lowest:
-///
-/// ```text
-///     [ padding (nu) | real (m) ]
-/// ```
-///
-/// The padded layer is the unpadded one with its numerators scaled by
-/// $\textsf{eq}(0^\nu, Z')$ and its denominators wrapped in the one-padding
-/// $\textsf{sel}(\textsf{eq}(0^\nu, Z'), \cdot)$ over the padding variables. MLE-check binds
-/// variables from the highest index down, so the real rounds come first and the padding rounds
-/// last:
-///
-/// - **Real rounds.** Delegate to `inner`, the ordinary MLE-check over the unpadded layer, and
-///   correct its two round polynomials, where $q$ is the equality weight $\textsf{eq}(0^\nu,
-///   \rho_\text{pa})$ of the claim point's padding segment. Off the all-zeros padding slab every
-///   leaf is the zero fraction, whose numerator composition vanishes and whose denominator
-///   composition is one, so the numerator's polynomial is scaled to $q \cdot R(X)$ and the
-///   denominator's shifted to $1 + q \cdot (R(X) - 1)$.
-/// - **Padding rounds.** No multilinear is touched. Every real variable is bound by now, so
-///   `inner`'s four child evaluations are scalars and both round polynomials are closed forms in
-///   them, quadratic through $E(X)$, the equality weight of the padding coordinates already bound
-///   together with this round's.
-///
-/// [`MleCheckProver::finish`] returns the *padded* layer's child evaluations, which is what the
-/// batch's selector rounds consume.
-pub struct ZeroPadMleCheckProver<F: Field, Inner> {
-	/// The padded claim point `[padding | real]`, low variables first.
-	eval_point: Vec<F>,
-	/// Length of the point's padding segment.
-	pad_len: usize,
-	/// Number of folds performed so far.
-	round: usize,
-	/// Equality weights of the claim point's padding segment: entry `i` is
-	/// $\prod_{c < i} \textsf{eq}(0, \rho_{\text{pa}, c})$, so the last entry is $q$.
-	pad_eq_prefixes: Vec<F>,
-	phase: Phase<F, Inner>,
-}
-
-/// The segment of rounds the prover is in. See [`ZeroPadMleCheckProver`].
-enum Phase<F, Inner> {
-	/// Reducing the unpadded layer's real node variables.
-	Real(Inner),
-	/// Every real variable is bound, leaving a closed form in these scalars.
-	Padding {
-		/// The unpadded layer's child evaluations `[num_0, num_1, den_0, den_1]`.
-		children: [F; 4],
-		/// $\prod \textsf{eq}(0, r)$ over the padding challenges bound so far, which is the
-		/// constant factor of $E$.
-		bound_eq: F,
-	},
-}
+pub type ZeroPadMleCheckProver<F, Inner> = PadMleCheckProver<F, Inner, FractionAdd, 4>;
 
 /// Divides the padding back out of a padded layer's claims.
 ///
@@ -106,27 +58,17 @@ enum Phase<F, Inner> {
 /// * `claims` - The padded layer's numerator and denominator claims.
 pub fn unpad_claims<F: Field>(pad_eq_inv: F, claims: [F; 2]) -> [F; 2] {
 	let [num, den] = claims;
-	[num * pad_eq_inv, select(pad_eq_inv, den)]
+	[
+		Fill::Zero.at(num, pad_eq_inv),
+		Fill::One.at(den, pad_eq_inv),
+	]
 }
 
 /// Creates the prover for one padded fractional-addition layer.
 ///
-/// # Arguments
-///
-/// * `pad_eq_prefixes` - Equality weights of the claim point's padding segment: entry `i` is
-///   $\prod_{c < i} \textsf{eq}(0, \rho_{\text{pa}, c})$. Its length fixes the padding segment at
-///   one less, so a single-entry table leaves the inner reduction uncorrected. Every layer of a
-///   batch shares one point, so one table of prefix products serves them all.
-/// * `eval_point` - The padded layer's claim point, `[padding | real]`.
-/// * `inner` - The unpadded layer's MLE-check, seeded at the real segment of the claim point with
-///   the claims [`unpad_claims`] returns.
-///
-/// # Preconditions
-///
-/// * `pad_eq_prefixes` is non-empty and its last entry — the padding segment's equality weight — is
-///   non-zero
-/// * `eval_point.len() + 1 >= pad_eq_prefixes.len()`
-/// * `inner.n_vars() == eval_point.len() + 1 - pad_eq_prefixes.len()`
+/// The inner MLE-check is seeded at the real segment of the claim point, with the de-padded claims.
+/// The prefix table's length fixes the padding segment at one less, and every layer of a batch
+/// shares one such table.
 pub fn new<F, Inner>(
 	pad_eq_prefixes: Vec<F>,
 	eval_point: Vec<F>,
@@ -136,24 +78,7 @@ where
 	F: Field,
 	Inner: MleCheckProver<F>,
 {
-	let pad_len = pad_eq_prefixes
-		.len()
-		.checked_sub(1)
-		.expect("precondition: non-empty");
-	assert!(eval_point.len() >= pad_len); // precondition
-	assert_ne!(pad_eq_prefixes[pad_len], F::ZERO); // precondition
-	assert_eq!(inner.n_vars(), eval_point.len() - pad_len); // precondition
-
-	let mut prover = ZeroPadMleCheckProver {
-		eval_point,
-		pad_len,
-		round: 0,
-		pad_eq_prefixes,
-		phase: Phase::Real(inner),
-	};
-	// A layer with no real variables starts in the padding phase.
-	prover.advance();
-	prover
+	ZeroPadMleCheckProver::new(pad_eq_prefixes, eval_point, inner)
 }
 
 /// The layer a tree contributes while the batch is still above it: one fraction beside the zero
@@ -161,8 +86,8 @@ where
 ///
 /// Such a layer is a padding of the tree's own fractional sum, so its low child is that sum and its
 /// high child is identically $0/1$. Every one of its variables is a padding variable, so there is
-/// nothing to reduce — [`ZeroPadMleCheckProver`] goes straight to its padding rounds and only ever
-/// asks for these four child evaluations.
+/// nothing to reduce: the wrapper goes straight to its padding rounds and only ever asks for these
+/// four child evaluations.
 pub struct ConstantFraction<F> {
 	/// The child evaluations `[num_0, num_1, den_0, den_1]`.
 	children: [F; 4],
@@ -199,121 +124,6 @@ impl<F: Field> MleCheckProver<F> for ConstantFraction<F> {
 	}
 }
 
-impl<F: Field, Inner: MleCheckProver<F>> ZeroPadMleCheckProver<F, Inner> {
-	/// The number of rounds that reduce the unpadded layer's real variables.
-	const fn n_real_rounds(&self) -> usize {
-		self.eval_point.len() - self.pad_len
-	}
-
-	/// Finishes the inner prover once its last real variable is bound, fixing the child evaluations
-	/// the padding rounds close over.
-	fn advance(&mut self) {
-		if self.round != self.n_real_rounds() || !matches!(self.phase, Phase::Real(_)) {
-			return;
-		}
-		// The guard above pins the phase, so this placeholder is overwritten before it is read.
-		let placeholder = Phase::Padding {
-			children: [F::ONE; 4],
-			bound_eq: F::ONE,
-		};
-		let Phase::Real(inner) = mem::replace(&mut self.phase, placeholder) else {
-			unreachable!("the guard checked the phase");
-		};
-		self.phase = Phase::Padding {
-			children: inner
-				.finish()
-				.try_into()
-				.expect("the layer prover reduces four multilinears"),
-			bound_eq: F::ONE,
-		};
-	}
-}
-
-impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for ZeroPadMleCheckProver<F, Inner> {
-	fn n_vars(&self) -> usize {
-		self.eval_point.len() - self.round
-	}
-
-	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
-		// Destructured so a padding round can read the prefix table while the phase is borrowed.
-		let Self {
-			eval_point,
-			pad_len,
-			round,
-			pad_eq_prefixes,
-			phase,
-		} = self;
-		let n_vars = eval_point.len() - *round;
-
-		match phase {
-			Phase::Real(inner) => {
-				let mut round_coeffs = inner.execute();
-				assert_eq!(round_coeffs.len(), 2, "the layer prover carries two claims");
-				let mut den = round_coeffs.pop().expect("the vector holds two elements");
-				let mut num = round_coeffs.pop().expect("the vector holds two elements");
-				// Off the all-zeros padding slab every leaf is the zero fraction: its numerator
-				// composition vanishes and its denominator composition is one, the latter picking
-				// up the residual weight 1 - q.
-				let pad_eq = pad_eq_prefixes[*pad_len];
-				num *= pad_eq;
-				den *= pad_eq;
-				den.0[0] += F::ONE - pad_eq;
-				vec![num, den]
-			}
-			Phase::Padding { children, bound_eq } => {
-				// The equality weight of the padding coordinates still unbound below this round's.
-				let unbound_eq = pad_eq_prefixes[n_vars - 1];
-				// E(X) = bound_eq * eq(0, X) in monomial coefficients.
-				let big_e = [*bound_eq, -*bound_eq];
-				let [num_0, num_1, den_0, den_1] = *children;
-				// The padded children, linear in X: a numerator is scaled by E(X), a denominator
-				// pushed through the one-padding selector at E(X).
-				let [a_0, a_1] = [num_0, num_1].map(|num| [num * big_e[0], num * big_e[1]]);
-				let [b_0, b_1] =
-					[den_0, den_1].map(|den| [select(big_e[0], den), (den - F::ONE) * big_e[1]]);
-
-				// R_num(X) = e * (A_0 B_1 + A_1 B_0) and R_den(X) = (1 - e) + e * B_0 B_1: off the
-				// all-zeros slab of the still-unbound padding coordinates the numerators vanish and
-				// both denominators are one.
-				let num_coeffs = (mul_linear(a_0, b_1) + &mul_linear(a_1, b_0)) * unbound_eq;
-				let mut den_coeffs = mul_linear(b_0, b_1) * unbound_eq;
-				den_coeffs.0[0] += F::ONE - unbound_eq;
-				vec![num_coeffs, den_coeffs]
-			}
-		}
-	}
-
-	fn fold(&mut self, challenge: F) {
-		match &mut self.phase {
-			Phase::Real(inner) => inner.fold(challenge),
-			Phase::Padding { bound_eq, .. } => {
-				*bound_eq *= eq_one_var(F::ZERO, challenge);
-			}
-		}
-		self.round += 1;
-		self.advance();
-	}
-
-	fn finish(self) -> Vec<F> {
-		match self.phase {
-			Phase::Padding { children, bound_eq } => {
-				let [num_0, num_1, den_0, den_1] = children;
-				vec![
-					num_0 * bound_eq,
-					num_1 * bound_eq,
-					select(bound_eq, den_0),
-					select(bound_eq, den_1),
-				]
-			}
-			Phase::Real(_) => panic!("finish requires every variable to be bound"),
-		}
-	}
-
-	fn eval_point(&self) -> &[F] {
-		&self.eval_point[..self.n_vars()]
-	}
-}
-
 // The prover is checked against the padded layer it stands in for: the same reduction run by an
 // ordinary fractional-addition MLE-check over an explicitly materialized padded layer must produce
 // the same round polynomials and the same child evaluations.
@@ -325,7 +135,7 @@ mod tests {
 	use binius_field::{Random, arithmetic_traits::InvertOrZero, field::FieldOps};
 	use binius_math::{
 		FieldBuffer,
-		multilinear::evaluate::evaluate,
+		multilinear::{eq::eq_one_var, evaluate::evaluate},
 		test_utils::{Packed128b, random_field_buffer, random_scalars},
 	};
 	use rand::prelude::*;
@@ -339,7 +149,7 @@ mod tests {
 	/// Materializes the `pad_len`-fold padding of a layer buffer, whose variables are
 	/// `[real | split]`, filling the extra positions with `fill`.
 	///
-	/// The padding variables land below the real ones, matching the claim-point layout [`new`]
+	/// The padding variables land below the real ones, matching the claim-point layout the wrapper
 	/// expects.
 	fn pad_layer(layer: &FieldBuffer<P>, pad_len: usize, fill: F) -> FieldBuffer<P> {
 		let values = (0..1 << (layer.log_len() + pad_len))
@@ -429,8 +239,11 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(1);
 		let alloc = GlobalAllocator;
 
-		for n_real_rounds in [0, 1, 3] {
-			for pad_len in [0, 1, 3] {
+		// A layer of `n_real_rounds + 1` variables splits into two halves of `n_real_rounds`, so
+		// zero real rounds is a layer of one fraction pair. The packing width is 4 scalars, so the
+		// range straddles it in both directions, and 3 and 5 padding rows are not powers of two.
+		for n_real_rounds in [0, 1, 2, 3, 5] {
+			for pad_len in [0, 1, 2, 3, 5] {
 				let num = random_field_buffer::<P>(&mut rng, n_real_rounds + 1);
 				let den = random_field_buffer::<P>(&mut rng, n_real_rounds + 1);
 				let (padded_num, padded_den, eval_point, claims) =
@@ -461,7 +274,7 @@ mod tests {
 	fn constant_fraction_matches_padded_reference() {
 		let mut rng = StdRng::seed_from_u64(2);
 
-		for pad_len in [1, 2, 4] {
+		for pad_len in [1, 2, 3, 4, 5] {
 			let root_num = F::random(&mut rng);
 			let root_den = F::random(&mut rng);
 			let num = FieldBuffer::<P>::from_values(&[root_num, F::ZERO]);

--- a/crates/ip-prover/src/prodcheck/one_pad_mle.rs
+++ b/crates/ip-prover/src/prodcheck/one_pad_mle.rs
@@ -7,82 +7,40 @@
 //! pads each shallow tree up to the deepest one, so the batch's layer loop runs a single uniform
 //! schedule and the verifier never learns the individual depths. See the *Batched Product Checks of
 //! Unequal Depths* appendix of the Binius64 whitepaper for the protocol and the derivation behind
-//! the round polynomials below.
+//! the round polynomials.
 //!
-//! The point of this module is that the prover never materializes a padded layer:
-//! [`OnePadMleCheckProver`] wraps the unpadded layer's own MLE-check and corrects its messages at a
-//! cost of $O(1)$ per round.
-
-use std::{iter, mem};
+//! No padded layer is ever materialized.
+//! The shared wrapper corrects the unpadded layer's own messages, at $O(1)$ per round.
 
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldVec, multilinear::eq::eq_one_var};
+use binius_math::FieldVec;
 
-use crate::sumcheck::{bivariate_product_mle, common::MleCheckProver};
+use crate::sumcheck::{
+	bivariate_product_mle,
+	common::MleCheckProver,
+	pad_mle::{Fill, PadMleCheckProver, PadShape, mul_linear, pad_eq_prefixes},
+};
 
-/// The one-padding selector $\textsf{sel}(s, v) = 1 + (v - 1) s$.
+/// The composition one product layer reduces.
 ///
-/// It interpolates between the constant one at $s = 0$ and $v$ at $s = 1$, which is how a padded
-/// leaf position holds a one while a real one holds the witness value.
-fn select<F: Field>(s: F, v: F) -> F {
-	F::ONE + (v - F::ONE) * s
+/// The layer carries one claim, the product of the two halves of the child layer on its highest
+/// variable.
+pub struct BivariateProduct;
+
+impl<F: Field> PadShape<F, 2> for BivariateProduct {
+	const CHILDREN: [Fill; 2] = [Fill::One, Fill::One];
+	const CLAIMS: &'static [Fill] = &[Fill::One];
+
+	#[inline(always)]
+	fn compose([g_0, g_1]: [[F; 2]; 2]) -> Vec<RoundCoeffs<F>> {
+		vec![mul_linear(g_0, g_1)]
+	}
 }
 
 /// MLE-check prover for one layer of a product check over a one-padded witness.
-///
-/// The tree's product is a scalar, so the layer's claim point is node coordinates only, split into
-/// two segments with the padding ones lowest:
-///
-/// ```text
-///     [ padding (nu) | real (m) ]
-/// ```
-///
-/// The padded layer is the unpadded one wrapped in the one-padding
-/// $\textsf{sel}(\textsf{eq}(0^\nu, Z'), \cdot)$ over the padding variables. MLE-check binds
-/// variables from the highest index down, so the real rounds come first and the padding rounds
-/// last:
-///
-/// - **Real rounds.** Delegate to `inner`, the ordinary MLE-check over the unpadded layer, and
-///   correct each round polynomial by the affine map $R'(X) = 1 + q \cdot (R(X) - 1)$, where $q$ is
-///   the equality weight $\textsf{eq}(0^\nu, \rho_\text{pa})$ of the claim point's padding segment.
-///   Off the all-zeros padding slab both children are one, which is where the residual weight $1 -
-///   q$ comes from.
-/// - **Padding rounds.** No multilinear is touched. Every real variable is bound by now, so
-///   `inner`'s two child evaluations $g_0, g_1$ are scalars and the round polynomial is the closed
-///   form $R'(X) = (1 - e) + e \cdot \textsf{sel}(E(X), g_0) \cdot \textsf{sel}(E(X), g_1)$, where
-///   $e$ is the equality weight of the padding coordinates still unbound and $E(X)$ that of the
-///   ones already bound.
-///
-/// Finishing returns the *padded* layer's child evaluations $\textsf{sel}(e^*, g_b)$, which is
-/// what the batch's selector rounds consume.
-pub struct OnePadMleCheckProver<F: Field, Inner> {
-	/// The padded claim point `[padding | real]`, low variables first.
-	eval_point: Vec<F>,
-	/// Length of the point's padding segment.
-	pad_len: usize,
-	/// Number of folds performed so far.
-	round: usize,
-	/// Equality weights of the claim point's padding segment: entry `i` is
-	/// $\prod_{c < i} \textsf{eq}(0, \rho_{\text{pa}, c})$, so the last entry is $q$.
-	pad_eq_prefixes: Vec<F>,
-	phase: Phase<F, Inner>,
-}
-
-/// The segment of rounds the prover is in. See [`OnePadMleCheckProver`].
-enum Phase<F, Inner> {
-	/// Reducing the unpadded layer's real node variables.
-	Real(Inner),
-	/// Every real variable is bound, leaving a closed form in these scalars.
-	Padding {
-		/// The unpadded layer's two child evaluations.
-		children: [F; 2],
-		/// $\prod \textsf{eq}(0, r)$ over the padding challenges bound so far, which is the
-		/// constant factor of $E$.
-		bound_eq: F,
-	},
-}
+pub type OnePadMleCheckProver<F, Inner> = PadMleCheckProver<F, Inner, BivariateProduct, 2>;
 
 /// Creates the prover for one padded product-check layer.
 ///
@@ -121,20 +79,14 @@ where
 	let n_real_rounds = layer.log_len() - 1;
 	assert_eq!(eval_point.len(), pad_len + n_real_rounds); // precondition
 
-	// Prefix products over the padding segment, so both the round polynomials' `e` factors and the
-	// claim's `q` are lookups.
-	let pad_eq_prefixes = iter::once(F::ONE)
-		.chain(eval_point[..pad_len].iter().scan(F::ONE, |acc, &coord| {
-			*acc *= eq_one_var(F::ZERO, coord);
-			Some(*acc)
-		}))
-		.collect::<Vec<_>>();
-	let pad_eq = pad_eq_prefixes[pad_len];
+	// The round polynomials' equality weights and the claim's are all lookups into one table.
+	let prefixes = pad_eq_prefixes(&eval_point[..pad_len]);
+	let pad_eq = prefixes[pad_len];
 	assert!(pad_eq != F::ZERO, "a padding coordinate of the claim point equals one");
 
-	// The padded claim is `sel(q, z)` for the unpadded claim `z`, so the inner prover starts from
-	// the preimage.
-	let inner_claim = F::ONE + (claim - F::ONE) * pad_eq.invert_or_zero();
+	// The padded claim runs from one at padding weight zero to the unpadded claim at weight one, so
+	// the inner prover starts from the preimage.
+	let inner_claim = Fill::One.at(claim, pad_eq.invert_or_zero());
 	let inner = bivariate_product_mle::new_split_half(
 		alloc,
 		layer,
@@ -142,119 +94,7 @@ where
 		inner_claim,
 	);
 
-	let mut prover = OnePadMleCheckProver {
-		eval_point,
-		pad_len,
-		round: 0,
-		pad_eq_prefixes,
-		phase: Phase::Real(inner),
-	};
-	// A layer with no real variables starts in the padding phase.
-	prover.advance();
-	prover
-}
-
-impl<F: Field, Inner: MleCheckProver<F>> OnePadMleCheckProver<F, Inner> {
-	/// The number of rounds that reduce the unpadded layer's real variables.
-	const fn n_real_rounds(&self) -> usize {
-		self.eval_point.len() - self.pad_len
-	}
-
-	/// Finishes the inner prover once its last real variable is bound, fixing the child evaluations
-	/// the padding rounds close over.
-	fn advance(&mut self) {
-		if self.round != self.n_real_rounds() || !matches!(self.phase, Phase::Real(_)) {
-			return;
-		}
-		// The guard above pins the phase, so this placeholder is overwritten before it is read.
-		let placeholder = Phase::Padding {
-			children: [F::ONE; 2],
-			bound_eq: F::ONE,
-		};
-		let Phase::Real(inner) = mem::replace(&mut self.phase, placeholder) else {
-			unreachable!("the guard checked the phase");
-		};
-		self.phase = Phase::Padding {
-			children: inner
-				.finish()
-				.try_into()
-				.expect("the layer prover reduces two multilinears"),
-			bound_eq: F::ONE,
-		};
-	}
-}
-
-impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for OnePadMleCheckProver<F, Inner> {
-	fn n_vars(&self) -> usize {
-		self.eval_point.len() - self.round
-	}
-
-	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
-		// Destructured so a padding round can read the prefix table while the phase is borrowed.
-		let Self {
-			eval_point,
-			pad_len,
-			round,
-			pad_eq_prefixes,
-			phase,
-		} = self;
-		let n_vars = eval_point.len() - *round;
-
-		let coeffs = match phase {
-			Phase::Real(inner) => {
-				let mut round_coeffs = inner.execute();
-				assert_eq!(round_coeffs.len(), 1, "the layer prover carries one claim");
-				let mut coeffs = round_coeffs.pop().expect("the vector holds one element");
-				// R'(X) = 1 + q * (R(X) - 1): on the all-zeros padding slab the sum is the unpadded
-				// one, weighted by q; off it both children are one and the weights sum to 1 - q.
-				let pad_eq = pad_eq_prefixes[*pad_len];
-				coeffs *= pad_eq;
-				coeffs.0[0] += F::ONE - pad_eq;
-				coeffs
-			}
-			Phase::Padding { children, bound_eq } => {
-				// The equality weight of the padding coordinates still unbound below this round's.
-				let unbound_eq = pad_eq_prefixes[n_vars - 1];
-				// E(X) = bound_eq * eq(0, X) in monomial coefficients, then each child pushed
-				// through the one-padding selector at E(X).
-				let big_e = [*bound_eq, -*bound_eq];
-				let [[a_0, a_1], [b_0, b_1]] =
-					children.map(|child| [select(big_e[0], child), (child - F::ONE) * big_e[1]]);
-				// R'(X) = (1 - e) + e * sel(E(X), g_0) * sel(E(X), g_1): off the all-zeros slab of
-				// those unbound coordinates both children are one.
-				RoundCoeffs(vec![
-					F::ONE - unbound_eq + unbound_eq * a_0 * b_0,
-					unbound_eq * (a_0 * b_1 + a_1 * b_0),
-					unbound_eq * a_1 * b_1,
-				])
-			}
-		};
-		vec![coeffs]
-	}
-
-	fn fold(&mut self, challenge: F) {
-		match &mut self.phase {
-			Phase::Real(inner) => inner.fold(challenge),
-			Phase::Padding { bound_eq, .. } => {
-				*bound_eq *= eq_one_var(F::ZERO, challenge);
-			}
-		}
-		self.round += 1;
-		self.advance();
-	}
-
-	fn finish(self) -> Vec<F> {
-		match self.phase {
-			Phase::Padding { children, bound_eq } => {
-				children.map(|child| select(bound_eq, child)).to_vec()
-			}
-			Phase::Real(_) => panic!("finish requires every variable to be bound"),
-		}
-	}
-
-	fn eval_point(&self) -> &[F] {
-		&self.eval_point[..self.n_vars()]
-	}
+	OnePadMleCheckProver::new(prefixes, eval_point, inner)
 }
 
 // The prover is checked against the padded layer it stands in for: the same reduction run by an
@@ -278,7 +118,7 @@ mod tests {
 
 	/// Materializes `OnePad_{pad_len}` of a layer, whose variables are `[real | split]`.
 	///
-	/// The padding variables land below the real ones, matching the claim-point layout [`new`]
+	/// The padding variables land below the real ones, matching the claim-point layout the wrapper
 	/// expects.
 	fn one_pad_layer(layer: &FieldBuffer<P>, pad_len: usize) -> FieldBuffer<P> {
 		let values = (0..1 << (layer.log_len() + pad_len))
@@ -334,8 +174,11 @@ mod tests {
 	#[test]
 	fn matches_padded_reference() {
 		let mut rng = StdRng::seed_from_u64(1);
-		for n_real_rounds in [0, 1, 3] {
-			for pad_len in [0, 1, 3] {
+		// A layer of `n_real_rounds + 1` variables splits into two halves of `n_real_rounds`, so
+		// zero real rounds is a layer of one pair. The packing width is 4 scalars, so the range
+		// straddles it in both directions, and 3 and 5 padding rows are not powers of two.
+		for n_real_rounds in [0, 1, 2, 3, 5] {
+			for pad_len in [0, 1, 2, 3, 5] {
 				let layer = random_field_buffer::<P>(&mut rng, n_real_rounds + 1);
 				assert_matches_padded_reference(layer, pad_len);
 			}
@@ -348,7 +191,7 @@ mod tests {
 	#[test]
 	fn matches_padded_reference_with_constant_one_child() {
 		let mut rng = StdRng::seed_from_u64(2);
-		for pad_len in [1, 2, 4] {
+		for pad_len in [1, 2, 3, 4, 5] {
 			let product = F::random(&mut rng);
 			let layer = FieldBuffer::<P>::from_values(&[product, F::ONE]);
 			assert_matches_padded_reference(layer, pad_len);

--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -11,6 +11,7 @@ pub mod factored_multilinear;
 pub mod mle_store;
 mod mle_to_sumcheck;
 pub mod multilinear_eval;
+pub mod pad_mle;
 mod padded;
 mod prove;
 pub mod quadratic_mle_evaluator;

--- a/crates/ip-prover/src/sumcheck/pad_mle.rs
+++ b/crates/ip-prover/src/sumcheck/pad_mle.rs
@@ -1,0 +1,319 @@
+// Copyright 2026 The Binius Developers
+
+//! MLE-check prover for one layer of a padded tree check.
+//!
+//! Padding fills a shallow tree's extra leaves with the value its fold ignores.
+//! Batching unequal depths pads each tree up to the deepest, so one schedule runs the batch.
+//!
+//! No padded layer is materialized.
+//! Every padded quantity is one interpolation: the fill at weight zero, the value at weight one.
+
+use std::{array, iter, marker::PhantomData, mem};
+
+use binius_field::Field;
+use binius_ip::sumcheck::RoundCoeffs;
+use binius_math::multilinear::eq::eq_one_var;
+
+use crate::sumcheck::common::MleCheckProver;
+
+/// The value a padded quantity takes where the padding fills the layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fill {
+	/// Zero, which is what a padded fractional numerator holds.
+	Zero,
+	/// One, which is what a padded denominator or product factor holds.
+	One,
+}
+
+impl Fill {
+	/// The fill itself.
+	#[inline(always)]
+	const fn value<F: Field>(self) -> F {
+		match self {
+			Self::Zero => F::ZERO,
+			Self::One => F::ONE,
+		}
+	}
+
+	/// The padded quantity at padding weight `s`: the fill at zero, `v` at one.
+	pub fn at<F: Field>(self, v: F, s: F) -> F {
+		let fill = self.value::<F>();
+		fill + (v - fill) * s
+	}
+
+	/// The padded quantity as a linear polynomial, for a padding weight given in monomial
+	/// coefficients.
+	#[inline(always)]
+	fn linear<F: Field>(self, v: F, [s_0, s_1]: [F; 2]) -> [F; 2] {
+		let fill = self.value::<F>();
+		let slope = v - fill;
+		[fill + slope * s_0, slope * s_1]
+	}
+
+	/// Scales a round polynomial to `weight`, with the fill carrying the residual weight.
+	#[inline(always)]
+	fn correct<F: Field>(self, coeffs: &mut RoundCoeffs<F>, weight: F) {
+		*coeffs *= weight;
+		// Off the all-zeros padding slab the composition is constant at the fill, so only a
+		// fill of one contributes.
+		if self == Self::One {
+			coeffs.0[0] += F::ONE - weight;
+		}
+	}
+}
+
+/// The composition one padded layer reduces.
+pub trait PadShape<F: Field, const N: usize> {
+	/// The fill of each child the unpadded layer reduces.
+	const CHILDREN: [Fill; N];
+	/// The fill of each claim's composition, one entry per emitted polynomial.
+	const CLAIMS: &'static [Fill];
+
+	/// The claims' round polynomials, from the padded children as linear polynomials in this
+	/// round's variable.
+	fn compose(children: [[F; 2]; N]) -> Vec<RoundCoeffs<F>>;
+}
+
+/// The product of two linear polynomials, in monomial coefficients.
+#[inline(always)]
+pub fn mul_linear<F: Field>([p_0, p_1]: [F; 2], [q_0, q_1]: [F; 2]) -> RoundCoeffs<F> {
+	RoundCoeffs(vec![p_0 * q_0, p_0 * q_1 + p_1 * q_0, p_1 * q_1])
+}
+
+/// Prefix products of the equality weights of `coords` against zero.
+///
+/// Entry `i` is the product over the first `i` coordinates, so the last entry weights them all.
+/// Every layer of a batch shares one claim point, so one table serves all of its trees.
+pub fn pad_eq_prefixes<F: Field>(coords: &[F]) -> Vec<F> {
+	iter::once(F::ONE)
+		.chain(coords.iter().scan(F::ONE, |acc, &coord| {
+			*acc *= eq_one_var(F::ZERO, coord);
+			Some(*acc)
+		}))
+		.collect()
+}
+
+/// MLE-check prover for one layer of a tree check over a padded witness.
+///
+/// The claim point is node coordinates only, padding lowest:
+///
+/// ```text
+///     [ padding (nu) | real (m) ]
+/// ```
+///
+/// Variables bind highest first, so the real rounds run before the padding ones.
+/// Finishing returns the padded layer's child evaluations.
+pub struct PadMleCheckProver<F: Field, Inner, S, const N: usize> {
+	/// The padded claim point `[padding | real]`, low variables first.
+	eval_point: Vec<F>,
+	/// Length of the point's padding segment.
+	pad_len: usize,
+	/// Number of folds performed so far.
+	round: usize,
+	/// Equality weights of the claim point's padding segment: entry `i` is
+	/// $\prod_{c < i} \textsf{eq}(0, \rho_{\text{pa}, c})$, so the last entry is $q$.
+	pad_eq_prefixes: Vec<F>,
+	/// Which segment of rounds the prover is in.
+	phase: Phase<F, Inner, N>,
+	/// The composition being reduced, carried by the type alone.
+	shape: PhantomData<S>,
+}
+
+/// The segment of rounds the prover is in.
+enum Phase<F, Inner, const N: usize> {
+	/// Reducing the unpadded layer's real node variables.
+	Real(Inner),
+	/// Every real variable is bound, leaving a closed form in these scalars.
+	Padding {
+		/// The unpadded layer's child evaluations.
+		children: [F; N],
+		/// $\prod \textsf{eq}(0, r)$ over the padding challenges bound so far, which is the
+		/// constant factor of $E$.
+		bound_eq: F,
+	},
+}
+
+impl<F: Field, Inner: MleCheckProver<F>, S, const N: usize> PadMleCheckProver<F, Inner, S, N> {
+	/// Creates the prover for one padded layer.
+	///
+	/// # Arguments
+	///
+	/// * `pad_eq_prefixes` - Equality weights of the padding segment, entry `i` being the product
+	///   over the first `i` coordinates. Its length fixes that segment at one less.
+	/// * `eval_point` - The padded layer's claim point, `[padding | real]`.
+	/// * `inner` - The unpadded layer's MLE-check, seeded at the real segment of the claim point
+	///   with the de-padded claims.
+	///
+	/// # Preconditions
+	///
+	/// * `pad_eq_prefixes` is non-empty
+	/// * `eval_point.len() + 1 >= pad_eq_prefixes.len()`
+	/// * `inner.n_vars() == eval_point.len() + 1 - pad_eq_prefixes.len()`
+	///
+	/// # Panics
+	///
+	/// Panics if the padding segment's equality weight is zero, which needs a verifier challenge
+	/// to land on one.
+	pub fn new(pad_eq_prefixes: Vec<F>, eval_point: Vec<F>, inner: Inner) -> Self {
+		let pad_len = pad_eq_prefixes
+			.len()
+			.checked_sub(1)
+			.expect("precondition: non-empty");
+		assert!(eval_point.len() >= pad_len); // precondition
+		assert!(
+			pad_eq_prefixes[pad_len] != F::ZERO,
+			"a padding coordinate of the claim point equals one"
+		);
+		assert_eq!(inner.n_vars(), eval_point.len() - pad_len); // precondition
+
+		let mut prover = Self {
+			eval_point,
+			pad_len,
+			round: 0,
+			pad_eq_prefixes,
+			phase: Phase::Real(inner),
+			shape: PhantomData,
+		};
+		// A layer with no real variables starts in the padding phase.
+		prover.advance();
+		prover
+	}
+
+	/// The number of rounds that reduce the unpadded layer's real variables.
+	const fn n_real_rounds(&self) -> usize {
+		self.eval_point.len() - self.pad_len
+	}
+
+	/// Finishes the inner prover once its last real variable is bound, fixing the child evaluations
+	/// the padding rounds close over.
+	fn advance(&mut self) {
+		if self.round != self.n_real_rounds() || !matches!(self.phase, Phase::Real(_)) {
+			return;
+		}
+		// The guard above pins the phase, so this placeholder is overwritten before it is read.
+		let placeholder = Phase::Padding {
+			children: [F::ONE; N],
+			bound_eq: F::ONE,
+		};
+		let Phase::Real(inner) = mem::replace(&mut self.phase, placeholder) else {
+			unreachable!("the guard checked the phase");
+		};
+		self.phase = Phase::Padding {
+			children: inner
+				.finish()
+				.try_into()
+				.expect("the layer prover reduces one multilinear per child"),
+			bound_eq: F::ONE,
+		};
+	}
+}
+
+impl<F: Field, Inner: MleCheckProver<F>, S: PadShape<F, N>, const N: usize> MleCheckProver<F>
+	for PadMleCheckProver<F, Inner, S, N>
+{
+	fn n_vars(&self) -> usize {
+		self.eval_point.len() - self.round
+	}
+
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
+		// Destructured so a padding round can read the prefix table while the phase is borrowed.
+		let Self {
+			eval_point,
+			pad_len,
+			round,
+			pad_eq_prefixes,
+			phase,
+			..
+		} = self;
+		let n_vars = eval_point.len() - *round;
+
+		// Both phases produce the polynomials of an unpadded composition, and the weight the
+		// padding still owes them.
+		let (mut coeffs, weight) = match phase {
+			Phase::Real(inner) => {
+				let coeffs = inner.execute();
+				assert_eq!(
+					coeffs.len(),
+					S::CLAIMS.len(),
+					"the layer prover carries one claim per composition"
+				);
+				(coeffs, pad_eq_prefixes[*pad_len])
+			}
+			Phase::Padding { children, bound_eq } => {
+				// E(X) = bound_eq * eq(0, X) in monomial coefficients.
+				let big_e = [*bound_eq, -*bound_eq];
+				let padded = array::from_fn(|i| S::CHILDREN[i].linear(children[i], big_e));
+				// The equality weight of the padding coordinates still unbound below this round's.
+				(S::compose(padded), pad_eq_prefixes[n_vars - 1])
+			}
+		};
+
+		// Corrected in place, so a round allocates only the vector it returns.
+		for (coeffs, &fill) in iter::zip(&mut coeffs, S::CLAIMS) {
+			fill.correct(coeffs, weight);
+		}
+		coeffs
+	}
+
+	fn fold(&mut self, challenge: F) {
+		match &mut self.phase {
+			Phase::Real(inner) => inner.fold(challenge),
+			Phase::Padding { bound_eq, .. } => {
+				*bound_eq *= eq_one_var(F::ZERO, challenge);
+			}
+		}
+		self.round += 1;
+		self.advance();
+	}
+
+	fn finish(self) -> Vec<F> {
+		match self.phase {
+			Phase::Padding { children, bound_eq } => iter::zip(children, S::CHILDREN)
+				.map(|(child, fill)| fill.at(child, bound_eq))
+				.collect(),
+			Phase::Real(_) => panic!("finish requires every variable to be bound"),
+		}
+	}
+
+	fn eval_point(&self) -> &[F] {
+		&self.eval_point[..self.n_vars()]
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::Ghash128b;
+
+	use super::*;
+	use crate::{
+		fracaddcheck::zero_pad_mle::FractionAdd, prodcheck::one_pad_mle::BivariateProduct,
+	};
+
+	type F = Ghash128b;
+
+	// Invariant: at padding weight zero every child sits at its fill, so the composition does too.
+	// The round polynomials carry the residual weight as a constant, which needs exactly that.
+	fn assert_claim_fills_are_the_composed_child_fills<S, const N: usize>()
+	where
+		S: PadShape<F, N>,
+	{
+		// A witness value that is neither fill, so a shape that reads the child rather than its
+		// fill cannot pass by coincidence.
+		let witness = F::new(3);
+		// Weight zero in monomial coefficients: the padded child collapses to its fill.
+		let padded = S::CHILDREN.map(|fill| fill.linear(witness, [F::ZERO, F::ZERO]));
+
+		let composed = S::compose(padded);
+		assert_eq!(composed.len(), S::CLAIMS.len());
+		for (coeffs, &fill) in iter::zip(&composed, S::CLAIMS) {
+			assert_eq!(coeffs.0[0], fill.value::<F>());
+			assert!(coeffs.0[1..].iter().all(|&coeff| coeff == F::ZERO));
+		}
+	}
+
+	#[test]
+	fn claim_fills_are_the_composed_child_fills() {
+		assert_claim_fills_are_the_composed_child_fills::<FractionAdd, 4>();
+		assert_claim_fills_are_the_composed_child_fills::<BivariateProduct, 2>();
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-630](https://linear.app/jimpo/issue/BINIUS-630).

Collapses the fractional-addition and product-check padding wrappers into one generic prover.
Pure refactor — the round polynomials and the reported evaluations are unchanged.

### The problem

Two modules stand in for a padded tree layer, and they implement the same wrapper twice.

The fractional-addition side pads a shallow tree with the zero fraction $0/1$.
The product side pads with ones.
Neither prover materializes the padded layer: each runs the *unpadded* layer's MLE-check and corrects its messages in $O(1)$ per round.

Both defined the same padding selector, the same two-phase state machine (real rounds, then padding rounds), the same phase transition with the same placeholder dance, the same real-round count, and the same table of prefix products over the padding coordinates' equality weights.

That is around 200 duplicated lines in the crate's subtlest algebra, where drift between the copies is a correctness bug no single module's tests would catch.

Only one copy had the better prefix-table discipline.
The fractional-addition batch builds one table per layer and shares it across the trees; the product side rebuilt the table inside every per-tree call.

### The idea

The two closed forms look different, but one rule generates both.

Write "fill" for what a padded position holds where the padding fills the layer: zero for a fractional numerator, one for a denominator or a product factor.
Then every padded quantity is the same line:

```
padded(v, w) = fill + (v - fill) * w
```

the fill at padding weight `w = 0`, the witness value at `w = 1`.

That single rule generates, with no case analysis:

- the padded children in a padding round, at `w = E(X)`;
- the child evaluations reported at the end, at `w` the product of the bound padding challenges;
- the de-padding of a claim, at `w = q^-1`;
- the round-polynomial correction in **both** phases, applied coefficientwise — scale by the weight, and let the fill carry the residual `1 - w`.

The last one is the surprise: the real-round correction and the tail of the padding-round closed form are the same operation, so the two phases differ only in where the polynomials and the weight come from.

### Per protocol

- **before:** a struct, a phase enum, a phase transition, a real-round count, a prefix table, a five-method prover impl, and two closed forms
- **after:** two constant tables and a `compose` of one or two lines

```rust
impl<F: Field> PadShape<F, 4> for FractionAdd {
	const CHILDREN: [Fill; 4] = [Fill::Zero, Fill::Zero, Fill::One, Fill::One];
	const CLAIMS: &'static [Fill] = &[Fill::Zero, Fill::One];

	fn compose([a_0, a_1, b_0, b_1]: [[F; 2]; 4]) -> Vec<RoundCoeffs<F>> {
		vec![mul_linear(a_0, b_1) + &mul_linear(a_1, b_0), mul_linear(b_0, b_1)]
	}
}
```

### The change

```
sumcheck/pad_mle.rs                 new: the interpolation rule, the state machine, the phase
                                    transition, the real-round count, the prefix-table constructor
fracaddcheck/zero_pad_mle.rs        -273 lines: keeps its composition, its de-padding and its
                                    constructor; the prover is now a type alias
prodcheck/one_pad_mle.rs            -231 lines: keeps its composition and its constructor
```

Both public prover names survive as type aliases, so no call site outside these files changes.

### Soundness

Each wrapper must emit the round polynomials of the *padded* layer's compositions against the padded claim point, and report the padded child evaluations at the end.

- On the all-zeros padding slab the columns are the unpadded ones, weighted by the segment's equality weight $q$.
- Off that slab every position holds its fill, so each composition is constant there and picks up the residual weight $1 - q$.

Those two facts *are* the shared correction, which is why the two protocols are one mechanism and not two.
A new test pins the invariant that ties the two constant tables together: composing the children's fills must land on the claims' fills.

### Scope

- **new:** `crates/ip-prover/src/sumcheck/pad_mle.rs`
- **changed:** the two padding modules and one line of `sumcheck/mod.rs`
- **left untouched:** every caller, and both modules' materialized-reference tests, which pass unchanged
- **follow-up:** hoisting the prefix table in the product-check batch driver, which touches `prodcheck/mod.rs`

### Verification

- `cargo test -p binius-ip-prover` (107 tests), `--release`, and `cargo test -p binius-prover` — clean. The one release failure is the pre-existing `logup_star::prove::tests::test_out_of_range_index_panics`, fixed by #2421.
- `clippy -p binius-ip-prover --all-targets --all-features -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items`, nightly `fmt --check`, `typos`, `cargo check --workspace --all-targets` — clean.
- **Shape coverage.** The reference grid is widened from 3 x 3 to 5 x 5 in both modules: 0, 1, 2, 3 and 5 real rounds against 0, 1, 2, 3 and 5 padding rows. That covers zero padding, one real round, a single fraction pair, non-power-of-two padding, and layers on both sides of the 4-scalar packing width. The widened grid was first run against the *old* implementations and passes there too, so both versions agree with the same independent materialized reference at every shape.
- **Mutation testing.** Six plausible mutations of the new code were each confirmed to fail a test: an off-by-one in the unbound-padding prefix index, a phase transition one round early and one round late, an off-by-one in the real-round count, swapped cross terms in the fraction composition, a wrong child fill, and swapped claim fills.

### Benchmark

A/B in one process, both arms driven over the same inner layer prover, alternating, median of 21 (closed form) and 15 (layer) interleaved rounds. 32 cores, `-C target-cpu=native`, measured at load average 5.1–7.6.

| arm | old | new | ratio |
|---|---|---|---|
| full layer reduction, $2^{21}$ layer, 20 real + 4 padding rounds | 6.9 ms | 6.8 ms | 0.98 |
| full layer reduction, $2^{17}$ layer, 16 real + 4 padding rounds | 0.45 ms | 0.45 ms | 0.99 |
| padding-round closed form, in isolation | 55.4 ns/round | 55.2 ns/round | 1.00 |
| heap allocations per round | 4 | 4 | 1.00 |

Parity everywhere.
Getting there needed two things, both of which are in the diff: correcting the round polynomials in place rather than collecting a fresh vector, and force-inlining the per-round helpers so the fills fold to compile-time constants. Without the inline hints the isolated closed form ran about 18% slower — invisible in the layer number, but real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)