### PR TITLE
BINIUS-635: Add `collect_into_alloc_vec` and adopt it where it fits

### DIFF
--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -8,3 +8,4 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+rayon.workspace = true

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -10,8 +10,13 @@
 //! [`VecLike`] buffers, letting the prover's allocation code be written against `&impl Allocator`
 //! rather than a concrete pool. `&BufferPool` is the primary [`Allocator`], producing [`PoolVec`]
 //! buffers.
+//!
+//! [`CollectIntoAllocVec`] is the rayon seam over the same machinery: it collects a parallel
+//! iterator straight into one of those buffers.
 
 use std::{mem, mem::MaybeUninit, ops::DerefMut};
+
+use rayon::prelude::*;
 
 pub mod buffer_pool;
 
@@ -43,6 +48,42 @@ pub trait Allocator: Sync + Copy {
 
 	/// Allocates an empty buffer with room for at least `capacity` elements of type `T`.
 	fn alloc<T: Send>(&self, capacity: usize) -> Self::Vec<T>;
+}
+
+/// Collects a parallel iterator into a buffer drawn from an [`Allocator`].
+///
+/// The allocator's counterpart to [`IndexedParallelIterator::collect_into_vec`], which targets a
+/// `&mut Vec` that a generic buffer is not. The buffer is sized to the iterator's length, and its
+/// uninitialized capacity is written in parallel rather than zero-filled first.
+pub trait CollectIntoAllocVec: IndexedParallelIterator {
+	/// Allocates a buffer holding one element per item and fills it with the iterator's items.
+	///
+	/// ```
+	/// use binius_compute::{CollectIntoAllocVec, GlobalAllocator};
+	/// use rayon::prelude::*;
+	///
+	/// let squares = (0..8usize).into_par_iter().map(|i| i * i);
+	/// let buffer = squares.collect_into_alloc_vec(&GlobalAllocator);
+	/// assert_eq!(&*buffer, &[0, 1, 4, 9, 16, 25, 36, 49]);
+	/// ```
+	fn collect_into_alloc_vec<A: Allocator>(self, alloc: &A) -> A::Vec<Self::Item>;
+}
+
+impl<I: IndexedParallelIterator> CollectIntoAllocVec for I {
+	fn collect_into_alloc_vec<A: Allocator>(self, alloc: &A) -> A::Vec<Self::Item> {
+		let len = self.len();
+		let mut buffer = alloc.alloc::<Self::Item>(len);
+		// The allocator may hand back more capacity than requested, so bound the spare slice to the
+		// item count: a rayon zip yields as many items as its shorter side holds.
+		self.zip(&mut buffer.spare_capacity_mut()[..len])
+			.for_each(|(item, slot)| {
+				slot.write(item);
+			});
+		// SAFETY: the two zipped sides are both `len` long, so the loop wrote each of the `len`
+		// slots exactly once.
+		unsafe { buffer.set_len(len) };
+		buffer
+	}
 }
 
 /// Backing store of a `binius_math::FieldBuffer` that can be shrunk in place.
@@ -233,6 +274,22 @@ mod tests {
 		buffer.extend_from_slice(&[2, 3]);
 		buffer.resize(5, 0);
 		buffer
+	}
+
+	#[test]
+	fn collect_into_alloc_vec_fills_the_whole_buffer() {
+		// The pool rounds its blocks up, so 1000 items draw a buffer with spare slots past them.
+		// Those slots must stay outside the collected length.
+		let pool = BufferPool::new();
+		let squares = (0..1000usize).into_par_iter().map(|i| (i * i) as u64);
+		let buffer = squares.collect_into_alloc_vec(&&pool);
+		assert_eq!(buffer.len(), 1000);
+		assert!(
+			buffer
+				.iter()
+				.enumerate()
+				.all(|(i, &sq)| sq == (i * i) as u64)
+		);
 	}
 
 	#[test]

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -3,11 +3,11 @@
 
 use std::{iter, ops::Deref};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::{Allocator, CollectIntoAllocVec, VecLike};
 use binius_field::{BinaryField, PackedField};
 use binius_iop::fri::FRIParams;
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT, reed_solomon::ReedSolomonCode};
-use binius_utils::{rand::par_rand, rayon::prelude::*};
+use binius_utils::rand::par_rand;
 use rand::{CryptoRng, rngs::StdRng};
 
 /// Reed-Solomon encodes one input oracle's interleaved message.
