### PR TITLE
BINIUS-633: Make the frontend IR declare only what it uses

### DIFF
--- a/crates/frontend/src/builder/tests.rs
+++ b/crates/frontend/src/builder/tests.rs
@@ -1102,6 +1102,30 @@ fn dead_code_elimination_flag_is_honoured() {
 }
 
 #[test]
+fn zero_propagation_flag_is_honoured() {
+	// Invariant: adding zero leaves the addend alone and carries nothing.
+	// So the flag decides whether a carry chain is paid for a value another wire already holds.
+	let and_count = |enable| {
+		stat_with(
+			Options {
+				enable_zero_propagation: enable,
+				..Options::default()
+			},
+			|b| {
+				let x = b.add_inout();
+				let zero = b.add_constant(Word::ZERO);
+				let sum = b.iadd_32(x, zero);
+				let out = b.add_inout();
+				b.assert_eq("sum", sum, out);
+			},
+		)
+		.n_and_constraints
+	};
+	assert_eq!(and_count(true), 0, "readers move to the addend, so the gate is dropped");
+	assert_eq!(and_count(false), 1, "the carry chain is emitted and constrained in full");
+}
+
+#[test]
 fn test_scratch_pooling_matches_scalar_per_instance_batched() {
 	// Invariant: the batched fill and the one-at-a-time fill must agree for every instance.
 	// This is where shared slots are most at risk.

--- a/crates/frontend/src/eval_form/batch.rs
+++ b/crates/frontend/src/eval_form/batch.rs
@@ -58,8 +58,6 @@ pub struct BatchPopulateError {
 pub struct BatchExecutionContext<'a, 'v> {
 	/// Rows are value-vector indices; columns are instances.
 	values: &'a mut StridedArray2DViewMut<'v, Word>,
-	/// The global instance index represented by local column 0.
-	instance_offset: usize,
 	/// Failures recorded for [`Self::min_failing_instance`], capped by [`MAX_ASSERTION_FAILURES`].
 	///
 	/// Cleared whenever a strictly lower failing instance is found.
@@ -74,13 +72,9 @@ pub struct BatchExecutionContext<'a, 'v> {
 }
 
 impl<'a, 'v> BatchExecutionContext<'a, 'v> {
-	pub const fn new(
-		values: &'a mut StridedArray2DViewMut<'v, Word>,
-		instance_offset: usize,
-	) -> Self {
+	pub const fn new(values: &'a mut StridedArray2DViewMut<'v, Word>) -> Self {
 		Self {
 			values,
-			instance_offset,
 			failures: Vec::new(),
 			min_failure_count: 0,
 			min_failing_instance: None,
@@ -132,16 +126,14 @@ impl EvalContext for BatchExecutionContext<'_, '_> {
 		self.values[(reg as usize, instance)] = value;
 	}
 
-	/// Record an assertion failure for one local instance.
+	/// Record an assertion failure for one instance.
 	///
 	/// A failure for a higher instance than the current lowest-failing one is dropped.
 	/// It can never become the reported instance.
 	/// A failure for a new, strictly lower instance clears every record kept so far.
 	/// Those records belonged to an instance that turned out not to be the one reported.
-	/// The stripe offset remaps the local index to a global instance index.
 	#[cold]
 	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String) {
-		let instance = self.instance_offset + instance;
 		match self.min_failing_instance {
 			Some(min) if instance > min => return,
 			Some(min) if instance < min => {

--- a/crates/frontend/src/eval_form/mod.rs
+++ b/crates/frontend/src/eval_form/mod.rs
@@ -98,17 +98,7 @@ impl EvalForm {
 		values: &mut StridedArray2DViewMut<'_, Word>,
 		path_spec_tree: Option<&PathSpecTree>,
 	) -> Result<(), BatchPopulateError> {
-		self.evaluate_stripe(values, 0, path_spec_tree)
-	}
-
-	/// Evaluate the bytecode over a view whose local column 0 is the global `instance_offset`.
-	fn evaluate_stripe(
-		&self,
-		values: &mut StridedArray2DViewMut<'_, Word>,
-		instance_offset: usize,
-		path_spec_tree: Option<&PathSpecTree>,
-	) -> Result<(), BatchPopulateError> {
-		let mut ctx = BatchExecutionContext::new(values, instance_offset);
+		let mut ctx = BatchExecutionContext::new(values);
 		self.executor().run(&mut ctx);
 		ctx.check_assertions(path_spec_tree)
 	}

--- a/crates/frontend/src/gates/icmp_eq.rs
+++ b/crates/frontend/src/gates/icmp_eq.rs
@@ -47,11 +47,10 @@ use crate::{
 pub struct IcmpEq;
 
 impl GateKind for IcmpEq {
-	// The auxiliary wire is the carry-out; the scratch wire holds the operands' difference.
+	// The scratch wires are the carry-out and the operands' difference.
 	const SHAPE: OpcodeShape = OpcodeShape::new(2, 1)
 		.with_consts(&[Word::ALL_ONE, Word::MSB_ONE])
-		.with_aux(1)
-		.with_scratch(1);
+		.with_scratch(2);
 
 	fn constrain(gate: GateParam<'_>, cb: &mut ConstraintBuilder) {
 		let [all_one, msb_one] = gate.const_wires();
@@ -68,8 +67,7 @@ impl GateKind for IcmpEq {
 		let [all_one, msb_one] = gate.const_wires();
 		let [x, y] = gate.in_wires();
 		let [out] = gate.out_wires();
-		let [cout] = gate.aux_wires();
-		let [diff] = gate.scratch_wires();
+		let [cout, diff] = gate.scratch_wires();
 
 		// diff = x ⊕ y
 		bc.emit_bxor(ctx.reg(diff), ctx.reg(x), ctx.reg(y));

--- a/crates/frontend/src/ir/mod.rs
+++ b/crates/frontend/src/ir/mod.rs
@@ -158,7 +158,11 @@ pub struct GateData {
 	/// This is empty for gates of constant shape. When the shape is variable, the number of
 	/// input, output and internal wires is a function of non-empty `dimensions`. This function is
 	/// typically linear.
-	pub dimensions: Vec<usize>,
+	///
+	/// Emission fixes the length, so a boxed slice replaces a vector.
+	/// That is 16 bytes against 24.
+	/// Neither allocates for the empty case that most gates hold.
+	pub dimensions: Box<[usize]>,
 }
 
 impl GateData {
@@ -344,7 +348,7 @@ impl GateGraph {
 		let data = GateData {
 			body: GateBody::Op(opcode),
 			wires,
-			dimensions: dimensions.to_vec(),
+			dimensions: dimensions.into(),
 			immediates: SmallVec::from_slice(immediates),
 		};
 		// Inline validate_shape: non-hint shape doesn't need a registry.
@@ -377,7 +381,7 @@ impl GateGraph {
 		let data = GateData {
 			body: GateBody::Hint(hint_id),
 			wires,
-			dimensions: dimensions.to_vec(),
+			dimensions: dimensions.into(),
 			immediates: SmallVec::new(),
 		};
 		let gate = self.gates.push(data);


### PR DESCRIPTION
Closes [BINIUS-633](https://linear.app/jimpo/issue/BINIUS-633).

Three frontend declarations claimed more than the program used, plus one missing option-flag test. Pure cleanup — no behavior change.

### The problem

**1. A parameter that is always zero.**

Batch evaluation carried a stripe offset through `BatchExecutionContext`, added to every reported instance index in `note_assertion_failure`.

- Callers of `evaluate_stripe`: **1**
- Values it ever passes: **`0`**

Meanwhile `Circuit::populate_batch_parallel_with_stripe_width` does the same remapping itself, adding `tile_start` to the error it gets back. Two mechanisms for one job; the one inside the context is never exercised.

**2. A wire declared as constrained that no constraint references.**

`OpcodeShape` draws a clear line between its two invisible-wire kinds:

- **aux** — "neither inputs nor outputs, but are still being used within constraint system"
- **scratch** — "neither inputs nor outputs. They also do not get referenced in the constraint system."

`IcmpEq` declares `.with_aux(1)` for its carry-out. Its `constrain` names `all_one`, `msb_one`, `x`, `y`, `out` — five wires, and the carry-out is not among them. The carry-out appears only in `emit`.

- Constraint operands referencing the `IcmpEq` carry-out: **0**

`AssertNonZero` is the only other `with_aux` user in the crate, and there the carry-out *is* referenced — twice, by the carry AND and by the `MSB(cout) = 1` ZERO constraint. That one is correctly declared and is left alone.

**3. A 24-byte field that is empty for almost every gate.**

`GateData::dimensions` is a `Vec<usize>`. Only `BxorMulti` and hint gates carry any dimensions; every other gate holds an empty vector — a null pointer, a zero length, and a zero capacity.

- `zklogin`, the largest example circuit: **388,535 gates**
- `GateData` before: **88 bytes** (`body` 8, `wires` 32, `immediates` 24, `dimensions` 24)

**4. A missing test.**

`enable_zero_propagation` was the only `Options` flag without a builder-level `*_flag_is_honoured` test. The other five have one.

### The idea

For (3), the win is not narrowing the element type — it is dropping the capacity word.

A `Vec<T>` is `(ptr, cap, len)` because it must be able to grow. `GateData::dimensions` is written once at emission and never pushed to, so that third word is dead weight:

```
Vec<usize>       = ptr + cap + len = 24 bytes
Box<[usize]>     = ptr + len       = 16 bytes
```

A boxed slice derefs to `&[usize]`, so every reader — `Opcode::shape`, `HintRegistry::shape`/`execute`, `emit_hint`, CSE's structural key — compiles unchanged. No public trait signature moves.

### The change

```
- pub dimensions: Vec<usize>,
+ pub dimensions: Box<[usize]>,

- dimensions: dimensions.to_vec(),      // both emit sites
+ dimensions: dimensions.into(),
```

```
  const SHAPE: OpcodeShape = OpcodeShape::new(2, 1)
      .with_consts(&[Word::ALL_ONE, Word::MSB_ONE])
-     .with_aux(1)
-     .with_scratch(1);
+     .with_scratch(2);

- let [cout] = gate.aux_wires();
- let [diff] = gate.scratch_wires();
+ let [cout, diff] = gate.scratch_wires();
```

Wire creation order is untouched — aux wires are allocated immediately before scratch wires, so the carry-out keeps its slot and its `Wire` index. Only its `WireKind` changes.

### Soundness

Nothing here touches the constraint system or a witness value.

For (2) specifically, aux and scratch are **already interchangeable at compile time**. `CircuitBuilder::build` classifies a gate-created wire by whether a constraint operand names it, not by the kind it was declared with:

```
WireKind::Internal | WireKind::Scratch => {
    if constrained_wires.contains(wire) { add_internal(wire) }
    else                                { add_scratch(wire, ...) }
}
```

Both kinds take the same branch, and the `IcmpEq` carry-out is in no operand, so it lands in the scratch segment before and after. This is asserted, not assumed — see Verification.

### On the three readings

| item | verdict |
|---|---|
| 1. stripe offset always zero | **Confirmed.** One caller, passes `0`; the parallel driver remaps separately. |
| 2. `IcmpEq` aux is really scratch | **Confirmed.** `constrain` never names it. `AssertNonZero`'s aux is genuine and untouched. |
| 3. `SmallVec<[u32; 1]>` gets `GateData` to 80 | **Refuted as stated, fixed differently.** |
| 4. missing flag test | **Confirmed.** |

On (3): a `SmallVec` on 64-bit can never be 16 bytes. It is a `usize` capacity plus a union whose heap arm is a `(ptr, len)` pair, so 24 bytes is its floor:

| type | size |
|---|---|
| `Vec<usize>` | 24 |
| `SmallVec<[u32; 1]>` | 24 |
| `SmallVec<[usize; 1]>` | 24 |
| `SmallVec<[u32; 2]>` | 24 |
| `Box<[usize]>` | **16** |

The companion premise does not hold either: dimensioned gates do not all carry one. `ModDivide` and `BigUintModPow` carry 3, `ModInverse` and `BigUintDivide` carry 2, and `ByteVecConcatHint` carries one per input vector. Narrowing `usize` to `u32` would also have meant changing `Hint::shape`, `Hint::execute` and `ChipGadget::build` across `binius-circuits`, `binius-recursion`, `binius-m4-prover` and `binius-m4-verifier` — well outside this PR's scope, for zero size gain.

`Box<[usize]>` reaches the intended 80 bytes with a smaller diff and no API change.

### Scope

- **changed:** `eval_form/mod.rs`, `eval_form/batch.rs`, `gates/icmp_eq.rs`, `ir/mod.rs`, `builder/tests.rs`
- **left untouched:** `AssertNonZero` — its aux wire is genuinely referenced by two constraints
- **left untouched:** the `Hint` and `ChipGadget` trait signatures, which keep taking `&[usize]`

### Verification

- `cargo test -p binius-frontend` — 266 pass; same in release with `-Ctarget-cpu=native`
- `cargo test -p binius-circuits` — 414 pass
- `clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` — clean
- `cargo +nightly-2026-07-01 fmt --all --check`, `check_copyright_notice.py`, `typos` — clean

**The snapshot gate is the real oracle here.** Nothing in this PR should move a statistic, so all fifteen circuits were checked and all fifteen pass **without being re-blessed** — `git status` shows no `.snap` touched:

```
ethsign  zklogin  sha256  sha512  keccak  blake2s  blake2b  blake3_compress
blake3  hashsign  ec_msm  bitcoin_header_chain  bitcoin_p2pkh  sha3  sha3_512
```

That is the proof for (2): had `WireKind::Internal` and `WireKind::Scratch` not been interchangeable, the `IcmpEq` carry-out would have moved between the committed and uncommitted segments and every circuit using `icmp_eq` would have drifted.

**Type size**, via `RUSTFLAGS="-Zprint-type-sizes"`:

| field | before | after |
|---|---|---|
| `body` | 8 | 8 |
| `wires` | 32 | 32 |
| `immediates` | 24 | 24 |
| `dimensions` | 24 | **16** |
| **`GateData`** | **88** | **80** |

**Peak RSS**, `zklogin check-snapshot`, release, three runs each:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 220.5 MB | 220.1 MB | 220.4 MB |
| after | 217.2 MB | 217.8 MB | 217.6 MB |

A ~2.9 MB drop with non-overlapping ranges, against a predicted 388,535 × 8 B = 3.11 MB. The measurement lands where the arithmetic says it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
