### PR TITLE
[reduction] Route IntMul, BinMul and Zero through the unified point

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -8,41 +8,25 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, ValueTable},
 	word::Word,
 };
-use binius_field::{Field, PackedField, Rijndael8b as B8};
+use binius_field::{PackedField, Rijndael8b as B8};
 use binius_hash_prover::ParallelHashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
-use binius_ip_prover::sumcheck::{
-	MleToSumCheckEvaluator,
-	batch::batch_prove_and_write_evals,
-	mle_store::MleStore,
-	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
-};
 use binius_m4_verifier::{IOPVerifier, Verifier};
 use binius_math::{
 	BinarySubspace,
-	inner_product::inner_product,
-	multilinear::eq::eq_ind_partial_eval_scalars,
 	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
-	univariate::EvaluationDomain,
 };
 use binius_prover::{
 	protocols::{
 		binmul, bitand, intmul,
-		shift::{KeyCollection, OperatorClaims, OperatorData},
+		rerand::OperandWitness,
+		shift::{KeyCollection, OperatorClaims},
 	},
 	ring_switch::{self, RingSwitchOutput},
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
-use binius_verifier::{
-	config::B128,
-	protocols::{
-		bitand::AndCheckOutput,
-		shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY},
-		zero,
-	},
-};
+use binius_verifier::{config::B128, protocols::bitand::AndCheckOutput};
 use digest::Output;
 
 use crate::{
@@ -139,8 +123,6 @@ impl IOPProver {
 		let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
 		// The shift domain drops that extra dimension.
 		// This is exactly the domain the AND-check folds its bit axis over.
-		// So the operand claims rebuilt below at the shared univariate challenge match the
-		// AND-check's.
 		let shift_domain = andcheck_domain
 			.reduce_dim(Word::LOG_BITS)
 			.isomorphic::<B128>();
@@ -156,8 +138,7 @@ impl IOPProver {
 		//
 		// The columns are the four operands of every constraint over every instance, laid out
 		// constraint-major.
-		// They are kept alongside the check output.
-		// The re-randomization re-reads them to build the instance-axis multilinears it transports.
+		// They are kept alongside the check output, since the BitAnd sumcheck re-reads them.
 		let mul = (!cs.imul_constraints.is_empty()).then(|| {
 			let columns = {
 				let _scope = tracing::debug_span!("Assemble IntMul witness").entered();
@@ -180,9 +161,8 @@ impl IOPProver {
 		//
 		// The six columns are the `(lo, hi)` word pairs of the two multiplicands and the product of
 		// every constraint over every instance, laid out constraint-major. They are kept alongside
-		// the check output; the re-randomization re-reads them to build the instance-axis
-		// multilinears it transports. BinMul commits no oracle, so nothing is added to
-		// `oracle_specs`.
+		// the check output, since the BitAnd sumcheck re-reads them. BinMul commits no oracle, so
+		// nothing is added to `oracle_specs`.
 		let bmul = (!cs.bmul_constraints.is_empty()).then(|| {
 			let columns = {
 				let _scope = tracing::debug_span!("Assemble BinMul witness").entered();
@@ -192,110 +172,43 @@ impl IOPProver {
 			(columns, output)
 		});
 
+		// The BitAnd sumcheck carries the multiplications' per-bit operand claims, IntMul first.
+		let operands = [
+			mul.as_ref().map(|(columns, output)| OperandWitness {
+				words: columns.as_slices().into(),
+				claims: output.operand_claims(),
+			}),
+			bmul.as_ref().map(|(columns, output)| OperandWitness {
+				words: columns.as_slices().into(),
+				claims: output.operand_claims(),
+			}),
+		]
+		.into_iter()
+		.flatten()
+		.collect::<Vec<_>>();
+
 		// AND-check the `A & B == C` relation over all `K * n_and` rows.
-		// Retain the operand columns when IntMul or BinMul ran, since the re-randomization re-reads
-		// them.
-		let (
-			and_columns,
-			AndCheckOutput {
-				z_challenge,
-				rerand,
-			},
-		) = {
+		let AndCheckOutput {
+			z_challenge,
+			rerand,
+		} = {
 			let _scope = tracing::debug_span!("BitAnd check").entered();
 
 			let columns = {
 				let _scope = tracing::debug_span!("Assemble BitAnd witness").entered();
 				OperandColumns::build(table, &cs.constants, &cs.and_constraints, alloc)
 			};
-			// Reduce over borrowed columns so the owned ones can be reused below without a clone.
-			// Nothing touches the channel between the reduction and the derivation, so the
-			// transcript is unchanged.
-			let output =
-				bitand::prove::<_, B128, P, _, _>(columns.as_slices(), &[], channel, alloc);
-			// The re-randomization re-reads all three columns, so derive the third only there.
-			let and_columns =
-				(mul.is_some() || bmul.is_some()).then(|| columns.with_derived_and(alloc));
-			(and_columns, output)
+			bitand::prove::<_, B128, P, _, _>(columns.as_slices(), &operands, channel, alloc)
 		};
 
-		let [a_eval, b_eval, c_eval] = rerand.bitand_evals;
-		let eval_point = rerand.eval_point;
-
-		// The AND-check row point is `r_rho_and || r_x_and`: the instance index on the low
-		// coordinates, the constraint index on the high coordinates.
-		let (r_rho_and, r_x_and) = eval_point.split_at(table.log_instances());
-
-		// The Zero reduction's claim, at the constraint half of the AND-check output point. See
-		// `IOPVerifier::verify_chip` for why it skips the re-randomization below.
-		let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
-		let zero_data = OperatorData {
-			evals: [B128::ZERO],
-			r_zhat_prime: z_challenge,
-			r_x_prime: zero::reduction_point(r_x_and, log_n_zero, || channel.sample()),
-		};
-
-		// Reduce to one shared instance point `r_rho` and the operand claims at that point.
-		//
-		// The re-randomization runs whenever IntMul or BinMul is present: BitAnd always enters,
-		// plus each present multiplication operation, all unified onto one shared `r_rho`.
-		let (r_rho, claims) = if mul.is_some() || bmul.is_some() {
-			// Every present operation enters the re-randomization as operand columns with their
-			// oblong claims at their own instance point.
-			// BitAnd is already oblong.
-			// IntMul and BinMul are collapsed from their per-bit form.
-			let lagrange = shift_domain.lagrange_evals::<B128>(&z_challenge);
-			let and_columns = and_columns
-				.expect("AND columns are retained whenever there are IMUL or BMUL constraints");
-			let log_instances = table.log_instances();
-			RerandomizedOperations {
-				bitand: Operation::new(&and_columns, [a_eval, b_eval, c_eval], r_x_and, r_rho_and),
-				// The operand order of each mapping is the order the columns were built in.
-				intmul: mul.as_ref().map(|(columns, out)| {
-					Operation::from_mul_check(
-						columns,
-						&out.eval_point,
-						[&out.a_evals, &out.b_evals, &out.c_lo_evals, &out.c_hi_evals],
-						&lagrange,
-						log_instances,
-					)
-				}),
-				binmul: bmul.as_ref().map(|(columns, out)| {
-					Operation::from_mul_check(
-						columns,
-						&out.eval_point,
-						[
-							&out.a_lo_evals,
-							&out.a_hi_evals,
-							&out.b_lo_evals,
-							&out.b_hi_evals,
-							&out.c_lo_evals,
-							&out.c_hi_evals,
-						],
-						&lagrange,
-						log_instances,
-					)
-				}),
-			}
-			.prove::<P, _>(zero_data, &lagrange, z_challenge, channel, alloc)
-		} else {
-			// Neither IMUL nor BMUL constraints: the AND-check instance point is used directly.
-			// The IntMul and BinMul claims are zero claims at an empty point, contributing nothing
-			// to the shift.
-			(
-				r_rho_and.to_vec(),
-				OperatorClaims {
-					zero: zero_data,
-					bitand: OperatorData {
-						evals: [a_eval, b_eval, c_eval],
-						r_zhat_prime: z_challenge,
-						r_x_prime: r_x_and.to_vec(),
-					},
-					intmul: OperatorData::zero_claim(z_challenge),
-					binmul: OperatorData::zero_claim(z_challenge),
-				},
-			)
-		};
+		// Every operation is claimed at a prefix of the sumcheck's point `r_rho || r_x_star`, so
+		// all of them share the instance point `r_rho`. The Zero point draws its extension here,
+		// where `IOPVerifier::verify_chip` does.
+		let log_instances = table.log_instances();
+		let r_rho = rerand.eval_point[..log_instances].to_vec();
+		let claims = OperatorClaims::from_rerand(cs, log_instances, z_challenge, &rerand, || {
+			channel.sample()
+		});
 
 		// Fold the committed witness over the instance axis at the shared point.
 		let folded_witness = {
@@ -449,245 +362,6 @@ where
 	}
 }
 
-/// One operation's operand columns, oblong claims, and the points they are claimed at.
-///
-/// The AND-check and the IntMul check both reduce to this shape.
-/// The re-randomization folds each column into its instance-axis multilinear.
-/// It then transports the claims to the instance point shared by both operations.
-struct Operation<'a, A: Allocator, const ARITY: usize> {
-	/// The operand columns of this operation, constraint-major, one per operand.
-	columns: &'a OperandColumns<A, ARITY>,
-	/// The oblong operand claim per operand: its multilinear-eval claim at the instance point.
-	operand_claims: [B128; ARITY],
-	/// The constraint-index point the operands are claimed at.
-	r_x: Vec<B128>,
-	/// The instance-index point the operands are claimed at.
-	r_rho: Vec<B128>,
-}
-
-impl<'a, A: Allocator, const ARITY: usize> Operation<'a, A, ARITY> {
-	/// The operand columns with their claims at the constraint point `r_x` and instance point
-	/// `r_rho`.
-	fn new(
-		columns: &'a OperandColumns<A, ARITY>,
-		operand_claims: [B128; ARITY],
-		r_x: &[B128],
-		r_rho: &[B128],
-	) -> Self {
-		Self {
-			columns,
-			operand_claims,
-			r_x: r_x.to_vec(),
-			r_rho: r_rho.to_vec(),
-		}
-	}
-
-	/// Adds this operation's operand evaluators to a shared store.
-	///
-	/// The operation's instance-point indicator is registered once, and every operand reads it.
-	/// So the store expands that indicator once, not once per operand.
-	/// Each operand's instance-axis multilinear becomes a store column.
-	/// Its evaluator is an identity-composition quadratic MLE-check: a multilinear evaluation.
-	fn push_to<'alloc, P>(
-		&self,
-		lagrange: &[B128],
-		store: &mut MleStore<'alloc, A, P>,
-		evaluators: &mut Vec<Box<dyn SumcheckRoundEvaluator<B128, P> + 'alloc>>,
-		claims: &mut Vec<B128>,
-		alloc: &'alloc A,
-	) where
-		P: PackedField<Scalar = B128>,
-	{
-		// The wrappers run under a plain sumcheck prover, so each holds this operation's shared eq
-		// tracker; register it once.
-		let eq_tracker = store.register_eq_tracker(&self.r_rho);
-		// The constraint tensor is the same for every operand of this operation, so expand it once.
-		let r_x_tensor = eq_ind_partial_eval_scalars(&self.r_x);
-		for (operand, &claim) in self.operand_claims.iter().enumerate() {
-			let col = store.push_owned(self.columns.rho_multilinear::<P>(
-				operand,
-				lagrange,
-				&r_x_tensor,
-				alloc,
-			));
-			let evaluator = QuadraticMleEvaluator::new(
-				[col],
-				|[operand]: [P; 1]| operand,
-				|[_operand]: [P; 1]| P::zero(),
-			);
-			evaluators.push(Box::new(MleToSumCheckEvaluator::new(evaluator, eq_tracker)));
-			// The driving prover, not the evaluator, holds the claim.
-			claims.push(claim);
-		}
-	}
-
-	/// Builds a multiplication operation by collapsing its per-bit operand claims.
-	///
-	/// IntMul and BinMul both close with one claim per bit of each operand.
-	/// The Lagrange weights fold those into one claim per operand, at the univariate challenge.
-	///
-	/// That is the oblong form the BitAnd claims already arrive in.
-	///
-	/// The row point splits at the instance count: instances low, constraints high.
-	fn from_mul_check(
-		columns: &'a OperandColumns<A, ARITY>,
-		eval_point: &[B128],
-		per_bit_evals: [&[B128]; ARITY],
-		lagrange: &[B128],
-		log_instances: usize,
-	) -> Self {
-		let (r_rho, r_x) = eval_point.split_at(log_instances);
-		let operand_claims = per_bit_evals
-			.map(|evals| inner_product(evals.iter().copied(), lagrange.iter().copied()));
-		Self::new(columns, operand_claims, r_x, r_rho)
-	}
-}
-
-/// The operations entering the batched instance re-randomization.
-///
-/// BitAnd is always present. IntMul and BinMul enter only when the circuit carries their
-/// constraints; an absent operation reduces to a zero claim contributing nothing to the shift.
-struct RerandomizedOperations<'a, A: Allocator> {
-	/// The BitAnd operation, at the AND-check instance point.
-	bitand: Operation<'a, A, BITAND_ARITY>,
-	/// The IntMul operation, at the IntMul instance point, when the circuit has IMUL constraints.
-	intmul: Option<Operation<'a, A, INTMUL_ARITY>>,
-	/// The BinMul operation, at the BinMul instance point, when the circuit has BMUL constraints.
-	binmul: Option<Operation<'a, A, BINMUL_ARITY>>,
-}
-
-impl<A: Allocator> RerandomizedOperations<'_, A> {
-	/// Re-randomizes every present operation's instance point to one shared point.
-	///
-	/// Each operation reduces to operand claims at its own instance point.
-	/// The witness folds over the instance axis only once, so the points must be unified first.
-	///
-	/// - Push every present operation's operand multilinears onto one store.
-	/// - Register one equality tracker per operation, so each indicator is expanded once.
-	/// - A batched sumcheck transports every claim to one shared instance point.
-	/// - The reduced evaluations there are the operand claims the shift consumes.
-	///
-	/// The operands are pushed in the order [BitAnd | IntMul (if present) | BinMul (if present)].
-	/// The reduced evaluations therefore split back into per-operation segments in that same order.
-	/// An absent operation reduces to a zero claim at an empty point.
-	///
-	/// The Zero reduction closes at its own constraint point, so it takes no part in this.
-	/// Its claim passes straight through into the returned bundle.
-	///
-	/// # Arguments
-	///
-	/// - `zero`: the Zero reduction's claim, carried into the result unchanged.
-	/// - `lagrange`: the Lagrange weights at the shared univariate challenge.
-	/// - `z_challenge`: that univariate challenge, carried by every returned claim.
-	///
-	/// # Returns
-	///
-	/// The shared instance point, and the operand claims of every operation at that point.
-	fn prove<'alloc, P, Channel>(
-		self,
-		zero: OperatorData<B128, ZERO_ARITY>,
-		lagrange: &[B128],
-		z_challenge: B128,
-		channel: &mut Channel,
-		alloc: &'alloc A,
-	) -> (Vec<B128>, OperatorClaims<B128>)
-	where
-		P: PackedField<Scalar = B128>,
-		Channel: IOPProverChannel<P, A>,
-	{
-		let _scope = tracing::debug_span!("Re-randomize instances").entered();
-
-		// Every operation reduces over the same instance axis.
-		// Recover its width from the BitAnd point.
-		let log_instances = self.bitand.r_rho.len();
-
-		// One shared store over the instance axis holds every present operation's operand
-		// multilinears. The evaluators list the operands in push order
-		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
-		// The verifier reads the reduced evaluations back in the same order.
-		let mut store = MleStore::<A, P>::new(log_instances, alloc);
-		let mut evaluators: Vec<Box<dyn SumcheckRoundEvaluator<B128, P> + 'alloc>> =
-			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
-		let mut claims: Vec<B128> = Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
-		self.bitand
-			.push_to(lagrange, &mut store, &mut evaluators, &mut claims, alloc);
-		if let Some(intmul) = &self.intmul {
-			intmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims, alloc);
-		}
-		if let Some(binmul) = &self.binmul {
-			binmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims, alloc);
-		}
-
-		// One shared prover drives all claims over the store in a single round pass.
-		// Its evaluations are the store's per-column values at the shared instance point, in push
-		// order.
-		let shared = SharedSumcheckProver::new(store, claims.into_iter().zip(evaluators));
-		let output = batch_prove_and_write_evals(vec![shared], channel);
-		let reduced = &output.multilinear_evals[0];
-
-		// The reduced evaluations split back into per-operation chunks, in push order.
-		// Each chunk is as wide as its operation's arity, so the split is driven by the types.
-		let (bitand_evals, reduced) = split_evals(reduced);
-		let bitand = OperatorData {
-			evals: bitand_evals,
-			r_zhat_prime: z_challenge,
-			r_x_prime: self.bitand.r_x,
-		};
-
-		// IntMul: the next chunk when present, else a zero claim that leaves the rest untouched.
-		let (intmul, reduced) = match self.intmul {
-			Some(intmul) => {
-				let (evals, reduced) = split_evals(reduced);
-				let data = OperatorData {
-					evals,
-					r_zhat_prime: z_challenge,
-					r_x_prime: intmul.r_x,
-				};
-				(data, reduced)
-			}
-			None => (OperatorData::zero_claim(z_challenge), reduced),
-		};
-
-		// BinMul: the final chunk when present, else a zero claim.
-		let binmul = match self.binmul {
-			Some(binmul) => OperatorData {
-				evals: split_evals(reduced).0,
-				r_zhat_prime: z_challenge,
-				r_x_prime: binmul.r_x,
-			},
-			None => OperatorData::zero_claim(z_challenge),
-		};
-
-		// `batch_prove` returns binding-order challenges; reverse to variable-indexed to match
-		// the verifier's `r_rho`.
-		let mut r_rho = output.challenges;
-		r_rho.reverse();
-		(
-			r_rho,
-			OperatorClaims {
-				zero,
-				bitand,
-				intmul,
-				binmul,
-			},
-		)
-	}
-}
-
-/// Takes one operation's reduced evaluations off the front, and returns the rest.
-///
-/// The chunk width is the operation's arity, inferred from the claim it is about to fill.
-///
-/// # Panics
-///
-/// Panics if fewer than `ARITY` evaluations remain.
-fn split_evals<const ARITY: usize>(reduced: &[B128]) -> ([B128; ARITY], &[B128]) {
-	let (chunk, rest) = reduced
-		.split_first_chunk::<ARITY>()
-		.expect("the sumcheck returns one evaluation per pushed operand");
-	(*chunk, rest)
-}
-
 #[cfg(test)]
 mod tests {
 	use std::array;
@@ -801,19 +475,15 @@ mod tests {
 
 	// A batch carrying ZERO constraints alongside AND, IMUL and BMUL round-trips.
 	//
-	// This is the case the Zero reduction has to survive in M4 but not in the single-instance
-	// protocol: with IMUL and BMUL present, the instance re-randomization runs, transporting every
-	// other operation's operand claims onto a shared instance point. The Zero claim skips it — a
-	// ZERO constraint array vanishes identically, so its fold at any instance point is still
-	// identically zero — and the reduction closes at the constraint half of the AND-check output
-	// point regardless.
+	// The BitAnd sumcheck carries the IMUL and BMUL operand claims, and the Zero claim sits at a
+	// prefix of its constraint point. A ZERO constraint array vanishes identically, so its claim is
+	// zero at any point.
 	#[test]
 	fn protocol_round_trips_with_zero_constraints() {
 		use binius_frontend::{Options, Wire};
 
 		// The `bxor` chain lowers to ZERO constraints under the option, `band` keeps the AND set
-		// non-empty, and `imul`/`bmul` bring the other two operations along so the re-randomization
-		// runs.
+		// non-empty, and `imul`/`bmul` bring the other two operations into the BitAnd sumcheck.
 		//
 		// Gate fusion is off: it inlines a linear definition into the gate that consumes it, which
 		// would leave no linear constraint to lower.
@@ -949,7 +619,7 @@ mod tests {
 	//     trace oracle    : the packed batch witness
 	//     logup* oracle   : the IntMul check's pushforward
 	//
-	// The IntMul and AND checks reduce to different instance points, which the re-randomization
+	// The IntMul and AND checks reduce to different instance points, which the BitAnd sumcheck
 	// unifies before the witness is folded.
 	//
 	// Fixture: one unsigned 64x64 -> 128 product per instance over 2^6 instances, both product
@@ -1132,10 +802,10 @@ mod tests {
 
 	// Independent AND constraints alongside IMUL constraints, so the two operations reduce to
 	// constraint points of different lengths (`log_n_and != log_n_imul`) and to genuinely different
-	// instance points that the re-randomization must unify.
+	// instance points that the BitAnd sumcheck must unify.
 	//
-	// Proving with a width-2 packing exercises the packed lane layout and zero-padding of the
-	// instance-axis multilinears, which the width-1 fixtures never reach.
+	// Proving with a width-2 packing exercises the packed lane layout of the folded operand
+	// columns, which the width-1 fixtures never reach.
 	#[test]
 	fn protocol_round_trips_with_mixed_constraints_and_wide_packing() {
 		use binius_field::PackedGhash2x128b;
@@ -1198,8 +868,8 @@ mod tests {
 	// A circuit carrying BMUL constraints round-trips through the whole protocol.
 	//
 	// BinMul commits no oracle, so the proof still commits only the trace oracle. The BinMul and
-	// AND checks reduce to different instance points, which the re-randomization unifies before
-	// the witness is folded.
+	// AND checks reduce to different instance points, which the BitAnd sumcheck unifies before the
+	// witness is folded.
 	//
 	// Fixture: one GHASH-field product `x * x` per instance over 2^6 instances, both product words
 	// force-committed. The `bmul` gate emits one BMUL constraint.
@@ -1252,11 +922,11 @@ mod tests {
 	}
 
 	// AND, IMUL, and BMUL constraints together, so the three operations reduce to constraint points
-	// of differing lengths and to genuinely different instance points that the re-randomization
+	// of differing lengths and to genuinely different instance points that the BitAnd sumcheck
 	// must unify onto one shared point.
 	//
-	// Proving with a width-2 packing exercises the packed lane layout and zero-padding of the
-	// instance-axis multilinears, which the width-1 fixtures never reach.
+	// Proving with a width-2 packing exercises the packed lane layout of the folded operand
+	// columns, which the width-1 fixtures never reach.
 	#[test]
 	fn protocol_round_trips_with_and_intmul_binmul_and_wide_packing() {
 		use binius_field::PackedGhash2x128b;

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -5,17 +5,13 @@
 
 use std::{iter, mem::MaybeUninit, ops::Deref, ptr};
 
-use binius_compute::{Allocator, CollectIntoAllocVec, VecLike};
+use binius_compute::{Allocator, VecLike};
 use binius_core::{
 	ValueSegment, ValueTable,
 	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex},
 	word::Word,
 };
-use binius_field::{Field, PackedField};
-use binius_math::{FieldBuffer, FieldVec};
-use binius_prover::fold_word::BitAxisFolder;
-use binius_utils::rayon::{prelude::*, task_size::IndexedParallelIteratorExt};
-use binius_verifier::config::B128;
+use binius_utils::rayon::prelude::*;
 
 /// The operand columns of one batched fixed-arity operation.
 ///
@@ -46,8 +42,6 @@ use binius_verifier::config::B128;
 pub struct OperandColumns<A: Allocator, const ARITY: usize> {
 	/// One column per operand position, in the constraint type's storage order.
 	columns: [A::Vec<Word>; ARITY],
-	/// The base-2 logarithm of the instance count, which is the stride of the constraint axis.
-	log_instances: usize,
 }
 
 impl<A: Allocator, const ARITY: usize> OperandColumns<A, ARITY> {
@@ -109,132 +103,12 @@ impl<A: Allocator, const ARITY: usize> OperandColumns<A, ARITY> {
 			.try_into()
 			.unwrap_or_else(|_| unreachable!("the source iterator has ARITY elements"));
 
-		Self {
-			columns,
-			log_instances: table.log_instances(),
-		}
+		Self { columns }
 	}
 
 	/// The columns as plain word slices, dropping whichever allocator produced them.
 	pub fn as_slices(&self) -> [&[Word]; ARITY] {
 		self.columns.each_ref().map(|column| &**column)
-	}
-
-	/// Folds one column over its bit and constraint axes, leaving the instance axis.
-	///
-	/// # Overview
-	///
-	/// A column is constraint-major, so collapsing its two other axes leaves one per instance:
-	///
-	/// ```text
-	/// M[rho] = sum_{local, j} lagrange[j] * r_x_tensor[local] * bit_j(column[local * K + rho])
-	/// ```
-	///
-	/// - The Lagrange weights fold each word over its bit axis at the shared univariate challenge.
-	/// - The constraint tensor folds the constraint axis, and is shared across the operands.
-	///
-	/// Evaluating the result at the operation's instance point gives that operand's oblong claim.
-	///
-	/// A sumcheck can then transport that claim to a point shared with the other operations.
-	///
-	/// # Panics
-	///
-	/// Panics if the constraint tensor does not cover the column's padded constraint axis.
-	pub fn rho_multilinear<P>(
-		&self,
-		operand: usize,
-		lagrange: &[B128],
-		r_x_tensor: &[B128],
-		alloc: &A,
-	) -> FieldVec<P, A>
-	where
-		P: PackedField<Scalar = B128>,
-	{
-		let column = &self.columns[operand];
-
-		// Fold each word's bits at the univariate challenge, giving one scalar per row.
-		// Scalars keep the row indexing flat for the constraint fold below.
-		//
-		// The fold rounds the row count up to a power of two and zero-extends to it, so the
-		// result spans the padded constraint axis even though the column itself stops at the last
-		// real constraint. Only the real rows are folded; the padding is never touched.
-		let folded_rows = BitAxisFolder::new(lagrange).fold::<B128, _>(alloc, column);
-		let folded_rows = folded_rows.as_ref();
-
-		// Invariant: the tensor carries one weight per padded constraint row.
-		assert_eq!(
-			r_x_tensor.len() << self.log_instances,
-			folded_rows.len(),
-			"the constraint tensor must cover the padded constraint axis"
-		);
-
-		// One packed element per parallel task, each lane holding one instance.
-		// Lanes past the instance count are the multilinear's zero padding.
-		let n_instances = 1usize << self.log_instances;
-		let packed_len = 1usize << self.log_instances.saturating_sub(P::LOG_WIDTH);
-		let packed = (0..packed_len)
-			.into_par_iter()
-			.map(|packed_index| {
-				P::from_scalars((0..P::WIDTH).map(|lane| {
-					let instance = (packed_index << P::LOG_WIDTH) | lane;
-					if instance < n_instances {
-						// Constraint `local` of this instance sits at row `local * K + rho`.
-						// So the constraint axis is the strided one.
-						r_x_tensor
-							.iter()
-							.enumerate()
-							.map(|(local, &weight)| {
-								weight * folded_rows[local * n_instances + instance]
-							})
-							.sum()
-					} else {
-						B128::ZERO
-					}
-				}))
-			})
-			.collect_into_alloc_vec(alloc);
-
-		FieldBuffer::new(self.log_instances, packed)
-	}
-}
-
-impl<A: Allocator> OperandColumns<A, 2> {
-	/// Appends the AND check's third column, derived word-by-word from the first two.
-	///
-	/// # Overview
-	///
-	/// The check itself stores only its two input operands.
-	///
-	/// On a satisfying witness the third is their conjunction.
-	/// Deriving it is therefore cheaper than building it from the constraints.
-	///
-	/// Only the re-randomization reads it, so it is materialized on that path alone.
-	///
-	/// # Performance
-	///
-	/// One conjunction per row is a single instruction.
-	///
-	/// The cost is streaming three word columns, two read and one written.
-	pub fn with_derived_and(self, alloc: &A) -> OperandColumns<A, 3> {
-		let Self {
-			columns: [a, b],
-			log_instances,
-		} = self;
-
-		// The parallel zip stops at the shorter of its two sides, and the derived column is sized
-		// to it. Equal input lengths are therefore what make it cover every row.
-		debug_assert_eq!(a.len(), b.len());
-
-		let c = (&a[..], &b[..])
-			.into_par_iter()
-			.with_min_task_bytes::<[Word; 3]>()
-			.map(|(&a_i, &b_i)| a_i & b_i)
-			.collect_into_alloc_vec(alloc);
-
-		OperandColumns {
-			columns: [a, b, c],
-			log_instances,
-		}
 	}
 }
 
@@ -513,7 +387,7 @@ mod tests {
 	use assert_matches::assert_matches;
 	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_core::constraint_system::{AndConstraint, Shift, ShiftVariant, ValueVec};
-	use binius_field::{PackedGhash1x128b, Random, Rijndael8b as B8};
+	use binius_field::{PackedGhash1x128b, Rijndael8b as B8};
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_ip::channel::Error as ChannelError;
 	use binius_math::{
@@ -529,7 +403,6 @@ mod tests {
 		verify_bitand_reduction,
 	};
 	use proptest::prelude::*;
-	use rand::prelude::*;
 
 	use super::*;
 
@@ -544,114 +417,6 @@ mod tests {
 		let c = and_circuit();
 		let table = populate_table(&c, &[(1, 3, 7), (5, 6, 0), (9, 12, 0xFF), (0xF0, 0x0F, 1)]);
 		(c, table)
-	}
-
-	#[test]
-	fn with_derived_and_appends_the_conjunction() {
-		// Invariant: the third column is the word-by-word conjunction of the first two.
-		// The two inputs pass through untouched.
-		//
-		// Fixture state: 4 instances, the AND circuit's own constraints.
-		let (c, table) = four_instance_and_table();
-		let and_constraints = table_constraints(&c);
-		let columns =
-			OperandColumns::build(&table, constants(&c), &and_constraints, &GlobalAllocator);
-
-		// Snapshot the inputs, since deriving the third column consumes the value.
-		let [a_before, b_before] = columns.as_slices().map(<[Word]>::to_vec);
-
-		let derived = columns.with_derived_and(&GlobalAllocator);
-		let [a, b, c_column] = derived.as_slices();
-
-		// The two input columns are carried over unchanged.
-		assert_eq!(a, &a_before[..]);
-		assert_eq!(b, &b_before[..]);
-
-		// Every row of the third column is the conjunction of the other two.
-		let expected: Vec<Word> = iter::zip(a, b).map(|(&a_i, &b_i)| a_i & b_i).collect();
-		assert_eq!(c_column, &expected[..]);
-
-		// Sanity: the fixture leaves at least one non-zero row, so the check is not vacuous.
-		assert!(c_column.iter().any(|&word| word != Word::ZERO));
-	}
-
-	#[test]
-	fn rho_multilinear_matches_the_direct_triple_sum() {
-		// Invariant: folding the bit and constraint axes leaves one element per instance.
-		//
-		//     M[rho] = sum_{local, j} lagrange[j] * tensor[local] * bit_j(column[local*K + rho])
-		//
-		// Fixture state: 4 instances, random weights on both folded axes.
-		let (c, table) = four_instance_and_table();
-		let and_constraints = table_constraints(&c);
-		let columns = OperandColumns::<_, 2>::build(
-			&table,
-			constants(&c),
-			&and_constraints,
-			&GlobalAllocator,
-		);
-
-		// The tensor spans the padded constraint axis; the column stops at the last real
-		// constraint.
-		let n_instances = table.n_instances();
-		let n_padded = (columns.as_slices()[0].len() / n_instances).next_power_of_two();
-
-		// Independent weights per axis, so a swapped index cannot pass by coincidence.
-		let mut rng = StdRng::seed_from_u64(0);
-		let lagrange: Vec<B128> = (0..Word::BITS).map(|_| B128::random(&mut rng)).collect();
-		let r_x_tensor: Vec<B128> = (0..n_padded).map(|_| B128::random(&mut rng)).collect();
-
-		for operand in 0..2 {
-			let column = columns.as_slices()[operand];
-			let folded =
-				columns.rho_multilinear::<P>(operand, &lagrange, &r_x_tensor, &GlobalAllocator);
-			let got: Vec<B128> = folded.iter_scalars().collect();
-
-			// One element per instance, each the triple sum over that instance's column entries.
-			assert_eq!(got.len(), n_instances);
-			for (rho, &value) in got.iter().enumerate() {
-				let mut expected = B128::ZERO;
-				for (local, &weight) in r_x_tensor.iter().enumerate() {
-					// A row at or past the last real constraint reads as zero.
-					let word = column
-						.get(local * n_instances + rho)
-						.copied()
-						.unwrap_or(Word::ZERO);
-					for (j, &basis) in lagrange.iter().enumerate() {
-						// A set bit contributes both of its axis weights.
-						if (word.0 >> j) & 1 == 1 {
-							expected += weight * basis;
-						}
-					}
-				}
-				assert_eq!(value, expected, "operand {operand}, instance {rho}");
-			}
-		}
-	}
-
-	#[test]
-	#[should_panic(expected = "the constraint tensor must cover the padded constraint axis")]
-	fn rho_multilinear_rejects_a_tensor_of_the_wrong_width() {
-		let (c, table) = four_instance_and_table();
-		let and_constraints = table_constraints(&c);
-		let columns = OperandColumns::<_, 2>::build(
-			&table,
-			constants(&c),
-			&and_constraints,
-			&GlobalAllocator,
-		);
-
-		// Mutation: one weight short of the padded constraint axis.
-		//
-		//     rows in the column:  n_padded * n_instances
-		//     weights supplied:    n_padded - 1
-		//
-		// The fold indexes the folded rows by the tensor, so a short one would drop constraint
-		// rows.
-		let n_padded = (columns.as_slices()[0].len() / table.n_instances()).next_power_of_two();
-		let lagrange = vec![B128::ZERO; Word::BITS];
-		let short = vec![B128::ZERO; n_padded - 1];
-		let _ = columns.rho_multilinear::<P>(0, &lagrange, &short, &GlobalAllocator);
 	}
 
 	// The univariate-skip domain the AND-check runs over: one dimension above the 64-bit word.
@@ -1051,12 +816,11 @@ mod tests {
 	}
 
 	#[test]
-	fn unpadded_columns_fold_identically_to_padded_ones() {
-		// Invariant: dropping the padding stripes changes nothing a consumer can observe.
+	fn unpadded_columns_are_padded_ones_without_the_zero_tail() {
+		// Invariant: dropping the padding stripes changes no word a consumer reads.
 		//
-		// An `AndConstraint::default()` has empty operands, so its stripe is identically zero —
-		// exactly the padding stripe this module used to materialize. Appending enough of them
-		// reconstructs the old shape, and the two must agree on both the words and the fold.
+		// An `AndConstraint::default()` has empty operands, so its stripe is identically zero, as a
+		// padding stripe is. Appending enough of them pads the constraint axis to a power of two.
 		//
 		// Fixture state: 4 instances, 3 constraints, padded up to 4.
 		let (c, table) = four_instance_and_table();
@@ -1076,11 +840,6 @@ mod tests {
 			&GlobalAllocator,
 		);
 
-		// Random weights on both folded axes, so a coincidence cannot pass for agreement.
-		let mut rng = StdRng::seed_from_u64(0);
-		let lagrange: Vec<B128> = (0..Word::BITS).map(|_| B128::random(&mut rng)).collect();
-		let r_x_tensor: Vec<B128> = (0..n_padded).map(|_| B128::random(&mut rng)).collect();
-
 		for operand in 0..2 {
 			// The unpadded column is the padded one with its zero tail cut off.
 			let short = unpadded.as_slices()[operand];
@@ -1089,17 +848,6 @@ mod tests {
 			assert_eq!(long.len(), n_padded * n_instances);
 			assert_eq!(short, &long[..short.len()]);
 			assert!(long[short.len()..].iter().all(|&word| word == Word::ZERO));
-
-			// Both fold to the same instance-axis multilinear, at the same tensor width.
-			let from_short =
-				unpadded.rho_multilinear::<P>(operand, &lagrange, &r_x_tensor, &GlobalAllocator);
-			let from_long =
-				padded.rho_multilinear::<P>(operand, &lagrange, &r_x_tensor, &GlobalAllocator);
-			assert_eq!(
-				from_short.iter_scalars().collect::<Vec<_>>(),
-				from_long.iter_scalars().collect::<Vec<_>>(),
-				"operand {operand}"
-			);
 		}
 	}
 

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -242,10 +242,7 @@ fn prove_secp256k1_add_incomplete() {
 	prove_once::<Secp256k1AddIncompleteCircuit>("secp256k1_add", log_additions);
 }
 
-// A batch of one instance, with IMUL constraints.
-//
-// The re-randomization still runs here, over no rounds, since a batch of one is still a batch.
-// Nothing else covers that degenerate sumcheck, on either side.
+// A batch of one instance, with IMUL constraints: the instance axis and `r_rho` are empty.
 #[test]
 fn prove_integer_multiplication_single_instance() {
 	prove_once::<ImulCircuit>("imul-1", 0);

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -19,7 +19,7 @@ use binius_verifier::{
 	Error, SECURITY_BITS,
 	config::{B1, B128},
 	protocols::shift::WiringEvalClaim,
-	reduction::{Instances, reduce_constraints},
+	reduction::reduce_constraints,
 	ring_switch::{self, RingSwitchVerifyOutput},
 };
 use digest::Output;
@@ -137,9 +137,7 @@ impl IOPVerifier {
 			.collect::<Vec<_>>();
 		let reduction = reduce_constraints(
 			&self.cs,
-			Instances::Batch {
-				log_instances: self.layout.log_instances,
-			},
+			self.layout.log_instances,
 			InoutSegment::Hidden,
 			&constants,
 			channel,

--- a/crates/prover/src/protocols/shift/claims.rs
+++ b/crates/prover/src/protocols/shift/claims.rs
@@ -16,13 +16,18 @@
 //! The batched form erases that arity, because a shift key picks its operation at run time.
 //! There the operation is named by indexing instead: `prepared[key.operation]`.
 
-use std::ops::Index;
+use std::{array, iter, ops::Index};
 
+use binius_core::constraint_system::ConstraintSystem;
 use binius_field::Field;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
-use binius_verifier::protocols::shift::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_MAX_ARITY, LOG_OPERATION_COUNT, ZERO_ARITY,
+use binius_verifier::protocols::{
+	rerand::RerandOutput,
+	shift::{
+		BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_MAX_ARITY, LOG_OPERATION_COUNT, ZERO_ARITY,
+	},
+	zero,
 };
 
 use super::{Operation, OperatorData, PreparedOperatorData};
@@ -43,6 +48,51 @@ pub struct OperatorClaims<F: Field> {
 }
 
 impl<F: Field> OperatorClaims<F> {
+	/// Assembles the four claims from the output of the BitAnd sumcheck.
+	///
+	/// The sumcheck's point is `r_rho || r_x_star`, instance index low, constraint index high.
+	/// Each operation is claimed at the prefix of `r_x_star` its rows span, so all four share
+	/// `r_rho`. The Zero point comes from [`zero::reduction_point`], which draws any extra
+	/// challenges from `sample`.
+	///
+	/// An operation the constraint system does not use gets a zero claim.
+	///
+	/// # Arguments
+	///
+	/// - `cs`: the constraint system, whose row counts pick each operation's prefix.
+	/// - `log_instances`: the instance variables at the low end of the point.
+	/// - `z_challenge`: the univariate challenge, shared by every operation.
+	/// - `rerand`: the sumcheck's output, with the IntMul operand evaluations before the BinMul
+	///   ones.
+	/// - `sample`: draws the Zero point's extra challenges from the transcript.
+	pub fn from_rerand(
+		cs: &ConstraintSystem,
+		log_instances: usize,
+		z_challenge: F,
+		rerand: &RerandOutput<F>,
+		sample: impl FnMut() -> F,
+	) -> Self {
+		let r_x_star = &rerand.eval_point[log_instances..];
+		let mut evals = iter::chain(rerand.bitand_evals, rerand.operand_evals.iter().copied());
+		// The BitAnd check has no skip branch: an empty AND set reduces over one zero row.
+		let log_n_and = cs.log_and_constraints().unwrap_or(0);
+		let bitand = operation_claim(Some(log_n_and), r_x_star, z_challenge, &mut evals);
+		let intmul = operation_claim(cs.log_imul_constraints(), r_x_star, z_challenge, &mut evals);
+		let binmul = operation_claim(cs.log_bmul_constraints(), r_x_star, z_challenge, &mut evals);
+		let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
+		let zero = OperatorData {
+			evals: [F::ZERO],
+			r_zhat_prime: z_challenge,
+			r_x_prime: zero::reduction_point(r_x_star, log_n_zero, sample),
+		};
+		Self {
+			zero,
+			bitand,
+			intmul,
+			binmul,
+		}
+	}
+
 	/// Draws the two batching challenge vectors and folds their weights into the claims.
 	///
 	/// An operation holds one claim per operand, and the reduction proves them all at once.
@@ -84,6 +134,29 @@ impl<F: Field> OperatorClaims<F> {
 			operand_weights,
 		}
 	}
+}
+
+/// An operation's claim at its prefix of `r_x_star`, or a zero claim when it is absent.
+///
+/// A present operation takes its `ARITY` evaluations off the front of `evals`.
+fn operation_claim<F: Field, const ARITY: usize>(
+	log_n_constraints: Option<usize>,
+	r_x_star: &[F],
+	z_challenge: F,
+	evals: &mut impl Iterator<Item = F>,
+) -> OperatorData<F, ARITY> {
+	log_n_constraints.map_or_else(
+		|| OperatorData::zero_claim(z_challenge),
+		|log_n| OperatorData {
+			evals: array::from_fn(|_| {
+				evals
+					.next()
+					.expect("the sumcheck returns one evaluation per operand column")
+			}),
+			r_zhat_prime: z_challenge,
+			r_x_prime: r_x_star[..log_n].to_vec(),
+		},
+	)
 }
 
 /// The claims with their batching weights folded in, as both proving phases read them.

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -8,16 +8,14 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, InoutSegment, Operand, ValueVec},
 	word::Word,
 };
-use binius_field::{Field, PackedField, Rijndael8b as B8};
+use binius_field::{PackedField, Rijndael8b as B8};
 use binius_hash_prover::ParallelHashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::WordIPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec,
-	inner_product::inner_product,
 	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
-	univariate::EvaluationDomain,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{
@@ -27,7 +25,7 @@ use binius_utils::{
 use binius_verifier::{
 	IOPVerifier, Verifier,
 	config::{B128, LOG_WORDS_PER_ELEM},
-	protocols::{binmul::BinMulOutput, bitand::AndCheckOutput, intmul::IntMulOutput, zero},
+	protocols::bitand::AndCheckOutput,
 };
 use digest::Output;
 
@@ -35,7 +33,8 @@ use super::error::Error;
 use crate::{
 	protocols::{
 		binmul, bitand, intmul,
-		shift::{self, KeyCollection, OperatorClaims, OperatorData, ShiftOutput},
+		rerand::OperandWitness,
+		shift::{self, KeyCollection, OperatorClaims, ShiftOutput},
 	},
 	ring_switch,
 };
@@ -121,9 +120,10 @@ impl IOPProver {
 		//
 		// Skipped entirely (no transcript messages) when the constraint system has no IMUL
 		// constraints. The verifier applies the identical guard, so the transcript stays in sync;
-		// the zero `OperatorData` synthesized below then contributes nothing to the shift
-		// reduction.
-		let intmul_output = if cs.n_imul_constraints() > 0 {
+		// the IntMul claim is then a zero claim, contributing nothing to the shift reduction.
+		//
+		// The columns are kept with the output, since the BitAnd sumcheck re-reads them.
+		let intmul = if cs.n_imul_constraints() > 0 {
 			let intmul_guard = tracing::info_span!(
 				"[phase] IntMul check",
 				n_constraints = cs.imul_constraints.len()
@@ -135,7 +135,7 @@ impl IOPProver {
 			let [a, b, lo, hi] = &mul_columns;
 			let intmul_output = intmul::prove::<_, _, P, _>([a, b, lo, hi], &mut *channel, alloc)?;
 			drop(intmul_guard);
-			Some(intmul_output)
+			Some((mul_columns, intmul_output))
 		} else {
 			None
 		};
@@ -144,9 +144,9 @@ impl IOPProver {
 		//
 		// Runs immediately after the IntMul reduction and before BitAnd, matching the verifier so
 		// the transcript stays in sync. Skipped entirely (no transcript messages) when there are
-		// no BMUL constraints; the zero `OperatorData` synthesized below then contributes nothing
-		// to the shift reduction.
-		let binmul_output = if cs.n_bmul_constraints() > 0 {
+		// no BMUL constraints; the BinMul claim is then a zero claim, contributing nothing to the
+		// shift reduction.
+		let binmul = if cs.n_bmul_constraints() > 0 {
 			let binmul_guard = tracing::info_span!(
 				"[phase] BinMul check",
 				n_constraints = cs.bmul_constraints.len()
@@ -162,113 +162,51 @@ impl IOPProver {
 				alloc,
 			);
 			drop(binmul_guard);
-			Some(binmul_output)
+			Some((binmul_columns, binmul_output))
 		} else {
 			None
 		};
 
 		// [phase] BitAnd Reduction - AND constraint reduction
+		//
+		// Its sumcheck carries the multiplications' per-bit operand claims, IntMul first.
+		let operands = [
+			intmul.as_ref().map(|(columns, output)| OperandWitness {
+				words: columns.iter().map(|column| &**column).collect(),
+				claims: output.operand_claims(),
+			}),
+			binmul.as_ref().map(|(columns, output)| OperandWitness {
+				words: columns.iter().map(|column| &**column).collect(),
+				claims: output.operand_claims(),
+			}),
+		]
+		.into_iter()
+		.flatten()
+		.collect::<Vec<_>>();
 		let bitand_guard =
 			tracing::info_span!("[phase] BitAnd check", n_constraints = cs.and_constraints.len())
 				.entered();
-		let bitand_claim = {
+		let AndCheckOutput {
+			z_challenge,
+			rerand,
+		} = {
 			// Only the `A` and `B` columns are built; the reduction derives `C = A & B`.
 			let bitand_columns = tracing::debug_span!("Assemble columns")
 				.in_scope(|| build_operation_columns(&cs.and_constraints, witness, alloc));
-
-			let AndCheckOutput {
-				z_challenge,
-				rerand,
-			} = bitand::prove::<_, B128, P, _, _>(bitand_columns, &[], &mut *channel, alloc);
-			OperatorData {
-				evals: rerand.bitand_evals,
-				r_zhat_prime: z_challenge,
-				r_x_prime: rerand.eval_point,
-			}
+			bitand::prove::<_, B128, P, _, _>(bitand_columns, &operands, &mut *channel, alloc)
 		};
 		drop(bitand_guard);
 
-		// Build `OperatorData` for IntMul using the same `r_zhat_prime`
-		// challenge as in BitAnd. Sharing this univariate challenge
-		// improves ShiftReduction perf. When IntMul was skipped, synthesize a zero claim (four
-		// zero evals at an empty point): the shift reduction iterates the (empty) IMUL constraints,
-		// so this claim contributes zero to its batched evaluation.
-		//
-		// Build the oblong domain subspace once and pass it into the shift reduction, mirroring
-		// the verifier side (`shift::check_eval` takes the domain subspace). It is reused for the
-		// IntMul claim collapse below.
-		let subspace = BinarySubspace::<B8>::with_dim(Word::LOG_BITS).isomorphic();
-		let intmul_claim = match intmul_output {
-			Some(IntMulOutput {
-				eval_point,
-				a_evals,
-				b_evals,
-				c_lo_evals,
-				c_hi_evals,
-			}) => {
-				let r_zhat_prime = bitand_claim.r_zhat_prime;
-				let l_tilde = subspace.lagrange_evals_buffer(r_zhat_prime);
-				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
-				OperatorData {
-					evals: [
-						make_final_claim(a_evals),
-						make_final_claim(b_evals),
-						make_final_claim(c_lo_evals),
-						make_final_claim(c_hi_evals),
-					],
-					r_zhat_prime,
-					r_x_prime: eval_point,
-				}
-			}
-			None => OperatorData::zero_claim(bitand_claim.r_zhat_prime),
-		};
-
-		// Build `OperatorData` for BinMul using the same shared `r_zhat_prime` challenge,
-		// collapsing each of the six per-bit operand columns identically to IntMul. When BinMul
-		// was skipped, synthesize a zero claim (six zero evals at an empty point): the shift
-		// reduction iterates the (empty) BMUL constraints, so this claim contributes zero to its
-		// batched evaluation.
-		let binmul_claim = match binmul_output {
-			Some(BinMulOutput {
-				eval_point,
-				a_lo_evals,
-				a_hi_evals,
-				b_lo_evals,
-				b_hi_evals,
-				c_lo_evals,
-				c_hi_evals,
-			}) => {
-				let r_zhat_prime = bitand_claim.r_zhat_prime;
-				let l_tilde = subspace.lagrange_evals_buffer(r_zhat_prime);
-				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
-				OperatorData {
-					evals: [
-						make_final_claim(a_lo_evals),
-						make_final_claim(a_hi_evals),
-						make_final_claim(b_lo_evals),
-						make_final_claim(b_hi_evals),
-						make_final_claim(c_lo_evals),
-						make_final_claim(c_hi_evals),
-					],
-					r_zhat_prime,
-					r_x_prime: eval_point,
-				}
-			}
-			None => OperatorData::zero_claim(bitand_claim.r_zhat_prime),
-		};
-
 		// [phase] Zero Reduction - linear constraint reduction
 		//
-		// The reduction's claim, at the point the BitAnd sumcheck just output. See
-		// `IOPVerifier::verify` for why it carries no message.
-		let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
-		let zero_claim = OperatorData {
-			evals: [B128::ZERO],
-			r_zhat_prime: bitand_claim.r_zhat_prime,
-			r_x_prime: zero::reduction_point(&bitand_claim.r_x_prime, log_n_zero, || {
-				channel.sample()
-			}),
-		};
+		// Every operation is claimed at a prefix of the BitAnd sumcheck's point. The Zero point
+		// draws its extension here, where the verifier does. See `IOPVerifier::verify` for why the
+		// Zero reduction carries no message.
+		let claims = OperatorClaims::from_rerand(cs, 0, z_challenge, &rerand, || channel.sample());
+
+		// The shift reduction folds the bit axis over the 64-point domain, as the verifier's
+		// `shift::check_eval` does.
+		let subspace = BinarySubspace::<B8>::with_dim(Word::LOG_BITS).isomorphic();
 
 		// [phase] Shift Reduction - shift operations
 		let shift_guard = tracing::info_span!(
@@ -287,12 +225,7 @@ impl IOPProver {
 			&self.key_collection,
 			witness.public(),
 			witness.non_public(),
-			OperatorClaims {
-				zero: zero_claim,
-				bitand: bitand_claim,
-				intmul: intmul_claim,
-				binmul: binmul_claim,
-			},
+			claims,
 			&subspace,
 			&mut *channel,
 			alloc,

--- a/crates/verifier/src/protocols/zero.rs
+++ b/crates/verifier/src/protocols/zero.rs
@@ -22,10 +22,11 @@
 
 /// Builds the constraint point the Zero reduction closes at.
 ///
-/// The reduction runs directly after the BitAnd reduction and evaluates at the point that reduction
-/// has just produced: `rho` is the length-`log_zero_constraints` prefix of the BitAnd sumcheck's
-/// output challenges, extended by fresh challenges from `sample` when the ZERO set has more rows
-/// than the AND set. The prover and verifier derive it identically, so `sample` draws the same
+/// The reduction runs directly after the BitAnd sumcheck and evaluates at the constraint half of
+/// the point that sumcheck has just produced, `r_x_star`: `rho` is its
+/// length-`log_zero_constraints` prefix. The sumcheck runs over the longest of the AND, IMUL and
+/// BMUL arrays, so fresh challenges from `sample` extend `r_x_star` only when the ZERO array is
+/// longer still. The prover and verifier derive it identically, so `sample` draws the same
 /// challenges at the same point in both transcripts.
 ///
 /// `sample` stands in for the channel: the prover and verifier channel traits are unrelated, so one
@@ -43,14 +44,14 @@
 /// leaves untouched. What it does require is that every challenge be drawn after the witness is
 /// committed, which the phase ordering guarantees.
 pub fn reduction_point<F: Clone>(
-	bitand_eval_point: &[F],
+	r_x_star: &[F],
 	log_zero_constraints: usize,
 	mut sample: impl FnMut() -> F,
 ) -> Vec<F> {
-	// The ZERO and AND sets are padded to power-of-two row counts independently, so a ZERO set
-	// with more rows than the AND set runs past the BitAnd point and samples the rest.
+	// Each set is padded to a power-of-two row count independently, so a ZERO set with more rows
+	// than every AND, IMUL and BMUL set runs past `r_x_star` and samples the rest.
 	(0..log_zero_constraints)
-		.map(|i| bitand_eval_point.get(i).map_or_else(&mut sample, F::clone))
+		.map(|i| r_x_star.get(i).map_or_else(&mut sample, F::clone))
 		.collect()
 }
 

--- a/crates/verifier/src/reduction.rs
+++ b/crates/verifier/src/reduction.rs
@@ -3,19 +3,17 @@
 
 //! The constraint reduction shared by the single-instance and batched Binius64 verifiers.
 //!
-//! One circuit, and `2^k` instances of one circuit, reduce the same way.
-//! Which of the two it is enters as [`Instances`], and its count joins every row count.
+//! One circuit, and `2^k` instances of one circuit, reduce the same way. The instance count joins
+//! every row count, instance index low, constraint index high. One circuit is the batch with
+//! `k = 0`.
 //!
-//! A batch adds one step the monolithic reduction does not have:
+//! The BitAnd sumcheck carries the IntMul and BinMul operand claims, each zero-padded on its high
+//! end. So it ends at one point, and every operation is claimed at a prefix of it:
 //!
 //! ```text
-//! monolithic   every operand claim already sits at a common point
-//! batch        each operation's claims sit at its own instance point
-//!              -> one sumcheck transports them onto a shared point
+//! r_rho      the instance, shared by every operation
+//! r_x_star   the constraint; each operation reads the prefix its row count spans
 //! ```
-//!
-//! A batch of one instance still runs that sumcheck, over no rounds.
-//! It is the batched protocol either way, because its prover folds a batched witness.
 
 use std::iter;
 
@@ -26,17 +24,12 @@ use binius_core::{
 use binius_field::{ExtensionField, FieldOps, Rijndael8b as B8};
 use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::{
-	channel::{IPVerifierChannel, WordIPVerifierChannel},
-	sumcheck::{BatchSumcheckOutput, SumcheckOutput, batch_verify, verify as verify_sumcheck},
+	channel::WordIPVerifierChannel,
+	sumcheck::{SumcheckOutput, verify as verify_sumcheck},
 };
 use binius_math::{
 	BinarySubspace,
-	inner_product::inner_product,
-	multilinear::{
-		eq::{eq_ind, eq_ind_zero},
-		evaluate::evaluate_inplace_scalars,
-	},
-	univariate::{EvaluationDomain, evaluate_univariate},
+	multilinear::{eq::eq_ind_zero, evaluate::evaluate_inplace_scalars},
 };
 
 use crate::{
@@ -46,61 +39,21 @@ use crate::{
 		binmul::{BinMulOutput, verify as verify_binmul_reduction},
 		bitand::AndCheckOutput,
 		intmul::{IntMulOutput, verify as verify_intmul_reduction},
-		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, WiringEvalClaim},
+		rerand::RerandOutput,
+		shift::{self, BINMUL_ARITY, INTMUL_ARITY, WiringEvalClaim},
 		zero,
 	},
 	ring_switch::{self, RingSwitchVerifyOutput, eval_rs_eq},
 	verify_bitand_reduction,
 };
 
-/// The degree of the instance re-randomization's round polynomials.
-///
-/// Each operand is a multilinear evaluation, expressed with the quadratic evaluator.
-/// Its degree-2 prime polynomial gains one degree from the equality factor, giving 3.
-// TODO: a degree-1 multilinear-eval store evaluator would drop this to 2; none exists yet.
-const RERAND_DEGREE: usize = 3;
-
-/// The instances a reduction runs over.
-///
-/// This picks the protocol, not just a count.
-/// A batch of one instance is still a batch: its prover folds a batched witness, where the
-/// monolithic prover reads packed words.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Instances {
-	/// One circuit, with no instance axis at all.
-	Single,
-	/// `2^log_instances` instances of one circuit, sharing its constraint system.
-	Batch {
-		/// The base-2 logarithm of the instance count.
-		log_instances: usize,
-	},
-}
-
-impl Instances {
-	/// The instance variables every reduction's row count includes.
-	pub const fn log_count(self) -> usize {
-		match self {
-			Self::Single => 0,
-			Self::Batch { log_instances } => log_instances,
-		}
-	}
-
-	/// Whether the operand claims need transporting onto a shared instance point.
-	///
-	/// Only a batch does. A batch of one transports over no rounds rather than skipping the step,
-	/// which is what keeps its transcript the same shape at every instance count.
-	const fn transports_claims(self) -> bool {
-		matches!(self, Self::Batch { .. })
-	}
-}
-
 /// What [`reduce_constraints`] leaves for the caller: the claim on the committed trace, and the
 /// wiring claim the constraint system is read through.
 #[derive(Debug)]
 pub struct ReductionOutput<'a, F> {
-	/// The instance point every operand claim was transported onto.
+	/// The instance point every operation is claimed at.
 	///
-	/// Empty for the monolithic reduction, which transports nothing.
+	/// Empty for a single circuit.
 	pub r_rho: Vec<F>,
 	/// The shift reduction's output, holding the claimed witness evaluation.
 	pub shift: shift::VerifyOutput<F>,
@@ -115,7 +68,7 @@ impl<F: Clone> ReductionOutput<'_, F> {
 	///
 	/// ```text
 	/// r_j     the bit within a word
-	/// r_rho   the instance, empty for the monolithic reduction
+	/// r_rho   the instance, empty for a single circuit
 	/// r_y     the committed word
 	/// ```
 	///
@@ -131,13 +84,13 @@ impl<F: Clone> ReductionOutput<'_, F> {
 /// The reductions run in this order, and the order is load-bearing:
 ///
 /// ```text
-/// IntMul -> BinMul -> BitAnd -> Zero -> re-randomization -> shift -> public check
+/// IntMul -> BinMul -> BitAnd -> Zero -> shift -> public check
 /// ```
 ///
 /// # Arguments
 ///
 /// - `cs`: the single-instance constraint system every instance satisfies.
-/// - `instances`: whether this is the monolithic reduction or a batch, and how wide.
+/// - `log_instances`: the base-2 logarithm of the instance count, 0 for a single circuit.
 /// - `inout`: which value segment the inout words sit in.
 /// - `public`: the declared public values as the channel carries them, unpadded — the constants,
 ///   then the inout values.
@@ -156,7 +109,7 @@ impl<F: Clone> ReductionOutput<'_, F> {
 /// Do not reorder these, and keep the same order in the prover.
 pub fn reduce_constraints<'a, Channel>(
 	cs: &'a ConstraintSystem,
-	instances: Instances,
+	log_instances: usize,
 	inout: InoutSegment,
 	public: &[Channel::Word],
 	channel: &mut Channel,
@@ -165,8 +118,6 @@ where
 	Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128>,
 	Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 {
-	let log_instances = instances.log_count();
-
 	// One base domain shared by the AND-check, the shift, and the operand collapse.
 	// The AND-check's univariate-skip domain spans one dimension above the 64-bit word.
 	let andcheck_domain = BinarySubspace::<B8>::default()
@@ -207,12 +158,25 @@ where
 		None => None,
 	};
 
+	// The BitAnd sumcheck carries the multiplications' per-bit operand claims, IntMul first.
+	let operands = [
+		intmul_output.as_ref().map(IntMulOutput::operand_claims),
+		binmul_output.as_ref().map(BinMulOutput::operand_claims),
+	]
+	.into_iter()
+	.flatten()
+	.collect::<Vec<_>>();
+
 	// The BitAnd check has no skip branch: an empty AND set still reduces, over the single all-zero
 	// padding row, so `None` is zero constraint variables.
 	let log_n_and = cs.log_and_constraints().unwrap_or(0);
 	let AndCheckOutput {
 		z_challenge,
-		rerand,
+		rerand: RerandOutput {
+			eval_point,
+			bitand_evals,
+			operand_evals,
+		},
 	} = {
 		let _guard = tracing::info_span!(
 			"[phase] Verify BitAnd Reduction",
@@ -221,57 +185,35 @@ where
 			n_constraints = cs.n_and_constraints()
 		)
 		.entered();
-		verify_bitand_reduction(log_instances + log_n_and, &andcheck_domain, &[], channel)?
+		verify_bitand_reduction(log_instances + log_n_and, &andcheck_domain, &operands, channel)?
 	};
-	let [a_eval, b_eval, c_eval] = rerand.bitand_evals;
-	let eval_point = rerand.eval_point;
 
-	// The AND-check row point is `r_rho_and || r_x_and`: the instance index low, the constraint
-	// index high. With one instance the instance half is empty.
-	let (r_rho_and, r_x_and) = eval_point.split_at(log_instances);
+	// The sumcheck's point is `r_rho || r_x_star`: the instance index low, the constraint index
+	// high. Every operation is claimed at `r_rho` and the prefix of `r_x_star` its rows span.
+	let (r_rho, r_x_star) = eval_point.split_at(log_instances);
 
 	// The Zero reduction reads nothing and runs no sumcheck.
 	// A ZERO constraint is linear, so its oblong form vanishing at one unpredictable point
 	// certifies it.
 	//
-	// The point is the constraint half of the AND-check's, extended when ZERO has more rows.
-	// The prover draws the same extension at the same place.
-	//
-	// It skips the re-randomization below: a ZERO array vanishes identically, so its fold at any
-	// instance point is still zero.
+	// A ZERO array vanishes identically, so its claim is zero at any point. The prover draws the
+	// same extension of `r_x_star` at the same place.
 	let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
-	let zero_point = zero::reduction_point(r_x_and, log_n_zero, || channel.sample());
+	let zero_point = zero::reduction_point(r_x_star, log_n_zero, || channel.sample());
 	let zero = shift::OperationClaim::new(zero_point, vec![Channel::Elem::zero()]);
 
-	// Collapse the multiplications' per-bit operand claims to the oblong form BitAnd already has.
-	// The Lagrange weights fold them at the univariate challenge BitAnd just drew.
-	let lagrange = shift_domain.lagrange_evals::<Channel::Elem>(&z_challenge);
-	let bitand_claim = OperationClaim::new([a_eval, b_eval, c_eval], r_x_and, r_rho_and);
-	let intmul_claim =
-		intmul_output.map(|output| OperationClaim::from_intmul(output, &lagrange, log_instances));
-	let binmul_claim =
-		binmul_output.map(|output| OperationClaim::from_binmul(output, &lagrange, log_instances));
-
-	// Transport every operand claim onto one shared instance point.
-	// The monolithic reduction has only one point to begin with, and so does a batch with no
-	// multiplication constraints.
-	let needs_rerandomization =
-		instances.transports_claims() && (intmul_claim.is_some() || binmul_claim.is_some());
-	let (r_rho, bitand, intmul, binmul) = if needs_rerandomization {
-		RerandomizedOperations {
-			bitand: bitand_claim,
-			intmul: intmul_claim,
-			binmul: binmul_claim,
-		}
-		.verify(channel)?
-	} else {
-		(
-			bitand_claim.r_rho,
-			shift::OperationClaim::new(bitand_claim.r_x, bitand_claim.operand_claims.to_vec()),
-			absent_or_claimed(intmul_claim),
-			absent_or_claimed(binmul_claim),
-		)
-	};
+	let bitand = shift::OperationClaim::new(r_x_star[..log_n_and].to_vec(), bitand_evals.to_vec());
+	let mut operand_evals = operand_evals.into_iter();
+	let intmul = absent_or_claimed::<_, INTMUL_ARITY>(
+		cs.log_imul_constraints(),
+		r_x_star,
+		&mut operand_evals,
+	);
+	let binmul = absent_or_claimed::<_, BINMUL_ARITY>(
+		cs.log_bmul_constraints(),
+		r_x_star,
+		&mut operand_evals,
+	);
 
 	// The four operations' claims, in the order the shift reduction batches them.
 	let claims = [&zero, &bitand, &intmul, &binmul];
@@ -311,7 +253,7 @@ where
 	};
 
 	Ok(ReductionOutput {
-		r_rho,
+		r_rho: r_rho.to_vec(),
 		shift,
 		wiring,
 	})
@@ -399,208 +341,19 @@ where
 	Ok(eq_ind_zero(&r_y[log_packed_words..]) * public_eval)
 }
 
-/// An operation's operand data, or a zero claim at an empty point when it is absent.
+/// An operation's claim at its prefix of `r_x_star`, or a zero claim at an empty point when it is
+/// absent.
 ///
+/// A present operation takes its `ARITY` evaluations off the front of `evals`.
 /// An absent operation has an empty constraint set, so the shift finds no key naming it.
 /// Its zero claim therefore contributes nothing.
 fn absent_or_claimed<F: FieldOps, const ARITY: usize>(
-	claim: Option<OperationClaim<F, ARITY>>,
+	log_n_constraints: Option<usize>,
+	r_x_star: &[F],
+	evals: impl Iterator<Item = F>,
 ) -> shift::OperationClaim<F> {
-	match claim {
-		Some(claim) => shift::OperationClaim::new(claim.r_x, claim.operand_claims.to_vec()),
-		None => shift::OperationClaim::new(Vec::new(), vec![F::zero(); ARITY]),
-	}
-}
-
-/// The shared instance point together with every operation's operand data at that point.
-type RerandOutput<F> =
-	(Vec<F>, shift::OperationClaim<F>, shift::OperationClaim<F>, shift::OperationClaim<F>);
-
-/// One operation's oblong operand claims and the points they are claimed at.
-///
-/// Every operation reduces to this shape.
-/// The re-randomization transports the claims to the instance point shared by all of them.
-///
-/// Generic over the channel's element type `F`, so this composes with a channel whose challenges
-/// live in an extension of the base field (e.g. a symbolic verifier channel), not only `B128`.
-struct OperationClaim<F, const ARITY: usize> {
-	/// The oblong operand claim per operand, in operand order.
-	operand_claims: [F; ARITY],
-	/// The constraint-index point the operands are claimed at.
-	r_x: Vec<F>,
-	/// The instance-index point the operands are claimed at.
-	r_rho: Vec<F>,
-}
-
-impl<F: FieldOps, const ARITY: usize> OperationClaim<F, ARITY> {
-	/// The operand claims at the constraint point `r_x` and instance point `r_rho`.
-	fn new(operand_claims: [F; ARITY], r_x: &[F], r_rho: &[F]) -> Self {
-		Self {
-			operand_claims,
-			r_x: r_x.to_vec(),
-			r_rho: r_rho.to_vec(),
-		}
-	}
-}
-
-impl<F: FieldOps> OperationClaim<F, INTMUL_ARITY> {
-	/// Builds the IntMul claim by collapsing its per-bit operand claims to oblong claims.
-	///
-	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
-	/// This gives the oblong form the BitAnd claims already have.
-	/// The IntMul row point splits into an instance part (low) and a constraint part (high).
-	fn from_intmul(intmul_output: IntMulOutput<F>, lagrange: &[F], log_instances: usize) -> Self {
-		let IntMulOutput {
-			eval_point: r_out_mul,
-			a_evals,
-			b_evals,
-			c_lo_evals,
-			c_hi_evals,
-		} = intmul_output;
-		let oblong = |evals: [F; Word::BITS]| inner_product(evals, lagrange.iter().cloned());
-		let (r_rho, r_x) = r_out_mul.split_at(log_instances);
-		Self::new(
-			[
-				oblong(a_evals),
-				oblong(b_evals),
-				oblong(c_lo_evals),
-				oblong(c_hi_evals),
-			],
-			r_x,
-			r_rho,
-		)
-	}
-}
-
-impl<F: FieldOps> OperationClaim<F, BINMUL_ARITY> {
-	/// Builds the BinMul claim by collapsing its per-bit operand claims to oblong claims.
-	///
-	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
-	/// This gives the oblong form the BitAnd claims already have.
-	/// The BinMul row point splits into an instance part (low) and a constraint part (high).
-	fn from_binmul(binmul_output: BinMulOutput<F>, lagrange: &[F], log_instances: usize) -> Self {
-		let BinMulOutput {
-			eval_point: r_out_binmul,
-			a_lo_evals,
-			a_hi_evals,
-			b_lo_evals,
-			b_hi_evals,
-			c_lo_evals,
-			c_hi_evals,
-		} = binmul_output;
-		let oblong = |evals: [F; Word::BITS]| inner_product(evals, lagrange.iter().cloned());
-		let (r_rho, r_x) = r_out_binmul.split_at(log_instances);
-		Self::new(
-			[
-				oblong(a_lo_evals),
-				oblong(a_hi_evals),
-				oblong(b_lo_evals),
-				oblong(b_hi_evals),
-				oblong(c_lo_evals),
-				oblong(c_hi_evals),
-			],
-			r_x,
-			r_rho,
-		)
-	}
-}
-
-/// The operations' claims entering the batched instance re-randomization.
-///
-/// BitAnd is always present. IntMul and BinMul enter only when the circuit carries their
-/// constraints; an absent operation reduces to a zero claim contributing nothing to the shift.
-struct RerandomizedOperations<F> {
-	/// The BitAnd operand claims at the AND-check instance point.
-	bitand: OperationClaim<F, BITAND_ARITY>,
-	/// The IntMul operand claims at the IntMul instance point, when the circuit has IMUL
-	/// constraints.
-	intmul: Option<OperationClaim<F, INTMUL_ARITY>>,
-	/// The BinMul operand claims at the BinMul instance point, when the circuit has BMUL
-	/// constraints.
-	binmul: Option<OperationClaim<F, BINMUL_ARITY>>,
-}
-
-impl<F: FieldOps> RerandomizedOperations<F> {
-	/// Verifies the batched sumcheck that unifies every present operation's instance point.
-	///
-	/// - Check the sumcheck transporting every operand claim onto one shared instance point.
-	/// - Read the reduced operand evaluations at that point.
-	/// - Bind them to the sumcheck.
-	///
-	/// The operands are ordered [BitAnd | IntMul (if present) | BinMul (if present)], matching the
-	/// prover's push order, so the sums, the reduced evaluations, and the binding all agree. An
-	/// absent operation reduces to a zero claim at an empty point.
-	///
-	/// # Returns
-	///
-	/// The shared instance point, the BitAnd operand data, the IntMul operand data, and the BinMul
-	/// operand data.
-	fn verify<Channel>(self, channel: &mut Channel) -> Result<RerandOutput<F>, Error>
-	where
-		Channel: IPVerifierChannel<B128, Elem = F>,
-	{
-		// Every operation reduces over the same instance axis; recover its width from the BitAnd
-		// point.
-		let log_instances = self.bitand.r_rho.len();
-
-		// Verify the batched sumcheck: one multilinear-eval claim per operand, in push order
-		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
-		let mut sums: Vec<F> = self.bitand.operand_claims.to_vec();
-		if let Some(intmul) = &self.intmul {
-			sums.extend(intmul.operand_claims.iter().cloned());
-		}
-		if let Some(binmul) = &self.binmul {
-			sums.extend(binmul.operand_claims.iter().cloned());
-		}
-		let BatchSumcheckOutput {
-			batch_coeff,
-			eval,
-			mut challenges,
-		} = batch_verify(log_instances, RERAND_DEGREE, &sums, channel)?;
-		challenges.reverse();
-		let r_rho = challenges;
-
-		// The prover wrote the reduced operand evaluations at `r_rho`, grouped by operation in push
-		// order. These are the operand claims the shift consumes.
-		let bitand_evals = channel.recv_array::<BITAND_ARITY>()?;
-		let intmul_evals = self
-			.intmul
-			.as_ref()
-			.map(|_| channel.recv_array::<INTMUL_ARITY>())
-			.transpose()?;
-		let binmul_evals = self
-			.binmul
-			.as_ref()
-			.map(|_| channel.recv_array::<BINMUL_ARITY>())
-			.transpose()?;
-
-		// Bind the reduced evals to the sumcheck: each claim's contribution is its
-		// eq(instance_point, r_rho) weight times its reduced eval, batched by `batch_coeff`. The
-		// contributions follow the same push order as `sums`.
-		let eq_and = eq_ind(&self.bitand.r_rho, &r_rho);
-		let mut expected: Vec<F> = bitand_evals
-			.iter()
-			.map(|eval| eval.clone() * &eq_and)
-			.collect();
-		if let (Some(intmul), Some(evals)) = (&self.intmul, &intmul_evals) {
-			let eq_mul = eq_ind(&intmul.r_rho, &r_rho);
-			expected.extend(evals.iter().map(|eval| eval.clone() * &eq_mul));
-		}
-		if let (Some(binmul), Some(evals)) = (&self.binmul, &binmul_evals) {
-			let eq_binmul = eq_ind(&binmul.r_rho, &r_rho);
-			expected.extend(evals.iter().map(|eval| eval.clone() * &eq_binmul));
-		}
-		channel.assert_zero(evaluate_univariate(&expected, &batch_coeff) - eval)?;
-
-		let bitand_data = shift::OperationClaim::new(self.bitand.r_x, bitand_evals.to_vec());
-		let intmul_data = match (self.intmul, intmul_evals) {
-			(Some(intmul), Some(evals)) => shift::OperationClaim::new(intmul.r_x, evals.to_vec()),
-			_ => shift::OperationClaim::new(Vec::new(), vec![F::zero(); INTMUL_ARITY]),
-		};
-		let binmul_data = match (self.binmul, binmul_evals) {
-			(Some(binmul), Some(evals)) => shift::OperationClaim::new(binmul.r_x, evals.to_vec()),
-			_ => shift::OperationClaim::new(Vec::new(), vec![F::zero(); BINMUL_ARITY]),
-		};
-		Ok((r_rho, bitand_data, intmul_data, binmul_data))
-	}
+	log_n_constraints.map_or_else(
+		|| shift::OperationClaim::new(Vec::new(), vec![F::zero(); ARITY]),
+		|log_n| shift::OperationClaim::new(r_x_star[..log_n].to_vec(), evals.take(ARITY).collect()),
+	)
 }

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -30,7 +30,7 @@ use crate::{
 		rerand::{self, OperandClaims},
 		shift::WiringEvalClaim,
 	},
-	reduction::{Instances, reduce_constraints},
+	reduction::reduce_constraints,
 	ring_switch,
 };
 
@@ -180,7 +180,7 @@ impl IOPVerifier {
 		// Reduce every constraint to one claim on the committed trace.
 		let reduction = reduce_constraints(
 			self.constraint_system(),
-			Instances::Single,
+			0,
 			InoutSegment::Public,
 			&public,
 			channel,


### PR DESCRIPTION
Linear: [BINIUS-648](https://linear.app/jimpo/issue/BINIUS-648/reduction-route-intmul-binmul-and-zero-through-the-unified-point)

This PR is the protocol switch that follows #2475 (BINIUS-647). The IntMul and BinMul per-bit operand claims now go into the BitAnd sumcheck (`rerand`). Each operand summand is zero-padded on its high (constraint) end. So the sumcheck ends at `r_rho || r_x_star`, and every operation is claimed at `r_rho` followed by a prefix of `r_x_star`. The M4 prover's separate instance re-randomization sumcheck is therefore redundant, and this PR deletes it on both sides.

One commit, because the transcript changes on both sides at once.

## Verifier (`crates/verifier/src/reduction.rs`)
- `reduce_constraints` takes `log_instances: usize`. The `Instances` enum is gone, because a single circuit and a batch of one now run the same protocol.
- Deleted: `RerandomizedOperations`, the `RerandOutput` tuple alias, `RERAND_DEGREE`, the private `OperationClaim` (with `from_intmul` / `from_binmul`), and the identity branch. `absent_or_claimed` stays and now reads its evals from `operand_evals`.
- Zero, BitAnd, IntMul and BinMul are each claimed at `r_x_star[..ℓ_op]`. `zero::reduction_point` takes `r_x_star`, and its doc now says so.

## Prover (`crates/prover/src/prove.rs`)
- Deleted: the lagrange fold of the per-bit evals.
- The IMUL and BMUL word columns are kept and passed to `bitand::prove` as `OperandWitness`.
- New `OperatorClaims::from_rerand` (in `shift/claims.rs`) builds the shift claims from `RerandOutput`. The M4 prover calls it too.

## M4 prover (`crates/m4-prover`)
- Deleted: `Operation`, `RerandomizedOperations`, `split_evals`, the retention of the AND columns, `OperandColumns::rho_multilinear` and `with_derived_and`, and their tests.
- `unpadded_columns_fold_identically_to_padded_ones` keeps its word-level checks, renamed to `unpadded_columns_are_padded_ones_without_the_zero_tail`.
- `r_rho` is `rerand.eval_point[..log_instances]`.

## Soundness order
The order does not change. The per-bit evals go into the transcript before `z`. `θ` is drawn after the folded `α_z` are fixed. The shift's batching challenges are drawn after all thirteen evals.

## Note for review
The single-instance prover now keeps the IMUL and BMUL word columns alive through the BitAnd sumcheck, because that sumcheck folds them. They are freed at the end of `prove`.

## Testing
- `cargo nextest run --workspace --release`: 1930 passed, 0 failed, 16 skipped (`#[ignore]`). This covers `prove_verify.rs` and the three non-ignored `recursion_end_to_end.rs` tests (the symbolic `Elem` path).
- The M4 acceptance tests are `#[ignore]` timing runs, so I ran them separately: `cargo nextest run --release -p binius-m4-prover --test prove_hash_based_sig --test prove_hash_primitives --run-ignored all`. 10 passed, including `prove_integer_multiplication_single_instance`.
- `cargo clippy --workspace --all-targets -- -D warnings`, rustdoc with `-D warnings`, and nightly rustfmt are clean.
- `RerandomizedOperations` and `rho_multilinear` no longer appear anywhere in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRbjR4tdz1huqXLJQV8hdZ