### PR TITLE
Drop the import aliases that just rename a type to itself

### DIFF
--- a/crates/field/benches/ghash_invert.rs
+++ b/crates/field/benches/ghash_invert.rs
@@ -9,7 +9,7 @@
 use std::hint::black_box;
 
 use binius_field::{
-	Ghash128b as GhashB128, PackedField, PackedGhash1x128b, PackedGhash2x128b, PackedGhash4x128b,
+	Ghash128b, PackedField, PackedGhash1x128b, PackedGhash2x128b, PackedGhash4x128b,
 };
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
@@ -36,7 +36,7 @@ fn bench_ghash_invert(c: &mut Criterion) {
 	let mut group = c.benchmark_group("ghash_invert");
 
 	for &n in &[16, 256, 4096] {
-		bench_width::<GhashB128>(&mut group, "scalar", n);
+		bench_width::<Ghash128b>(&mut group, "scalar", n);
 		bench_width::<PackedGhash1x128b>(&mut group, "1x128b", n);
 		bench_width::<PackedGhash2x128b>(&mut group, "2x128b", n);
 		bench_width::<PackedGhash4x128b>(&mut group, "4x128b", n);

--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -18,7 +18,7 @@ use bytemuck::TransparentWrapper;
 
 use super::super::m128::M128;
 use crate::{
-	Ghash128b as GhashB128, WideMul,
+	Ghash128b, WideMul,
 	arch::portable::arithmetic::ghash::POLY,
 	arithmetic_traits::{MulX, Square},
 	packed_fields::primitive::PackedPrimitiveType,
@@ -54,7 +54,7 @@ pub fn mul_x(x: M128) -> M128 {
 #[derive(bytemuck::TransparentWrapper)]
 pub struct GhashMulX<T>(T);
 
-impl MulX for GhashMulX<PackedPrimitiveType<M128, GhashB128>> {
+impl MulX for GhashMulX<PackedPrimitiveType<M128, Ghash128b>> {
 	#[inline]
 	fn mul_x(self) -> Self {
 		Self::wrap(PackedPrimitiveType::wrap(mul_x(PackedPrimitiveType::peel(Self::peel(self)))))
@@ -134,7 +134,7 @@ pub fn square_clmul(x: M128) -> M128 {
 #[derive(TransparentWrapper)]
 pub struct GhashClMul<T>(T);
 
-impl Square for GhashClMul<PackedPrimitiveType<M128, GhashB128>> {
+impl Square for GhashClMul<PackedPrimitiveType<M128, Ghash128b>> {
 	#[inline]
 	fn square(self) -> Self {
 		Self::wrap(PackedPrimitiveType::from_underlier(square_clmul(
@@ -267,7 +267,7 @@ impl SubAssign for WideGhashProduct {
 #[derive(bytemuck::TransparentWrapper)]
 pub struct GhashClMulWideMul<T>(T);
 
-impl WideMul for GhashClMulWideMul<PackedPrimitiveType<M128, GhashB128>> {
+impl WideMul for GhashClMulWideMul<PackedPrimitiveType<M128, Ghash128b>> {
 	type Output = WideGhashProduct;
 
 	// Why always inline: every packed multiply funnels through this wrapper.

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -12,7 +12,7 @@ use bytemuck::TransparentWrapper;
 
 use super::super::univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64};
 use crate::{
-	BinaryField, Divisible, Ghash128b as GhashB128, WideMul,
+	BinaryField, Divisible, Ghash128b, WideMul,
 	arithmetic_traits::{MulX, Square},
 	packed_fields::primitive::PackedPrimitiveType,
 	underlier::Underlier,
@@ -217,7 +217,7 @@ impl<U: Underlier128bLanes> SubAssign for WideGhashProduct<U> {
 #[derive(bytemuck::TransparentWrapper)]
 pub struct GhashWideMul<T>(T);
 
-impl<U: Underlier128bLanes> WideMul for GhashWideMul<PackedPrimitiveType<U, GhashB128>> {
+impl<U: Underlier128bLanes> WideMul for GhashWideMul<PackedPrimitiveType<U, Ghash128b>> {
 	type Output = WideGhashProduct<U>;
 
 	#[inline]
@@ -259,7 +259,7 @@ impl<U: Underlier + Divisible<u128>, F: BinaryField> MulX for GhashMulX<PackedPr
 #[derive(TransparentWrapper)]
 pub struct GhashSoftMul<T>(T);
 
-impl<U: Underlier128bLanes> Square for GhashSoftMul<PackedPrimitiveType<U, GhashB128>> {
+impl<U: Underlier128bLanes> Square for GhashSoftMul<PackedPrimitiveType<U, Ghash128b>> {
 	#[inline]
 	fn square(self) -> Self {
 		Self::wrap(PackedPrimitiveType::wrap(ghash_square(PackedPrimitiveType::peel(Self::peel(

--- a/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
+++ b/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
@@ -11,7 +11,7 @@
 //!
 //! Squaring `beta_a` repeatedly `b` times (the `x -> x^(2^b)` power map) is an `F_2`-linear
 //! transformation. We precompute each power map as a [`BytewiseLookupTransformation`] (the [Method
-//! of Four Russians]), wrapped into a `GhashB128 -> GhashB128` transform, and hold them in a
+//! of Four Russians]), wrapped into a `Ghash128b -> Ghash128b` transform, and hold them in a
 //! process-wide [`LazyLock`] so the tables are computed once and shared read-only across all
 //! threads.
 //!
@@ -22,10 +22,9 @@ use std::{array, iter, ops::Mul, sync::LazyLock};
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	BinaryField1b, Divisible, ExtensionField,
+	BinaryField1b, Divisible, ExtensionField, Ghash128b,
 	arch::M128,
 	arithmetic_traits::{InvertOrZero, Square},
-	fields::ghash::Ghash128b as GhashB128,
 	linear_transformation::{
 		BytewiseLookupTransformation, BytewiseLookupTransformationFactory,
 		InputWrappingTransformationFactory, LinearTransformationFactory,
@@ -36,12 +35,12 @@ use crate::{
 /// Number of bits in a GHASH element.
 const FIELD_BITS: usize = 128;
 
-/// A precomputed `x -> x^(2^n)` power map as a byte-lookup transform on `GhashB128`.
+/// A precomputed `x -> x^(2^n)` power map as a byte-lookup transform on `Ghash128b`.
 ///
 /// The underlying [`BytewiseLookupTransformation`] operates on the underlier `M128`; the input and
-/// output wrappers lift it to a `GhashB128 -> GhashB128` transform.
+/// output wrappers lift it to a `Ghash128b -> Ghash128b` transform.
 type GhashPowerMap =
-	WrappingTransformation<BytewiseLookupTransformation<M128, M128>, GhashB128, GhashB128>;
+	WrappingTransformation<BytewiseLookupTransformation<M128, M128>, Ghash128b, Ghash128b>;
 
 /// The power maps needed by the Itoh-Tsujii addition chain for the GHASH field.
 ///
@@ -70,15 +69,15 @@ impl GhashPowerMapTables {
 static GHASH_POWER_MAP_TABLES: LazyLock<GhashPowerMapTables> =
 	LazyLock::new(GhashPowerMapTables::new);
 
-/// Build the byte-lookup transform for the power map `x -> x^(2^n)` over `GhashB128`.
+/// Build the byte-lookup transform for the power map `x -> x^(2^n)` over `Ghash128b`.
 ///
 /// The power map is the `F_2`-linear transformation whose matrix has one column per input bit
 /// (`compute_power_map_matrix`). [`BytewiseLookupTransformation`] turns that column set into
-/// byte-indexed lookup tables; the input/output wrappers make it accept and return `GhashB128`.
+/// byte-indexed lookup tables; the input/output wrappers make it accept and return `Ghash128b`.
 fn compute_power_map_transform(n: usize) -> GhashPowerMap {
 	let matrix = compute_power_map_matrix(n);
-	OutputWrappingTransformationFactory::<_, GhashB128, GhashB128>::new(
-		InputWrappingTransformationFactory::<_, GhashB128, M128>::new(
+	OutputWrappingTransformationFactory::<_, Ghash128b, Ghash128b>::new(
+		InputWrappingTransformationFactory::<_, Ghash128b, M128>::new(
 			BytewiseLookupTransformationFactory,
 		),
 	)
@@ -89,9 +88,9 @@ fn compute_power_map_transform(n: usize) -> GhashPowerMap {
 ///
 /// Column `i` is the image of the `i`-th basis element, i.e. `basis(i)^(2^n)`, obtained by squaring
 /// `n` times.
-fn compute_power_map_matrix(n: usize) -> [GhashB128; FIELD_BITS] {
+fn compute_power_map_matrix(n: usize) -> [Ghash128b; FIELD_BITS] {
 	array::from_fn(|i| {
-		let basis = <GhashB128 as ExtensionField<BinaryField1b>>::basis(i);
+		let basis = <Ghash128b as ExtensionField<BinaryField1b>>::basis(i);
 		iter::successors(Some(basis), |basis_pow_2_i| Some(basis_pow_2_i.square()))
 			.nth(n)
 			.expect("closure always returns Some")
@@ -103,15 +102,15 @@ fn compute_power_map_matrix(n: usize) -> [GhashB128; FIELD_BITS] {
 /// Zero elements map to zero, matching `InvertOrZero` semantics.
 ///
 /// The bound is phrased in terms of the field operations (`Square`, `Mul`) plus
-/// `Divisible<GhashB128>` rather than `P: PackedField`. `PackedField`'s blanket impl lists
+/// `Divisible<Ghash128b>` rather than `P: PackedField`. `PackedField`'s blanket impl lists
 /// `InvertOrZero` in its where-clause, so requiring it here would form a trait-resolution cycle
-/// when this function backs the `InvertOrZero` impls. `Divisible<GhashB128>` carries no such
+/// when this function backs the `InvertOrZero` impls. `Divisible<Ghash128b>` carries no such
 /// obligation, keeps the function statically GHASH-typed, and is satisfied both by the GHASH packed
 /// fields and (reflexively) by the scalar `Ghash128b`, so the scalar inverts directly
 /// without routing through a packed type.
 pub fn invert_b128<P>(x: P) -> P
 where
-	P: Copy + Square + Mul<Output = P> + Divisible<GhashB128>,
+	P: Copy + Square + Mul<Output = P> + Divisible<Ghash128b>,
 {
 	let tables = &*GHASH_POWER_MAP_TABLES;
 
@@ -134,10 +133,10 @@ where
 /// Apply the power map `x -> x^(2^n)` to every GHASH scalar of `x`.
 fn pow_2_n<P>(x: P, power_map: &GhashPowerMap) -> P
 where
-	P: Divisible<GhashB128>,
+	P: Divisible<Ghash128b>,
 {
-	Divisible::<GhashB128>::from_iter(
-		Divisible::<GhashB128>::value_iter(x).map(|scalar| power_map.transform(&scalar)),
+	Divisible::<Ghash128b>::from_iter(
+		Divisible::<Ghash128b>::value_iter(x).map(|scalar| power_map.transform(&scalar)),
 	)
 }
 
@@ -153,7 +152,7 @@ pub struct GhashItohTsujii<T>(T);
 
 impl<P> InvertOrZero for GhashItohTsujii<P>
 where
-	P: Copy + Square + Mul<Output = P> + Divisible<GhashB128>,
+	P: Copy + Square + Mul<Output = P> + Divisible<Ghash128b>,
 {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
@@ -173,7 +172,7 @@ mod tests {
 		// The 2^1 power map is just squaring; column i must equal basis(i)^2.
 		let matrix = compute_power_map_matrix(1);
 		for i in 0..FIELD_BITS {
-			let basis = <GhashB128 as ExtensionField<BinaryField1b>>::basis(i);
+			let basis = <Ghash128b as ExtensionField<BinaryField1b>>::basis(i);
 			assert_eq!(matrix[i], basis.square());
 		}
 	}
@@ -182,7 +181,7 @@ mod tests {
 	fn test_power_map_transform_matches_repeated_squaring() {
 		let power_map = compute_power_map_transform(7);
 		for &raw in &[0u128, 1, 2, 0x87, 0x21ac73a21d46a21badd6747bcdfc5d4d] {
-			let x = GhashB128::from(raw);
+			let x = Ghash128b::from(raw);
 			let mut expected = x;
 			for _ in 0..7 {
 				expected = expected.square();
@@ -193,10 +192,10 @@ mod tests {
 
 	#[test]
 	fn test_invert_b128_known_values() {
-		let one = PackedGhash1x128b::broadcast(GhashB128::ONE);
+		let one = PackedGhash1x128b::broadcast(Ghash128b::ONE);
 		assert_eq!(invert_b128(one), one);
 
-		let zero = PackedGhash1x128b::broadcast(GhashB128::ZERO);
+		let zero = PackedGhash1x128b::broadcast(Ghash128b::ZERO);
 		assert_eq!(invert_b128(zero), zero);
 	}
 
@@ -206,37 +205,37 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_invert_b128_is_multiplicative_inverse_scalar(raw in any::<u128>()) {
-			let x = GhashB128::from(raw);
+			let x = Ghash128b::from(raw);
 			let inv = invert_b128(x);
-			if x == GhashB128::ZERO {
-				prop_assert_eq!(inv, GhashB128::ZERO);
+			if x == Ghash128b::ZERO {
+				prop_assert_eq!(inv, Ghash128b::ZERO);
 			} else {
-				prop_assert_eq!(x * inv, GhashB128::ONE);
+				prop_assert_eq!(x * inv, Ghash128b::ONE);
 			}
 		}
 
 		#[test]
 		fn test_invert_b128_is_multiplicative_inverse_1x(raw in any::<u128>()) {
-			let scalar = GhashB128::from(raw);
+			let scalar = Ghash128b::from(raw);
 			let x = PackedGhash1x128b::broadcast(scalar);
 			let inv = invert_b128(x);
-			if scalar == GhashB128::ZERO {
+			if scalar == Ghash128b::ZERO {
 				prop_assert_eq!(inv, x);
 			} else {
-				prop_assert_eq!(x * inv, PackedGhash1x128b::broadcast(GhashB128::ONE));
+				prop_assert_eq!(x * inv, PackedGhash1x128b::broadcast(Ghash128b::ONE));
 			}
 		}
 
 		#[test]
 		fn test_invert_b128_is_multiplicative_inverse_2x(a in any::<u128>(), b in any::<u128>()) {
-			let x = PackedGhash2x128b::from_scalars([a, b].map(GhashB128::from));
+			let x = PackedGhash2x128b::from_scalars([a, b].map(Ghash128b::from));
 			let inv = invert_b128(x);
 			let ones = PackedGhash2x128b::from_scalars(
 				[a, b].map(|raw| {
-					if GhashB128::from(raw) == GhashB128::ZERO {
-						GhashB128::ZERO
+					if Ghash128b::from(raw) == Ghash128b::ZERO {
+						Ghash128b::ZERO
 					} else {
-						GhashB128::ONE
+						Ghash128b::ONE
 					}
 				}),
 			);

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -14,7 +14,7 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	Divisible, Ghash128b as GhashB128, WideMul,
+	Divisible, Ghash128b, WideMul,
 	arch::portable::arithmetic::ghash::POLY,
 	arithmetic_traits::{MulX, Square},
 	packed_fields::primitive::PackedPrimitiveType,
@@ -60,7 +60,7 @@ pub trait ClMulUnderlier: GhashLanes {
 #[derive(TransparentWrapper)]
 pub struct GhashMulX<T>(T);
 
-impl<U: GhashLanes> MulX for GhashMulX<PackedPrimitiveType<U, GhashB128>> {
+impl<U: GhashLanes> MulX for GhashMulX<PackedPrimitiveType<U, Ghash128b>> {
 	#[inline]
 	fn mul_x(self) -> Self {
 		Self::wrap(PackedPrimitiveType::wrap(mul_x(PackedPrimitiveType::peel(Self::peel(self)))))
@@ -108,7 +108,7 @@ pub fn square_clmul<U: ClMulUnderlier>(x: U) -> U {
 #[derive(TransparentWrapper)]
 pub struct GhashClMul<T>(T);
 
-impl<U: ClMulUnderlier> Square for GhashClMul<PackedPrimitiveType<U, GhashB128>> {
+impl<U: ClMulUnderlier> Square for GhashClMul<PackedPrimitiveType<U, Ghash128b>> {
 	#[inline]
 	fn square(self) -> Self {
 		Self::wrap(PackedPrimitiveType::from_underlier(square_clmul(
@@ -262,7 +262,7 @@ impl<U: ClMulUnderlier> SubAssign for WideGhashProduct<U> {
 #[derive(bytemuck::TransparentWrapper)]
 pub struct GhashClMulWideMul<T>(T);
 
-impl<U: ClMulUnderlier> WideMul for GhashClMulWideMul<PackedPrimitiveType<U, GhashB128>> {
+impl<U: ClMulUnderlier> WideMul for GhashClMulWideMul<PackedPrimitiveType<U, Ghash128b>> {
 	type Output = WideGhashProduct<U>;
 
 	fn wide_mul(a: Self, b: Self) -> Self::Output {

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -607,7 +607,6 @@ pub(crate) mod tests {
 	use binius_utils::{DeserializeBytes, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
 
-	use super::BinaryField1b as BF1;
 	use crate::{
 		BinaryField, BinaryField1b, ExtensionField, Field, Ghash128b, GhashSq256b, Rijndael8b,
 		arithmetic_traits::InvertOrZero,
@@ -615,26 +614,26 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_gf2_add() {
-		assert_eq!(BF1::from(0) + BF1::from(0), BF1::from(0));
-		assert_eq!(BF1::from(0) + BF1::from(1), BF1::from(1));
-		assert_eq!(BF1::from(1) + BF1::from(0), BF1::from(1));
-		assert_eq!(BF1::from(1) + BF1::from(1), BF1::from(0));
+		assert_eq!(BinaryField1b::from(0) + BinaryField1b::from(0), BinaryField1b::from(0));
+		assert_eq!(BinaryField1b::from(0) + BinaryField1b::from(1), BinaryField1b::from(1));
+		assert_eq!(BinaryField1b::from(1) + BinaryField1b::from(0), BinaryField1b::from(1));
+		assert_eq!(BinaryField1b::from(1) + BinaryField1b::from(1), BinaryField1b::from(0));
 	}
 
 	#[test]
 	fn test_gf2_sub() {
-		assert_eq!(BF1::from(0) - BF1::from(0), BF1::from(0));
-		assert_eq!(BF1::from(0) - BF1::from(1), BF1::from(1));
-		assert_eq!(BF1::from(1) - BF1::from(0), BF1::from(1));
-		assert_eq!(BF1::from(1) - BF1::from(1), BF1::from(0));
+		assert_eq!(BinaryField1b::from(0) - BinaryField1b::from(0), BinaryField1b::from(0));
+		assert_eq!(BinaryField1b::from(0) - BinaryField1b::from(1), BinaryField1b::from(1));
+		assert_eq!(BinaryField1b::from(1) - BinaryField1b::from(0), BinaryField1b::from(1));
+		assert_eq!(BinaryField1b::from(1) - BinaryField1b::from(1), BinaryField1b::from(0));
 	}
 
 	#[test]
 	fn test_gf2_mul() {
-		assert_eq!(BF1::from(0) * BF1::from(0), BF1::from(0));
-		assert_eq!(BF1::from(0) * BF1::from(1), BF1::from(0));
-		assert_eq!(BF1::from(1) * BF1::from(0), BF1::from(0));
-		assert_eq!(BF1::from(1) * BF1::from(1), BF1::from(1));
+		assert_eq!(BinaryField1b::from(0) * BinaryField1b::from(0), BinaryField1b::from(0));
+		assert_eq!(BinaryField1b::from(0) * BinaryField1b::from(1), BinaryField1b::from(0));
+		assert_eq!(BinaryField1b::from(1) * BinaryField1b::from(0), BinaryField1b::from(0));
+		assert_eq!(BinaryField1b::from(1) * BinaryField1b::from(1), BinaryField1b::from(1));
 	}
 
 	pub(crate) fn is_binary_field_valid_generator<F: BinaryField>() -> bool {

--- a/crates/math/benches/batch_invert.rs
+++ b/crates/math/benches/batch_invert.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{Ghash128b as Ghash, Random, arch::OptimalPackedB128};
+use binius_field::{Ghash128b, Random, arch::OptimalPackedB128};
 use binius_math::batch_invert::BatchInversion;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
@@ -11,10 +11,10 @@ fn bench_batch_inversion_scalar(c: &mut Criterion) {
 
 	for n in [1, 4, 6, 64, 96, 256, 384] {
 		group.throughput(Throughput::Elements(n as u64));
-		let mut elements: Vec<Ghash> = (0..n)
-			.map(|_| <Ghash as Random>::random(&mut rng))
+		let mut elements: Vec<Ghash128b> = (0..n)
+			.map(|_| <Ghash128b as Random>::random(&mut rng))
 			.collect();
-		let mut inverter = BatchInversion::<Ghash>::new(n);
+		let mut inverter = BatchInversion::<Ghash128b>::new(n);
 		group.bench_function(format!("{n}"), |b| {
 			b.iter(|| {
 				inverter.invert_or_zero(&mut elements);

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -254,7 +254,7 @@ fn unproduct_layer<P: PackedField>(input: &[P], output: &mut [P]) {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{Ghash128b as Ghash, Random, arithmetic_traits::InvertOrZero};
+	use binius_field::{Ghash128b, Random, arithmetic_traits::InvertOrZero};
 	use proptest::prelude::*;
 	use rand::{Rng, SeedableRng, rngs::StdRng, seq::IteratorRandom};
 
@@ -262,7 +262,7 @@ mod tests {
 
 	/// Shared helper to test batch inversion with a given inverter.
 	fn invert_with_inverter(
-		inverter: &mut BatchInversion<Ghash>,
+		inverter: &mut BatchInversion<Ghash128b>,
 		n: usize,
 		n_zeros: usize,
 		rng: &mut impl Rng,
@@ -277,14 +277,14 @@ mod tests {
 		let mut state = Vec::with_capacity(n);
 		for i in 0..n {
 			if zero_indices.contains(&i) {
-				state.push(Ghash::ZERO);
+				state.push(Ghash128b::ZERO);
 			} else {
-				state.push(Ghash::random(&mut *rng));
+				state.push(Ghash128b::random(&mut *rng));
 			}
 		}
 
 		// Reference result: invert every element independently, one call per element.
-		let expected: Vec<Ghash> = state
+		let expected: Vec<Ghash128b> = state
 			.iter()
 			.map(|x| InvertOrZero::invert_or_zero(*x))
 			.collect();
@@ -298,7 +298,7 @@ mod tests {
 
 	fn test_batch_inversion_for_size(n: usize, n_zeros: usize, rng: &mut impl Rng) {
 		// Fresh context sized for exactly n elements.
-		let mut inverter = BatchInversion::<Ghash>::new(n);
+		let mut inverter = BatchInversion::<Ghash128b>::new(n);
 		invert_with_inverter(&mut inverter, n, n_zeros, rng);
 	}
 
@@ -307,16 +307,16 @@ mod tests {
 		// So the non-zero-only entry point is safe to use directly.
 		let mut state = Vec::with_capacity(n);
 		for _ in 0..n {
-			state.push(Ghash::random(&mut *rng));
+			state.push(Ghash128b::random(&mut *rng));
 		}
 
 		// Reference result: invert every element independently, one call per element.
-		let expected: Vec<Ghash> = state
+		let expected: Vec<Ghash128b> = state
 			.iter()
 			.map(|x| InvertOrZero::invert_or_zero(*x))
 			.collect();
 
-		let mut inverter = BatchInversion::<Ghash>::new(n);
+		let mut inverter = BatchInversion::<Ghash128b>::new(n);
 		inverter.invert_nonzero(&mut state);
 
 		// The batched result must match the per-element reference exactly.
@@ -345,7 +345,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		// One context, reused across every zero count from 0 to 8 below.
 		// This checks that the zero mask from one call never leaks into the next.
-		let mut inverter = BatchInversion::<Ghash>::new(8);
+		let mut inverter = BatchInversion::<Ghash128b>::new(8);
 
 		for n_zeros in 0..=8 {
 			invert_with_inverter(&mut inverter, 8, n_zeros, &mut rng);
@@ -369,9 +369,9 @@ mod tests {
 			.map(|i| {
 				Packed128b::from_fn(|lane| {
 					if (i == 1 && lane == 0) || (i == 2 && lane == 2) {
-						Ghash::ZERO
+						Ghash128b::ZERO
 					} else {
-						Ghash::random(&mut rng)
+						Ghash128b::random(&mut rng)
 					}
 				})
 			})

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -28,7 +28,7 @@ use binius_verifier::{
 	protocols::shift::{OperationClaim, verify},
 };
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use sha2::{Digest, Sha256 as Sha256Hasher};
+use sha2::{Digest, Sha256};
 
 pub fn create_sha256_cs_with_witness(
 	log_message_len_bytes: usize,
@@ -68,7 +68,7 @@ pub fn create_sha256_cs_with_witness(
 	}
 
 	// Calculate SHA256 digest of the message dynamically and populate the expected digest wires.
-	let hash = Sha256Hasher::digest(&message_bytes);
+	let hash = Sha256::digest(&message_bytes);
 	let expected_bytes: [u8; 32] = hash.into();
 	for (i, wire) in expected_digest.iter().enumerate() {
 		let mut word = 0u32;

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -51,7 +51,7 @@ use std::{array, marker::PhantomData};
 
 use binius_core::Word;
 use binius_field::{
-	BinaryField, BinaryField1b as B1, Divisible, PackedField, PackedRijndael64x8b as Packed64xB8,
+	BinaryField, BinaryField1b as B1, Divisible, PackedField, PackedRijndael64x8b,
 	Rijndael8b as B8, UnderlierView, arch::M128, util::expand_subset_sums_array,
 };
 use binius_math::{
@@ -68,16 +68,16 @@ use binius_verifier::protocols::bitand::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS
 ///
 /// ## Structure
 ///
-/// The internal data structure is a boxed array `Box<[[Packed64xB8; 256]; 2]>` where:
+/// The internal data structure is a boxed array `Box<[[PackedRijndael64x8b; 256]; 2]>` where:
 /// - **First dimension**: the byte-position parity `b % 2`. Only these two tables are stored; the
 ///   remaining six byte positions are recovered by permutation (see the module-level "Compressed
 ///   storage" notes).
 /// - **Second dimension**: the 8-bit value (0-255) for that byte.
 ///
 /// Each entry holds the `ROWS_PER_HYPERCUBE_VERTEX` LDE evaluations of that byte's coefficients,
-/// packed into a single [`Packed64xB8`].
+/// packed into a single [`PackedRijndael64x8b`].
 #[derive(Debug, Clone)]
-pub struct NTTLookup(Box<[[Packed64xB8; 256]; 2]>);
+pub struct NTTLookup(Box<[[PackedRijndael64x8b; 256]; 2]>);
 
 impl NTTLookup {
 	/// Creates a new NTT lookup table by precomputing all possible NTT evaluations
@@ -99,7 +99,7 @@ impl NTTLookup {
 	pub fn new(subspace: &BinarySubspace<B8>) -> Self {
 		assert_eq!(subspace.dim(), SKIPPED_VARS + 1);
 
-		let lde = LowDegreeExtension::<Packed64xB8>::new(subspace);
+		let lde = LowDegreeExtension::<PackedRijndael64x8b>::new(subspace);
 		let lde_mat = array::from_fn::<_, 2, _>(|b| {
 			array::from_fn::<_, 8, _>(|i| {
 				let output = lde.transform(1 << (8 * b + i));
@@ -130,14 +130,14 @@ impl NTTLookup {
 	///
 	/// ## Returns
 	///
-	/// A [`Packed64xB8`] holding the `ROWS_PER_HYPERCUBE_VERTEX` LDE evaluations over the output
-	/// domain.
+	/// A [`PackedRijndael64x8b`] holding the `ROWS_PER_HYPERCUBE_VERTEX` LDE evaluations over the
+	/// output domain.
 	#[inline]
 	#[must_use]
-	pub fn ntt(&self, input: Word) -> Packed64xB8 {
+	pub fn ntt(&self, input: Word) -> PackedRijndael64x8b {
 		let input_bytes = input.as_u64().to_le_bytes();
 
-		let mut out = Packed64xB8::default();
+		let mut out = PackedRijndael64x8b::default();
 		// This will get unrolled, so indexing arithmetic washes away.
 		for b in 0..8 {
 			let packed = &self.0[b % 2][input_bytes[b] as usize];
@@ -145,7 +145,7 @@ impl NTTLookup {
 			let dst_bitvec = Divisible::<M128>::from_iter(
 				(0..4).map(|i| Divisible::<M128>::get(bitvec, i ^ (b / 2))),
 			);
-			out += Packed64xB8::from_underlier(dst_bitvec);
+			out += PackedRijndael64x8b::from_underlier(dst_bitvec);
 		}
 		out
 	}

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -5,8 +5,8 @@ use std::{array, borrow::Cow, iter};
 
 use binius_core::word::Word;
 use binius_field::{
-	BinaryField, BinaryField1b as B1, ExtensionField, Field, PackedField,
-	PackedRijndael64x8b as Packed64xB8, Rijndael8b as B8, WideMul, util::expand_subset_sums_array,
+	BinaryField, BinaryField1b as B1, ExtensionField, Field, PackedField, PackedRijndael64x8b,
+	Rijndael8b as B8, WideMul, util::expand_subset_sums_array,
 };
 use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::rayon::{self, iter::Either, prelude::*};
@@ -120,7 +120,7 @@ where
 	let eq_ind_small: [_; 1 << N_FIXED_SMALL_CHALLENGES] =
 		eq_ind_partial_eval::<B8>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
 			.iter_scalars()
-			.map(Packed64xB8::broadcast)
+			.map(PackedRijndael64x8b::broadcast)
 			.collect::<Vec<_>>()
 			.try_into()
 			.expect("PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len() == N_FIXED_SMALL_CHALLENGES");
@@ -147,7 +147,7 @@ where
 			for (a_subchunk, b_subchunk, outer_weight) in
 				izip!(a_subchunks, b_subchunks, &outer_weight_mul_maps)
 			{
-				let mut summed_ntt = <Packed64xB8 as WideMul>::Output::default();
+				let mut summed_ntt = <PackedRijndael64x8b as WideMul>::Output::default();
 				for (&a_i, &b_i, inner_weight) in izip!(a_subchunk, b_subchunk, &eq_ind_small) {
 					let c_i = a_i & b_i;
 
@@ -157,10 +157,11 @@ where
 					let c_lde = ntt_lookup.ntt(c_i);
 
 					// Compute the weighted composition of the LDE values.
-					summed_ntt += Packed64xB8::wide_mul(a_lde * b_lde - c_lde, *inner_weight);
+					summed_ntt +=
+						PackedRijndael64x8b::wide_mul(a_lde * b_lde - c_lde, *inner_weight);
 				}
 
-				let summed_ntt_reduced = Packed64xB8::reduce(summed_ntt);
+				let summed_ntt_reduced = PackedRijndael64x8b::reduce(summed_ntt);
 				for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt_reduced.into_iter()) {
 					*acc_i += outer_weight.call(summed_ntt_i);
 				}

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -32,7 +32,7 @@ use binius_verifier::{
 };
 use itertools::Itertools;
 use rand::{SeedableRng, rngs::StdRng};
-use sha2::{Digest, Sha256 as Sha256Hasher};
+use sha2::{Digest, Sha256};
 
 pub fn create_sha256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	let builder = CircuitBuilder::new();
@@ -66,7 +66,7 @@ pub fn create_sha256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	message.populate_data(&mut witness_filler, message_bytes);
 
 	// Calculate SHA256 digest of the message dynamically
-	let hash = Sha256Hasher::digest(message_bytes);
+	let hash = Sha256::digest(message_bytes);
 	let expected_digest: [u8; 32] = hash.into();
 	for (i, chunk) in expected_digest.chunks(8).enumerate() {
 		witness_filler[digest[i]] = Word(u64::from_be_bytes(chunk.try_into().unwrap()));


### PR DESCRIPTION
Follow-up to the review comment on #2453.

Removes five import aliases whose new name says nothing the real name doesn't. Pure rename — no behaviour change.

### The problem

An import alias earns its keep in exactly two ways.

- It disambiguates two things that would otherwise collide.
- It is meaningfully shorter than what it stands for.

Five aliases in the tree do neither.

| alias | files | what it buys |
|---|---|---|
| `Ghash128b as GhashB128` | 5 | nothing — same length, same word |
| `Ghash128b as Ghash` | 2 | drops the width, gains nothing |
| `PackedRijndael64x8b as Packed64xB8` | 2 | same length, reordered |
| `BinaryField1b as BF1` | 1 | the same module already imports `BinaryField1b` |
| `Sha256 as Sha256Hasher` | 2 | nothing named `Sha256` to collide with |

`GhashB128` is the worst of them: it renames `Ghash128b` to a rearrangement of its own syllables, then uses that in 33 places in one file. A reader has to hold two names for one type.

### The change

Each alias is expanded to the real name at every use site.

```
- use crate::{Ghash128b as GhashB128, WideMul};
+ use crate::{Ghash128b, WideMul};
```

Nothing needed disambiguating. In `binary_field.rs` the `BF1` alias sat next to an import of `BinaryField1b` from the same type, so that import line disappears rather than being rewritten.

One extra tidy in `itoh_tsujii.rs`: it reached the type through `fields::ghash::Ghash128b` while its three sibling arch modules use the crate-root `Ghash128b`. It now matches them.

### What is deliberately left alone

The `B128` / `B8` / `B1` shorthand stays.

- `Ghash128b as B128` — 56 sites
- `Rijndael8b as B8` — 10 sites
- `BinaryField1b as B1` — 6 sites

Those are genuinely shorter than the names they stand for, and they are the convention across every crate in the workspace. Unwinding them is a naming decision for the whole repo, not a cleanup.

Disambiguating aliases (`Error as TranscriptError`, `Error as ChannelError`, `vec::IntoIter as VecIntoIter`, and friends) also stay — they exist to resolve a real collision.

### Scope

- **changed:** 12 files across `field`, `math`, `prover` — 93 insertions, 94 deletions.
- **untouched:** the `B128`/`B8`/`B1` convention, every alias that resolves a name collision, and all behaviour.

### Verification

Clean, native (`RUSTFLAGS="-Ctarget-cpu=native"`):

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (debug, so the `debug_assert`s run) — all green

Clean, portable (`RUSTFLAGS` unset):

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (debug) — all green

The `#[cfg]`-gated backends the host build skips were checked by cross-compiling:

- `--target aarch64-unknown-linux-gnu` with `-Ctarget-feature=+neon,+aes` — the aarch64 GHASH module is one of the files touched
- host with `-Ctarget-feature=+avx512f,+vpclmulqdq,...` for the wide CLMUL paths

Other gates:

- `cargo +nightly-2026-07-01 fmt --all --check`
- `typos`
- `python3 tools/check_copyright_notice.py` — 688 files, 0 wrong, 0 missing
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --document-private-items --no-deps`

A whole-tree grep for `GhashB128`, `Packed64xB8`, `BF1`, and `Sha256Hasher` returns zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)