### PR TITLE
Say that the scalar eq-indicator expansion is serial

### DIFF
--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -141,7 +141,9 @@ pub fn eq_ind_zero<F: FieldOps>(point: &[F]) -> F {
 
 /// Computes the partial evaluation of the equality indicator polynomial, returning scalars.
 ///
-/// This is the scalar-only engine, which never touches a packed store.
+/// This is the scalar-only engine, which never touches a packed store. It expands the tensor on
+/// one thread, one doubling per coordinate, so it costs `2^n` scalar multiplications serially;
+/// [`eq_ind_partial_eval`] expands wide points in parallel over a packed buffer.
 pub fn eq_ind_partial_eval_scalars<F: FieldOps>(point: &[F]) -> Vec<F> {
 	hypercube::eq_ind_partial_eval_scalars::<OneCube, F>(point)
 }


### PR DESCRIPTION
## What

`eq_ind_partial_eval_scalars` expands the tensor on one thread, one doubling per coordinate. Its rustdoc now says so and points at `eq_ind_partial_eval`, whose packed expansion goes wide.

## Why

We built a prover-side table from it at 26 coordinates, once per claim, and the serial `2^26` multiplications were the largest single term of that prover's per-claim cost. Nothing in the doc distinguished the two functions beyond "scalar-only".

### Checks

```
cargo +nightly-2026-07-01 fmt --check
cargo doc --no-deps -p binius-math
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgDiptgjwWBQdZijmKqqVP
