### PR TITLE
BINIUS-631: Intern path-spec names and tally gate kinds without buffering them

### DIFF
--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -124,7 +124,7 @@ impl JwtClaims {
 			}
 
 			// Assert that we found the pattern (found_start should be msb-true)
-			b.assert_true("attr_found".to_string(), found_start);
+			b.assert_true("attr_found", found_start);
 
 			// ---- Find value terminator
 			//

--- a/crates/frontend/src/artifact/dump.rs
+++ b/crates/frontend/src/artifact/dump.rs
@@ -10,10 +10,9 @@ use crate::ir::{
 
 struct PathSpecData {
 	name: String,
-	gates: Vec<GateBody>,
 	parent: Option<PathSpec>,
 	children: Vec<PathSpec>,
-	breakdown: Option<GateBreakdown>,
+	breakdown: GateBreakdown,
 	cum_breakdown: Option<GateBreakdown>,
 }
 
@@ -21,10 +20,9 @@ impl PathSpecData {
 	const fn new() -> Self {
 		PathSpecData {
 			name: String::new(),
-			gates: Vec::new(),
 			parent: None,
 			children: Vec::new(),
-			breakdown: None,
+			breakdown: GateBreakdown::new(),
 			cum_breakdown: None,
 		}
 	}
@@ -37,14 +35,14 @@ struct GateBreakdown {
 }
 
 impl GateBreakdown {
-	fn count(gates: &[GateBody]) -> GateBreakdown {
-		let mut breakdown = GateBreakdown {
+	const fn new() -> Self {
+		GateBreakdown {
 			by_kind: BTreeMap::new(),
-		};
-		for &kind in gates {
-			*breakdown.by_kind.entry(kind).or_insert(0) += 1;
 		}
-		breakdown
+	}
+
+	fn add(&mut self, kind: GateBody) {
+		*self.by_kind.entry(kind).or_insert(0) += 1;
 	}
 
 	fn merge(mut self, other: &GateBreakdown) -> GateBreakdown {
@@ -122,9 +120,9 @@ impl Cx {
 			self.data.entry(path_spec).or_insert_with(PathSpecData::new);
 		}
 
-		// Now add gates to their respective PathSpecs
+		// Now tally gates into their respective PathSpecs
 		for &(path, body) in gate_records {
-			self.data.get_mut(&path).unwrap().gates.push(body);
+			self.data.get_mut(&path).unwrap().breakdown.add(body);
 		}
 	}
 
@@ -141,12 +139,6 @@ impl Cx {
 	fn symbolicate_paths(&mut self, path_spec_tree: &PathSpecTree) {
 		for (path, data) in &mut self.data {
 			path_spec_tree.stringify(*path, &mut data.name);
-		}
-	}
-
-	fn compute_breakdowns(&mut self) {
-		for data in self.data.values_mut() {
-			data.breakdown = Some(GateBreakdown::count(&data.gates));
 		}
 	}
 
@@ -191,7 +183,7 @@ impl Cx {
 			// accumulating and the list handed straight back.
 			let children = std::mem::take(&mut self.data.get_mut(&path_spec).unwrap().children);
 
-			let mut cum_breakdown = self.data[&path_spec].breakdown.as_ref().unwrap().clone();
+			let mut cum_breakdown = self.data[&path_spec].breakdown.clone();
 			for child in &children {
 				if let Some(child_cum) = self.data[child].cum_breakdown.as_ref() {
 					cum_breakdown = cum_breakdown.merge(child_cum);
@@ -249,7 +241,6 @@ pub(crate) fn dump_composition(
 	cx.bucket_gates(path_spec_tree, gate_records);
 	cx.recover_hierarchy(path_spec_tree);
 	cx.compute_postorder(path_spec_tree);
-	cx.compute_breakdowns();
 	cx.compute_cum_breakdowns();
 	cx.symbolicate_paths(path_spec_tree);
 

--- a/crates/frontend/src/builder/mod.rs
+++ b/crates/frontend/src/builder/mod.rs
@@ -797,11 +797,11 @@ impl CircuitBuilder {
 	///
 	/// Note that this is the same builder instance, but with a different namespace, and that means
 	/// calling [`Self::build`] on the returned builder is going to build the whole circuit.
-	pub fn subcircuit(&self, name: impl Into<String>) -> CircuitBuilder {
+	pub fn subcircuit(&self, name: impl AsRef<str>) -> CircuitBuilder {
 		let nested_path = self
 			.graph_mut()
 			.path_spec_tree
-			.extend(self.current_path, name);
+			.extend(self.current_path, name.as_ref());
 		CircuitBuilder {
 			current_path: nested_path,
 			shared: self.shared.clone(),
@@ -1388,7 +1388,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_eq(&self, name: impl Into<String>, x: Wire, y: Wire) {
+	pub fn assert_eq(&self, name: impl AsRef<str>, x: Wire, y: Wire) {
+		let name = name.as_ref();
 		let mut graph = self.graph_mut();
 		let gate = graph.emit_gate(self.current_path, Opcode::AssertEq, [x, y], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
@@ -1405,8 +1406,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// N AND constraints (one per element).
-	pub fn assert_eq_v<const N: usize>(&self, name: impl Into<String>, x: [Wire; N], y: [Wire; N]) {
-		let base_name = name.into();
+	pub fn assert_eq_v<const N: usize>(&self, name: impl AsRef<str>, x: [Wire; N], y: [Wire; N]) {
+		let base_name = name.as_ref();
 		for i in 0..N {
 			self.assert_eq(format!("{base_name}[{i}]"), x[i], y[i]);
 		}
@@ -1419,7 +1420,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_zero(&self, name: impl Into<String>, x: Wire) {
+	pub fn assert_zero(&self, name: impl AsRef<str>, x: Wire) {
+		let name = name.as_ref();
 		let mut graph = self.graph_mut();
 		let gate = graph.emit_gate(self.current_path, Opcode::AssertZero, [x], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
@@ -1433,7 +1435,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_non_zero(&self, name: impl Into<String>, x: Wire) {
+	pub fn assert_non_zero(&self, name: impl AsRef<str>, x: Wire) {
+		let name = name.as_ref();
 		let mut graph = self.graph_mut();
 		let gate = graph.emit_gate(self.current_path, Opcode::AssertNonZero, [x], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
@@ -1452,7 +1455,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_false(&self, name: impl Into<String>, x: Wire) {
+	pub fn assert_false(&self, name: impl AsRef<str>, x: Wire) {
+		let name = name.as_ref();
 		let mut graph = self.graph_mut();
 		let gate = graph.emit_gate(self.current_path, Opcode::AssertFalse, [x], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
@@ -1471,7 +1475,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_true(&self, name: impl Into<String>, x: Wire) {
+	pub fn assert_true(&self, name: impl AsRef<str>, x: Wire) {
+		let name = name.as_ref();
 		let mut graph = self.graph_mut();
 		let gate = graph.emit_gate(self.current_path, Opcode::AssertTrue, [x], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
@@ -1530,7 +1535,8 @@ impl CircuitBuilder {
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_eq_cond(&self, name: impl Into<String>, x: Wire, y: Wire, cond: Wire) {
+	pub fn assert_eq_cond(&self, name: impl AsRef<str>, x: Wire, y: Wire, cond: Wire) {
+		let name = name.as_ref();
 		let mut graph = self.graph_mut();
 		let gate = graph.emit_gate(self.current_path, Opcode::AssertEqCond, [x, y, cond], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);

--- a/crates/frontend/src/ir/path.rs
+++ b/crates/frontend/src/ir/path.rs
@@ -9,7 +9,10 @@ pub struct PathSpec(u32);
 cranelift_entity::entity_impl!(PathSpec);
 
 struct Node {
-	name: String,
+	/// Offset of the name within the tree's name buffer.
+	start: u32,
+	/// Length of the name in bytes.
+	len: u32,
 	parent: PathSpec,
 }
 
@@ -17,6 +20,11 @@ struct Node {
 pub struct PathSpecTree {
 	root: PathSpec,
 	nodes: PrimaryMap<PathSpec, Node>,
+	/// Every node name, concatenated in the order the nodes were created.
+	///
+	/// Names are only ever appended.
+	/// A node's range therefore stays valid for the life of the tree.
+	names: String,
 }
 
 impl PathSpecTree {
@@ -24,17 +32,25 @@ impl PathSpecTree {
 	pub fn new() -> Self {
 		let mut nodes = PrimaryMap::new();
 		let root = nodes.push(Node {
-			name: String::new(),
+			start: 0,
+			len: 0,
 			parent: PathSpec(0),
 		});
-		Self { root, nodes }
+		Self {
+			root,
+			nodes,
+			names: String::new(),
+		}
 	}
 
 	/// Extend the tree with a new branch that stems from the given `parent` and has a certain
 	/// `name`.
-	pub fn extend(&mut self, parent: PathSpec, name: impl Into<String>) -> PathSpec {
+	pub fn extend(&mut self, parent: PathSpec, name: &str) -> PathSpec {
+		let start = self.names.len() as u32;
+		self.names.push_str(name);
 		self.nodes.push(Node {
-			name: name.into(),
+			start,
+			len: name.len() as u32,
 			parent,
 		})
 	}
@@ -47,20 +63,16 @@ impl PathSpecTree {
 	/// The buffer is appended to rather than reset.
 	/// A caller that reuses a buffer therefore has to clear it first.
 	pub fn stringify(&self, ls: PathSpec, out: &mut String) {
-		fn stringify_rec(
-			root: PathSpec,
-			nodes: &PrimaryMap<PathSpec, Node>,
-			ls: PathSpec,
-			out: &mut String,
-		) {
-			if ls == root {
+		fn stringify_rec(tree: &PathSpecTree, ls: PathSpec, out: &mut String) {
+			if ls == tree.root {
 				return;
 			}
-			stringify_rec(root, nodes, nodes[ls].parent, out);
+			let node = &tree.nodes[ls];
+			stringify_rec(tree, node.parent, out);
 			out.push('.');
-			out.push_str(&nodes[ls].name);
+			out.push_str(&tree.names[node.start as usize..(node.start + node.len) as usize]);
 		}
-		stringify_rec(self.root, &self.nodes, ls, out);
+		stringify_rec(self, ls, out);
 	}
 
 	/// Returns the parent of the given path or null if `root` was supplied.
@@ -80,5 +92,56 @@ impl PathSpecTree {
 impl Default for PathSpecTree {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn every_node_renders_its_own_name_after_later_nodes_are_added() {
+		let mut tree = PathSpecTree::new();
+		let root = tree.root();
+
+		// Two branches under the root, each extended after the other was created.
+		let a = tree.extend(root, "alpha");
+		let a_child = tree.extend(a, "one");
+		let b = tree.extend(root, "b");
+		let b_child = tree.extend(b, "considerably_longer");
+
+		let render = |path| {
+			let mut out = String::new();
+			tree.stringify(path, &mut out);
+			out
+		};
+
+		assert_eq!(render(root), "");
+		assert_eq!(render(a), ".alpha");
+		assert_eq!(render(a_child), ".alpha.one");
+		assert_eq!(render(b), ".b");
+		assert_eq!(render(b_child), ".b.considerably_longer");
+	}
+
+	#[test]
+	fn an_empty_name_renders_as_a_bare_separator() {
+		let mut tree = PathSpecTree::new();
+		let root = tree.root();
+		let empty = tree.extend(root, "");
+		let below = tree.extend(empty, "leaf");
+
+		let mut out = String::new();
+		tree.stringify(below, &mut out);
+		assert_eq!(out, "..leaf");
+	}
+
+	#[test]
+	fn the_root_has_no_parent() {
+		let mut tree = PathSpecTree::new();
+		let root = tree.root();
+		let child = tree.extend(root, "child");
+
+		assert_eq!(tree.parent(root), None);
+		assert_eq!(tree.parent(child), Some(root));
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-631](https://linear.app/jimpo/issue/BINIUS-631).

Stops two diagnostic paths in the frontend from retaining one allocation per item to produce a summary that never needs them.
Pure refactor — rendered assertion paths and JSON dump output are byte-identical.

### The problem

**Named assertions.**
Every named assertion and every subcircuit pushes a node onto the path tree.
The tree is carried into the built `Circuit` so assertion failures and JSON dumps can be symbolicated.

Each node owned a `String`: 24 inline bytes of pointer/length/capacity, plus a separate heap allocation for the text.
`assert_eq_v` formats one name per element, so a vectorised assertion over `N` wires pays that `N` times.

At 200,000 named assertions that is **3.67 MiB retained after the build finishes** — 19 bytes per assertion on top of the name text itself.

**The JSON dump.**
`PathSpecData` collected every gate body into a `Vec<GateBody>` for its path.
The only thing ever done with that vector was `GateBreakdown::count`, which tallies it into a `BTreeMap`.

For the 146,297-gate SHA-256 circuit that is **146,297 entries buffered to produce a histogram of at most 22 buckets**.

### The idea

Both are the same shape: keep the summary, drop the per-item storage.

For the path tree, **intern**.
One shared buffer holds every name back to back, and a node keeps a range into it.

```
before: Node { name: String,  parent: PathSpec }          // 32 bytes + 1 heap alloc each
after:  Node { start: u32, len: u32, parent: PathSpec }   // 12 bytes, one shared buffer
```

The read path barely moves.
`stringify` already walked parents appending into a caller-supplied buffer, so it now appends a slice of the shared buffer instead of a slice of an owned one.

For the dump, **count on the way in**.
The gate loop increments the path's breakdown directly, and the separate counting pass goes away.

### Per named assertion

- **before:** one 32-byte node + one heap allocation for the name text
- **after:** one 12-byte node + `len` bytes appended to a shared buffer

→ 19 bytes and one allocation less, retained for the circuit's lifetime.

### The change

```diff
- pub fn extend(&mut self, parent: PathSpec, name: impl Into<String>) -> PathSpec
+ pub fn extend(&mut self, parent: PathSpec, name: &str) -> PathSpec
```

```diff
- self.data.get_mut(&path).unwrap().gates.push(body);
+ self.data.get_mut(&path).unwrap().breakdown.add(body);
```

Interning wants a `&str`, and `Into<String>` would force an allocation the interner then copies out of and drops.
Both bounds were measured rather than guessed.

- The transient allocation is genuinely free on the synthetic workload — identical retained heap, identical peak, identical allocation count.
- It costs 525 allocations on a real SHA-256 build, where most names are `&'static str` that would round-trip through a `String` for nothing.

So the assertion builders and `subcircuit` take `impl AsRef<str>`.

**This needed one call-site fix, in another crate.**
Every caller still *compiles* untouched, but one had a redundant `.to_string()` that the owned bound was hiding:

```diff
- b.assert_true("attr_found".to_string(), found_start);
+ b.assert_true("attr_found", found_start);
```

Under `Into<String>` that allocation looked load-bearing, so clippy stayed quiet.
Under `AsRef<str>` it is plainly redundant and `unnecessary_to_owned` fires.
That is mild evidence for the change: the old signature let a pointless allocation sit unnoticed in `binius-circuits`.

### What I measured and dropped

Two smaller items were scoped in and are not here, because measuring them killed them.

**`Cx::data` as a `Vec` indexed by the entity, rather than a `BTreeMap`.**
Path specs are sparse relative to gates.
An assertion's gate is emitted at the *current* path; the assertion's own path spec is a childless leaf that never carries a gate.
So the 200,000-assertion circuit creates 200,001 path specs and exactly **one** of them appears in the dump.
A dense map indexed by the entity would allocate 200,001 slots to describe one — a pessimisation, not a cleanup.

**`collect_postorder` as an explicit stack.**
It would not remove the depth bound.
`build_subcircuit_info_recursive` and `PathSpecTree::stringify` still recurse on the same subcircuit depth, in the same file.
De-recursing one of three traversals changes no reachable behaviour, so it is churn.

### Scope

- **changed:** `ir/path.rs` (the interner), `artifact/dump.rs` (direct tally), `builder/mod.rs` (the seven assertion builders and `subcircuit`).
- **also changed:** one line in `crates/circuits/src/jwt_claims.rs` — the redundant `.to_string()` above.
- **new:** three unit tests in `ir/path.rs` pinning what a node renders as after later nodes are appended.
- **untouched:** every other call site, every snapshot, and `dump_composition`'s public signature.

### Verification

Rendering must not move, so that is what was checked hardest.

- `tests/test_assertion_paths.rs` passes untouched — it asserts on rendered paths like `.module_a.submodule.test_assertion`.
- `Circuit::simple_json_dump` captured before and after on `sha256_fixed(8192)` and on a nested-subcircuit fixture, then `diff`ed: **byte-identical**, same md5 on both fixtures.
- All thirteen `circuits-snapshot` examples pass with their committed snapshots **untouched**.
- `cargo test -p binius-frontend` (debug, so `debug_assert!` fires) — 262 + 6 pass.
- `cargo test -p binius-frontend --release`, `cargo test -p binius-circuits` (414) — pass.
- `zklogin` is the snapshot example that exercises the touched `jwt_claims` call site, and it passes unchanged.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean, run to completion across every crate.
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean.
- `cargo +nightly-2026-07-01 fmt --all --check`, `tools/check_copyright_notice.py`, `typos`, `cargo build -p binius-examples` — clean.

### Benchmark

Interleaved runs of a before- and after-binary, 15 reps, median and minimum, noise floor ~3%.
Heap figures come from a counting global allocator, so they are exact rather than page-granular.

**Synthetic worst case — 200,000 `assert_eq` calls with `format!("pairs[{i}]")` names:**

| metric | before | after | delta |
|---|---|---|---|
| peak RSS (`VmHWM`) | 39368 KiB | 31572 KiB | **−7.6 MiB, −19.8%** |
| heap retained by the built circuit | 17366 KiB | 13608 KiB | **−3.67 MiB, −21.6%** |
| naming loop | 11.89 ms (min 11.07) | 10.52 ms (min 9.80) | **−11.5%** |
| naming + build | 26.80 ms | 25.40 ms | −5.2% |

**Realistic circuit — `sha256_fixed(8192)`, 146,297 gates, few named assertions:**

| metric | before | after | delta |
|---|---|---|---|
| build time | 88.0 ms (min 77.3) | 86.8 ms (min 85.1) | noise |
| peak RSS | 78952 KiB | 79172 KiB | **no change** |
| allocations during build | 507243 | 506718 | −525 |

The win here is **near zero, and that is the honest headline** — a circuit with 146k gates and a handful of named assertions was never paying much for the path tree.
The interning matters for circuits that name a lot of assertions, not for gate count.

**`simple_json_dump` on the same SHA-256 circuit:**

| metric | before | after | delta |
|---|---|---|---|
| transient heap peak during the dump | 2132 KiB | 64 KiB | **33× less** |
| bytes allocated during the dump | 4297 KiB | 168 KiB | **−96%** |
| allocations during the dump | 1638 | 924 | −44% |
| dump time | 1.58 ms (min 1.56) | 1.53 ms (min 1.51) | ~3%, at the noise floor |

Peak RSS across the dump call does **not** move: the allocator serves the dump out of pages the build already freed.
The win is allocator pressure, not resident set — worth having on a hygiene basis, and it makes the dump's cost independent of gate count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

