### PR TITLE
BINIUS-644: Fix Rust cache invalidation by pinning Swatinem/rust-cache directly

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -30,16 +30,30 @@ runs:
           HASH=portable
         fi
         echo "key=cpu-${HASH}" >> "$GITHUB_OUTPUT"
+    - name: Setup Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: ${{ inputs.components }}
+        target: ${{ inputs.target }}
+        cache: false
+    # actions-rust-lang/setup-rust-toolchain bundles Swatinem/rust-cache v2.9.1, which drops the
+    # .fingerprint/build metadata for every crate whose name contains a hyphen when it sweeps
+    # workspace-crate artifacts before saving (the sweep's keep-list only had the hyphenated Cargo
+    # package name, not the underscored target name Cargo actually uses on disk for those
+    # directories). Without that metadata cargo can't trust the surviving .rlib/.rmeta files, so it
+    # recompiles the whole dependency tree on every restore even on an exact cache-key match. Fixed
+    # in rust-cache v2.9.2, which setup-rust-toolchain hasn't picked up in a tagged release yet
+    # (github.com/actions-rust-lang/setup-rust-toolchain/pull/102), so call it directly here instead.
+    #
     # Actions scopes every cache entry to the ref that wrote it, and a run may only restore from
     # its own ref, its base branch, or the default branch. Merge-queue runs execute on
     # `refs/heads/gh-readonly-queue/main/pr-<N>-<sha>`, which GitHub deletes the moment the run
     # finishes, so anything they save is unreachable from that point on — it only occupies the
     # repo's cache quota and evicts entries that pull-request and main runs can still restore.
     # Merge-queue runs therefore restore as usual but do not write.
-    - name: Setup Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Setup Rust Caching
+      uses: Swatinem/rust-cache@v2.9.2
       with:
-        components: ${{ inputs.components }}
-        target: ${{ inputs.target }}
-        cache-key: ${{ steps.cpu.outputs.key }}
-        cache-save-if: ${{ github.event_name != 'merge_group' }}
+        key: ${{ steps.cpu.outputs.key }}
+        cache-on-failure: true
+        save-if: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
## Summary

CI's `rust-checks-*` jobs were recompiling the entire dependency tree on
almost every run, despite the Rust build cache reporting a hit — even an
exact ("full match: true") cache-key hit with nothing changed since the
cache was saved (BINIUS-644).

## Root cause

`Swatinem/rust-cache` v2.9.1 — bundled inside
`actions-rust-lang/setup-rust-toolchain@v1`, which we can't bump
independently — has a bug in its pre-save cleanup: it sweeps
`target/*/build` and `target/*/.fingerprint` to strip out workspace-crate
artifacts (we run with `cache-workspace-crates: false`), keeping only
entries for known dependency packages. The keep-list is built from
hyphenated Cargo package names, but the on-disk `.fingerprint`/`build`
directory names use Cargo's underscore-normalized target names. Every crate
whose name contains a hyphen — most of this workspace's own `binius-*`
crates, plus a good chunk of the third-party dependency tree
(`hex-conservative`, `tracing-subscriber`, ...) — never matches, so its
fingerprint metadata gets deleted on every cache save. The compiled
`.rlib`/`.rmeta` files under `deps/` can survive, but without a fingerprint
record Cargo can't trust them and recompiles from scratch on the next
restore.

This is fixed in rust-cache
[v2.9.2](https://github.com/Swatinem/rust-cache/blob/master/CHANGELOG.md#292)
("Improvements to cleanup, preserving more valid targets"), which
`setup-rust-toolchain`'s own `main` branch has already picked up
([actions-rust-lang/setup-rust-toolchain#102](https://github.com/actions-rust-lang/setup-rust-toolchain/pull/102))
but hasn't cut a tagged release for yet, so our `@v1` pin still resolves to
the broken v2.9.1.

## Fix

Disable `setup-rust-toolchain`'s bundled caching (`cache: false`) and call
`Swatinem/rust-cache@v2.9.2` directly as a separate step in
`.github/actions/setup-rust/action.yml`, passing through the same
key/`cache-on-failure`/`save-if` configuration it was given before. This is
now a normal direct dependency dependabot tracks, so it'll pick up the
inevitable future release of `setup-rust-toolchain` that folds this back in
on its own.

## Test plan

- [x] CI on this PR: confirm `rust-checks-*` jobs restore a cache and the
      `Compile` step no longer recompiles every dependency crate from
      scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdLMLXD5oL3FX9n8ozrjyR
