### PR TITLE
[rerand] Carry the operand-column MLE-checks in the BitAnd sumcheck

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -198,11 +198,8 @@ impl IOPProver {
 		let (
 			and_columns,
 			AndCheckOutput {
-				a_eval,
-				b_eval,
-				c_eval,
 				z_challenge,
-				eval_point,
+				rerand,
 			},
 		) = {
 			let _scope = tracing::debug_span!("BitAnd check").entered();
@@ -214,12 +211,16 @@ impl IOPProver {
 			// Reduce over borrowed columns so the owned ones can be reused below without a clone.
 			// Nothing touches the channel between the reduction and the derivation, so the
 			// transcript is unchanged.
-			let output = bitand::prove::<_, B128, P, _, _>(columns.as_slices(), channel, alloc);
+			let output =
+				bitand::prove::<_, B128, P, _, _>(columns.as_slices(), &[], channel, alloc);
 			// The re-randomization re-reads all three columns, so derive the third only there.
 			let and_columns =
 				(mul.is_some() || bmul.is_some()).then(|| columns.with_derived_and(alloc));
 			(and_columns, output)
 		};
+
+		let [a_eval, b_eval, c_eval] = rerand.bitand_evals;
+		let eval_point = rerand.eval_point;
 
 		// The AND-check row point is `r_rho_and || r_x_and`: the instance index on the low
 		// coordinates, the constraint index on the high coordinates.

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -1328,13 +1328,18 @@ mod tests {
 
 		// Prover and verifier agree on the reduced claim over the batched columns.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let prove_output =
-			bitand::prove::<_, B128, P, _, _>([a, b], &mut prover_transcript, &GlobalAllocator);
+		let prove_output = bitand::prove::<_, B128, P, _, _>(
+			[a, b],
+			&[],
+			&mut prover_transcript,
+			&GlobalAllocator,
+		);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let verify_output = verify_bitand_reduction(
 			log_total,
 			&message_domain().isomorphic::<B128>(),
+			&[],
 			&mut verifier_transcript,
 		)
 		.unwrap();
@@ -1362,7 +1367,12 @@ mod tests {
 
 		// Produce a faithful proof.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let _ = bitand::prove::<_, B128, P, _, _>([a, b], &mut prover_transcript, &GlobalAllocator);
+		let _ = bitand::prove::<_, B128, P, _, _>(
+			[a, b],
+			&[],
+			&mut prover_transcript,
+			&GlobalAllocator,
+		);
 		let mut proof = prover_transcript.finalize();
 
 		// Mutation: flip a bit in the prover's first message, the univariate round evaluations.
@@ -1375,12 +1385,13 @@ mod tests {
 		let err = verify_bitand_reduction(
 			log_total,
 			&message_domain().isomorphic::<B128>(),
+			&[],
 			&mut verifier_transcript,
 		)
 		.unwrap_err();
 
-		// The closing check is `A_eval * B_eval - C_eval == sumcheck_eval`.
-		// The tampered message moves the claim, so this equality no longer holds.
+		// The closing check ties `A_eval * B_eval - C_eval`, weighted by its indicator, to the
+		// sumcheck eval. The tampered message moves the claim, so this equality no longer holds.
 		// The channel rejects the non-zero assertion, the protocol's terminal check.
 		assert_matches!(err, VerifierError::Channel(ChannelError::InvalidAssert));
 	}
@@ -1416,24 +1427,20 @@ mod tests {
 			let log_total = checked_log_2(a.len());
 
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let prove_output = bitand::prove::<_, B128, P, _, _>(columns.as_slices(), &mut prover_transcript, &GlobalAllocator);
+			let prove_output = bitand::prove::<_, B128, P, _, _>(columns.as_slices(), &[], &mut prover_transcript, &GlobalAllocator);
 
 			let mut verifier_transcript = prover_transcript.into_verifier();
 			let verify_output =
-				verify_bitand_reduction(log_total, &message_domain().isomorphic::<B128>(), &mut verifier_transcript).unwrap();
+				verify_bitand_reduction(log_total, &message_domain().isomorphic::<B128>(), &[], &mut verifier_transcript).unwrap();
 			verifier_transcript.finalize().expect("no trailing proof data");
 
 			// Both sides reach the same reduced claim.
 			prop_assert_eq!(&prove_output, &verify_output);
 
 			// Each claimed eval is the column's multilinear, folded at z and evaluated at the point.
-			let AndCheckOutput {
-				a_eval,
-				b_eval,
-				c_eval,
-				z_challenge,
-				eval_point,
-			} = verify_output;
+			let AndCheckOutput { z_challenge, rerand } = verify_output;
+			let [a_eval, b_eval, c_eval] = rerand.bitand_evals;
+			let eval_point = rerand.eval_point;
 			prop_assert_eq!(fold_eval_column(a, z_challenge, &eval_point), a_eval);
 			prop_assert_eq!(fold_eval_column(b, z_challenge, &eval_point), b_eval);
 			prop_assert_eq!(fold_eval_column(&c_cols, z_challenge, &eval_point), c_eval);

--- a/crates/prover/src/protocols/bitand/prove.rs
+++ b/crates/prover/src/protocols/bitand/prove.rs
@@ -7,18 +7,21 @@ use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField, Rijndael8b as B8};
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::BinarySubspace;
+use binius_math::{BinarySubspace, univariate::EvaluationDomain};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, protocols::bitand::AndCheckOutput,
 };
 
 use super::prover::OblongZerocheckProver;
+use crate::protocols::rerand::{self, OperandWitness};
 
 /// Proves the AND constraint reduction over the two operand columns `A` and `B`.
 ///
 /// This wraps [`OblongZerocheckProver`], the univariate-skip zerocheck kernel, so both the
 /// single-instance prover and the M4 batch prover route their AND check through one entry point.
+/// Its multilinear rounds are one sumcheck with the operand-column MLE-checks of `operands`; see
+/// [`rerand::prove`].
 /// The `C` operand is never passed: the reduction derives `C = A & B` word-by-word, which is sound
 /// because folding is F2-linear on word bits (see [`OblongZerocheckProver::new`]).
 ///
@@ -42,6 +45,7 @@ use super::prover::OblongZerocheckProver;
 /// Panics if the two operand columns don't have equal length.
 pub fn prove<A, F, PChallenge, Channel, Data>(
 	columns: [Data; 2],
+	operands: &[OperandWitness<'_, F>],
 	channel: &mut Channel,
 	alloc: &A,
 ) -> AndCheckOutput<F>
@@ -77,7 +81,24 @@ where
 		&prover_message_domain,
 	);
 
-	prover.prove_with_channel::<PChallenge, _>(channel, alloc)
+	channel.send_many(prover.round_message());
+	let z_challenge = channel.sample();
+	let claim = prover.univariate_claim(z_challenge);
+
+	let domain = prover_message_domain.isomorphic::<F>();
+	let bitand = tracing::debug_span!("Fold univariate round").in_scope(|| {
+		prover.fold_and_send_reduced_prover::<PChallenge, _>(&domain, z_challenge, alloc)
+	});
+	// The operand columns fold over the 64-point domain: the skip domain less its top dimension.
+	let lagrange = domain
+		.reduce_dim(Word::LOG_BITS)
+		.lagrange_evals(&z_challenge);
+	let rerand =
+		rerand::prove::<_, PChallenge, _, _>(bitand, claim, &lagrange, operands, channel, alloc);
+	AndCheckOutput {
+		z_challenge,
+		rerand,
+	}
 }
 
 #[cfg(test)]
@@ -126,6 +147,7 @@ mod tests {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let output = prove::<_, B128, OptimalPackedB128, _, _>(
 					columns,
+					&[],
 					&mut transcript,
 					&GlobalAllocator,
 				);
@@ -142,6 +164,7 @@ mod tests {
 			let verify_output = verify_bitand_reduction(
 				log_rows,
 				&BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1).isomorphic::<B128>(),
+				&[],
 				&mut verifier_transcript,
 			)
 			.unwrap();

--- a/crates/prover/src/protocols/bitand/prover.rs
+++ b/crates/prover/src/protocols/bitand/prover.rs
@@ -6,16 +6,10 @@ use std::ops::Deref;
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField, Rijndael8b as B8};
-use binius_ip_prover::{
-	channel::IPProverChannel,
-	sumcheck::{
-		ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck, quadratic_mlecheck_prover,
-	},
-};
+use binius_ip_prover::sumcheck::{common::MleCheckProver, quadratic_mlecheck_prover};
 use binius_math::{BinarySubspace, univariate::EvaluationDomain};
 use binius_verifier::{
-	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
-	protocols::bitand::{AndCheckOutput, ROWS_PER_HYPERCUBE_VERTEX},
+	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, protocols::bitand::ROWS_PER_HYPERCUBE_VERTEX,
 };
 
 use super::sumcheck_round_messages;
@@ -132,6 +126,17 @@ where
 		&self.univariate_round_message
 	}
 
+	/// The univariate round polynomial at `challenge`: the claim the multilinear rounds prove.
+	///
+	/// The polynomial is zero on the base half of the domain, and the round message holds its
+	/// evaluations on the upper half.
+	pub fn univariate_claim(&self, challenge: F) -> F {
+		let mut coeffs = vec![F::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
+		coeffs[ROWS_PER_HYPERCUBE_VERTEX..].copy_from_slice(&self.univariate_round_message);
+		self.univariate_round_message_domain
+			.extrapolate(&coeffs, &challenge)
+	}
+
 	/// Folds the oblong multilinears at the univariate challenge and creates the sumcheck prover.
 	///
 	/// This method performs the transition between Phase 1 (univariate polynomial) and Phase 2
@@ -168,6 +173,7 @@ where
 		challenge: F,
 		alloc: &'alloc A,
 	) -> impl MleCheckProver<F> + 'alloc {
+		let claim = self.univariate_claim(challenge);
 		let univariate_domain = round_message_domain.reduce_dim(round_message_domain.dim() - 1);
 		let lagrange_evals = univariate_domain.lagrange_evals(&challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
@@ -185,87 +191,14 @@ where
 			.chain(self.big_field_zerocheck_challenges)
 			.collect::<Vec<_>>();
 
-		let mut first_round_message_coeffs = vec![F::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
-
-		first_round_message_coeffs[ROWS_PER_HYPERCUBE_VERTEX..2 * ROWS_PER_HYPERCUBE_VERTEX]
-			.copy_from_slice(&self.univariate_round_message);
-
 		quadratic_mlecheck_prover(
 			alloc,
 			proving_polys,
 			|[a, b, c]| a * b - c,
 			|[a, b, _]| a * b,
 			verifier_field_zerocheck_challenges,
-			round_message_domain.extrapolate(&first_round_message_coeffs, &challenge),
+			claim,
 		)
-	}
-
-	/// Executes the complete AND reduction protocol with an IP prover channel.
-	///
-	/// This method orchestrates the entire AND reduction protocol:
-	/// 1. Sends the univariate polynomial evaluations to the channel
-	/// 2. Receives the univariate challenge via Fiat-Shamir
-	/// 3. Folds the oblong multilinears at the challenge point
-	/// 4. Runs the multilinear sumcheck protocol
-	///
-	/// # Arguments
-	///
-	/// * `channel` - The prover's channel for non-interactive proof generation
-	///
-	/// # Returns
-	///
-	/// Returns `ProveAndReductionOutput` containing:
-	/// - The sumcheck output with evaluation claims and challenges
-	/// - The univariate challenge used for folding
-	///
-	/// # Protocol Flow
-	///
-	/// 1. **Phase 1**: Write univariate polynomial evaluations to channel
-	/// 2. **Challenge**: Sample univariate challenge z via Fiat-Shamir
-	/// 3. **Transition**: Fold oblong multilinears at Z = z
-	/// 4. **Phase 2**: Execute sumcheck protocol on folded multilinears
-	///
-	/// # Panics
-	///
-	/// Panics if the MLE-check sumcheck does not resolve to exactly 3 evaluation claims (one each
-	/// for A, B, and C).
-	pub fn prove_with_channel<PChallenge: PackedField<Scalar = F>, A: Allocator>(
-		self,
-		channel: &mut impl IPProverChannel<F>,
-		alloc: &A,
-	) -> AndCheckOutput<F> {
-		let univariate_message_coeffs = self.round_message();
-
-		channel.send_many(univariate_message_coeffs);
-
-		let univariate_sumcheck_challenge = channel.sample();
-		let univariate_round_message_domain = self.univariate_round_message_domain.clone();
-		let sumcheck_prover = tracing::debug_span!("Fold univariate round").in_scope(|| {
-			self.fold_and_send_reduced_prover::<PChallenge, A>(
-				&univariate_round_message_domain,
-				univariate_sumcheck_challenge,
-				alloc,
-			)
-		});
-
-		let ProveSingleOutput {
-			multilinear_evals: mle_claims,
-			challenges: mut eval_point,
-		} = tracing::debug_span!("MLE-check remaining rounds")
-			.in_scope(|| prove_single_mlecheck(sumcheck_prover, channel));
-
-		eval_point.reverse();
-
-		assert_eq!(mle_claims.len(), 3);
-		channel.send_many(&mle_claims);
-
-		AndCheckOutput {
-			a_eval: mle_claims[0],
-			b_eval: mle_claims[1],
-			c_eval: mle_claims[2],
-			z_challenge: univariate_sumcheck_challenge,
-			eval_point,
-		}
 	}
 }
 
@@ -279,15 +212,15 @@ mod test {
 	use binius_math::{
 		BinarySubspace, FieldBuffer, multilinear::evaluate::evaluate, univariate::EvaluationDomain,
 	};
-	use binius_transcript::{ProverTranscript, fiat_shamir::CanSample};
+	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
-		config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, StdChallenger},
-		protocols::bitand::{AndCheckOutput, SKIPPED_VARS, verify_with_channel},
+		config::{B128, StdChallenger},
+		protocols::bitand::{AndCheckOutput, SKIPPED_VARS},
+		verify_bitand_reduction,
 	};
 	use rand::prelude::*;
 
