### PR TITLE
ci: stop building the 23 examples in rust-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,15 @@ jobs:
           tool: cargo-nextest
       - name: Install lld
         run: sudo apt-get update -qq && sudo apt-get install -y lld
-      # Don't *build* benchmarks: each criterion bench is a separate binary linking the whole crate,
-      # and CI never runs them (`cargo bench`), so codegen + linking them is pure overhead. Clippy
-      # below still checks them via `--all-targets` — that's front-end only (no codegen/link), so it
-      # guards against bench bitrot (API drift) for a fraction of a full build.
+      # Build only the targets this job runs. Benchmarks and examples are both excluded: each is a
+      # separate binary linking the whole crate, and this job runs neither. Codegen + linking them
+      # is pure overhead, and for the 23 examples it is the single largest item in this step —
+      # ~59% of its CPU time, because most of them monomorphize the whole prover stack (see
+      # BINIUS-656). Clippy below still checks both via `--all-targets` — that's front-end only
+      # (no codegen/link), so it guards against bitrot (API drift) for a fraction of a full build.
+      # 13 of the examples are still built *and executed* by the `circuits-snapshot` job.
       - name: Compile
-        run: cargo build --workspace --lib --bins --tests --examples
+        run: cargo build --workspace --lib --bins --tests
       - name: Run platform diagnostics
         if: github.event_name != 'push'
         run: cargo test -p binius-utils --features platform-diagnostics test_platform_diagnostics -- --nocapture
@@ -124,9 +127,12 @@ jobs:
       - name: Run clippy
         if: github.event_name != 'push'
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      # The target selection repeats the Compile step's, and is load-bearing: nextest inherits
+      # `cargo test`'s default target selection, which includes examples. A bare `--workspace`
+      # here builds all 23 of them, paying in this step the cost Compile above declines to pay.
       - name: Run tests
         if: github.event_name != 'push'
-        run: cargo nextest run --workspace --no-fail-fast ${{ matrix.arch.test_args }}
+        run: cargo nextest run --workspace --lib --bins --tests --no-fail-fast ${{ matrix.arch.test_args }}
       # Must run doctests separately, see https://github.com/nextest-rs/nextest/issues/16
       - name: Run doctests
         if: github.event_name != 'push'


### PR DESCRIPTION
Closes [BINIUS-655](https://linear.app/jimpo/issue/BINIUS-655/stop-building-the-23-examples-in-rust-checks-58percent-of-the-compile). Follow-up to BINIUS-654's measurement of the Compile step.

The 23 example binaries are ~59% of the `rust-checks` Compile step's CPU time. All three matrix legs build them, and none of them runs a single one.

## The change

Two lines, and **both are required**:

1. `Compile` drops `--examples`.
2. `Run tests` names its targets explicitly: `--lib --bins --tests`.

Doing only (1) is a **zero delta**. `cargo nextest run --workspace` inherits `cargo test`'s default target selection, which includes examples — so without (2) the 2322s simply moves out of Compile and into Run tests.

I verified this rather than taking it on trust, on a throwaway 3-target crate that isolates the cargo/nextest semantics from anything binius-specific:

| command | example binaries built |
| -- | -- |
| `cargo nextest list --workspace` | 2 |
| `cargo nextest list --workspace --lib --bins --tests` | 0 |
| `cargo nextest run --workspace --lib --bins --tests --no-fail-fast -E '…'` | 0 (tests still run) |
| `cargo test --doc --workspace` | 0 |

Doc tests build no examples, so `Run doctests` needs no change.

## Verified on this tree

`cargo build --workspace --lib --bins --tests` from a cold target dir: **4m17s wall, 1754s CPU, zero binaries in `target/debug/examples/`.** (Local profile differs from CI's — no `-Ctarget-cpu=native`, no lld, no `CARGO_PROFILE_DEV_DEBUG` — so treat the CPU number as indicative and the example count as the real oracle.)

Also confirmed against the tree, rather than inherited from the issue:

* **23 examples** = 16 auto-discovered in `crates/examples/examples/` + 7 `[[example]]` tutorials in `crates/examples/Cargo.toml:100+`.
* **16** of them go through `Cli::<E>` — not 17; none of the 7 tutorials do.
* `crates/examples` is the **only** crate in the workspace with example targets, and `Run platform diagnostics` is `-p binius-utils`, so no other step in the job can pull them back in.

## Coverage is unchanged where it counts

* Every example stays **type-checked**: `Run clippy` already passes `--all-targets`, which is front-end only. That is the same argument the existing comment makes for excluding benches.
* **13 of the 23 are still built *and executed*** by `circuits-snapshot` via `cargo run --example` — so the expensive prover-stack examples remain genuinely exercised in CI, once, instead of three times in a job that never ran them.
* The remaining 10 are clippy-checked only, which is exactly how benches are already treated.

## Expected saving

The issue projects ~6m41s of CPU-bound floor against the current 16m49s, with **7–10 min** the realistic range: what remains has a real dependency chain (`utils → field → … → m4-prover`) where the examples were embarrassingly parallel, so the critical path may bind before CPU does.

**This PR's own CI run is the measurement** — worth reading the actual Compile time off it before merging, and confirming `Run tests` stays near its current 0.25s rather than absorbing the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4QbApMbHfjdkQnjNqfT4W