### PR TITLE
Update CI runners from Ubuntu 24.04 to 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   format:
     name: format
     if: github.event_name != 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -67,15 +67,15 @@ jobs:
           # than `cargo --exclude`: keeping the build set at `--workspace` matches the Compile step's
           # feature unification, so the dependency tree is not recompiled. See BINIUS-151.
           - name: x86_64-portable
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             rustflags: # portable
             test_args: "-E 'not package(binius-circuits)'"
           - name: x86_64
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             rustflags: "-Ctarget-cpu=native"
             test_args: ""
           - name: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-26.04-arm
             rustflags: "-Ctarget-cpu=native"
             test_args: "-E 'not package(binius-circuits)'"
     name: rust-checks-${{ matrix.arch.name }}
@@ -137,7 +137,7 @@ jobs:
   unused-deps:
     name: unused-deps
     if: github.event_name != 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -158,7 +158,7 @@ jobs:
   wasm-vanilla-build:
     name: wasm-vanilla-build
     if: github.event_name != 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -176,7 +176,7 @@ jobs:
   wasm-simd128-build:
     name: wasm-simd128-build
     if: github.event_name != 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       RUSTFLAGS: "-C target-feature=+simd128"
     steps:
@@ -192,7 +192,7 @@ jobs:
   wasm-tests:
     name: wasm-tests
     if: github.event_name != 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7


### PR DESCRIPTION
Moves every CI job pinned to `ubuntu-24.04`/`ubuntu-24.04-arm` onto the `ubuntu-26.04`/`ubuntu-26.04-arm` preview runner images. `ubuntu-latest` jobs are left as-is since that label isn't pinned to a version.

Fixes BINIUS-663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4y5rfdmRfKPvECdcaCb3p