-	use super::OblongZerocheckProver;
-	use crate::fold_word::BitAxisFolder;
+	use crate::{fold_word::BitAxisFolder, protocols::bitand::prove};
 
 	fn random_words(log_num_words: usize, mut rng: impl Rng) -> Vec<Word> {
 		repeat_with(|| Word(rng.random()))
@@ -301,8 +234,6 @@ mod test {
 		let log_num_rows = 6;
 		let mut rng = StdRng::seed_from_u64(0);
 
-		let small_field_zerocheck_challenges =
-			[Rijndael8b::new(2), Rijndael8b::new(4), Rijndael8b::new(16)];
 		let first_mlv = random_words(log_num_rows, &mut rng);
 		let second_mlv = random_words(log_num_rows, &mut rng);
 		// The prover receives only the A and B columns.
@@ -315,51 +246,30 @@ mod test {
 		let prover_message_domain = BinarySubspace::<Rijndael8b>::with_dim(SKIPPED_VARS + 1);
 		let verifier_message_domain = prover_message_domain.isomorphic();
 
-		// Prover is instantiated
-		let big_field_zerocheck_challenges = prover_challenger
-			.sample_vec(log_num_rows - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
-		let prover = OblongZerocheckProver::<_, _>::new(
-			log_num_rows,
-			first_mlv.clone(),
-			second_mlv.clone(),
-			big_field_zerocheck_challenges,
-			&prover_message_domain,
+		let prove_output = prove::<_, B128, OptimalPackedB128, _, _>(
+			[first_mlv.clone(), second_mlv.clone()],
+			&[],
+			&mut prover_challenger,
+			&GlobalAllocator,
 		);
 
-		let prove_output = prover
-			.prove_with_channel::<OptimalPackedB128, _>(&mut prover_challenger, &GlobalAllocator);
-
-		// Verifier is instantiated
 		let mut verifier_challenger = prover_challenger.into_verifier();
-
-		let big_field_zerocheck_challenges = verifier_challenger.sample_vec(log_num_rows - 3);
-
-		let mut all_zerocheck_challenges = vec![];
-
-		for small_field_challenge in small_field_zerocheck_challenges {
-			all_zerocheck_challenges.push(B128::from(small_field_challenge));
-		}
-
-		for big_field_challenge in &big_field_zerocheck_challenges {
-			all_zerocheck_challenges.push(*big_field_challenge);
-		}
-
-		let verify_output = verify_with_channel(
-			&all_zerocheck_challenges,
-			&mut verifier_challenger,
+		let verify_output = verify_bitand_reduction(
+			log_num_rows,
 			&verifier_message_domain,
+			&[],
+			&mut verifier_challenger,
 		)
 		.unwrap();
 
 		assert_eq!(prove_output, verify_output);
 
 		let AndCheckOutput {
-			a_eval,
-			b_eval,
-			c_eval,
 			z_challenge,
-			eval_point,
+			rerand,
 		} = verify_output;
+		let [a_eval, b_eval, c_eval] = rerand.bitand_evals;
+		let eval_point = rerand.eval_point;
 
 		let verifier_univariate_domain = verifier_message_domain.reduce_dim(SKIPPED_VARS);
 

--- a/crates/prover/src/protocols/mod.rs
+++ b/crates/prover/src/protocols/mod.rs
@@ -3,4 +3,5 @@
 pub mod binmul;
 pub mod bitand;
 pub mod intmul;
+pub mod rerand;
 pub mod shift;

--- a/crates/prover/src/protocols/rerand.rs
+++ b/crates/prover/src/protocols/rerand.rs
@@ -1,0 +1,308 @@
+// Copyright 2026 The Binius Developers
+
+//! Prover for the BitAnd sumcheck batched with the operand-column MLE-checks.
+//!
+//! See [`binius_verifier::protocols::rerand`] for the protocol.
+
+use std::iter;
+
+use binius_compute::Allocator;
+use binius_core::word::Word;
+use binius_field::{BinaryField, PackedField};
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{
+		MleToSumCheckDecorator, PaddedSumcheckDecorator, batch::batch_prove_and_write_evals,
+		common::MleCheckProver, mle_store::MleStore, multilinear_eval::MultilinearEvalEvaluator,
+		round_evaluator::SharedMleCheckProver,
+	},
+};
+use binius_math::inner_product::inner_product;
+use binius_verifier::protocols::rerand::{OperandClaims, RerandOutput, SUMCHECK_DEGREE};
+use either::Either;
+
+use crate::fold_word::BitAxisFolder;
+
+/// One reduction's operand word columns with their per-bit claims.
+pub struct OperandWitness<'a, F> {
+	/// One column per operand, in the same order as `claims.columns`.
+	pub words: Vec<&'a [Word]>,
+	/// The per-bit claims on the columns, at the reduction's point.
+	pub claims: OperandClaims<'a, F>,
+}
+
+/// Proves the BitAnd sumcheck batched with the operand-column MLE-checks.
+///
+/// Every summand runs as a sumcheck in plain form, zero-padded on its high variables to the
+/// longest summand's variable count. The evaluations go out flat in summand order:
+/// `[a, b, c, sigma_1, ..., sigma_n]`.
+///
+/// # Arguments
+///
+/// * `bitand` - the BitAnd MLE-check prover, from the univariate skip's fold.
+/// * `bitand_claim` - its claim, the univariate-skip polynomial at `z`.
+/// * `lagrange` - the Lagrange weights at `z` on the 64-point domain.
+/// * `operands` - the operand columns of each multiplication reduction, with their claims.
+///
+/// The per-bit claims of `operands` must be in the transcript before `z` was drawn, matching
+/// [`binius_verifier::protocols::rerand::verify`].
+///
+/// # Preconditions
+///
+/// * each operand's column count equals its claim count
+/// * each column's length rounds up to `2^point.len()` for its reduction's point
+pub fn prove<F, P, Channel, A>(
+	bitand: impl MleCheckProver<F>,
+	bitand_claim: F,
+	lagrange: &[F],
+	operands: &[OperandWitness<'_, F>],
+	channel: &mut Channel,
+	alloc: &A,
+) -> RerandOutput<F>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+	A: Allocator,
+{
+	let _scope = tracing::debug_span!("BitAnd batched sumcheck").entered();
+
+	// ponytail: ten columns in the sumcheck where two theta-combined tables would do (spec §4.7.1).
+	// Combine them only if this sumcheck shows in a profile.
+	let folder = BitAxisFolder::new(lagrange);
+	let operand_provers = operands.iter().map(|operand| {
+		let OperandClaims { point, columns } = &operand.claims;
+		assert_eq!(operand.words.len(), columns.len());
+
+		let mut store = MleStore::<A, P>::new(point.len(), alloc);
+		let evaluators = iter::zip(&operand.words, columns)
+			.map(|(words, per_bit_claims)| {
+				let col = store.push_owned(folder.fold::<P, _>(alloc, words));
+				let claim = inner_product(per_bit_claims.iter().copied(), lagrange.iter().copied());
+				(claim, MultilinearEvalEvaluator::new(col))
+			})
+			.collect::<Vec<_>>();
+		let claims = evaluators.iter().map(|&(claim, _)| claim).collect();
+		(SharedMleCheckProver::new(store, evaluators, point.to_vec()), claims)
+	});
+	let summands = iter::once((Either::Left(bitand), vec![bitand_claim]))
+		.chain(operand_provers.map(|(prover, claims)| (Either::Right(prover), claims)))
+		.collect::<Vec<_>>();
+
+	let n_vars = summands
+		.iter()
+		.map(|(prover, _)| prover.n_vars())
+		.max()
+		.expect("the BitAnd summand is always present");
+	let provers = summands
+		.into_iter()
+		.map(|(prover, claims)| {
+			let n_extra_vars = n_vars - prover.n_vars();
+			let prover = MleToSumCheckDecorator::new(prover);
+			PaddedSumcheckDecorator::new(prover, n_extra_vars, claims, SUMCHECK_DEGREE)
+		})
+		.collect();
+
+	let output = batch_prove_and_write_evals(provers, channel);
+
+	let mut evals = output.multilinear_evals.into_iter();
+	let bitand_evals = evals
+		.next()
+		.and_then(|evals| evals.try_into().ok())
+		.expect("the BitAnd summand reduces to its three columns");
+	let operand_evals = evals.flatten().collect();
+	let mut eval_point = output.challenges;
+	eval_point.reverse();
+	RerandOutput {
+		eval_point,
+		bitand_evals,
+		operand_evals,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{array, iter::repeat_with};
+
+	use binius_compute::GlobalAllocator;
+	use binius_field::{Field, Rijndael8b as B8, arch::OptimalPackedB128};
+	use binius_ip::channel::Error as ChannelError;
+	use binius_math::{
+		BinarySubspace, FieldBuffer,
+		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
+		test_utils::random_scalars,
+		univariate::EvaluationDomain,
+	};
+	use binius_transcript::{ProverTranscript, VerifierTranscript};
+	use binius_verifier::{
+		Error as VerifierError,
+		config::{B128, StdChallenger},
+		protocols::bitand::AndCheckOutput,
+		verify_bitand_reduction,
+	};
+	use rand::prelude::*;
+
+	use super::*;
+	use crate::protocols::bitand;
+
+	fn random_words(rng: &mut StdRng, n: usize) -> Vec<Word> {
+		repeat_with(|| Word(rng.random())).take(n).collect()
+	}
+
+	/// A synthetic multiplication reduction: random word columns, and their honest per-bit claims
+	/// at a random point.
+	struct Reduction {
+		columns: Vec<Vec<Word>>,
+		point: Vec<B128>,
+		per_bit_claims: Vec<[B128; Word::BITS]>,
+	}
+
+	impl Reduction {
+		fn random(rng: &mut StdRng, n_vars: usize, n_columns: usize) -> Self {
+			let point = random_scalars::<B128>(&mut *rng, n_vars);
+			let eq = eq_ind_partial_eval_scalars(&point);
+			let columns = repeat_with(|| random_words(rng, 1 << n_vars))
+				.take(n_columns)
+				.collect::<Vec<_>>();
+			// Bit `i` of every word, as a multilinear, evaluated at the point.
+			let per_bit_claims = columns
+				.iter()
+				.map(|words| {
+					array::from_fn(|bit| {
+						iter::zip(words, &eq)
+							.filter(|(word, _)| (word.0 >> bit) & 1 == 1)
+							.map(|(_, &eq)| eq)
+							.sum()
+					})
+				})
+				.collect();
+			Self {
+				columns,
+				point,
+				per_bit_claims,
+			}
+		}
+
+		fn claims(&self) -> OperandClaims<'_, B128> {
+			OperandClaims {
+				point: &self.point,
+				columns: self.per_bit_claims.iter().collect(),
+			}
+		}
+
+		fn witness(&self) -> OperandWitness<'_, B128> {
+			OperandWitness {
+				words: self.columns.iter().map(Vec::as_slice).collect(),
+				claims: self.claims(),
+			}
+		}
+	}
+
+	fn andcheck_domain() -> BinarySubspace<B128> {
+		BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1).isomorphic()
+	}
+
+	/// Proves BitAnd over random columns of `2^log_and` rows, batched with `reductions`.
+	fn prove_random(
+		rng: &mut StdRng,
+		log_and: usize,
+		reductions: &[Reduction],
+	) -> (AndCheckOutput<B128>, Vec<u8>) {
+		let columns = [
+			random_words(rng, 1 << log_and),
+			random_words(rng, 1 << log_and),
+		];
+		let operands = reductions
+			.iter()
+			.map(Reduction::witness)
+			.collect::<Vec<_>>();
+		let mut transcript = ProverTranscript::new(StdChallenger::default());
+		let output = bitand::prove::<_, B128, OptimalPackedB128, _, _>(
+			columns,
+			&operands,
+			&mut transcript,
+			&GlobalAllocator,
+		);
+		(output, transcript.finalize())
+	}
+
+	fn verify_proof(
+		log_and: usize,
+		reductions: &[Reduction],
+		proof: Vec<u8>,
+	) -> Result<AndCheckOutput<B128>, VerifierError> {
+		let claims = reductions.iter().map(Reduction::claims).collect::<Vec<_>>();
+		let mut transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		let output =
+			verify_bitand_reduction(log_and, &andcheck_domain(), &claims, &mut transcript)?;
+		transcript.finalize().expect("no trailing proof data");
+		Ok(output)
+	}
+
+	#[test]
+	fn prover_and_verifier_agree() {
+		let mut rng = StdRng::seed_from_u64(0);
+		// `(log_and, [log_z per reduction])`: shorter, equal and longer than BitAnd, two reductions
+		// of different lengths, no reductions, and an empty BitAnd axis.
+		let grid: [(usize, &[usize]); 6] = [
+			(5, &[3]),
+			(4, &[4]),
+			(3, &[5]),
+			(4, &[2, 6]),
+			(4, &[]),
+			(0, &[2]),
+		];
+		for (log_and, log_zs) in grid {
+			// IntMul's and BinMul's column counts, alternating.
+			let reductions = iter::zip(log_zs, [4, 6])
+				.map(|(&n_vars, n_columns)| Reduction::random(&mut rng, n_vars, n_columns))
+				.collect::<Vec<_>>();
+			let (output, proof) = prove_random(&mut rng, log_and, &reductions);
+			let verified = verify_proof(log_and, &reductions, proof).unwrap();
+			assert_eq!(output, verified, "at log_and = {log_and}, log_zs = {log_zs:?}");
+
+			// Each operand eval is its folded column at its point's prefix of the unified point.
+			let lagrange = andcheck_domain()
+				.reduce_dim(Word::LOG_BITS)
+				.lagrange_evals(&output.z_challenge);
+			let folder = &BitAxisFolder::new(&lagrange);
+			let rerand = output.rerand;
+			let expected = reductions
+				.iter()
+				.flat_map(|reduction| {
+					let point = &rerand.eval_point[..reduction.point.len()];
+					reduction.columns.iter().map(move |words| {
+						let folded: FieldBuffer<B128> = folder.fold(&GlobalAllocator, words);
+						evaluate(&folded, point)
+					})
+				})
+				.collect::<Vec<_>>();
+			assert_eq!(rerand.operand_evals, expected);
+		}
+	}
+
+	#[test]
+	fn mutated_operand_eval_is_rejected() {
+		let mut rng = StdRng::seed_from_u64(1);
+		let reductions = [Reduction::random(&mut rng, 5, 4)];
+		let (_, mut proof) = prove_random(&mut rng, 4, &reductions);
+
+		// The last operand eval is the proof's final element.
+		*proof.last_mut().unwrap() ^= 1;
+
+		let err = verify_proof(4, &reductions, proof).unwrap_err();
+		assert!(matches!(err, VerifierError::Channel(ChannelError::InvalidAssert)));
+	}
+
+	#[test]
+	fn mutated_per_bit_claim_is_rejected() {
+		let mut rng = StdRng::seed_from_u64(2);
+		let mut reductions = [Reduction::random(&mut rng, 3, 6)];
+		let (_, proof) = prove_random(&mut rng, 4, &reductions);
+
+		reductions[0].per_bit_claims[2][17] += B128::ONE;
+
+		let err = verify_proof(4, &reductions, proof).unwrap_err();
+		assert!(matches!(err, VerifierError::Channel(ChannelError::InvalidAssert)));
+	}
+}

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -177,16 +177,13 @@ impl IOPProver {
 				.in_scope(|| build_operation_columns(&cs.and_constraints, witness, alloc));
 
 			let AndCheckOutput {
-				a_eval,
-				b_eval,
-				c_eval,
 				z_challenge,
-				eval_point,
-			} = bitand::prove::<_, B128, P, _, _>(bitand_columns, &mut *channel, alloc);
+				rerand,
+			} = bitand::prove::<_, B128, P, _, _>(bitand_columns, &[], &mut *channel, alloc);
 			OperatorData {
-				evals: [a_eval, b_eval, c_eval],
+				evals: rerand.bitand_evals,
 				r_zhat_prime: z_challenge,
-				r_x_prime: eval_point,
+				r_x_prime: rerand.eval_point,
 			}
 		};
 		drop(bitand_guard);

--- a/crates/verifier/src/protocols/binmul.rs
+++ b/crates/verifier/src/protocols/binmul.rs
@@ -5,7 +5,7 @@ use binius_field::{BinaryField, field::FieldOps};
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck::SumcheckOutput};
 use binius_math::inner_product::inner_product;
 
-use crate::Error;
+use crate::{Error, protocols::rerand::OperandClaims};
 
 /// Output of the BinMul reduction.
 ///
@@ -26,6 +26,23 @@ pub struct BinMulOutput<F> {
 	pub b_hi_evals: [F; Word::BITS],
 	pub c_lo_evals: [F; Word::BITS],
 	pub c_hi_evals: [F; Word::BITS],
+}
+
+impl<F> BinMulOutput<F> {
+	/// The operand claims, in the shift operand order `[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi]`.
+	pub fn operand_claims(&self) -> OperandClaims<'_, F> {
+		OperandClaims {
+			point: &self.eval_point,
+			columns: vec![
+				&self.a_lo_evals,
+				&self.a_hi_evals,
+				&self.b_lo_evals,
+				&self.b_hi_evals,
+				&self.c_lo_evals,
+				&self.c_hi_evals,
+			],
+		}
+	}
 }
 
 /// Verify the binary-field multiplication check (BinMul) reduction.

