### PR TITLE
[ci] Add wasm32 simd128 build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,26 @@ jobs:
       - name: Compile vanilla wasm32
         run: cargo build -p binius-field --target wasm32-unknown-unknown
 
+  # Build against wasm32-unknown-unknown with the simd128 target feature enabled. This is the
+  # only configuration that compiles the SIMD GHASH implementation in
+  # crates/field/src/arch/wasm32: the vanilla build above leaves it unbuilt, so without this job
+  # it type-checks nowhere in CI.
+  wasm-simd128-build:
+    name: wasm-simd128-build
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    env:
+      RUSTFLAGS: "-C target-feature=+simd128"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          target: wasm32-unknown-unknown
+      - name: Compile wasm32 with simd128
+        run: cargo build -p binius-field --target wasm32-unknown-unknown
+
   wasm-tests:
     name: wasm-tests
     if: github.event_name != 'push'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,12 +88,15 @@ RUSTFLAGS="-C target-feature=+neon,+aes" \
 RUSTFLAGS="-C target-feature=+sse2,+avx2,+pclmulqdq,+vpclmulqdq" \
   cargo check --target x86_64-unknown-linux-gnu -p binius-field -p binius-arith-bench
 
-# wasm32 — matches CI (binius-field on wasm32-unknown-unknown; the wider crate set on wasm32-wasip1)
+# wasm32 — matches CI (binius-field on wasm32-unknown-unknown, portable and with simd128 to
+# also exercise the SIMD GHASH path; the wider crate set on wasm32-wasip1)
 cargo build -p binius-field --target wasm32-unknown-unknown
+RUSTFLAGS="-C target-feature=+simd128" \
+  cargo build -p binius-field --target wasm32-unknown-unknown
 cargo build -p binius-field --target wasm32-wasip1
 ```
 
-(All four commands above are verified to compile cleanly. The 512-bit AVX-512 path —
+(All five commands above are verified to compile cleanly. The 512-bit AVX-512 path —
 `+sse2,+avx2,+avx512f,+pclmulqdq,+vpclmulqdq` — also compiles cleanly, including
 `cargo build --all-targets` and a full `--workspace` build, even on a host without AVX-512:
 its `std::arch::x86_64::_mm512_*` intrinsics are stable on the pinned toolchain. Older Rust,


### PR DESCRIPTION
Fixes [BINIUS-396](https://linear.app/jimpo/issue/BINIUS-396/ci-configuration-for-wasm32-with-simd128).

Followup from #1993: `crates/field/src/arch/wasm32` (the SIMD GHASH module) is only compiled when `target_feature = "simd128"` is active, and no existing CI job enables that feature — so the module type-checks nowhere in CI and can silently rot again.

## Changes

- Add a `wasm-simd128-build` job to `.github/workflows/ci.yml`, alongside `wasm-vanilla-build`: compiles `binius-field` for `wasm32-unknown-unknown` with `RUSTFLAGS="-C target-feature=+simd128"`.
- Document the matching cross-compile command in `DEVELOPMENT.md`'s Cross-compilation section.

## Verification

Ran the new build command locally: `RUSTFLAGS="-C target-feature=+simd128" cargo build -p binius-field --target wasm32-unknown-unknown` compiles cleanly (two pre-existing unused-import warnings in `crates/field/src/arch/wasm32/m128.rs`, unrelated to this change and not promoted to errors here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjgcVcfKDvvbjdYBesUkE6