### PR TITLE
BINIUS-634: Give the GHASH multiply real test coverage

### DIFF
--- a/crates/field/src/fields/ghash.rs
+++ b/crates/field/src/fields/ghash.rs
@@ -491,7 +491,174 @@ mod tests {
 		}
 	}
 
+	/// Reads a 16-byte GHASH block, given as a big-endian `u128`, as a field element.
+	///
+	/// GCM numbers bits from the left: the leading bit of the block is the coefficient of `X^0`.
+	/// `Ghash128b` numbers them from the right: bit `i` of the `u128` is the coefficient of `X^i`.
+	/// Reversing the 128 bits is therefore the whole conversion.
+	fn from_gcm_block(block: u128) -> Ghash128b {
+		Ghash128b::new(block.reverse_bits())
+	}
+
+	/// Carry-less multiply of `x` by the reduction tail `X^7 + X^2 + X + 1`, as `(lo, hi)`.
+	fn mul_by_reduction_tail(x: u128) -> (u128, u128) {
+		(x ^ (x << 1) ^ (x << 2) ^ (x << 7), (x >> 127) ^ (x >> 126) ^ (x >> 121))
+	}
+
+	/// Schoolbook carry-less multiply and reduce, written from the field definition alone.
+	///
+	/// Bit `i` is the coefficient of `X^i`, so a left shift by `i` multiplies by `X^i`.
+	/// The high half folds back down through `X^128 = X^7 + X^2 + X + 1`.
+	fn schoolbook_mul(a: u128, b: u128) -> u128 {
+		let mut lo = 0u128;
+		let mut hi = 0u128;
+		for i in 0..128 {
+			if (a >> i) & 1 == 1 {
+				lo ^= b << i;
+				hi ^= (b >> 1) >> (127 - i);
+			}
+		}
+		while hi != 0 {
+			let (fold_lo, fold_hi) = mul_by_reduction_tail(hi);
+			lo ^= fold_lo;
+			hi = fold_hi;
+		}
+		lo
+	}
+
+	/// Walks the GHASH recurrence `X_i = (X_{i-1} + B_i) * H`, checking every `X_i`.
+	fn check_ghash_chain(h: u128, blocks: &[u128], expected: &[u128]) {
+		assert_eq!(blocks.len(), expected.len());
+		let h = from_gcm_block(h);
+		let mut acc = Ghash128b::ZERO;
+		for (block, want) in blocks.iter().zip(expected) {
+			acc = (acc + from_gcm_block(*block)) * h;
+			assert_eq!(acc, from_gcm_block(*want), "block {block:#034x}");
+		}
+	}
+
+	fn boundary_values() -> [u128; 7] {
+		[
+			0,
+			1,
+			2,
+			0x87,
+			1 << 127,
+			u128::MAX,
+			Ghash128b::MULTIPLICATIVE_GENERATOR.into(),
+		]
+	}
+
+	#[test]
+	fn test_gcm_spec_test_case_2() {
+		check_ghash_chain(
+			0x66e94bd4ef8a2c3b884cfa59ca342b2e,
+			&[
+				0x0388dace60b6a392f328c2b971b2fe78,
+				0x00000000000000000000000000000080,
+			],
+			&[
+				0x5e2ec746917062882c85b0685353deb7,
+				0xf38cbb1ad69223dcc3457ae5b6b0f885,
+			],
+		);
+	}
+
+	#[test]
+	fn test_gcm_spec_test_case_3() {
+		check_ghash_chain(
+			0xb83b533708bf535d0aa6e52980d53b78,
+			&[
+				0x42831ec2217774244b7221b784d0d49c,
+				0xe3aa212f2c02a4e035c17e2329aca12e,
+				0x21d514b25466931c7d8f6a5aac84aa05,
+				0x1ba30b396a0aac973d58e091473f5985,
+				0x00000000000000000000000000000200,
+			],
+			&[
+				0x59ed3f2bb1a0aaa07c9f56c6a504647b,
+				0xb714c9048389afd9f9bc5c1d4378e052,
+				0x47400c6577b1ee8d8f40b2721e86ff10,
+				0x4796cf49464704b5dd91f159bb1b7f95,
+				0x7f1b32b81b820d02614f8895ac1d4eac,
+			],
+		);
+	}
+
+	#[test]
+	fn test_gcm_spec_test_case_4() {
+		check_ghash_chain(
+			0xb83b533708bf535d0aa6e52980d53b78,
+			&[
+				0xfeedfacedeadbeeffeedfacedeadbeef,
+				0xabaddad2000000000000000000000000,
+				0x42831ec2217774244b7221b784d0d49c,
+				0xe3aa212f2c02a4e035c17e2329aca12e,
+				0x21d514b25466931c7d8f6a5aac84aa05,
+				0x1ba30b396a0aac973d58e09100000000,
+				0x00000000000000a000000000000001e0,
+			],
+			&[
+				0xed56aaf8a72d67049fdb9228edba1322,
+				0xcd47221ccef0554ee4bb044c88150352,
+				0x54f5e1b2b5a8f9525c23924751a3ca51,
+				0x324f585c6ffc1359ab371565d6c45f93,
+				0xca7dd446af4aa70cc3c0cd5abba6aa1c,
+				0x1590df9b2eb6768289e57d56274c8570,
+				0x698e57f70e6ecc7fd9463b7260a9ae5f,
+			],
+		);
+	}
+
+	#[test]
+	fn test_boundary_products_match_schoolbook() {
+		for a in boundary_values() {
+			for b in boundary_values() {
+				assert_eq!(
+					Ghash128b::from(a) * Ghash128b::from(b),
+					Ghash128b::new(schoolbook_mul(a, b)),
+					"{a:#034x} * {b:#034x}"
+				);
+			}
+		}
+	}
+
 	proptest! {
+		#[test]
+		fn test_mul_matches_schoolbook(a in any::<u128>(), b in any::<u128>()) {
+			assert_eq!(
+				Ghash128b::from(a) * Ghash128b::from(b),
+				Ghash128b::new(schoolbook_mul(a, b))
+			);
+		}
+
+		#[test]
+		fn test_mul_is_commutative(a in any::<u128>(), b in any::<u128>()) {
+			let (a, b) = (Ghash128b::from(a), Ghash128b::from(b));
+			assert_eq!(a * b, b * a);
+		}
+
+		#[test]
+		fn test_mul_is_associative(a in any::<u128>(), b in any::<u128>(), c in any::<u128>()) {
+			let (a, b, c) = (Ghash128b::from(a), Ghash128b::from(b), Ghash128b::from(c));
+			assert_eq!((a * b) * c, a * (b * c));
+		}
+
+		#[test]
+		fn test_mul_distributes_over_addition(
+			a in any::<u128>(), b in any::<u128>(), c in any::<u128>(),
+		) {
+			let (a, b, c) = (Ghash128b::from(a), Ghash128b::from(b), Ghash128b::from(c));
+			assert_eq!(a * (b + c), a * b + a * c);
+		}
+
+		#[test]
+		fn test_mul_by_one_and_zero(a in any::<u128>()) {
+			let a = Ghash128b::from(a);
+			assert_eq!(a * Ghash128b::ONE, a);
+			assert_eq!(a * Ghash128b::ZERO, Ghash128b::ZERO);
+		}
+
 		#[test]
 		fn test_conversion_from_aes_consistency(a in any::<u8>(), b in any::<u8>()) {
 			let a_val = Rijndael8b::new(a);

--- a/crates/frontend/src/eval_form/exec.rs
+++ b/crates/frontend/src/eval_form/exec.rs
@@ -500,3 +500,54 @@ impl<'a> Executor<'a> {
 		PathSpec::from_u32(self.read_u32())
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Reads a 16-byte GHASH block, given as a big-endian `u128`, as a `(lo, hi)` word pair.
+	///
+	/// GCM numbers bits from the left: the leading bit of the block is the coefficient of `X^0`.
+	/// Here bit `i` of `lo` is the coefficient of `X^i`, and bit `i` of `hi` that of `X^(64 + i)`.
+	/// Reversing the 128 bits and splitting it in half is therefore the whole conversion.
+	fn from_gcm_block(block: u128) -> (Word, Word) {
+		let value = block.reverse_bits();
+		(Word::from_u64(value as u64), Word::from_u64((value >> 64) as u64))
+	}
+
+	/// Walks the GHASH recurrence `X_i = (X_{i-1} + B_i) * H`, checking every `X_i`.
+	fn check_ghash_chain(h: u128, blocks: &[u128], expected: &[u128]) {
+		assert_eq!(blocks.len(), expected.len());
+		let (h_lo, h_hi) = from_gcm_block(h);
+		let (mut lo, mut hi) = (Word::ZERO, Word::ZERO);
+		for (block, want) in blocks.iter().zip(expected) {
+			let (b_lo, b_hi) = from_gcm_block(*block);
+			(lo, hi) = ghash_mul(lo ^ b_lo, hi ^ b_hi, h_lo, h_hi);
+			assert_eq!((lo, hi), from_gcm_block(*want), "block {block:#034x}");
+		}
+	}
+
+	#[test]
+	fn test_ghash_mul_gcm_spec_test_case_2() {
+		check_ghash_chain(
+			0x66e94bd4ef8a2c3b884cfa59ca342b2e,
+			&[
+				0x0388dace60b6a392f328c2b971b2fe78,
+				0x00000000000000000000000000000080,
+			],
+			&[
+				0x5e2ec746917062882c85b0685353deb7,
+				0xf38cbb1ad69223dcc3457ae5b6b0f885,
+			],
+		);
+	}
+
+	#[test]
+	fn test_ghash_mul_splits_coefficients_at_x64() {
+		// X^63 * X = X^64, the one product that crosses from `lo` into `hi`.
+		assert_eq!(
+			ghash_mul(Word::from_u64(1 << 63), Word::ZERO, Word::from_u64(2), Word::ZERO),
+			(Word::ZERO, Word::from_u64(1))
+		);
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-634](https://linear.app/jimpo/issue/BINIUS-634).

Gives the GHASH field multiply known-answer tests from the GCM specification and a proptest against an independently written reference. Test-only — no change to `ghash_mul` or any gate.

### The problem

`differential_against_interpreter` in `crates/frontend/src/eval_form/const_eval.rs` rests on one premise: that `evaluate_gate_constants` and the bytecode interpreter are two independent statements of the same gate semantics, so they must agree.

For `Opcode::Bmul` that premise is false. Both sides call the same function.

```rust
// crates/frontend/src/eval_form/const_eval.rs
Opcode::Bmul => {
    let [a_lo, a_hi, b_lo, b_hi] = constants else { unreachable!() };
    let (c_lo, c_hi) = ghash_mul(*a_lo, *a_hi, *b_lo, *b_hi);
    Ok(vec![c_lo, c_hi])
}
```

```rust
// crates/frontend/src/eval_form/exec.rs, exec_bmul
let (lo, hi) = ghash_mul(
    ctx.load(a_lo, i),
    ctx.load(a_hi, i),
    ctx.load(b_lo, i),
    ctx.load(b_hi, i),
);
```

`ghash_mul` lives in `exec.rs`; `const_eval.rs` imports it on line 7. So the differential proves only that six operands are threaded in the same order — nothing about GHASH multiplication itself. A wrong reduction polynomial, a swapped limb order, a bad bit-reflection: all invisible.

This is measured, not argued. Swapping the two output limbs of `ghash_mul`:

```diff
-(Word::from_u64(product as u64), Word::from_u64((product >> 64) as u64))
+(Word::from_u64((product >> 64) as u64), Word::from_u64(product as u64))
```

leaves `differential_against_interpreter` **passing**.

### Soundness — this is not a niche opcode

`CircuitBuilder::select` lowers to exactly 1 BMUL constraint (`crates/frontend/src/gates/select.rs`):

```
(cond >> 63) * (t ^ f) = out ^ f      // over the GHASH field
```

Every conditional in every circuit rests on this multiply, as does the GHASH/GCM work in the gadget library.

### Where the coverage belongs

`ghash_mul` is a three-line wrapper. The arithmetic is `Ghash128b`'s `Mul`, which dispatches at compile time to `arch::x86_64::packed_ghash_128` (pclmulqdq) or the portable bit-reversal implementation.

So the field arithmetic is tested in `binius-field`, and only the limb threading in `binius-frontend`.

**What `binius-field` already had:**

- hand-computed small products in `test_ghash_mul`
- `mul_x` / `mul_inv_x` agree with the generic multiply
- `wide_mul` then `reduce` agrees with the fused multiply
- `Rijndael8b` embeds multiplicatively into `Ghash128b`
- the multiplicative generator really has order `2^128 - 1` — a genuinely strong structural check

**What it did not have,** and what this PR adds:

- any known-answer test against a published vector
- any comparison against an implementation written independently of the crate's own machinery

### The convention — where GHASH implementations actually go wrong

`Ghash128b` is $\mathbb{F}_{2^{128}}$ modulo $X^{128} + X^7 + X^2 + X + 1$, but **not** in GCM's bit-reflected byte convention. `arch/portable/arithmetic/ghash.rs` says so outright: *"does not conform to the bit-endianness requirements of the GCM specification, but is a valid GHASH field multiplication with the modified representation."*

- **Crate:** bit `i` of the `u128` is the coefficient of `X^i`. `lo` carries `1, X, ..., X^63`; `hi` carries `X^64, ..., X^127`. Confirmed against the `bmul` builder doc and `ghash_mul`'s own header.
- **GCM:** bits run left to right, so the leading bit of the 16-byte block is the coefficient of `X^0`.

The two are the same field in opposite bit orders, so the conversion is a 128-bit reversal:

```
element = block_as_big_endian_u128.reverse_bits()
```

This was **verified against the vectors**, not assumed: all 14 spec triples below round-trip through it. It is the one thing in the diff that earns a comment, and it has one, next to each helper.

### Per source — where each KAT came from

**McGrew & Viega, *The Galois/Counter Mode of Operation (GCM)*, Appendix B (AES Test Vectors).**

Appendix B publishes `H`, the AAD/ciphertext blocks, the length block, and — crucially — the intermediate GHASH accumulator values `X1, X2, ...`. Each consecutive pair is one field multiplication, because GHASH is the recurrence

```
X_i = (X_{i-1} + B_i) * H
```

Rather than pin derived products, the tests **replay that recurrence** and check every `X_i`. So every literal in the diff is a value read straight off the appendix table, and a reviewer can diff it against the document line by line.

| Test Case | `H` | multiplications | source fields used |
|---|---|---|---|
| 2 | `66e94bd4...ca342b2e` | 2 | `C`, `len(A)||len(C)`, `X1`, `GHASH(H,A,C)` |
| 3 | `b83b5337...80d53b78` | 5 | `C` (4 blocks), `len(A)||len(C)`, `X1..X4`, `GHASH(H,A,C)` |
| 4 | `b83b5337...80d53b78` | 7 | `A` (2 blocks, padded), `C` (4 blocks, last padded), `len(A)||len(C)`, `X1..X6`, `GHASH(H,A,C)` |

All 14 were independently confirmed with a from-scratch implementation of the spec's own multiplication algorithm (the `0xe1` right-shift form from §2.5) before being pinned.

Test Case 1 is omitted: its only multiplication is `0 * H`, already covered by the annihilation law.

### The change

**`crates/field/src/fields/ghash.rs`** — where the arithmetic lives:

- `test_gcm_spec_test_case_2` / `_3` / `_4` — the 14 known-answer multiplications
- `schoolbook_mul` — a reference written from the field definition alone: shift-and-XOR the 128 partial products into 256 bits, then fold the high half down through `X^128 = X^7 + X^2 + X + 1`
- `test_mul_matches_schoolbook` — proptest over random pairs
- `test_boundary_products_match_schoolbook` — the full 7×7 cross product of `0`, `1`, `X`, `0x87`, `X^127`, all-ones, and the multiplicative generator
- `test_mul_is_commutative`, `test_mul_is_associative`, `test_mul_distributes_over_addition`, `test_mul_by_one_and_zero`

**`crates/frontend/src/eval_form/exec.rs`** — where the wrapper lives:

- `test_ghash_mul_gcm_spec_test_case_2` — one KAT chain through the `(lo, hi)` word interface, which is what `Bmul` consumes
- `test_ghash_mul_splits_coefficients_at_x64` — `X^63 * X = X^64`, the one product that crosses from `lo` into `hi`

### Scope

- **test-only** — `ghash_mul` and every gate are untouched; `circuits-snapshot` cannot move
- the existing differential test is **left as it is** — it is the right test for the other eighteen opcodes, and this fills its one blind spot from outside
- no duplication: reduction (`X^127 * X = 0x87`), identity, and zero at the `Bmul` level are already covered by `test_bmul_constant_eval` and `eval_form::tests::test_bmul_*`, so those are not repeated

### Verification

Every check passed, and no KAT or property failed — there is no bug in the field arithmetic.

```
cargo check --workspace --all-targets                                        clean
cargo test -p binius-frontend                                                261 passed
cargo test -p binius-field                                                   267 passed
RUSTFLAGS=-Ctarget-cpu=native cargo test -p binius-frontend --release        261 passed
RUSTFLAGS=-Ctarget-cpu=native cargo test -p binius-field --release           284 passed
RUSTFLAGS=-Ctarget-cpu=native cargo clippy -p binius-frontend -p binius-field \
    --all-targets --all-features -- -D warnings                              clean
RUSTDOCFLAGS=-D warnings cargo doc --document-private-items --no-deps        clean
cargo +nightly-2026-07-01 fmt --all --check                                  clean
python3 tools/check_copyright_notice.py                                      277 correct, 0 wrong
typos                                                                        clean
```

**Both arch paths were exercised against the vectors,** since the pclmulqdq path is a compile-time `target_feature` gate with a portable fallback:

| build | GHASH implementation | result |
|---|---|---|
| `-Ctarget-feature=-pclmulqdq` | portable bit-reversal | 16 passed |
| `-Ctarget-feature=+pclmulqdq` | `_mm_clmulepi64_si128` | 16 passed |

**Runtime.** All 16 tests in the `ghash` module — 9 new, 7 pre-existing — run in **0.01 s** in debug, at proptest's default 256 cases. The schoolbook reference is 128 iterations of `u128` shift-and-XOR, so no `ProptestConfig::cases` tuning was needed.

**The new tests bite.** Two negative controls, both reverted:

| injected bug | differential test | new tests |
|---|---|---|
| `ghash_mul` output limbs swapped | passes | `test_ghash_mul_*` fail |
| reference reduction tail `0x87` → `0x47` | n/a | `test_mul_matches_schoolbook`, `test_boundary_*` fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