--- a/crates/verifier/src/protocols/bitand.rs
+++ b/crates/verifier/src/protocols/bitand.rs
@@ -4,9 +4,10 @@
 use std::iter::{self};
 
 use binius_field::{BinaryField, field::FieldOps};
-use binius_ip::{channel::IPVerifierChannel, mlecheck::verify, sumcheck::SumcheckOutput};
+use binius_ip::channel::IPVerifierChannel;
 use binius_math::{BinarySubspace, univariate::EvaluationDomain};
 
+use super::rerand::RerandOutput;
 use crate::Error;
 
 /// log2 size of the univariate domain
@@ -15,17 +16,25 @@ pub const SKIPPED_VARS: usize = binius_core::Word::LOG_BITS;
 /// Size of the univariate domain
 pub const ROWS_PER_HYPERCUBE_VERTEX: usize = 1 << SKIPPED_VARS;
 
-/// Output from the AND constraint reduction protocol verification.
-#[derive(Debug, PartialEq, Eq)]
-pub struct AndCheckOutput<F> {
-	pub a_eval: F,
-	pub b_eval: F,
-	pub c_eval: F,
+/// Output of the univariate skip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnivariateSkipOutput<F> {
+	/// The univariate challenge `z` sampled for the bit-index variable.
 	pub z_challenge: F,
-	pub eval_point: Vec<F>,
+	/// The univariate polynomial at `z`, `g(z)`: the claim the multilinear rounds prove.
+	pub claim: F,
 }
 