@@ -134,19 +134,8 @@ where
 	let packed_len = 1usize << log_len.saturating_sub(P::LOG_WIDTH);
 
 	let gen_mask_scope = tracing::debug_span!("Generate random mask").entered();
-	// `par_rand` is a parallel iterator, so the buffer is filled by writing into its uninitialized
-	// capacity rather than collected — an allocator's buffer has no rayon `collect` to target.
-	let mut mask_values = alloc.alloc::<P>(packed_len);
-	(
-		mask_values.spare_capacity_mut()[..packed_len].par_iter_mut(),
-		par_rand::<StdRng, _, _>(packed_len, &mut rng, P::random),
-	)
-		.into_par_iter()
-		.for_each(|(slot, value)| {
-			slot.write(value);
-		});
-	// SAFETY: the loop above wrote every one of the leading `packed_len` words.
-	unsafe { mask_values.set_len(packed_len) };
+	let mask_values =
+		par_rand::<StdRng, _, _>(packed_len, &mut rng, P::random).collect_into_alloc_vec(alloc);
 	let mask = FieldBuffer::new(log_len, mask_values);
 	drop(gen_mask_scope);
 

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -11,7 +11,7 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::{Allocator, CollectIntoAllocVec, VecLike};
 use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec, multilinear::eq::scaled_eq_ind_partial_eval_into,
@@ -306,18 +306,11 @@ where
 	// One denominator per row: c minus the row's embedded index value.
 	// Subtract a full word at a time: one packed subtraction per word, built in parallel straight
 	// into the allocator's buffer.
-	let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 	let c_packed = P::broadcast(c);
-	let mut packed = alloc.alloc::<P>(packed_len);
-	packed
-		.spare_capacity_mut()
-		.par_iter_mut()
-		.zip(index.par_chunks(P::WIDTH))
-		.for_each(|(slot, chunk)| {
-			slot.write(c_packed - P::from_scalars(chunk.iter().copied().map(embed_position::<F>)));
-		});
-	// Safety: every packed slot is written exactly once by the parallel loop above.
-	unsafe { packed.set_len(packed_len) };
+	let packed = index
+		.par_chunks(P::WIDTH)
+		.map(|chunk| c_packed - P::from_scalars(chunk.iter().copied().map(embed_position::<F>)))
+		.collect_into_alloc_vec(alloc);
 
 	FieldBuffer::new(log_len, packed)
 }

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -4,7 +4,7 @@
 
 use std::ops::Deref;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::{Allocator, CollectIntoAllocVec, VecLike};
 use binius_core::{ValueTable, word::Word};
 use binius_field::{BinaryField, PackedField};
 use binius_math::{FieldVec, inner_product::inner_product};
@@ -82,20 +82,13 @@ impl<F: BinaryField, A: Allocator> FoldedWitness<F, A> {
 		debug_assert_eq!(table.as_words().len(), n_words << table.log_instances());
 
 		// One output element per committed word position.
-		let mut words = alloc.alloc::<FoldedWord<F>>(n_words);
-		table
+		let words = table
 			.as_words()
 			// One chunk is one word position across every instance of the batch.
 			.par_chunks(1 << table.log_instances())
-			.zip(words.spare_capacity_mut())
-			.for_each(|(instance_words, out)| {
-				// Collapse those instances into 64 elements, one per bit position.
-				out.write(folder.fold(instance_words));
-			});
-
-		// SAFETY: chunks and output elements correspond one-to-one by the equality above, so the
-		// loop writes each of the `n_words` elements exactly once.
-		unsafe { words.set_len(n_words) };
+			// Collapse those instances into 64 elements, one per bit position.
+			.map(|instance_words| folder.fold(instance_words))
+			.collect_into_alloc_vec(alloc);
 
 		Self { words }
 	}

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -5,7 +5,7 @@
 
 use std::{iter, mem::MaybeUninit, ops::Deref, ptr};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::{Allocator, CollectIntoAllocVec, VecLike};
 use binius_core::{
 	ValueSegment, ValueTable,
 	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex},
