### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @jimpo @tcoratger


### PR DESCRIPTION
## Summary
- Removes the `CODEOWNERS` file. GitHub branch protection already requires review from the maintainers team directly, so per-path codeowner review requirements are redundant for a team this small.

Closes BINIUS-650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q32d8BdU56S8ZkRJmQ1E6p