-/// Verifies the AND constraint reduction protocol via univariate zerocheck.
+/// Output of the whole BitAnd reduction: the univariate skip, then the batched sumcheck.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AndCheckOutput<F> {
+	/// The univariate challenge `z` sampled for the bit-index variable.
+	pub z_challenge: F,
+	/// The batched sumcheck's evaluation claims. See [`super::rerand`].
+	pub rerand: RerandOutput<F>,
+}
+
+/// Verifies the univariate skip of the AND constraint reduction.
 ///
 /// Note: Following section 4.4 of the Binius64 writeup, Z is the bit index within a word, and X is
 /// the word index
@@ -34,68 +43,25 @@ pub struct AndCheckOutput<F> {
 ///
 /// Let our zerocheck challenges be (r₀, ...)
 ///
-/// This protocol reduces the verification of AND constraints (A(Z,X₀,...,Xₙ₋₁)·B(Z,X₀,...,Xₙ₋₁) -
-/// C(Z,X₀,...,Xₙ₋₁) = 0) over a multivariate domain to a single multilinear polynomial evaluation.
-/// The key insight is that A·B-C = 0 if and only if for all Z, the multilinear extension of A·B-C
-/// evaluates to zero at a random point (Z,r₀,...,rₙ₋₁), (up to some negligible error probability).
-///
-/// Note: This is equivalent to proving |D| multilinear zerochecks at once, all using the same
-/// random zerocheck challenges
-///
-/// ## Phase 1: Univariate Polynomial Verification
+/// The reduction checks A·B-C = 0 on every row. That holds if and only if, for all Z, the
+/// multilinear extension of A·B-C evaluates to zero at a random point (Z,r₀,...,rₙ₋₁), up to some
+/// negligible error probability.
 ///
 /// The prover sends a univariate polynomial R₀(Z) that encodes the sum:
 ///
 /// R₀(Z) = ∑_{X₀,...,Xₙ₋₁ ∈ {0,1}} (A(Z,X₀,...,Xₙ₋₁)·B(Z,X₀,...,Xₙ₋₁) -
 /// C(Z,X₀,...,Xₙ₋₁))·eq(X₀,...,Xₙ₋₁; r₀,...,rₙ₋₁)
 ///
-/// where:
-/// - A(Z,X₀,...,Xₙ₋₁), B(Z,X₀,...,Xₙ₋₁), C(Z,X₀,...,Xₙ₋₁) are oblong multilinear polynomials
-///   representing the AND constraint operands
-/// - eq(X₀,...,Xₙ₋₁; r₀,...,rₙ₋₁) is the multilinear equality indicator partially evaluated at a
-///   series of random and compile-time pre-known challenges r₀,...,rₙ₋₁ (note: Z is not included in
-///   the equality check)
-/// - Z ranges over a univariate domain of size 2^(SKIPPED_VARS + 1)
+/// Z ranges over a univariate domain of size 2^(SKIPPED_VARS + 1). The polynomial R₀(Z) has degree
+/// at most 2*(|D| - 1). The prover only sends evaluations on the upper half of the domain, since
+/// R₀(Z) = 0 on the base domain when all AND constraints are satisfied.
 ///
-/// The equality indicator eq(X₀,...,Xₙ₋₁; r₀,...,rₙ₋₁) = ∏ᵢ₌₀ⁿ⁻¹(Xᵢ·rᵢ + (1-Xᵢ)·(1-rᵢ)) ensures
-/// we're checking that the multilinear extension of A·B-C evaluates to zero at the random point
-/// (Z, r₀,...,rₙ₋₁) for each Z in the domain.
-///
-/// The polynomial R₀(Z) has degree at most 2*(|D| - 1) where |D| is the domain size. The prover
-/// only sends evaluations on an extension domain (the upper half) since R₀(Z) = 0 on the base
-/// domain when all AND constraints are satisfied.
-///
-/// ## Phase 2: Multilinear Sumcheck Reduction
-///
-/// After the verifier samples a random challenge z for Z, the protocol continues with a standard
-/// sumcheck protocol on the remaining variables X₀,...,Xₙ₋₁ to verify that:
-///
-/// R₀(z) = ∑_{X₀,...,Xₙ₋₁ ∈ {0,1}} (A(z,X₀,...,Xₙ₋₁)·B(z,X₀,...,Xₙ₋₁) -
-/// C(z,X₀,...,Xₙ₋₁))·eq(X₀,...,Xₙ₋₁; r₀,...,rₙ₋₁)
-///
-///
-/// This reduces to a single evaluation of the folded polynomial at the sumcheck challenge point.
-///
-/// ## Arguments
-///
-/// * `n_vars` - The number of variables in the sumcheck protocol (excluding the univariate variable
-///   Z)
-/// * `transcript` - The verifier's transcript for reading prover messages and sampling challenges
-/// * `round_message_univariate_domain` - The univariate domain D for polynomial evaluations
-///
-/// ## Returns
-///
-/// Returns `AndCheckOutput` containing:
-/// - `z_challenge`: The univariate challenge z sampled for the bit-index variable
-/// - `eval_point`: The multilinear evaluation point. Prepened with the `z_challenge` this makes the
-///   oblong evaluation point
-/// - `a_eval`, `b_eval`, `c_eval`: The claimed evaluations of the A, B, and C at the oblong
-///   evaluation point
-pub fn verify_with_channel<F, C>(
-	all_zerocheck_challenges: &[C::Elem],
+/// The verifier samples a challenge z for Z. The claim R₀(z) is then proven by the batched
+/// sumcheck in [`super::rerand`], over the remaining variables X₀,...,Xₙ₋₁.
+pub fn verify_univariate_skip<F, C>(
 	channel: &mut C,
-	round_message_univariate_domain: &BinarySubspace<F>,
-) -> Result<AndCheckOutput<C::Elem>, Error>
+	domain: &BinarySubspace<F>,
+) -> Result<UnivariateSkipOutput<C::Elem>, Error>
 where
 	F: BinaryField,
 	C: IPVerifierChannel<F>,
@@ -110,27 +76,8 @@ where
 	)
 	.collect::<Vec<_>>();
 