@@ -172,13 +172,10 @@ impl<A: Allocator, const ARITY: usize> OperandColumns<A, ARITY> {
 		// Lanes past the instance count are the multilinear's zero padding.
 		let n_instances = 1usize << self.log_instances;
 		let packed_len = 1usize << self.log_instances.saturating_sub(P::LOG_WIDTH);
-		let mut packed = alloc.alloc::<P>(packed_len);
-		packed
-			.spare_capacity_mut()
-			.par_iter_mut()
-			.enumerate()
-			.for_each(|(packed_index, slot)| {
-				slot.write(P::from_scalars((0..P::WIDTH).map(|lane| {
+		let packed = (0..packed_len)
+			.into_par_iter()
+			.map(|packed_index| {
+				P::from_scalars((0..P::WIDTH).map(|lane| {
 					let instance = (packed_index << P::LOG_WIDTH) | lane;
 					if instance < n_instances {
 						// Constraint `local` of this instance sits at row `local * K + rho`.
@@ -193,10 +190,9 @@ impl<A: Allocator, const ARITY: usize> OperandColumns<A, ARITY> {
 					} else {
 						B128::ZERO
 					}
-				})));
-			});
-		// SAFETY: the parallel loop writes every packed slot exactly once.
-		unsafe { packed.set_len(packed_len) };
+				}))
+			})
+			.collect_into_alloc_vec(alloc);
 
 		FieldBuffer::new(self.log_instances, packed)
 	}
@@ -225,20 +221,15 @@ impl<A: Allocator> OperandColumns<A, 2> {
 			log_instances,
 		} = self;
 
-		// The parallel zip stops at the shortest of its three sides.
-		// Equal input lengths are therefore what make the output fully written.
+		// The parallel zip stops at the shorter of its two sides, and the derived column is sized
+		// to it. Equal input lengths are therefore what make it cover every row.
 		debug_assert_eq!(a.len(), b.len());
-		let n_rows = a.len();
 
-		let mut c = alloc.alloc::<Word>(n_rows);
-		(&a[..], &b[..], c.spare_capacity_mut())
+		let c = (&a[..], &b[..])
 			.into_par_iter()
 			.with_min_task_bytes::<[Word; 3]>()
-			.for_each(|(&a_i, &b_i, out)| {
-				out.write(a_i & b_i);
-			});
-		// SAFETY: the loop above writes each of the `n_rows` entries exactly once.
-		unsafe { c.set_len(n_rows) };
+			.map(|(&a_i, &b_i)| a_i & b_i)
+			.collect_into_alloc_vec(alloc);
 
 		OperandColumns {
 			columns: [a, b, c],

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -14,7 +14,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use binius_compute::{Allocator, BufferData, VecLike};
+use binius_compute::{Allocator, BufferData, CollectIntoAllocVec};
 use binius_field::{Field, PackedField};
 use binius_utils::{
 	random_access_sequence::RandomAccessSequence,
@@ -89,19 +89,12 @@ pub fn fold_highest_var<A: Allocator, P: PackedField, Data: Deref<Target = [P]>>
 	let (lo, hi) = values.split_half();
 
 	// Interpolate the line through each pair at the challenge directly into a fresh buffer
-	// drawn from the allocator, writing the uninitialized spare capacity in parallel rather
-	// than zero-filling first.
-	let len = lo.as_ref().len();
-	let mut data = alloc.alloc::<P>(len);
-	let spare = &mut data.spare_capacity_mut()[..len];
-	(spare, lo.as_ref(), hi.as_ref())
+	// drawn from the allocator.
+	let data = (lo.as_ref(), hi.as_ref())
 		.into_par_iter()
 		.with_min_task(WorkPerItem::FieldMuls)
-		.for_each(|(out, &lo_i, &hi_i)| {
-			out.write(extrapolate_line(lo_i, hi_i, broadcast_scalar));
-		});
-	// SAFETY: the parallel loop initialized all `len` slots.
-	unsafe { data.set_len(len) };
+		.map(|(&lo_i, &hi_i)| extrapolate_line(lo_i, hi_i, broadcast_scalar))
+		.collect_into_alloc_vec(alloc);
 	FieldBuffer::new(values.log_len() - 1, data)
 }
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -537,8 +537,9 @@ pub fn pack_witness<P: PackedField<Scalar = B128>, A: Allocator>(
 	let (pairs, word_remaining) = witness.as_chunks::<2>();
 	let aligned_len = pairs.len() / P::WIDTH * P::WIDTH;
 	let (pairs_aligned, word_pair_remaining) = pairs.split_at(aligned_len);
-	// `collect_into_vec` needs a `&mut Vec`, which the generic buffer is not, so the aligned groups
-	// are written straight into the buffer's spare capacity instead.
+	// The buffer is sized for the whole padded witness, which the trailing element and the zero
+	// padding below fill out, so the aligned groups are written straight into its spare capacity
+	// rather than collected into a buffer of their own.
 	let n_aligned_elems = aligned_len / P::WIDTH;
 	(
 		pairs_aligned.par_chunks(P::WIDTH),

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::{Allocator, CollectIntoAllocVec, VecLike};
 use binius_field::{Field, PackedField};
 use binius_math::{FieldBuffer, FieldSlice, FieldVec};
 use binius_spartan_frontend::constraint_system::{
@@ -111,16 +111,13 @@ pub fn fold_constraints<A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 	let log_size = transposed.log_size();
 	let len = 1 << log_size.saturating_sub(P::LOG_WIDTH);
 
-	// Fill the packed words in parallel through the allocated buffer's spare capacity, then commit
-	// the length once every word has been written.
-	let mut result = alloc.alloc::<P>(len);
-	result.spare_capacity_mut()[..len]
-		.par_iter_mut()
-		.enumerate()
-		.for_each(|(packed_idx, slot)| {
+	// Build the packed words in parallel, straight into a buffer drawn from the allocator.
+	let result = (0..len)
+		.into_par_iter()
+		.map(|packed_idx| {
 			let base_idx = packed_idx << P::LOG_WIDTH;
 
-			slot.write(P::from_fn(|scalar_idx| {
+			P::from_fn(|scalar_idx| {
 				let idx = base_idx + scalar_idx;
 				if idx >= segment_size {
 					return F::ZERO;
@@ -133,10 +130,9 @@ pub fn fold_constraints<A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 					acc += r_x_weight * lambda_weight;
 				}
 				acc
-			}));
-		});
-	// SAFETY: the loop above initialized every one of the `len` spare words.
-	unsafe { result.set_len(len) };
+			})
+		})
+		.collect_into_alloc_vec(alloc);
 
 	FieldBuffer::new(log_size, result)
 }


### PR DESCRIPTION
Closes [BINIUS-635](https://linear.app/jimpo/issue/BINIUS-635/collect-into-alloc-vec-for-rayon).

### The problem

Rayon's `collect_into_vec` targets a `&mut Vec`, which an `Allocator`'s buffer is not. So the prover builds those buffers by hand:

```rust
let mut buffer = alloc.alloc(len);
(inputs, buffer.spare_capacity_mut()[..len].par_iter_mut())
    .into_par_iter()
    .for_each(|(input, out)| out.write(f(input)));
// SAFETY: the zip is over equal-length sides, so ...
unsafe { buffer.set_len(len) };
```

Every site repeats the same soundness argument — a rayon zip yields as many items as its shorter side holds, so a length mismatch leaves trailing slots uninitialized — and several sites also have to remember that the allocator may hand back more capacity than it was asked for, and bound the spare slice themselves.

### The change

**Commit 1** adds `CollectIntoAllocVec` to `binius-compute`: an extension trait on `IndexedParallelIterator`, blanket-implemented, mirroring `binius-utils`' existing `IndexedParallelIteratorExt`. It sizes a buffer from the iterator's length, fills the spare capacity in parallel, and hands the buffer back, so the argument above is made once.

It lives in `binius-compute` because it is about `Allocator`. That gives the crate its first dependency, on `binius-utils`, for the `rayon` re-export the rest of the workspace already builds its parallel loops from — `binius-utils` has no `binius-*` dependencies, so the edge is new but not circular.

**Commit 2** adopts it at the seven sites where the loop produces exactly one element per output slot:

| crate | site |
|---|---|
| `binius-math` | `multilinear/fold.rs` — `fold_highest_var` |
| `binius-iop-prover` | `fri/encode.rs` — the random mask |
| `binius-ip-prover` | `logup_star/witness.rs` — `looker_denominator` |
| `binius-spartan-prover` | `wiring.rs` — `fold_constraints` |
| `binius-m4-prover` | `witness/instance_fold.rs` |
| `binius-m4-prover` | `witness/operand_columns.rs` (×2) |

Seven `unsafe { set_len }` blocks go away, along with the per-site length reasoning. The loops now say what one item is rather than where it lands:

```rust
let data = (lo.as_ref(), hi.as_ref())
    .into_par_iter()
    .with_min_task(WorkPerItem::FieldMuls)
    .map(|(&lo_i, &hi_i)| extrapolate_line(lo_i, hi_i, broadcast_scalar))
    .collect_into_alloc_vec(alloc);
```

The net is 88 insertions / 88 deletions — the consumer costs about what it removes at seven sites, and pays off at the eighth.

### What is deliberately left alone

I went through every `alloc` + `spare_capacity_mut` + `set_len` site in the workspace. The rest do not fit this consumer:

- **Several outputs per pass.** `fracaddcheck/circuit.rs` writes a numerator and a denominator; `spartan-prover/wiring.rs`'s mul witness writes `a`, `b` and `c`. Collecting each separately would repeat the shared work.
- **Chunk-shaped writes, not one slot per item.** `ring_switch.rs`, `FieldBuffer`'s copy, `fri/fold.rs`, `operand_columns.rs`'s striped writer, `binary_merkle_tree.rs`, and `intmul/witness.rs`'s strided column view.
- **The buffer is pre-sized past the iterator.** `prove.rs`'s witness packing and `shift/key_collection/collection.rs` allocate the whole padded power-of-two length, then push a tail element and zero-pad into it. Collecting would size the buffer to the aligned prefix and reallocate the largest prover buffer. `prove.rs` carried a comment naming `collect_into_vec`'s `&mut Vec` as the obstacle, which this PR would have made stale; it now states the reason that actually holds.
- **Not parallel.** `logup_star`'s `table_denominator` and `shift/monster.rs` are sequential loops.

### Testing

`cargo test --workspace` passes (I excluded `binius-examples` on the final run only because the box ran out of disk linking its example binaries; it type-checks under the clippy run below). `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo doc --no-deps --document-private-items`, `cargo +nightly fmt --check` and `typos` are all clean. The new trait has a doc example and a unit test over `BufferPool`, whose block rounding is what makes the bounded spare slice load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HhgduRiSH5dYWtrDXNkiL