### PR TITLE
Scope pull-request CI by architecture and pin target features

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,8 +1,5 @@
 name: Setup Rust
-description: >-
-  Install the Rust toolchain and enable caching, with the cache key namespaced
-  by the runner's CPU feature set so heterogeneous GitHub-hosted runners never
-  share build artifacts.
+description: Install the Rust toolchain and enable caching.
 inputs:
   components:
     description: Comma-separated rustup components to install (e.g. clippy, rustfmt).
@@ -15,21 +12,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # GitHub-hosted x86_64 runners include both Intel (with AVX-512/GFNI) and AMD (without) SKUs.
-    # With `-Ctarget-cpu=native`, build artifacts cached on one SKU produce illegal instructions
-    # when restored on another. Hash the CPU feature set into the cache key so heterogeneous runners
-    # do not share artifacts. Jobs that build CPU-agnostic output are unaffected beyond landing in a
-    # stable per-SKU cache bucket.
-    - name: Compute CPU feature cache key
-      id: cpu
-      shell: bash
-      run: |
-        if [ -r /proc/cpuinfo ]; then
-          HASH=$(grep -m1 -E '^(flags|Features)[[:space:]]*:' /proc/cpuinfo | sha256sum | cut -c1-16)
-        else
-          HASH=portable
-        fi
-        echo "key=cpu-${HASH}" >> "$GITHUB_OUTPUT"
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
@@ -54,6 +36,5 @@ runs:
     - name: Setup Rust Caching
       uses: Swatinem/rust-cache@v2.9.2
       with:
-        key: ${{ steps.cpu.outputs.key }}
         cache-on-failure: true
         save-if: ${{ github.event_name != 'merge_group' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          # binius-circuits tests are architecture-independent (the crate depends only on
-          # binius-frontend + binius-core, which contain no arch-specific code), so they run only on
-          # the x86_64 leg. The other legs skip them with nextest's run-layer filter (`-E`) rather
-          # than `cargo --exclude`: keeping the build set at `--workspace` matches the Compile step's
-          # feature unification, so the dependency tree is not recompiled. See BINIUS-151.
-          #
           # The feature-enabled legs pin an explicit target-feature set rather than asking for
           # `-Ctarget-cpu=native`. GitHub's runner fleet is heterogeneous, so `native` makes the
           # generated code — and therefore which `cfg(target_feature)` paths CI compiles and runs
@@ -76,18 +70,20 @@ jobs:
           # AES/SHA2 are present on every arm64 runner. Wider x86_64 features — AVX-512, GFNI,
           # VAES, VPCLMULQDQ, SHA-NI — are only on some SKUs, so they are type-checked by the
           # check-only clippy pass below instead of executed.
+          #
+          # `arch_packages_on_pr` marks a leg that narrows to the architecture-specific packages on
+          # a pull request. See `PACKAGES` below.
           - name: x86_64-portable
             runner: ubuntu-26.04
             rustflags: # portable
-            test_args: "-E 'not package(binius-circuits)'"
+            arch_packages_on_pr: true
           - name: x86_64
             runner: ubuntu-26.04
             rustflags: "-Ctarget-cpu=x86-64-v3 -Ctarget-feature=+pclmulqdq,+aes"
-            test_args: ""
           - name: arm64
             runner: ubuntu-26.04-arm
             rustflags: "-Ctarget-feature=+neon,+aes,+sha2"
-            test_args: "-E 'not package(binius-circuits)'"
+            arch_packages_on_pr: true
     name: rust-checks-${{ matrix.arch.name }}
     # This job also runs on pushes to main, where it stops after Compile and exists only to write a
     # cache entry that pull-request and merge-queue runs can restore. The verification steps below
@@ -104,6 +100,20 @@ jobs:
       # example binaries, where bfd is a serial bottleneck. Appended to the per-arch target
       # features. lld is installed below.
       RUSTFLAGS: "${{ matrix.arch.rustflags }} -Clink-arg=-fuse-ld=lld"
+      # Package selection for the build, test and doctest steps: either the packages that contain
+      # architecture-specific code, or the whole workspace. A pull request takes the narrow set on
+      # the two secondary legs — the rest of the workspace is architecture-independent, so building
+      # and testing it three times asks the same question three times. Everything else — the x86_64
+      # leg, the merge queue, the push warmers — takes the workspace, so the whole of it is still
+      # built and tested on all three legs before anything reaches main.
+      #
+      # The `field` SIMD paths are also exercised transitively by the `prover` and `math` tests,
+      # which the narrow set drops. A SIMD bug that `field`'s own tests miss therefore bounces a
+      # merge rather than failing the pull request.
+      #
+      # Clippy below stays on the whole workspace on every leg and every event: it is the cheap way
+      # to type-check the arch-gated code under this leg's cfg.
+      PACKAGES: ${{ github.event_name == 'pull_request' && matrix.arch.arch_packages_on_pr && '-p binius-field -p binius-hash-prover -p binius-arith-bench' || '--workspace' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -125,7 +135,7 @@ jobs:
       # build. The demo circuits are not among the examples: they are subcommands of the
       # `binius-examples` binary, which `--bins` builds here and `circuits-snapshot` runs.
       - name: Compile
-        run: cargo build --workspace --lib --bins --tests
+        run: cargo build $PACKAGES --lib --bins --tests
       - name: Run platform diagnostics
         if: github.event_name != 'push'
         run: cargo test -p binius-utils --features platform-diagnostics test_platform_diagnostics -- --nocapture
@@ -137,11 +147,11 @@ jobs:
       # here builds every one of them, paying in this step the cost Compile above declines to pay.
       - name: Run tests
         if: github.event_name != 'push'
-        run: cargo nextest run --workspace --lib --bins --tests --no-fail-fast ${{ matrix.arch.test_args }}
+        run: cargo nextest run $PACKAGES --lib --bins --tests --no-fail-fast
       # Must run doctests separately, see https://github.com/nextest-rs/nextest/issues/16
       - name: Run doctests
         if: github.event_name != 'push'
-        run: cargo test --doc --workspace
+        run: cargo test --doc $PACKAGES
       # The AVX-512, GFNI, VAES, VPCLMULQDQ and SHA-NI paths are compiled nowhere else in CI: the
       # x86_64 leg's pinned features stop at what every runner is guaranteed to have, so nothing
       # above type-checks them. Clippy is check-only, so it compiles those `cfg(target_feature)`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,27 @@ jobs:
           # the x86_64 leg. The other legs skip them with nextest's run-layer filter (`-E`) rather
           # than `cargo --exclude`: keeping the build set at `--workspace` matches the Compile step's
           # feature unification, so the dependency tree is not recompiled. See BINIUS-151.
+          #
+          # The feature-enabled legs pin an explicit target-feature set rather than asking for
+          # `-Ctarget-cpu=native`. GitHub's runner fleet is heterogeneous, so `native` makes the
+          # generated code — and therefore which `cfg(target_feature)` paths CI compiles and runs
+          # — a property of whichever SKU the job landed on, and it makes every artifact
+          # unshareable between SKUs. The sets below are the ones every SKU in the fleet has:
+          # AES-NI and PCLMULQDQ are Westmere-era, AVX2 (`x86-64-v3`) is Haswell-era, and Armv8
+          # AES/SHA2 are present on every arm64 runner. Wider x86_64 features — AVX-512, GFNI,
+          # VAES, VPCLMULQDQ, SHA-NI — are only on some SKUs, so they are type-checked by the
+          # check-only clippy pass below instead of executed.
           - name: x86_64-portable
             runner: ubuntu-26.04
             rustflags: # portable
             test_args: "-E 'not package(binius-circuits)'"
           - name: x86_64
             runner: ubuntu-26.04
-            rustflags: "-Ctarget-cpu=native"
+            rustflags: "-Ctarget-cpu=x86-64-v3 -Ctarget-feature=+pclmulqdq,+aes"
             test_args: ""
           - name: arm64
             runner: ubuntu-26.04-arm
-            rustflags: "-Ctarget-cpu=native"
+            rustflags: "-Ctarget-feature=+neon,+aes,+sha2"
             test_args: "-E 'not package(binius-circuits)'"
     name: rust-checks-${{ matrix.arch.name }}
     # This job also runs on pushes to main, where it stops after Compile and exists only to write a
@@ -91,8 +101,8 @@ jobs:
     runs-on: ${{ matrix.arch.runner }}
     env:
       # Link with lld instead of the default ld.bfd: the rust-checks build links many test and
-      # example binaries, where bfd is a serial bottleneck. Appended to the per-arch flags
-      # (target-cpu). lld is installed below.
+      # example binaries, where bfd is a serial bottleneck. Appended to the per-arch target
+      # features. lld is installed below.
       RUSTFLAGS: "${{ matrix.arch.rustflags }} -Clink-arg=-fuse-ld=lld"
     steps:
       - name: Checkout Repository
@@ -132,6 +142,26 @@ jobs:
       - name: Run doctests
         if: github.event_name != 'push'
         run: cargo test --doc --workspace
+      # The AVX-512, GFNI, VAES, VPCLMULQDQ and SHA-NI paths are compiled nowhere else in CI: the
+      # x86_64 leg's pinned features stop at what every runner is guaranteed to have, so nothing
+      # above type-checks them. Clippy is check-only, so it compiles those `cfg(target_feature)`
+      # branches without ever running the instructions. Only the three crates with
+      # architecture-specific code are checked; the rest of the workspace is feature-agnostic.
+      # Executing these paths needs a runner that has the features, and is not attempted here.
+      #
+      # `--target` is load-bearing rather than redundant. Without it cargo applies RUSTFLAGS to
+      # build scripts and proc macros as well, which it then executes on the runner — and those
+      # die with SIGILL the moment the compiler uses an instruction the runner lacks. Naming the
+      # target explicitly splits host units from target units, leaving the host ones on the
+      # default feature set.
+      - name: Run clippy with the wide x86_64 feature set
+        if: github.event_name != 'push' && matrix.arch.name == 'x86_64'
+        env:
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3 -Ctarget-feature=+pclmulqdq,+vpclmulqdq,+aes,+vaes,+sha,+gfni,+avx512f,+avx512bw -Clink-arg=-fuse-ld=lld"
+        run: >-
+          cargo clippy --target x86_64-unknown-linux-gnu
+          -p binius-field -p binius-hash-prover -p binius-arith-bench
+          --all-targets -- -D warnings
 
   unused-deps:
     name: unused-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,8 +30,6 @@ jobs:
           cargo doc --no-deps --all-features
           # Create redirect to main crate (binius_core) - using relative path for GitHub Pages compatibility
           echo '<html><head><meta http-equiv="refresh" content="0; url=binius_core/"></head><body>Redirecting to <a href="binius_core/">binius_core</a></body></html>' > target/doc/index.html
-        env:
-          RUSTFLAGS: "-C target-cpu=native"
 
       - name: Upload Documentation Artifact
         uses: actions/upload-pages-artifact@v5

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,8 +53,9 @@ $ prek run --all-files
 implementations of `GF(2^128)` (and related) arithmetic, selected at compile time with
 `#[cfg(target_arch = ...)]` and `#[cfg(target_feature = ...)]`. Code on an *inactive* arch/feature
 path is never type-checked by your native build, so it is easy to break the `aarch64` paths from an
-`x86_64` host (or vice versa) and not notice until CI fails — CI builds `x86_64` (both portable and
-`-Ctarget-cpu=native`), `aarch64`, and `wasm32`.
+`x86_64` host (or vice versa) and not notice until CI fails — CI builds `x86_64` (portable, a pinned
+CLMUL/AVX2 set that it also runs, and a check-only pass over the wider AVX-512/GFNI/VAES set),
+`aarch64`, and `wasm32`.
 
 When you touch these crates, cross-compile them for the target(s) you are not running natively.
 You do **not** need an emulator — compiling is enough to type-check the inactive paths.


### PR DESCRIPTION
Closes [BINIUS-665](https://linear.app/jimpo/issue/BINIUS-665/scope-pull-request-ci-by-architecture-arch-specific-crates).

Two commits, each standalone.

### 1. Pin CI target features instead of `-Ctarget-cpu=native`

`native` made two things a property of whichever runner SKU a job landed on: the machine code it built, and — through `cfg(target_feature)` — which source paths it compiled and ran at all.

The first forced the CPU feature hash into the cache key, splitting the cache into one bucket per SKU. The repo is at its 10 GB quota, so the rare buckets get evicted and a job that draws one rebuilds the whole dependency tree; on run 34381460029 the native leg restored no cache and rebuilt 289 third-party crates. The second made coverage nondeterministic: on that same run the native leg's SKU reported `avx512f, gfni` and the portable leg's reported them absent.

Each leg now pins an explicit feature set, so artifacts are portable across runners, the CPU feature hash leaves the cache key, and the per-SKU buckets collapse into one per architecture:

* x86_64: `-Ctarget-cpu=x86-64-v3 -Ctarget-feature=+pclmulqdq,+aes`
* arm64: `-Ctarget-feature=+neon,+aes,+sha2`

**The pinned sets are narrower than the issue proposed, deliberately.** RUSTFLAGS apply to everything the job *executes*, so a feature that some SKU lacks is not a lost optimization but a SIGILL. AES-NI and PCLMULQDQ are Westmere-era, AVX2 is Haswell-era, and Armv8 AES/SHA2 are on every arm64 runner; VAES, VPCLMULQDQ, SHA-NI, GFNI and AVX-512 are not on the whole fleet (Cascade Lake, for one, has AVX-512 but none of VAES/VPCLMULQDQ/GFNI/SHA-NI). Raising the executed baseline is a follow-up worth doing once the fleet's guaranteed set is confirmed from the `Run platform diagnostics` output, which prints it on every run.

So the wider features are type-checked instead of executed, by a check-only clippy pass over the three crates that hold architecture-specific code. Nothing else in CI compiles those paths.

`--target x86_64-unknown-linux-gnu` on that step is load-bearing, not decoration: without it cargo applies RUSTFLAGS to build scripts and proc macros as well, and *runs* them. Locally, the same command without `--target` dies before reaching any Binius crate:

```
error: failed to run custom build command for `proc-macro2 v1.0.107`
  process didn't exit successfully: [...] (signal: 4, SIGILL: illegal instruction)
```

Also drops `-Ctarget-cpu=native` from the documentation build, where it bought nothing and cost a cache bucket of its own.

### 2. Scope pull-request test legs to the arch-specific crates

Only `binius-field`, `binius-hash-prover` and `binius-arith-bench` contain architecture-specific code, but every pull request built and tested the whole workspace on all three legs. On `pull_request` the portable and arm64 legs now build, test and doctest those three crates alone. The x86_64 leg stays full on every event, `merge_group` stays full on every leg, and the `push` warmers stay full so the merge queue restores a full cache.

Workspace clippy stays on every leg and every event — it is the cheap way to type-check the arch-gated code under each leg's cfg.

**Risk accepted, as the issue states it:** the `field` SIMD paths are also exercised transitively by the `prover` and `math` tests, which no longer run on the two secondary PR legs. A SIMD bug that `field`'s own tests miss now surfaces in the merge queue, bouncing a merge rather than reaching main.

### Verification

Run locally on this tree, since nothing here can be checked without executing CI:

* Wide-feature clippy, with `--target`: clean in 28s.
* `cargo build`/`nextest run`/`test --doc` over the three-crate set under the pinned x86_64 flags: 399 tests pass.
* `cargo clippy --workspace --all-targets -- -D warnings` under the pinned x86_64 flags: clean.

This PR's own CI run is the first real measurement — it runs on `pull_request`, so the reduced legs are live here.

### Noted, not changed

`DEVELOPMENT.md`'s cross-compilation section names `binius-field` and `binius-arith-bench` as the arch-specific crates and omits `binius-hash-prover`, whose SHA-NI/AVX-512/NEON paths are equally cross-arch. Pre-existing, and a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZGaaPNGLAjY4BXQU1HPVy