-	let univariate_sumcheck_challenge = channel.sample();
+	let z_challenge = channel.sample();
+	let claim = domain.extrapolate(&univariate_message_coeffs, &z_challenge);
 
-	let sumcheck_claim = round_message_univariate_domain
-		.extrapolate(&univariate_message_coeffs, &univariate_sumcheck_challenge);
-
-	let SumcheckOutput {
-		eval,
-		challenges: mut eval_point,
-	} = verify(all_zerocheck_challenges, 2, sumcheck_claim, channel)?;
-
-	let [a_eval, b_eval, c_eval] = channel.recv_array()?;
-
-	channel.assert_zero(a_eval.clone() * &b_eval - &c_eval - &eval)?;
-
-	eval_point.reverse();
-
-	Ok(AndCheckOutput {
-		a_eval,
-		b_eval,
-		c_eval,
-		z_challenge: univariate_sumcheck_challenge,
-		eval_point,
-	})
+	Ok(UnivariateSkipOutput { z_challenge, claim })
 }

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -7,6 +7,8 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, field::FieldOps};
 use itertools::iterate;
 
+use crate::protocols::rerand::OperandClaims;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntMulOutput<F> {
 	pub eval_point: Vec<F>,
@@ -14,6 +16,21 @@ pub struct IntMulOutput<F> {
 	pub b_evals: [F; Word::BITS],
 	pub c_lo_evals: [F; Word::BITS],
 	pub c_hi_evals: [F; Word::BITS],
+}
+
+impl<F> IntMulOutput<F> {
+	/// The operand claims, in the shift operand order `[a, b, c_lo, c_hi]`.
+	pub fn operand_claims(&self) -> OperandClaims<'_, F> {
+		OperandClaims {
+			point: &self.eval_point,
+			columns: vec![
+				&self.a_evals,
+				&self.b_evals,
+				&self.c_lo_evals,
+				&self.c_hi_evals,
+			],
+		}
+	}
 }
 
 /// Output of Phase 1: GKR reduction of the exponentiation product tree.

--- a/crates/verifier/src/protocols/mod.rs
+++ b/crates/verifier/src/protocols/mod.rs
@@ -5,5 +5,6 @@ pub mod binmul;
 pub mod bitand;
 pub mod intmul;
 pub mod pubcheck;
+pub mod rerand;
 pub mod shift;
 pub mod zero;

--- a/crates/verifier/src/protocols/rerand.rs
+++ b/crates/verifier/src/protocols/rerand.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 The Binius Developers
+
+//! The BitAnd sumcheck, batched with the multiplication reductions' operand-column MLE-checks.
+//!
+//! After the univariate skip, the BitAnd claim `g(z)` is the MLE-check
+//!
+//! ```text
+//! g(z) = sum_x eq(x, r_x) * (A(z, x) * B(z, x) - C(z, x))
+//! ```
+//!
+//! at the zerocheck point `r_x`. Each operand column of an IntMul or BinMul reduction carries one
+//! claim per bit at that reduction's own point `rho`. The Lagrange weights at `z` fold them to one
+//! MLE-check per column, `alpha = sum_x eq(x, rho) * Z(z, x)`, with no transcript traffic.
+//!
+//! One sumcheck in plain form proves all of them, batched by powers of one challenge `theta`,
+//! BitAnd first. It runs over the longest summand's variables. A shorter summand is zero-padded on
+//! its high variables, so its point is a prefix of the unified point `r*`.
+//!
+//! The round polynomials have degree 3: BitAnd's composition has degree 2, and its equality
+//! indicator adds one.
+
+use std::iter;
+
+use binius_core::word::Word;
+use binius_field::Field;
+use binius_ip::{
+	channel::IPVerifierChannel,
+	sumcheck::{BatchSumcheckOutput, batch_verify},
+};
+use binius_math::{
+	inner_product::inner_product,
+	multilinear::eq::{eq_ind, eq_ind_zero},
+	univariate::evaluate_univariate,
+};
+
+use crate::Error;
+
+/// One reduction's per-bit evaluation claims on its operand columns, at that reduction's point.
+pub struct OperandClaims<'a, E> {
+	/// The reduction's constraint point. In batch mode: instances low, constraints high.
+	pub point: &'a [E],
+	/// One 64-entry array per operand column, in the shift reduction's operand order.
+	pub columns: Vec<&'a [E; Word::BITS]>,
+}
+
+/// Degree of the batched round polynomials: the BitAnd summand's prime degree 2 plus its indicator.
+pub const SUMCHECK_DEGREE: usize = 3;
+
+/// The evaluation claims the batched sumcheck reduces to, all at prefixes of one point.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RerandOutput<F> {
+	/// The unified point `r*`, low-to-high. Its length is the longest summand's variable count.
+	pub eval_point: Vec<F>,
+	/// The evaluations of `A`, `B` and `C`, folded at `z`, at `eval_point[..r_x.len()]`.
+	pub bitand_evals: [F; 3],
+	/// One evaluation per operand column, flattened in input order, each at
+	/// `eval_point[..point.len()]` for its reduction's point.
+	pub operand_evals: Vec<F>,
+}
+
+/// Verifies the BitAnd sumcheck batched with the operand-column MLE-checks.
+///
+/// The prover sends the round polynomials, then the evaluations `[a, b, c]`, then one evaluation
+/// per operand column in input order.
+///
+/// # Arguments
+///
+/// * `zerocheck_challenges` - the BitAnd summand's point `r_x`.
+/// * `bitand_claim` - the univariate-skip polynomial at `z`, `g(z)`.
+/// * `lagrange` - the Lagrange weights at `z` on the 64-point domain.
+/// * `operands` - the operand claims of each multiplication reduction.
+/// * `channel` - the verifier channel.
+///
+/// # Soundness
+///
+/// The per-bit claims of `operands` must be in the transcript before `z` was drawn. Otherwise a
+/// prover can choose them as a function of the weights that fold them.
+///
+/// # Errors
+///
+/// Returns an error if the sumcheck or its closing check fails.
+pub fn verify<F, C>(
+	zerocheck_challenges: &[C::Elem],
+	bitand_claim: C::Elem,
+	lagrange: &[C::Elem],
+	operands: &[OperandClaims<'_, C::Elem>],
+	channel: &mut C,
+) -> Result<RerandOutput<C::Elem>, Error>
+where
+	F: Field,
+	C: IPVerifierChannel<F>,
+{
+	// Fold each column's per-bit claims to one MLE-check claim at the reduction's point.
+	let operand_claims = operands.iter().flat_map(|operand| {
+		operand
+			.columns
+			.iter()
+			.map(|column| inner_product(column.iter().cloned(), lagrange.iter().cloned()))
+	});
+	let sums = iter::once(bitand_claim)
+		.chain(operand_claims)
+		.collect::<Vec<_>>();
+
+	let n_vars = operands
+		.iter()
+		.map(|operand| operand.point.len())
+		.fold(zerocheck_challenges.len(), usize::max);
+	let BatchSumcheckOutput {
+		batch_coeff,
+		eval,
+		challenges: mut eval_point,
+	} = batch_verify(n_vars, SUMCHECK_DEGREE, &sums, channel)?;
+	eval_point.reverse();
+
+	let bitand_evals = channel.recv_array::<3>()?;
+	let operand_evals = channel.recv_many(sums.len() - 1)?;
+
+	// A summand at `point` is weighted by its indicator on the low coordinates and by the zero
+	// indicator on the padding coordinates above them.
+	let weight = |point: &[C::Elem]| {
+		let (low, padding) = eval_point.split_at(point.len());
+		eq_ind(point, low) * eq_ind_zero(padding)
+	};
+	let [a, b, c] = bitand_evals.clone();
+	let bitand_term = weight(zerocheck_challenges) * (a * b - c);
+	let operand_weights = operands
+		.iter()
+		.flat_map(|operand| iter::repeat_n(weight(operand.point), operand.columns.len()));
+	let operand_terms =
+		iter::zip(operand_weights, &operand_evals).map(|(weight, eval)| weight * eval.clone());
+	let terms = iter::once(bitand_term)
+		.chain(operand_terms)
+		.collect::<Vec<_>>();
+	channel.assert_zero(evaluate_univariate(&terms, &batch_coeff) - eval)?;
+
+	Ok(RerandOutput {
+		eval_point,
+		bitand_evals,
+		operand_evals,
+	})
+}

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -211,11 +211,8 @@ where
 	// padding row, so `None` is zero constraint variables.
 	let log_n_and = cs.log_and_constraints().unwrap_or(0);
 	let AndCheckOutput {
-		a_eval,
-		b_eval,
-		c_eval,
 		z_challenge,
-		eval_point,
+		rerand,
 	} = {
 		let _guard = tracing::info_span!(
 			"[phase] Verify BitAnd Reduction",
@@ -224,8 +221,10 @@ where
 			n_constraints = cs.n_and_constraints()
 		)
 		.entered();
-		verify_bitand_reduction(log_instances + log_n_and, &andcheck_domain, channel)?
+		verify_bitand_reduction(log_instances + log_n_and, &andcheck_domain, &[], channel)?
 	};
+	let [a_eval, b_eval, c_eval] = rerand.bitand_evals;
+	let eval_point = rerand.eval_point;
 
 	// The AND-check row point is `r_rho_and || r_x_and`: the instance index low, the constraint
 	// index high. With one instance the instance half is empty.

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -14,7 +14,7 @@ use binius_iop::{
 	channel::{IOPVerifierChannel, OracleSpec, oracle_setup::OracleSetupChannel},
 };
 use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
-use binius_math::BinarySubspace;
+use binius_math::{BinarySubspace, univariate::EvaluationDomain};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::DeserializeBytes;
 use digest::Output;
@@ -26,7 +26,8 @@ use crate::{
 	fri::{ConstantArityStrategy, FRIParams, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
 	protocols::{
-		bitand::{AndCheckOutput, verify_with_channel},
+		bitand::{AndCheckOutput, UnivariateSkipOutput, verify_univariate_skip},
+		rerand::{self, OperandClaims},
 		shift::WiringEvalClaim,
 	},
 	reduction::{Instances, reduce_constraints},
@@ -366,7 +367,9 @@ where
 /// Verifies the batched BitAnd check: `A & B == C` on every row.
 ///
 /// This is the univariate-skip zerocheck of `A(Z, X) * B(Z, X) - C(Z, X) == 0` for all rows
-/// `(Z, X)`, where `Z` is the bit index within a 64-bit word and `X` is the row index.
+/// `(Z, X)`, where `Z` is the bit index within a 64-bit word and `X` is the row index. Its
+/// multilinear rounds are one sumcheck with the operand-column MLE-checks of `operands`; see
+/// [`rerand`].
 ///
 /// # Arguments
 ///
@@ -376,6 +379,8 @@ where
 ///   there is an (instance, constraint) pair.
 /// - `eval_domain`: the univariate-skip domain, one dimension above the 64-bit word, already lifted
 ///   to `F`. The caller passes it so it matches the shift reduction's domain by construction.
+/// - `operands`: the multiplication reductions' per-bit operand claims. They must be in the
+///   transcript before this runs, since it draws the challenge that folds them.
 /// - `channel`: the verifier channel that reads messages and redraws Fiat-Shamir challenges.
 ///
 /// # Errors
@@ -384,6 +389,7 @@ where
 pub fn verify_bitand_reduction<F, C>(
 	log_constraint_count: usize,
 	eval_domain: &BinarySubspace<F>,
+	operands: &[OperandClaims<'_, C::Elem>],
 	channel: &mut C,
 ) -> Result<AndCheckOutput<C::Elem>, Error>
 where
@@ -404,5 +410,15 @@ where
 	let zerocheck_challenges =
 		chain!(small_field_zerocheck_challenges, big_field_zerocheck_challenges)
 			.collect::<Vec<_>>();
-	verify_with_channel(&zerocheck_challenges, channel, eval_domain)
+
+	let UnivariateSkipOutput { z_challenge, claim } = verify_univariate_skip(channel, eval_domain)?;
+	// The operand columns fold over the 64-point domain: the skip domain less its top dimension.
+	let lagrange = eval_domain
+		.reduce_dim(Word::LOG_BITS)
+		.lagrange_evals(&z_challenge);
+	let rerand = rerand::verify(&zerocheck_challenges, claim, &lagrange, operands, channel)?;
+	Ok(AndCheckOutput {
+		z_challenge,
+		rerand,
+	})
 }


### PR DESCRIPTION
Linear: [BINIUS-647](https://linear.app/jimpo/issue/BINIUS-647/rerand-carry-the-operand-column-mle-checks-in-the-bitand-sumcheck) (sub-issue 2 of [BINIUS-645](https://linear.app/jimpo/issue/BINIUS-645)). Spec: binius.xyz #125, §4.3.2 steps 3–5, §4.7.1.

## What changes

The BitAnd multilinear rounds become one batched sumcheck in plain form, degree 3. It also carries operand-column MLE-checks at their own points, zero-padded on their high variables to the longest summand. **Every caller passes no operands for now.** BINIUS-648 routes IntMul and BinMul through it. The transcript changes anyway: three sumcheck coefficients per round instead of the MLE-check form.

One commit:

- New `protocols::rerand` on both sides. The verifier has `OperandClaims`, `RerandOutput`, `SUMCHECK_DEGREE` and `verify`. The prover has `OperandWitness` and `prove`: each summand goes through `MleToSumCheckDecorator`, then `PaddedSumcheckDecorator`, then `batch_prove_and_write_evals`.
- Verifier `bitand.rs` keeps only the univariate skip (`verify_univariate_skip`). `AndCheckOutput` is now `{ z_challenge, rerand: RerandOutput }`.
- `verify_bitand_reduction` and `bitand::prove` take `operands` and drive the univariate skip into `rerand`. `prove_with_channel` and `verify_with_channel` are removed.
- `OblongZerocheckProver::univariate_claim(z)` gives `g(z)`. The padded BitAnd summand needs it, and `fold_and_send_reduced_prover` now uses it too.
- `IntMulOutput::operand_claims` and `BinMulOutput::operand_claims`, for BINIUS-648.

## Differences from the issue text

- `rerand::prove` also takes `bitand_claim`. `PaddedSumcheckDecorator` needs the inner claims for its padding rounds, and `MleCheckProver` does not expose them.
- The instance re-randomization (`RerandomizedOperations`) stays for now. With no operands passed, batch mode still needs it. BINIUS-648 deletes it.

## Tests

- New in `prover/src/protocols/rerand.rs`:
  - A prover/verifier round trip through `OblongZerocheckProver` over `(ℓ_and, ℓ_z)`: `ℓ_z` less than, equal to and greater than `ℓ_and`; two reductions of different lengths; no reductions; `ℓ_and = 0`. It also checks each operand eval against its folded column.
  - A mutated operand eval is rejected.
  - A mutated per-bit claim is rejected.
- `cargo nextest run --workspace`: 1929 passed. This includes `prove_verify.rs`, the M4 tests and `recursion_end_to_end.rs`.
- Clippy (`-D warnings`) is clean on the three changed crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmLLnt5Mae5xzNmxAH6773